### PR TITLE
Validate peer DID identifier 

### DIFF
--- a/pkg/didmethod/peer/did.go
+++ b/pkg/didmethod/peer/did.go
@@ -7,8 +7,9 @@ package peer
 
 import (
 	"crypto"
-	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
+	"regexp"
 	"strings"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
@@ -30,7 +31,61 @@ func newDid(doc *did.Doc) (string, error) {
 	if doc.PublicKey == nil || doc.Authentication == nil {
 		return "", errors.New("the genesis version must include public keys and authentication")
 	}
+	numBasis, err := numBasis(doc)
+	if err != nil {
+		return "", err
+	}
+	messageIdentifier := []string{peerPrefix, numAlgo, encAlgo, "-", numBasis}
+	peerDID := strings.Join(messageIdentifier, "")
 
+	return peerDID, nil
+}
+
+/*
+ validateDID checks the format of the doc's DID and checks that the DID's 'namestring' matches against its numeric basis as per the
+ Namestring Generation Method: https://openssi.github.io/peer-did-method-spec/index.html#namestring-generation-method
+ Note: this check should be done only on the resolved variant of the genesis version of Peer DID documents.
+*/
+func validateDID(doc *did.Doc) error {
+
+	peerDid := doc.ID
+
+	matched, _ := regexp.MatchString(`did:peer:11-([a-fA-F0-9]){64}`, peerDid)
+	if !matched {
+		return errors.Errorf("did doesnt follow matching regex")
+	}
+
+	//extracting numbasis from the validated did
+	splitDid := strings.FieldsFunc(peerDid, func(r rune) bool { return r == '-' })
+	extractedNumBasis := splitDid[1]
+
+	// genesis version(no did) of the peer DID doc
+	genesisDoc := &did.Doc{
+		Context:        doc.Context,
+		ID:             "",
+		PublicKey:      doc.PublicKey,
+		Service:        doc.Service,
+		Authentication: doc.Authentication,
+		Created:        doc.Created,
+		Updated:        doc.Updated,
+		Proof:          doc.Proof,
+	}
+
+	//calculate the numbasis of the genesis version of the peer DID doc
+	numBas, err := numBasis(genesisDoc)
+	if err != nil {
+		return err
+	}
+
+	if !(numBas == extractedNumBasis) {
+		return errors.New("hash of the doc doesnt match the computed hash")
+	}
+	return nil
+}
+
+/* numBasis is numeric basis. The spec requires a 256-bit (encoded using 64 hexadecimal digits) numBasis generated from a hash of the initial content of a DID doc i.e genesis doc.
+   Reference : https://dhh1128.github.io/peer-did-method-spec/#matching-regex */
+func numBasis(doc *did.Doc) (string, error) {
 	docBytes, err := json.Marshal(doc)
 	if err != nil {
 		return "", err
@@ -40,11 +95,9 @@ func newDid(doc *did.Doc) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	numBasis := base64.URLEncoding.EncodeToString(hash)
-	messageIdentifier := []string{peerPrefix, numAlgo, encAlgo, "-", numBasis}
-	peerDID := strings.Join(messageIdentifier, "")
+	numBasis := hex.EncodeToString(hash)
 
-	return peerDID, nil
+	return numBasis, nil
 }
 
 // computeHash will compute the hash for the supplied bytes


### PR DESCRIPTION
The receiving agent should have the capability to validate the DID Document against the name-string component of the DID Identifier.

closes #48 