### PR TITLE
feat: did-comm : Implement DID Exchange client APIs

### DIFF
--- a/pkg/common/metadata/metadata.go
+++ b/pkg/common/metadata/metadata.go
@@ -1,0 +1,11 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metadata
+
+const (
+	// AriesCommunityDID aries community DID
+	AriesCommunityDID = "did:sov:BzCbsNYhMrjHiqZDTUASHg"
+)

--- a/pkg/didcomm/protocol/decorator/decorator.go
+++ b/pkg/didcomm/protocol/decorator/decorator.go
@@ -1,0 +1,12 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package decorator
+
+// Thread thread data
+type Thread struct {
+	ID string `json:"@thid,omitempty"`
+}

--- a/pkg/didcomm/protocol/exchange/exchange.go
+++ b/pkg/didcomm/protocol/exchange/exchange.go
@@ -10,15 +10,62 @@ import (
 	"encoding/base64"
 	"encoding/json"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/metadata"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/pkg/errors"
 )
 
+const (
+	connectionSpec     = metadata.AriesCommunityDID + ";spec/connections/1.0/"
+	connectionInvite   = connectionSpec + "invitation"
+	connectionRequest  = connectionSpec + "request"
+	connectionResponse = connectionSpec + "response"
+)
+
 // Invitation defines DID exchange invitation message
+// https://github.com/hyperledger/aries-rfcs/tree/master/features/0023-did-exchange#0-invitation-to-exchange
 type Invitation struct {
-	Type  string `json:"@type,omitempty"`
-	ID    string `json:"@id,omitempty"`
-	Label string `json:"label,omitempty"`
-	DID   string `json:"did,omitempty"`
+	Type            string   `json:"@type,omitempty"`
+	ID              string   `json:"@id,omitempty"`
+	Label           string   `json:"label,omitempty"`
+	DID             string   `json:"did,omitempty"`
+	RecipientKeys   []string `json:"recipientKeys,omitempty"`
+	ServiceEndpoint string   `json:"serviceEndpoint,omitempty"`
+	RoutingKeys     []string `json:"routingKeys,omitempty"`
+}
+
+// Request defines a2a DID exchange request
+// https://github.com/hyperledger/aries-rfcs/tree/master/features/0023-did-exchange#1-exchange-request
+type Request struct {
+	Type       string      `json:"@type,omitempty"`
+	ID         string      `json:"@id,omitempty"`
+	Label      string      `json:"label,omitempty"`
+	Connection *Connection `json:"connection,omitempty"`
+}
+
+// Response defines a2a DID exchange response
+// https://github.com/hyperledger/aries-rfcs/tree/master/features/0023-did-exchange#2-exchange-response
+type Response struct {
+	Type                string               `json:"@type,omitempty"`
+	ID                  string               `json:"@id,omitempty"`
+	ConnectionSignature *ConnectionSignature `json:"connection~sig,omitempty"`
+	Thread              *decorator.Thread    `json:"~thread,omitempty"`
+}
+
+// ConnectionSignature connection signature
+type ConnectionSignature struct {
+	Type       string `json:"@type,omitempty"`
+	Signature  string `json:"signature,omitempty"`
+	SignedData string `json:"sig_data,omitempty"`
+	SignVerKey string `json:"signers,omitempty"`
+}
+
+// Connection connection
+type Connection struct {
+	DID    string   `json:"did,omitempty"`
+	DIDDoc *did.Doc `json:"did_doc,omitempty"`
 }
 
 // GenerateInviteWithPublicDID generates the DID exchange invitation string with public DID
@@ -30,11 +77,56 @@ func GenerateInviteWithPublicDID(invite *Invitation) (string, error) {
 	return encodedExchangeInvitation(invite)
 }
 
+// GenerateInviteWithKeyAndEndpoint generates the DID exchange invitation string with recipient key and endpoint
+func GenerateInviteWithKeyAndEndpoint(invite *Invitation) (string, error) {
+	if invite.ID == "" || invite.ServiceEndpoint == "" || len(invite.RecipientKeys) == 0 {
+		return "", errors.New("ID, Service Endpoint and Recipient Key are mandatory")
+	}
+
+	return encodedExchangeInvitation(invite)
+}
+
+// SendExchangeRequest sends exchange request
+func SendExchangeRequest(exchangeRequest *Request, destination string, transport transport.OutboundTransport) error {
+	if exchangeRequest == nil {
+		return errors.New("exchangeRequest cannot be nil")
+	}
+
+	exchangeRequest.Type = connectionRequest
+
+	// ignore response data as it is not used in this communication mode as defined in the spec
+	_, err := marshalAndSend(exchangeRequest, "Error Marshalling Exchange Request", destination, transport)
+	return err
+}
+
+// SendExchangeResponse sends exchange response
+func SendExchangeResponse(exchangeResponse *Response, destination string, transport transport.OutboundTransport) error {
+	if exchangeResponse == nil {
+		return errors.New("exchangeResponse cannot be nil")
+	}
+
+	exchangeResponse.Type = connectionResponse
+
+	// ignore response data as it is not used in this communication mode as defined in the spec
+	_, err := marshalAndSend(exchangeResponse, "Error Marshalling Exchange Response", destination, transport)
+	return err
+}
+
 func encodedExchangeInvitation(inviteMessage *Invitation) (string, error) {
+	inviteMessage.Type = connectionInvite
+
 	invitationJSON, err := json.Marshal(inviteMessage)
 	if err != nil {
 		return "", errors.Wrapf(err, "JSON Marshal Error")
 	}
 
 	return base64.URLEncoding.EncodeToString(invitationJSON), nil
+}
+
+func marshalAndSend(data interface{}, errorMsg, destination string, transport transport.OutboundTransport) (string, error) {
+	jsonString, err := json.Marshal(data)
+	if err != nil {
+		return "", errors.Wrapf(err, errorMsg)
+	}
+	return transport.Send(string(jsonString), destination)
 }

