### PR TITLE
feat: logging interface

### DIFF
--- a/pkg/common/log/api.go
+++ b/pkg/common/log/api.go
@@ -1,0 +1,46 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package log
+
+// Level defines all available log levels for logging messages.
+type Level int
+
+// Log levels.
+const (
+	CRITICAL Level = iota
+	ERROR
+	WARNING
+	INFO //default logging level
+	DEBUG
+)
+
+//Logger - Standard logger interface
+type Logger interface {
+
+	//Fatalf is critical fatal logging, should possibly followed by a call to os.Exit(1)
+	Fatalf(msg string, args ...interface{})
+
+	//Panicf is critical logging, should possibly followed by panic
+	Panicf(msg string, args ...interface{})
+
+	//Debugf is for logging verbose messages
+	Debugf(msg string, args ...interface{})
+
+	//Infof for logging general logging messages
+	Infof(msg string, args ...interface{})
+
+	//Warnf is for logging messages about possible issues
+	Warnf(msg string, args ...interface{})
+
+	//Errorf is for logging errors
+	Errorf(msg string, args ...interface{})
+}
+
+// LoggerProvider is a factory for moduled loggers
+type LoggerProvider interface {
+	GetLogger(module string) Logger
+}


### PR DESCRIPTION
-provided logging interface
-log levels supported - CRITICAL, ERROR, WARNING, INFO, DEBUG, where
INFO is default logging level
-logging provider implementation can be used to provide custom logging
provider
-Story: #21

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>