### PR TITLE
feat: Generate Peer Did Identifier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@
 module github.com/hyperledger/aries-framework-go
 
 require (
-	github.com/btcsuite/btcutil v0.0.0-20170419141449-a5ecb5d9547a
+	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	github.com/stretchr/testify v1.3.0
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	github.com/xeipuuv/gojsonschema v1.1.1-0.20190626083556-16a6735db808
+	github.com/xeipuuv/gojsonschema v1.1.0
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/btcsuite/btcutil v0.0.0-20170419141449-a5ecb5d9547a h1:UwuNC3d8iGIAwMyAO92ZGuVQYmdGkWXtQEGZdiIrJQs=
-github.com/btcsuite/btcutil v0.0.0-20170419141449-a5ecb5d9547a/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d h1:yJzD/yFppdVCf6ApMkVy8cUxV0XrxdP9rVf6D87/Mng=
+github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -26,8 +26,8 @@ github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
-github.com/xeipuuv/gojsonschema v1.1.1-0.20190626083556-16a6735db808 h1:RySiKkoBBLdM0Jis6C+ZBvU998pPB2niXl7UwvZ4L/4=
-github.com/xeipuuv/gojsonschema v1.1.1-0.20190626083556-16a6735db808/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
+github.com/xeipuuv/gojsonschema v1.1.0 h1:ngVtJC9TY/lg0AA/1k48FYhBrhRoFlEmWzsehpNAaZg=
+github.com/xeipuuv/gojsonschema v1.1.0/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=

--- a/pkg/didmethod/peer/did.go
+++ b/pkg/didmethod/peer/did.go
@@ -1,0 +1,61 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package peer
+
+import (
+	"crypto"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	errors "golang.org/x/xerrors"
+)
+
+const (
+	//numAlgo is the algorithm for choosing a numeric basis Reference: https://openssi.github.io/peer-did-method-spec/index.html#method-specific-identifier
+	numAlgo = "1"
+	//encAlgo  is the algorithm for encoding
+	encAlgo = "1"
+
+	peerPrefix = "did:peer:"
+)
+
+//newDid creates the peer DID. For example : did:peer:11-479cbc07c3f991725836a3aa2a581ca2029198aa420b9d99bc0e131d9f3e2cbe
+func newDid(doc *did.Doc) (string, error) {
+
+	if doc.PublicKey == nil || doc.Authentication == nil {
+		return "", errors.New("the genesis version must include public keys and authentication")
+	}
+
+	docBytes, err := json.Marshal(doc)
+	if err != nil {
+		return "", err
+	}
+
+	hash, err := computeHash(docBytes)
+	if err != nil {
+		return "", err
+	}
+	numBasis := base64.URLEncoding.EncodeToString(hash)
+	messageIdentifier := []string{peerPrefix, numAlgo, encAlgo, "-", numBasis}
+	peerDID := strings.Join(messageIdentifier, "")
+
+	return peerDID, nil
+}
+
+// computeHash will compute the hash for the supplied bytes
+func computeHash(bytes []byte) ([]byte, error) {
+
+	if len(bytes) == 0 {
+		return nil, errors.New("empty bytes")
+	}
+
+	h := crypto.SHA256.New()
+	hash := h.Sum(bytes)
+	return hash, nil
+
+}

--- a/pkg/didmethod/peer/did_test.go
+++ b/pkg/didmethod/peer/did_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package peer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDid(t *testing.T) {
+	storedDoc, err := GenerateGenesisDoc()
+	require.NoError(t, err)
+	require.NotNil(t, storedDoc)
+
+	peerDID, err := newDid(storedDoc)
+	require.NoError(t, err)
+	require.NotNil(t, peerDID)
+	assert.Contains(t, peerDID, "did:peer:11")
+}
+
+func TestNewDidError(t *testing.T) {
+	storedDoc := &did.Doc{ID: "did:peer:11"}
+	_, err := newDid(storedDoc)
+	require.Error(t, err)
+	assert.Equal(t, err.Error(), "the genesis version must include public keys and authentication")
+}
+
+func TestComputeHash(t *testing.T) {
+	hash, err := computeHash([]byte("Test"))
+	assert.Nil(t, err)
+	assert.NotNil(t, hash)
+}
+
+func TestComputeHashError(t *testing.T) {
+	hash, err := computeHash([]byte(""))
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "empty bytes")
+	assert.Nil(t, hash)
+}
+
+// GenerateGenesisDoc creates the doc without an id
+func GenerateGenesisDoc() (*did.Doc, error) {
+
+	pk := []did.PublicKey{
+		{
+			ID:         "did:example:123456789abcdefghi#keys-1",
+			Type:       "Secp256k1VerificationKey2018",
+			Controller: "did:example:123456789abcdefghi",
+			Value:      []byte(`"publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"`),
+		},
+		{
+			ID:         "did:example:123456789abcdefghw#key2",
+			Type:       "RsaVerificationKey2018",
+			Controller: "did:example:123456789abcdefghw",
+			Value:      []byte(`"publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAryQICCl6NZ5gDKrnSztO\n3Hy8PEUcuyvg/ikC+VcIo2SFFSf18a3IMYldIugqqqZCs4/4uVW3sbdLs/6PfgdX\n7O9D22ZiFWHPYA2k2N744MNiCD1UE+tJyllUhSblK48bn+v1oZHCM0nYQ2NqUkvS\nj+hwUU3RiWl7x3D2s9wSdNt7XUtW05a/FXehsPSiJfKvHJJnGOX0BgTvkLnkAOTd\nOrUZ/wK69Dzu4IvrN4vs9Nes8vbwPa/ddZEzGR0cQMt0JBkhk9kU/qwqUseP1QRJ\n5I1jR4g8aYPL/ke9K35PxZWuDp3U0UPAZ3PjFAh+5T+fc7gzCs9dPzSHloruU+gl\nFQIDAQAB\n-----END PUBLIC KEY-----"`),
+		},
+	}
+	auth := []did.VerificationMethod{
+		{
+			PublicKey: did.PublicKey{
+				ID:         "did:example:123456789abcdefghs#key3",
+				Type:       "RsaVerificationKey2018",
+				Controller: "did:example:123456789abcdefghs",
+				Value:      []byte(`"publicKeyHex": "02b97c30de767f084ce3080168ee293053ba33b235d7116a3263d29f1450936b71"`),
+			},
+		},
+	}
+
+	doc := &did.Doc{
+		Context:        []string{"https://w3id.org/did/v1", "https://w3id.org/did/v2"},
+		PublicKey:      pk,
+		Authentication: auth,
+		Created:        &time.Time{},
+	}
+	return &did.Doc{Context: doc.Context, PublicKey: doc.PublicKey, Authentication: doc.Authentication,
+		Created: doc.Created}, nil
+}


### PR DESCRIPTION
As defined in the [Spec.](https://openssi.github.io/peer-did-method-spec/index.html#method-specific-identifier), Peer did Identifier is generated. 

ABNF Syntax for Peer DID:

peer-did = "did:peer:" numalgo encalgo "-" numbasis 
numalgo = "1" 
encalgo = "1" 
numbasis = 64*HEXDIGCI 
HEXDIGCI = HEXDIG / "a" / "b" / "c" / "d" / "e" / "f"
The numbasis is generated from [Genesis Version](https://openssi.github.io/peer-did-method-spec/index.html#dfn-genesis-version) of the Peer DID. 

Signed-off-by: talwinder.kaur <talwinder.kaur@securekey.com>