### PR TITLE
feat: moduled levels and caller infos for logging

### DIFF
--- a/pkg/internal/common/logging/metadata/callerInfo.go
+++ b/pkg/internal/common/logging/metadata/callerInfo.go
@@ -1,0 +1,54 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metadata
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+)
+
+func newCallerInfo() *callerInfo {
+	return &callerInfo{
+		info: map[callerInfoKey]bool{
+			{"", log.CRITICAL}: true,
+			{"", log.ERROR}:    true,
+			{"", log.WARNING}:  true,
+			{"", log.INFO}:     true,
+			{"", log.DEBUG}:    true,
+		},
+	}
+}
+
+type callerInfoKey struct {
+	module string
+	level  log.Level
+}
+
+//callerInfo maintains module-level based information to show or hide caller info
+type callerInfo struct {
+	info map[callerInfoKey]bool
+}
+
+//ShowCallerInfo enables caller info for given module and level
+func (l *callerInfo) ShowCallerInfo(module string, level log.Level) {
+	l.info[callerInfoKey{module, level}] = true
+}
+
+//HideCallerInfo disables caller info for given module and level
+func (l *callerInfo) HideCallerInfo(module string, level log.Level) {
+	l.info[callerInfoKey{module, level}] = false
+}
+
+//IsCallerInfoEnabled returns if caller info enabled for given module and level
+func (l *callerInfo) IsCallerInfoEnabled(module string, level log.Level) bool {
+
+	show, exists := l.info[callerInfoKey{module, level}]
+	if !exists {
+		//If no callerinfo setting exists for given module, then look for default
+		return l.info[callerInfoKey{"", level}]
+	}
+	return show
+}

--- a/pkg/internal/common/logging/metadata/callerInfo_test.go
+++ b/pkg/internal/common/logging/metadata/callerInfo_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+)
+
+func TestCallerInfoSetting(t *testing.T) {
+
+	sampleCallerInfoSetting := newCallerInfo()
+	sampleModuleName := "sample-module-name"
+
+	//By default caller info should be enabled if not set
+	require.True(t, sampleCallerInfoSetting.IsCallerInfoEnabled(sampleModuleName, log.DEBUG), "Callerinfo supposed to be enabled for this level")
+	require.True(t, sampleCallerInfoSetting.IsCallerInfoEnabled(sampleModuleName, log.INFO), "Callerinfo supposed to be enabled for this level")
+	require.True(t, sampleCallerInfoSetting.IsCallerInfoEnabled(sampleModuleName, log.WARNING), "Callerinfo supposed to be enabled for this level")
+	require.True(t, sampleCallerInfoSetting.IsCallerInfoEnabled(sampleModuleName, log.ERROR), "Callerinfo supposed to be enabled for this level")
+	require.True(t, sampleCallerInfoSetting.IsCallerInfoEnabled(sampleModuleName, log.CRITICAL), "Callerinfo supposed to be enabled for this level")
+
+	sampleCallerInfoSetting.HideCallerInfo(sampleModuleName, log.DEBUG)
+	require.False(t, sampleCallerInfoSetting.IsCallerInfoEnabled(sampleModuleName, log.DEBUG), "Callerinfo supposed to be disabled for this level")
+
+	sampleCallerInfoSetting.ShowCallerInfo(sampleModuleName, log.DEBUG)
+	require.True(t, sampleCallerInfoSetting.IsCallerInfoEnabled(sampleModuleName, log.DEBUG), "Callerinfo supposed to be enabled for this level")
+
+	sampleCallerInfoSetting.HideCallerInfo(sampleModuleName, log.WARNING)
+	require.False(t, sampleCallerInfoSetting.IsCallerInfoEnabled(sampleModuleName, log.WARNING), "Callerinfo supposed to be disabled for this level")
+
+	sampleCallerInfoSetting.ShowCallerInfo(sampleModuleName, log.WARNING)
+	require.True(t, sampleCallerInfoSetting.IsCallerInfoEnabled(sampleModuleName, log.WARNING), "Callerinfo supposed to be enabled for this level")
+
+	sampleCallerInfoSetting.HideCallerInfo(sampleModuleName, log.DEBUG)
+	require.False(t, sampleCallerInfoSetting.IsCallerInfoEnabled(sampleModuleName, log.DEBUG), "Callerinfo supposed to be disabled for this level")
+
+	sampleCallerInfoSetting.ShowCallerInfo(sampleModuleName, log.DEBUG)
+	require.True(t, sampleCallerInfoSetting.IsCallerInfoEnabled(sampleModuleName, log.DEBUG), "Callerinfo supposed to be enabled for this level")
+
+	//By default caller info should be enabled for any module name not set before
+	moduleNames := []string{"sample-module-name-doesnt-exists", "", "@$#@$@"}
+	for _, moduleName := range moduleNames {
+		require.True(t, sampleCallerInfoSetting.IsCallerInfoEnabled(moduleName, log.INFO), "Callerinfo supposed to be enabled for this level")
+		require.True(t, sampleCallerInfoSetting.IsCallerInfoEnabled(moduleName, log.WARNING), "Callerinfo supposed to be enabled for this level")
+		require.True(t, sampleCallerInfoSetting.IsCallerInfoEnabled(moduleName, log.ERROR), "Callerinfo supposed to be enabled for this level")
+		require.True(t, sampleCallerInfoSetting.IsCallerInfoEnabled(moduleName, log.CRITICAL), "Callerinfo supposed to be enabled for this level")
+		require.True(t, sampleCallerInfoSetting.IsCallerInfoEnabled(moduleName, log.DEBUG), "Callerinfo supposed to be enabled for this level")
+	}
+}

