### PR TITLE
feat: add HTTP Inbound transport capability

### DIFF
--- a/pkg/didcomm/transport/http/inbound.go
+++ b/pkg/didcomm/transport/http/inbound.go
@@ -1,0 +1,85 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package http
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+// MessageHandler is a function that handles the inbound request payload
+// the payload will be unpacked prior to calling this function.
+type MessageHandler func(payload []byte)
+
+// NewInboundHandler will create a new handler to enforce Did-Comm HTTP transport specs
+// then routes processing to the mandatory 'msgHandler' argument.
+//
+// Arguments:
+// * 'msgHandler' is the handler function that will be executed with the inbound request payload.
+//    Users of this library must manage the handling of all inbound payloads in this function.
+func NewInboundHandler(msgHandler MessageHandler) (http.Handler, error) {
+	if msgHandler == nil {
+		log.Println("Error creating a new inbound handler: message handler function is nil")
+		return nil, errors.New("Failed to create NewInboundHandler")
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		processPOSTRequest(w, r, msgHandler)
+	}), nil
+}
+
+// TODO Log error message with a common logger library for aries-framework-go
+func processPOSTRequest(w http.ResponseWriter, r *http.Request, messageHandler MessageHandler) {
+	if valid := validateHTTPMethod(w, r); !valid {
+		return
+	}
+	if valid := validatePayload(r, w); !valid {
+		return
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("Error reading request body: %s - returning Code: %d", err, http.StatusInternalServerError)
+		http.Error(w, "Failed to read payload", http.StatusInternalServerError)
+	}
+
+	// TODO add Unpack(body) call here
+	//...
+
+	w.WriteHeader(http.StatusAccepted)
+
+	go messageHandler(body)
+}
+
+// validatePayload validate and get the payload from the request
+func validatePayload(r *http.Request, w http.ResponseWriter) bool {
+	if r.ContentLength == 0 { // empty payload should not be accepted
+		http.Error(w, "Empty payload", http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+// validateHTTPMethod validate HTTP method and content-type
+func validateHTTPMethod(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method != "POST" {
+		http.Error(w, "HTTP Method not allowed", http.StatusMethodNotAllowed)
+		return false
+	}
+
+	ct := r.Header.Get("Content-type")
+	if ct != commContentType {
+		http.Error(w, fmt.Sprintf("Unsupported Content-type \"%s\"", ct), http.StatusUnsupportedMediaType)
+		return false
+	}
+
+	return true
+}

--- a/pkg/didcomm/transport/http/inbound_test.go
+++ b/pkg/didcomm/transport/http/inbound_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package http
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mockMsgHandler is an http.msgHandler type, it is similar to MockHandler struct
+// but will be injected in WithInboundSetting() directly, will be used by each transport comm handle function
+func mockMsgHandler(payload []byte) {
+	log.Printf("Payload received is %s", payload)
+}
+
+func TestInboundHandler(t *testing.T) {
+	// test inboundHandler with empty args should fail
+	inHandler, err := NewInboundHandler(nil)
+	require.Error(t, err)
+	require.Nil(t, inHandler)
+
+	// now create a valid inboundHandler to continue testing..
+	inHandler, err = NewInboundHandler(mockMsgHandler)
+
+	require.NoError(t, err)
+	require.NotNil(t, inHandler)
+	server := startMockServer(inHandler)
+	port := getServerPort(server)
+	serverUrl := fmt.Sprintf("https://localhost:%d", port)
+	defer func() {
+		e := server.Close()
+		if e != nil {
+			log.Fatalf("Failed to stop server: %s", e)
+		}
+	}()
+
+	//build a mock cert pool
+	cp := x509.NewCertPool()
+	err = addCertsToCertPool(cp)
+	require.NoError(t, err)
+
+	// build a tls.Config instance to be used by the outbound transport
+	tlsConfig := &tls.Config{
+		RootCAs:      cp,
+		Certificates: nil,
+	}
+
+	// create an http client to communicate with the server that has our inbound handlers set above
+	client := http.Client{
+		Timeout: clientTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+
+	// test http.Get should should fail (not supported)
+	rs, err := client.Get(serverUrl + "/")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusMethodNotAllowed, rs.StatusCode)
+
+	// test accepted HTTP method (POST) but with bad content type
+	rs, err = client.Post(serverUrl+"/", "bad-content-type", bytes.NewBuffer([]byte("Hello World")))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnsupportedMediaType, rs.StatusCode)
+
+	// test with nil body ..
+	rs, err = client.Post(serverUrl+"/", commContentType, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, rs.StatusCode)
+
+	// finally test successful POST requests
+	data := "success"
+
+	resp, e := client.Post(serverUrl+"/", commContentType, bytes.NewBuffer([]byte(data)))
+	require.NoError(t, e)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+}

--- a/pkg/didcomm/transport/http/outbound_test.go
+++ b/pkg/didcomm/transport/http/outbound_test.go
@@ -9,23 +9,12 @@ package http
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"log"
-	"net"
-	"net/http"
-	"path/filepath"
-	"strings"
 	"testing"
-	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
-
-const certPrefix = "testdata/crypto/"
-const clientTimeout = 1 * time.Second
 
 func TestWithOutboundOpts(t *testing.T) {
 	opt := WithOutboundHTTPClient(nil)
@@ -47,9 +36,9 @@ func TestWithOutboundOpts(t *testing.T) {
 
 func TestOutboundHTTPTransport(t *testing.T) {
 	// prepare http server
-	server := startMockServer()
-	// read dynamic port assigned to the server to be used by the client
-	port := server.Addr().(*net.TCPAddr).Port
+	server := startMockServer(mockHttpHandler{})
+
+	port := getServerPort(server)
 	serverUrl := fmt.Sprintf("https://localhost:%d", port)
 	defer func() {
 		err := server.Close()
@@ -99,85 +88,4 @@ func TestOutboundHTTPTransport(t *testing.T) {
 	require.NoError(t, e)
 	require.NotEmpty(t, r)
 
-}
-
-func addCertsToCertPool(pool *x509.CertPool) error {
-	var rawCerts []string
-
-	// add contents of ec-pubCert(1, 2 and 3).pem to rawCerts
-	for i := 1; i <= 3; i++ {
-		certPath := fmt.Sprintf("%sec-pubCert%d.pem", certPrefix, i)
-		// Create a pool with server certificates
-		cert, e := ioutil.ReadFile(filepath.Clean(certPath))
-		if e != nil {
-			return errors.Wrap(e, "Failed Reading certificate")
-		}
-		rawCerts = append(rawCerts, string(cert))
-	}
-
-	certs := decodeCerts(rawCerts)
-	for i := range certs {
-		pool.AddCert(certs[i])
-	}
-	return nil
-}
-
-func startMockServer() net.Listener {
-	testHandler := mockHttpHandler{}
-	// ":0" will make the listener auto assign a free port
-	listener, err := net.Listen("tcp", ":0")
-	if err != nil {
-		log.Fatalf("HTTP listener failed to start: %s", err)
-	}
-	go func() {
-		err := http.ServeTLS(listener, testHandler, certPrefix+"ec-pubCert1.pem", certPrefix+"ec-key1.pem")
-		if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-			log.Fatalf("HTTP server failed to start: %s", err)
-		}
-	}()
-	return listener
-}
-
-type mockHttpHandler struct {
-}
-
-func (m mockHttpHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	if req.Body != nil {
-		body, err := ioutil.ReadAll(req.Body)
-		if err != nil || string(body) == "bad" {
-			res.WriteHeader(http.StatusBadRequest)
-			_, _ = res.Write([]byte(fmt.Sprintf("bad request: %s", body)))
-			return
-		}
-	}
-
-	// mocking successful response
-	res.WriteHeader(http.StatusAccepted) // usually DID-Comm expects StatusAccepted code (202)
-	res.Write([]byte("success"))
-}
-
-// decodeCerts will decode a list of pemCertsList (string) into a list of x509 certificates
-func decodeCerts(pemCertsList []string) []*x509.Certificate {
-	var certs []*x509.Certificate
-	for _, pemCertsString := range pemCertsList {
-		pemCerts := []byte(pemCertsString)
-		for len(pemCerts) > 0 {
-			var block *pem.Block
-			block, pemCerts = pem.Decode(pemCerts)
-			if block == nil {
-				break
-			}
-			if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
-				continue
-			}
-
-			cert, err := x509.ParseCertificate(block.Bytes)
-			if err != nil {
-				continue
-			}
-
-			certs = append(certs, cert)
-		}
-	}
-	return certs
 }

--- a/pkg/didcomm/transport/http/support_test.go
+++ b/pkg/didcomm/transport/http/support_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package http
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const certPrefix = "testdata/crypto/"
+const clientTimeout = 1 * time.Second
+
+func addCertsToCertPool(pool *x509.CertPool) error {
+	var rawCerts []string
+
+	// add contents of ec-pubCert(1, 2 and 3).pem to rawCerts
+	for i := 1; i <= 3; i++ {
+		certPath := fmt.Sprintf("%sec-pubCert%d.pem", certPrefix, i)
+		// Create a pool with server certificates
+		cert, e := ioutil.ReadFile(filepath.Clean(certPath))
+		if e != nil {
+			return errors.Wrap(e, "Failed Reading certificate")
+		}
+		rawCerts = append(rawCerts, string(cert))
+	}
+
+	certs := decodeCerts(rawCerts)
+	for i := range certs {
+		pool.AddCert(certs[i])
+	}
+	return nil
+}
+
+func startMockServer(handler http.Handler) net.Listener {
+	// ":0" will make the listener auto assign a free port
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		log.Fatalf("HTTP listener failed to start: %s", err)
+	}
+	go func() {
+		err := http.ServeTLS(listener, handler, certPrefix+"ec-pubCert1.pem", certPrefix+"ec-key1.pem")
+		if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			log.Fatalf("HTTP server failed to start: %s", err)
+		}
+	}()
+	return listener
+}
+
+type mockHttpHandler struct {
+}
+
+func (m mockHttpHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	if req.Body != nil {
+		body, err := ioutil.ReadAll(req.Body)
+		if err != nil || string(body) == "bad" {
+			res.WriteHeader(http.StatusBadRequest)
+			_, _ = res.Write([]byte(fmt.Sprintf("bad request: %s", body)))
+			return
+		}
+	}
+
+	// mocking successful response
+	res.WriteHeader(http.StatusAccepted) // usually DID-Comm expects StatusAccepted code (202)
+	res.Write([]byte("success"))
+}
+
+// decodeCerts will decode a list of pemCertsList (string) into a list of x509 certificates
+func decodeCerts(pemCertsList []string) []*x509.Certificate {
+	var certs []*x509.Certificate
+	for _, pemCertsString := range pemCertsList {
+		pemCerts := []byte(pemCertsString)
+		for len(pemCerts) > 0 {
+			var block *pem.Block
+			block, pemCerts = pem.Decode(pemCerts)
+			if block == nil {
+				break
+			}
+			if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+				continue
+			}
+
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				continue
+			}
+
+			certs = append(certs, cert)
+		}
+	}
+	return certs
+}
+
+func getServerPort(server net.Listener) int {
+	// read dynamic port assigned to the server to be used by the client
+	return server.Addr().(*net.TCPAddr).Port
+}


### PR DESCRIPTION
	Similar to the Outbound transport capability
	This change adds support for the Inbound transport cabaility
	as per the Aries Agent exchange communcation RFC-23 and 25

Closes: #8
Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>