--- a/pkg/didcomm/protocol/exchange/exchange_test.go
+++ b/pkg/didcomm/protocol/exchange/exchange_test.go
@@ -9,7 +9,13 @@ package exchange
 import (
 	"testing"
 
+	mocktransport "github.com/hyperledger/aries-framework-go/pkg/internal/didcomm/transport/mock"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	destinationURL  = "https://localhost:8090"
+	successResponse = "success"
 )
 
 func TestGenerateInviteWithPublicDID(t *testing.T) {
@@ -34,4 +40,68 @@ func TestGenerateInviteWithPublicDID(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Empty(t, invite)
+}
+
+func TestGenerateInviteWithKeyAndEndpoint(t *testing.T) {
+	invite, err := GenerateInviteWithKeyAndEndpoint(&Invitation{
+		ID:              "12345678900987654321",
+		Label:           "Alice",
+		RecipientKeys:   []string{"8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"},
+		ServiceEndpoint: "https://example.com/endpoint",
+		RoutingKeys:     []string{"8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"},
+	})
+	require.NotEmpty(t, invite)
+
+	invite, err = GenerateInviteWithKeyAndEndpoint(&Invitation{
+		Label:           "Alice",
+		RecipientKeys:   []string{"8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"},
+		ServiceEndpoint: "https://example.com/endpoint",
+		RoutingKeys:     []string{"8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"},
+	})
+	require.Error(t, err)
+	require.Empty(t, invite)
+
+	invite, err = GenerateInviteWithKeyAndEndpoint(&Invitation{
+		ID:            "12345678900987654321",
+		Label:         "Alice",
+		RecipientKeys: []string{"8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"},
+		RoutingKeys:   []string{"8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"},
+	})
+	require.Error(t, err)
+	require.Empty(t, invite)
+
+	invite, err = GenerateInviteWithKeyAndEndpoint(&Invitation{
+		ID:              "12345678900987654321",
+		Label:           "Alice",
+		ServiceEndpoint: "https://example.com/endpoint",
+		RoutingKeys:     []string{"8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"},
+	})
+	require.Error(t, err)
+	require.Empty(t, invite)
+}
+
+func TestSendRequest(t *testing.T) {
+	oTr := mocktransport.NewOutboundTransport(successResponse)
+
+	req := &Request{
+		ID:    "5678876542345",
+		Label: "Bob",
+	}
+
+	require.NoError(t, SendExchangeRequest(req, destinationURL, oTr))
+	require.Error(t, SendExchangeRequest(nil, destinationURL, oTr))
+}
+
+func TestSendResponse(t *testing.T) {
+	oTr := mocktransport.NewOutboundTransport(successResponse)
+
+	resp := &Response{
+		ID: "12345678900987654321",
+		ConnectionSignature: &ConnectionSignature{
+			Type: "did:trustbloc:RQkehfoFssiwQRuihskwoPSR;spec/ed25519Sha512_single/1.0/ed25519Sha512_single",
+		},
+	}
+
+	require.NoError(t, SendExchangeResponse(resp, destinationURL, oTr))
+	require.Error(t, SendExchangeResponse(nil, destinationURL, oTr))
 }

--- a/pkg/didcomm/transport/transport_interface.go
+++ b/pkg/didcomm/transport/transport_interface.go
@@ -1,0 +1,14 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package transport
+
+// OutboundTransport interface definition for transport layer
+// This is the client side of the agent
+type OutboundTransport interface {
+	// Send send a2a exchange data
+	Send(data string, destination string) (string, error)
+}

--- a/pkg/internal/didcomm/transport/mock/mock_transport.go
+++ b/pkg/internal/didcomm/transport/mock/mock_transport.go
@@ -1,0 +1,27 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocktransport
+
+import "errors"
+
+// OutboundTransport mock outbound transport structure
+type OutboundTransport struct {
+	ExpectedResponse string
+}
+
+// NewOutboundTransport new OutboundTransport instance
+func NewOutboundTransport(expectedResponse string) *OutboundTransport {
+	return &OutboundTransport{ExpectedResponse: expectedResponse}
+}
+
+// Send implementation of OutboundTransport.Send api
+func (transport *OutboundTransport) Send(data string, destination string) (string, error) {
+	if data == "" || destination == "" {
+		return "", errors.New("Data or destination can't be empty")
+	}
+
+	return transport.ExpectedResponse, nil
+}


### PR DESCRIPTION
Implement following DID exchange client APIs documented in Aries spec.
1. Generate Invitation with Public DID or service endpoints
2. Send Exchange Request
3. Send Exchange Response

Closes #12 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>