--- a/pkg/internal/common/logging/metadata/level.go
+++ b/pkg/internal/common/logging/metadata/level.go
@@ -1,0 +1,48 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metadata
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+)
+
+const (
+	defaultLogLevel   = log.INFO
+	defaultModuleName = ""
+)
+
+func newModuledLevels() *moduleLevels {
+	return &moduleLevels{levels: make(map[string]log.Level)}
+}
+
+//moduleLevels maintains log levels based on modules
+type moduleLevels struct {
+	levels map[string]log.Level
+}
+
+// GetLevel returns the log level for given module and level.
+func (l *moduleLevels) GetLevel(module string) log.Level {
+	level, exists := l.levels[module]
+	if !exists {
+		level, exists = l.levels[defaultModuleName]
+		// no configuration exists, default to info
+		if !exists {
+			return defaultLogLevel
+		}
+	}
+	return level
+}
+
+// SetLevel sets the log level for given module and level.
+func (l *moduleLevels) SetLevel(module string, level log.Level) {
+	l.levels[module] = level
+}
+
+// IsEnabledFor will return true if logging is enabled for given module and level.
+func (l *moduleLevels) IsEnabledFor(module string, level log.Level) bool {
+	return level <= l.GetLevel(module)
+}

--- a/pkg/internal/common/logging/metadata/level_test.go
+++ b/pkg/internal/common/logging/metadata/level_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+)
+
+func TestLogLevels(t *testing.T) {
+
+	mlevel := newModuledLevels()
+
+	mlevel.SetLevel("module-xyz-info", log.INFO)
+	mlevel.SetLevel("module-xyz-debug", log.DEBUG)
+	mlevel.SetLevel("module-xyz-error", log.ERROR)
+	mlevel.SetLevel("module-xyz-warning", log.WARNING)
+	mlevel.SetLevel("module-xyz-critical", log.CRITICAL)
+
+	//Run info level checks
+	require.True(t, mlevel.IsEnabledFor("module-xyz-info", log.CRITICAL))
+	require.True(t, mlevel.IsEnabledFor("module-xyz-info", log.ERROR))
+	require.True(t, mlevel.IsEnabledFor("module-xyz-info", log.WARNING))
+	require.True(t, mlevel.IsEnabledFor("module-xyz-info", log.INFO))
+	require.False(t, mlevel.IsEnabledFor("module-xyz-info", log.DEBUG))
+
+	//Run debug level checks
+	require.True(t, mlevel.IsEnabledFor("module-xyz-debug", log.CRITICAL))
+	require.True(t, mlevel.IsEnabledFor("module-xyz-debug", log.ERROR))
+	require.True(t, mlevel.IsEnabledFor("module-xyz-debug", log.WARNING))
+	require.True(t, mlevel.IsEnabledFor("module-xyz-debug", log.INFO))
+	require.True(t, mlevel.IsEnabledFor("module-xyz-debug", log.DEBUG))
+
+	//Run warning level checks
+	require.True(t, mlevel.IsEnabledFor("module-xyz-warning", log.CRITICAL))
+	require.True(t, mlevel.IsEnabledFor("module-xyz-warning", log.ERROR))
+	require.True(t, mlevel.IsEnabledFor("module-xyz-warning", log.WARNING))
+	require.False(t, mlevel.IsEnabledFor("module-xyz-warning", log.INFO))
+	require.False(t, mlevel.IsEnabledFor("module-xyz-warning", log.DEBUG))
+
+	//Run error level checks
+	require.True(t, mlevel.IsEnabledFor("module-xyz-error", log.CRITICAL))
+	require.True(t, mlevel.IsEnabledFor("module-xyz-error", log.ERROR))
+	require.False(t, mlevel.IsEnabledFor("module-xyz-error", log.WARNING))
+	require.False(t, mlevel.IsEnabledFor("module-xyz-error", log.INFO))
+	require.False(t, mlevel.IsEnabledFor("module-xyz-error", log.DEBUG))
+
+	//Run error critical checks
+	require.True(t, mlevel.IsEnabledFor("module-xyz-critical", log.CRITICAL))
+	require.False(t, mlevel.IsEnabledFor("module-xyz-critical", log.ERROR))
+	require.False(t, mlevel.IsEnabledFor("module-xyz-critical", log.WARNING))
+	require.False(t, mlevel.IsEnabledFor("module-xyz-critical", log.INFO))
+	require.False(t, mlevel.IsEnabledFor("module-xyz-critical", log.DEBUG))
+
+	//Run default log level check --> which is info level
+	require.True(t, mlevel.IsEnabledFor("module-xyz-random-module", log.CRITICAL))
+	require.True(t, mlevel.IsEnabledFor("module-xyz-random-module", log.ERROR))
+	require.True(t, mlevel.IsEnabledFor("module-xyz-random-module", log.WARNING))
+	require.True(t, mlevel.IsEnabledFor("module-xyz-random-module", log.INFO))
+	require.False(t, mlevel.IsEnabledFor("module-xyz-random-module", log.DEBUG))
+
+}

