### PR TITLE
feat: Add Outbound HTTPS transport layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ vendor
 
 # Test binary, build with `go test -c`
 *.test
+test/fixtures/keys
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,13 @@ license:
 	@scripts/check_license.sh
 
 .PHONY: unit-test
-unit-test:
+unit-test: generate-test-keys
 	@scripts/check_unit.sh
+
+generate-test-keys: clean
+	@scripts/openssl_env.sh scripts/generate_test_keys.sh
 
 .PHONY: clean
 clean:
+	rm -Rf test/fixtures/keys
 	rm -f coverage.txt

--- a/pkg/didcomm/transport/http/outbound.go
+++ b/pkg/didcomm/transport/http/outbound.go
@@ -1,0 +1,108 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package http
+
+import (
+	"bytes"
+	"crypto/tls"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const commContentType = "application/didcomm-envelope-enc"
+
+// outboundCommHTTPOpts holds options for the HTTP transport implementation of CommTransport
+// it has an http.Client instance
+type outboundCommHTTPOpts struct {
+	client *http.Client
+}
+
+// OutboundHTTPOpt is an outbound HTTP transport option
+type OutboundHTTPOpt func(opts *outboundCommHTTPOpts)
+
+// WithOutboundHTTPClient option is for creating an Outbound HTTP transport using an http.Client instance
+func WithOutboundHTTPClient(client *http.Client) OutboundHTTPOpt {
+	return func(opts *outboundCommHTTPOpts) {
+		opts.client = client
+	}
+}
+
+// WithOutboundTimeout option is for creating an Outbound HTTP transport using a client timeout value
+func WithOutboundTimeout(timeout time.Duration) OutboundHTTPOpt {
+	return func(opts *outboundCommHTTPOpts) {
+		opts.client.Timeout = timeout
+	}
+}
+
+// WithOutboundTLSConfig option is for creating an Outbound HTTP transport using a tls.Config instance
+func WithOutboundTLSConfig(tlsConfig *tls.Config) OutboundHTTPOpt {
+	return func(opts *outboundCommHTTPOpts) {
+		opts.client = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConfig,
+			},
+		}
+	}
+}
+
+// OutboundHTTPClient represents the Outbound HTTP transport instance
+type OutboundHTTPClient struct {
+	client *http.Client
+}
+
+// NewOutbound creates a new instance of Outbound HTTP transport to Post requests to other Agents.
+// An http.Client or tls.Config options is mandatory to create a transport instance.
+func NewOutbound(opts ...OutboundHTTPOpt) (*OutboundHTTPClient, error) {
+	clOpts := &outboundCommHTTPOpts{}
+	// Apply options
+	for _, opt := range opts {
+		opt(clOpts)
+	}
+
+	if clOpts.client == nil {
+		return nil, errors.New("Can't create an outbound transport without an HTTP client")
+	}
+
+	cs := &OutboundHTTPClient{
+		client: clOpts.client,
+	}
+	return cs, nil
+}
+
+// Send sends a2a exchange data via HTTP (client side)
+func (cs *OutboundHTTPClient) Send(data string, url string) (string, error) {
+	resp, err := cs.client.Post(url, commContentType, bytes.NewBuffer([]byte(data)))
+	if err != nil {
+		log.Printf("HTTP Transport - Error posting did envelope to agent at [%s]: %v", url, err)
+		return "", err
+	}
+
+	var respData string
+	if resp != nil {
+		isStatusSuccess := resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusOK
+		if !isStatusSuccess {
+			return "", errors.Errorf("Warning - Received non success POST HTTP status from agent at [%s]: status : %v", url, resp.Status)
+		}
+		// handle response
+		defer func() {
+			e := resp.Body.Close()
+			if e != nil {
+				log.Printf("HTTP Transport - Error closing response body: %v", e)
+			}
+		}()
+		buf := new(bytes.Buffer)
+		_, e := buf.ReadFrom(resp.Body)
+		if e != nil {
+			return "", e
+		}
+		respData = buf.String()
+	}
+	return respData, nil
+}

