### PR TITLE
test: remove parallel flag from unit test

### DIFF
--- a/scripts/check_unit.sh
+++ b/scripts/check_unit.sh
@@ -14,4 +14,4 @@ PKGS=`go list github.com/hyperledger/aries-framework-go/... 2> /dev/null | \
 
 go generate ./...
 
-go test $PKGS -count=1 -race -coverprofile=coverage.txt -covermode=atomic  -p 1 -timeout=10m
+go test $PKGS -count=1 -race -coverprofile=coverage.txt -covermode=atomic -timeout=10m


### PR DESCRIPTION
Removed parallel flag from go test command to run unit-tests.

Closes #62

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>