--- a/pkg/internal/common/logging/metadata/opts.go
+++ b/pkg/internal/common/logging/metadata/opts.go
@@ -1,0 +1,75 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metadata
+
+import (
+	"sync"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+)
+
+var rwmutex = &sync.RWMutex{}
+var levels = newModuledLevels()
+var callerInfos = newCallerInfo()
+
+//LoggerOpts for all logger customization options
+type LoggerOpts struct {
+	LevelEnabled      bool
+	CallerInfoEnabled bool
+}
+
+//SetLevel - setting log level for given module
+func SetLevel(module string, level log.Level) {
+	rwmutex.Lock()
+	defer rwmutex.Unlock()
+	levels.SetLevel(module, level)
+}
+
+//GetLevel - getting log level for given module
+func GetLevel(module string) log.Level {
+	rwmutex.RLock()
+	defer rwmutex.RUnlock()
+	return levels.GetLevel(module)
+}
+
+//IsEnabledFor - Check if given log level is enabled for given module
+func IsEnabledFor(module string, level log.Level) bool {
+	rwmutex.RLock()
+	defer rwmutex.RUnlock()
+	return levels.IsEnabledFor(module, level)
+}
+
+//ShowCallerInfo - Show caller info in log lines for given log level and module
+func ShowCallerInfo(module string, level log.Level) {
+	rwmutex.Lock()
+	defer rwmutex.Unlock()
+	callerInfos.ShowCallerInfo(module, level)
+}
+
+//HideCallerInfo - Do not show caller info in log lines for given log level and module
+func HideCallerInfo(module string, level log.Level) {
+	rwmutex.Lock()
+	defer rwmutex.Unlock()
+	callerInfos.HideCallerInfo(module, level)
+}
+
+//IsCallerInfoEnabled - returns if caller info enabled for given log level and module
+func IsCallerInfoEnabled(module string, level log.Level) bool {
+	rwmutex.Lock()
+	defer rwmutex.Unlock()
+	return callerInfos.IsCallerInfoEnabled(module, level)
+}
+
+//GetLoggerOpts - returns LoggerOpts which can be used for customization
+func GetLoggerOpts(module string, level log.Level) *LoggerOpts {
+	rwmutex.RLock()
+	defer rwmutex.RUnlock()
+	return &LoggerOpts{
+		LevelEnabled:      levels.IsEnabledFor(module, level),
+		CallerInfoEnabled: callerInfos.IsCallerInfoEnabled(module, level),
+	}
+}