--- a/pkg/didcomm/transport/http/outbound_test.go
+++ b/pkg/didcomm/transport/http/outbound_test.go
@@ -1,0 +1,179 @@
+/*
+	Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+	SPDX-License-Identifier: Apache-2.0
+*/
+
+package http
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+const certPrefix = "../../../../test/fixtures/keys/"
+
+func TestWithOutboundOpts(t *testing.T) {
+	opt := WithOutboundHTTPClient(nil)
+	require.NotNil(t, opt)
+	clOpts := &outboundCommHTTPOpts{}
+	opt(clOpts)
+
+	opt = WithOutboundTimeout(10 * time.Second)
+	require.NotNil(t, opt)
+	clOpts = &outboundCommHTTPOpts{}
+	// opt.client is nil, so setting timeout should panic
+	require.Panics(t, func() { opt(clOpts) })
+
+	opt = WithOutboundTLSConfig(nil)
+	require.NotNil(t, opt)
+	clOpts = &outboundCommHTTPOpts{}
+	opt(clOpts)
+}
+
+func TestOutboundHTTPTransport(t *testing.T) {
+	// prepare http server
+	server := startMockServer()
+	port := server.Addr().(*net.TCPAddr).Port
+	serverUrl := fmt.Sprintf("https://localhost:%d", port)
+	defer func() {
+		err := server.Close()
+		if err != nil {
+			log.Fatalf("Failed to stop server: %s", err)
+		}
+	}()
+
+	//build a mock cert pool
+	cp := x509.NewCertPool()
+	err := addCertsToCertPool(cp)
+	require.NoError(t, err)
+
+	// build a tls.Config instance to be used by the outbound transport
+	tlsConfig := &tls.Config{
+		RootCAs:      cp,
+		Certificates: nil,
+	}
+	// create a new invalid Outbound transport instance
+	ot, err := NewOutbound()
+	require.Error(t, err)
+	require.EqualError(t, err, "Can't create an outbound transport without an HTTP client")
+
+	// now create a new valid Outbound transport instance and test its Send() call
+	ot, err = NewOutbound(WithOutboundTLSConfig(tlsConfig), WithOutboundTimeout(1*time.Second))
+	require.NoError(t, err)
+	require.NotNil(t, ot)
+
+	// test Outbound transport's api
+	// first with an empty url
+	r, e := ot.Send("Hello World", "")
+	require.Error(t, e)
+	require.Empty(t, r)
+
+	// now try a bad url
+	r, e = ot.Send("Hello World", "https://badurl")
+	require.Error(t, e)
+	require.Empty(t, r)
+
+	// and try with a 'bad' payload with a valid url..
+	r, e = ot.Send("bad", serverUrl)
+	require.Error(t, e)
+	require.Empty(t, r)
+
+	// finally using a valid url
+	r, e = ot.Send("Hello World", serverUrl)
+	require.NoError(t, e)
+	require.NotEmpty(t, r)
+
+}
+
+func addCertsToCertPool(pool *x509.CertPool) error {
+	var rawCerts []string
+
+	for i := 1; i <= 3; i++ {
+		certPath := fmt.Sprintf("%sec-pubCert%d.pem", certPrefix, i)
+		// Create a pool with server certificates
+		cert, e := ioutil.ReadFile(filepath.Clean(certPath))
+		if e != nil {
+			return errors.Wrap(e, "Failed Reading certificate")
+		}
+		rawCerts = append(rawCerts, string(cert))
+	}
+
+	certs := decodeCerts(rawCerts)
+	for i := range certs {
+		pool.AddCert(certs[i])
+	}
+	return nil
+}
+
+func startMockServer() net.Listener {
+	testHandler := mockHttpHandler{}
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		log.Fatalf("HTTP listener failed to start: %s", err)
+	}
+	go func() {
+		err := http.ServeTLS(listener, testHandler, certPrefix+"ec-pubCert1.pem", certPrefix+"ec-key1.pem")
+		if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			log.Fatalf("HTTP server failed to start: %s", err)
+		}
+	}()
+	return listener
+}
+
+type mockHttpHandler struct {
+}
+
+func (m mockHttpHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	if req.Body != nil {
+		body, err := ioutil.ReadAll(req.Body)
+		if err != nil || string(body) == "bad" {
+			res.WriteHeader(http.StatusBadRequest)
+			_, _ = res.Write([]byte(fmt.Sprintf("bad request: %s", body)))
+			return
+		}
+	}
+
+	// mocking successful response
+	res.WriteHeader(http.StatusAccepted) // usually DID-Comm expects StatusAccepted code (202)
+	res.Write([]byte("success"))
+}
+
+// decodeCerts will decode a list of pemCertsList (string) into a list of x509 certificates
+func decodeCerts(pemCertsList []string) []*x509.Certificate {
+	var certs []*x509.Certificate
+	for _, pemCertsString := range pemCertsList {
+		pemCerts := []byte(pemCertsString)
+		for len(pemCerts) > 0 {
+			var block *pem.Block
+			block, pemCerts = pem.Decode(pemCerts)
+			if block == nil {
+				break
+			}
+			if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+				continue
+			}
+
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				continue
+			}
+
+			certs = append(certs, cert)
+		}
+	}
+	return certs
+}

