### PR TITLE
feat: Doc Storage interface definition

### DIFF
--- a/pkg/storage/connection/connstore.go
+++ b/pkg/storage/connection/connstore.go
@@ -1,0 +1,42 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package connstore
+
+// Connection is a pairwise relation between two DIDs (ours and theirs)
+type Connection struct {
+	MyDID          string
+	TheirDID       string
+	TheirPublicKey []byte
+	Label          string
+}
+
+// Provider storage provider interface
+type Provider interface {
+	// GetStoreHandle returns a handle to the connection store
+	GetStoreHandle(name string) (Store, error)
+
+	// Close closes the connection store provider
+	Close()
+}
+
+// ConnIterator connection iterator
+type ConnIterator interface {
+	// Next fetches the next connection record
+	Next() (*Connection, bool)
+}
+
+// Store is the storage interface for Connections
+type Store interface {
+	// Put stores the connection
+	Put(conn *Connection) error
+
+	// Iter fetches all the stored connections
+	Iter() ConnIterator
+
+	// LookupByTheirPublicKey fetches connection details based on their public key
+	LookupByTheirPublicKey(pubKey []byte) (*Connection, bool)
+}

--- a/pkg/storage/docstore/docstore.go
+++ b/pkg/storage/docstore/docstore.go
@@ -1,0 +1,29 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package docstore
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+)
+
+// Provider storage provider interface
+type Provider interface {
+	// GetStoreHandle returns a handle to the document store
+	GetStoreHandle() (Store, error)
+
+	// Close closes the document store provider
+	Close() error
+}
+
+// Store is the storage interface for DID Documents
+type Store interface {
+	// Put stores the DID Doc
+	Put(*did.Doc) error
+
+	// GetAll fetches the DID Doc based on DID
+	Get(string) (*did.Doc, error)
+}


### PR DESCRIPTION
The Aries Framework should support pluggable storage(e.g file store, embedded db store, cloud store, etc.) for DID documents along with Connections(pairwise mapping).

This change defines the interface for the doc storage.

Closes #22 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>