--- a/pkg/internal/common/logging/metadata/opts_test.go
+++ b/pkg/internal/common/logging/metadata/opts_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLevels(t *testing.T) {
+
+	module := "sample-module-critical"
+	SetLevel(module, log.CRITICAL)
+	require.Equal(t, log.CRITICAL, GetLevel(module))
+	verifyLevels(t, module, []log.Level{log.CRITICAL}, []log.Level{log.ERROR, log.WARNING, log.INFO, log.DEBUG})
+
+	module = "sample-module-error"
+	SetLevel(module, log.ERROR)
+	require.Equal(t, log.ERROR, GetLevel(module))
+	verifyLevels(t, module, []log.Level{log.CRITICAL, log.ERROR}, []log.Level{log.WARNING, log.INFO, log.DEBUG})
+
+	module = "sample-module-warning"
+	SetLevel(module, log.WARNING)
+	require.Equal(t, log.WARNING, GetLevel(module))
+	verifyLevels(t, module, []log.Level{log.CRITICAL, log.ERROR, log.WARNING}, []log.Level{log.INFO, log.DEBUG})
+
+	module = "sample-module-info"
+	SetLevel(module, log.INFO)
+	require.Equal(t, log.INFO, GetLevel(module))
+	verifyLevels(t, module, []log.Level{log.CRITICAL, log.ERROR, log.WARNING, log.INFO}, []log.Level{log.DEBUG})
+
+	module = "sample-module-debug"
+	SetLevel(module, log.DEBUG)
+	require.Equal(t, log.DEBUG, GetLevel(module))
+	verifyLevels(t, module, []log.Level{log.CRITICAL, log.ERROR, log.WARNING, log.INFO, log.DEBUG}, []log.Level{})
+
+}
+
+func TestCallerInfos(t *testing.T) {
+	module := "sample-module-caller-info"
+
+	require.True(t, GetLoggerOpts(module, log.CRITICAL).CallerInfoEnabled)
+	require.True(t, GetLoggerOpts(module, log.DEBUG).CallerInfoEnabled)
+	require.True(t, GetLoggerOpts(module, log.INFO).CallerInfoEnabled)
+	require.True(t, GetLoggerOpts(module, log.ERROR).CallerInfoEnabled)
+	require.True(t, GetLoggerOpts(module, log.WARNING).CallerInfoEnabled)
+
+	ShowCallerInfo(module, log.CRITICAL)
+	ShowCallerInfo(module, log.DEBUG)
+	HideCallerInfo(module, log.INFO)
+	HideCallerInfo(module, log.ERROR)
+	HideCallerInfo(module, log.WARNING)
+
+	require.True(t, GetLoggerOpts(module, log.CRITICAL).CallerInfoEnabled)
+	require.True(t, GetLoggerOpts(module, log.DEBUG).CallerInfoEnabled)
+	require.False(t, GetLoggerOpts(module, log.INFO).CallerInfoEnabled)
+	require.False(t, GetLoggerOpts(module, log.ERROR).CallerInfoEnabled)
+	require.False(t, GetLoggerOpts(module, log.WARNING).CallerInfoEnabled)
+
+	require.True(t, IsCallerInfoEnabled(module, log.CRITICAL))
+	require.True(t, IsCallerInfoEnabled(module, log.DEBUG))
+	require.False(t, IsCallerInfoEnabled(module, log.INFO))
+	require.False(t, IsCallerInfoEnabled(module, log.ERROR))
+	require.False(t, IsCallerInfoEnabled(module, log.WARNING))
+}
+
+func verifyLevels(t *testing.T, module string, enabled []log.Level, disabled []log.Level) {
+	for _, level := range enabled {
+		require.True(t, IsEnabledFor(module, level), "expected level [%s] to be enabled for module [%s]", ParseString(level), module)
+		require.True(t, GetLoggerOpts(module, level).LevelEnabled, "expected level [%s] to be enabled for module [%s] in logger opts", ParseString(level), module)
+	}
+	for _, level := range disabled {
+		require.False(t, IsEnabledFor(module, level), "expected level [%s] to be disabled for module [%s]", ParseString(level), module)
+		require.False(t, GetLoggerOpts(module, level).LevelEnabled, "expected level [%s] to be disabled for module [%s] in logger opts", ParseString(level), module)
+	}
+}