--- a/scripts/generate_test_keys.sh
+++ b/scripts/generate_test_keys.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+echo "Generating aries-framework-go Test PKI"
+mkdir -p test/fixtures/keys/tls
+
+#create CA for TLS creds
+openssl ecparam -name prime256v1 -genkey -noout -out test/fixtures/keys/tls/ec-cakey.pem
+openssl req -new -x509 -key test/fixtures/keys/tls/ec-cakey.pem -subj "/C=CA/ST=ON/O=Example Internet CA TLS Inc.:CA Sec/OU=CA Sec" -out test/fixtures/keys/tls/ec-cacert.pem
+
+#create TLS creds
+openssl ecparam -name prime256v1 -genkey -noout -out test/fixtures/keys/tls/ec-key.pem
+openssl req -new -key test/fixtures/keys/tls/ec-key.pem -subj "/C=CA/ST=ON/O=Example Inc.:aries-framework-go/OU=aries-framework-go/CN=*.example.com" -reqexts SAN -config ./test/fixtures/openssl/openssl.cnf -out test/fixtures/keys/tls/ec-key.csr
+openssl x509 -req -in test/fixtures/keys/tls/ec-key.csr -extensions SAN -extfile ./test/fixtures/openssl/openssl.cnf -CA test/fixtures/keys/tls/ec-cacert.pem -CAkey test/fixtures/keys/tls/ec-cakey.pem -CAcreateserial -out test/fixtures/keys/tls/ec-pubCert.pem -days 365
+
+#create CA for other creds
+openssl ecparam -name prime256v1 -genkey -noout -out test/fixtures/keys/ec-cakey.pem
+openssl req -new -x509 -key test/fixtures/keys/ec-cakey.pem -subj "/C=CA/ST=ON/O=Example Internet CA Inc.:CA Sec/OU=CA Sec" -out test/fixtures/keys/ec-cacert.pem
+
+#create creds 1
+openssl ecparam -name prime256v1 -genkey -noout -out test/fixtures/keys/ec-key1.pem
+openssl req -new -key test/fixtures/keys/ec-key1.pem -subj "/C=CA/ST=ON/O=Example Inc.:aries-framework-go/OU=aries-framework-go/CN=*.example.com" -reqexts SAN -config ./test/fixtures/openssl/openssl.cnf -out test/fixtures/keys/ec-key1.csr
+openssl x509 -req -in test/fixtures/keys/ec-key1.csr -extensions SAN -extfile ./test/fixtures/openssl/openssl.cnf -CA test/fixtures/keys/ec-cacert.pem -CAkey test/fixtures/keys/ec-cakey.pem -CAcreateserial -out test/fixtures/keys/ec-pubCert1.pem -days 365
+
+#extract pubkey 1
+openssl x509 -inform pem -in test/fixtures/keys/ec-pubCert1.pem -pubkey -noout > test/fixtures/keys/ec-pubKey1.pem
+
+#create creds 2
+openssl ecparam -name prime256v1 -genkey -noout -out test/fixtures/keys/ec-key2.pem
+openssl req -new -key test/fixtures/keys/ec-key2.pem -subj "/C=CA/ST=ON/O=Example Inc.:aries-framework-go/OU=aries-framework-go/CN=*.example.com" -reqexts SAN -config ./test/fixtures/openssl/openssl.cnf -out test/fixtures/keys/ec-key2.csr
+openssl x509 -req -in test/fixtures/keys/ec-key2.csr -extensions SAN -extfile ./test/fixtures/openssl/openssl.cnf -CA test/fixtures/keys/ec-cacert.pem -CAkey test/fixtures/keys/ec-cakey.pem -CAcreateserial -out test/fixtures/keys/ec-pubCert2.pem -days 365
+
+#extract pubkey 2
+openssl x509 -inform pem -in test/fixtures/keys/ec-pubCert2.pem -pubkey -noout > test/fixtures/keys/ec-pubKey2.pem
+
+#create creds 3
+openssl ecparam -name prime256v1 -genkey -noout -out test/fixtures/keys/ec-key3.pem
+openssl req -new -key test/fixtures/keys/ec-key3.pem -subj "/C=CA/ST=ON/O=Example Inc.:aries-framework-go/OU=aries-framework-go/CN=*.example.com" -reqexts SAN -config ./test/fixtures/openssl/openssl.cnf -out test/fixtures/keys/ec-key3.csr
+openssl x509 -req -in test/fixtures/keys/ec-key3.csr -extensions SAN -extfile ./test/fixtures/openssl/openssl.cnf -CA test/fixtures/keys/ec-cacert.pem -CAkey test/fixtures/keys/ec-cakey.pem -CAcreateserial -out test/fixtures/keys/ec-pubCert3.pem -days 365
+
+#extract pubkey 3
+openssl x509 -inform pem -in test/fixtures/keys/ec-pubCert3.pem -pubkey -noout > test/fixtures/keys/ec-pubKey3.pem
+
+echo "done generating aries-framework-go PKI"