--- a/pkg/internal/common/logging/metadata/util_test.go
+++ b/pkg/internal/common/logging/metadata/util_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package metadata
+
+import (
+	"testing"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLevel(t *testing.T) {
+
+	verifyLevelsNoError := func(expected log.Level, levels ...string) {
+		for _, level := range levels {
+			actual, err := ParseLevel(level)
+			require.NoError(t, err, "not supposed to fail while parsing level string [%s]", level)
+			require.Equal(t, expected, actual)
+		}
+	}
+
+	verifyLevelsNoError(log.CRITICAL, "critical", "CRITICAL", "CriticAL")
+	verifyLevelsNoError(log.ERROR, "error", "ERROR", "ErroR")
+	verifyLevelsNoError(log.WARNING, "warning", "WARNING", "WarninG")
+	verifyLevelsNoError(log.DEBUG, "debug", "DEBUG", "DebUg")
+	verifyLevelsNoError(log.INFO, "info", "INFO", "iNFo")
+}
+
+func TestParseLevelError(t *testing.T) {
+
+	verifyLevelError := func(expected log.Level, levels ...string) {
+		for _, level := range levels {
+			_, err := ParseLevel(level)
+			require.Error(t, err, "not supposed to succeed while parsing level string [%s]", level)
+		}
+	}
+
+	verifyLevelError(log.DEBUG, "", "D", "DE BUG", ".")
+
+}
+
+func TestParseString(t *testing.T) {
+	require.Equal(t, "CRITICAL", ParseString(log.CRITICAL))
+	require.Equal(t, "ERROR", ParseString(log.ERROR))
+	require.Equal(t, "WARNING", ParseString(log.WARNING))
+	require.Equal(t, "DEBUG", ParseString(log.DEBUG))
+	require.Equal(t, "INFO", ParseString(log.INFO))
+}

--- a/pkg/internal/common/logging/metadata/utils.go
+++ b/pkg/internal/common/logging/metadata/utils.go
@@ -1,0 +1,38 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metadata
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+)
+
+//levelNames - log level names in string
+var levelNames = []string{
+	"CRITICAL",
+	"ERROR",
+	"WARNING",
+	"INFO",
+	"DEBUG",
+}
+
+// ParseLevel returns the log level from a string representation.
+func ParseLevel(level string) (log.Level, error) {
+	for i, name := range levelNames {
+		if strings.EqualFold(name, level) {
+			return log.Level(i), nil
+		}
+	}
+	return log.ERROR, errors.New("logger: invalid log level")
+}
+
+//ParseString returns string representation of given log level
+func ParseString(level log.Level) string {
+	return levelNames[level]
+}


### PR DESCRIPTION
- added module based log levels implementation where default log level is INFO
- added module and log level based caller info feature which shows caller function
names in log lines for given module and level configured.
- logger opts implementation is added which can be used by logger implementation
- Story: #21

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>