--- a/scripts/openssl_env.sh
+++ b/scripts/openssl_env.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+OPENSSL_CMD=${OPENSSL_CMD:-openssl}
+
+if [ ! $(command -v ${OPENSSL_CMD}) ]; then
+	docker run -i --rm \
+		-v $(pwd):/opt/workspace \
+		--workdir /opt/workspace \
+		--entrypoint "$1" \
+		frapsoft/openssl
+    exit 0
+fi
+
+$1

--- a/test/fixtures/openssl/openssl.cnf
+++ b/test/fixtures/openssl/openssl.cnf
@@ -1,0 +1,11 @@
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[ req ]
+distinguished_name	= req_distinguished_name
+
+[ req_distinguished_name ]
+
+[SAN]
+subjectAltName=DNS:*.example.com,DNS:localhost


### PR DESCRIPTION
	Add HTTPS Outbound capability for Aries Agents to safely communicate between each other.

	This implements the HTTP(S) Aries-RFC 25:
	https://github.com/hyperledger/aries-rfcs/tree/master/features/0025-didcomm-transports#https

	Only HTTPS will be supported for secured communications.

	It support the DID Exchange Protocol 1.0 as per Aries-RFC 23:
	https://github.com/hyperledger/aries-rfcs/tree/master/features/0023-did-exchange

	To support unit-tests, sample test keys were generated using the openssl tool

	Future work (to be implemented):
	* Inbound HTTPS capability
	* Implement the Pack/Unpack messaging capability
	as described in Aries-RFC 19:
	https://github.com/hyperledger/aries-rfcs/tree/master/features/0019-encryption-envelope

closes issue #8
Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>