### PR TITLE
ci: include test files in linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,8 +11,6 @@ run:
   tests: true
   build-tags: [""]
   skip-dirs:  [""]
-  skip-files:
-    - ^(.*_test.go.*$)$
 
 output:
   format: colored-line-number

--- a/pkg/common/log/logger_test.go
+++ b/pkg/common/log/logger_test.go
@@ -106,14 +106,14 @@ func TestLogLevel(t *testing.T) {
 //TestParseLevelError testing 'LogLevel()' used for parsing log levels from strings
 func TestParseLevelError(t *testing.T) {
 
-	verifyLevelError := func(expected Level, levels ...string) {
+	verifyLevelError := func(levels ...string) {
 		for _, level := range levels {
 			_, err := ParseLevel(level)
 			require.Error(t, err, "not supposed to succeed while parsing level string [%s]", level)
 		}
 	}
 
-	verifyLevelError(DEBUG, "", "D", "DE BUG", ".")
+	verifyLevelError("", "D", "DE BUG", ".")
 
 }
 

--- a/pkg/didcomm/protocol/exchange/exchange_test.go
+++ b/pkg/didcomm/protocol/exchange/exchange_test.go
@@ -25,6 +25,7 @@ func TestGenerateInviteWithPublicDID(t *testing.T) {
 		DID:   "did:example:ZadolSRQkehfo",
 	})
 
+	require.NoError(t, err)
 	require.NotEmpty(t, invite)
 
 	invite, err = GenerateInviteWithPublicDID(&Invitation{
@@ -50,6 +51,7 @@ func TestGenerateInviteWithKeyAndEndpoint(t *testing.T) {
 		ServiceEndpoint: "https://example.com/endpoint",
 		RoutingKeys:     []string{"8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"},
 	})
+	require.NoError(t, err)
 	require.NotEmpty(t, invite)
 
 	invite, err = GenerateInviteWithKeyAndEndpoint(&Invitation{

--- a/pkg/didcomm/transport/http/inbound_test.go
+++ b/pkg/didcomm/transport/http/inbound_test.go
@@ -36,7 +36,7 @@ func TestInboundHandler(t *testing.T) {
 	require.NotNil(t, inHandler)
 	server := startMockServer(inHandler)
 	port := getServerPort(server)
-	serverUrl := fmt.Sprintf("https://localhost:%d", port)
+	serverURL := fmt.Sprintf("https://localhost:%d", port)
 	defer func() {
 		e := server.Close()
 		if e != nil {
@@ -64,25 +64,33 @@ func TestInboundHandler(t *testing.T) {
 	}
 
 	// test http.Get should should fail (not supported)
-	rs, err := client.Get(serverUrl + "/")
+	rs, err := client.Get(serverURL + "/")
+	require.NoError(t, err)
+	err = rs.Body.Close()
 	require.NoError(t, err)
 	require.Equal(t, http.StatusMethodNotAllowed, rs.StatusCode)
 
 	// test accepted HTTP method (POST) but with bad content type
-	rs, err = client.Post(serverUrl+"/", "bad-content-type", bytes.NewBuffer([]byte("Hello World")))
+	rs, err = client.Post(serverURL+"/", "bad-content-type", bytes.NewBuffer([]byte("Hello World")))
+	require.NoError(t, err)
+	err = rs.Body.Close()
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnsupportedMediaType, rs.StatusCode)
 
 	// test with nil body ..
-	rs, err = client.Post(serverUrl+"/", commContentType, nil)
+	rs, err = client.Post(serverURL+"/", commContentType, nil)
+	require.NoError(t, err)
+	err = rs.Body.Close()
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, rs.StatusCode)
 
 	// finally test successful POST requests
 	data := "success"
 
-	resp, e := client.Post(serverUrl+"/", commContentType, bytes.NewBuffer([]byte(data)))
-	require.NoError(t, e)
+	resp, err := client.Post(serverURL+"/", commContentType, bytes.NewBuffer([]byte(data)))
+	require.NoError(t, err)
+	err = resp.Body.Close()
+	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, http.StatusAccepted, resp.StatusCode)
 }

--- a/pkg/didcomm/transport/http/outbound_test.go
+++ b/pkg/didcomm/transport/http/outbound_test.go
@@ -35,10 +35,10 @@ func TestWithOutboundOpts(t *testing.T) {
 
 func TestOutboundHTTPTransport(t *testing.T) {
 	// prepare http server
-	server := startMockServer(mockHttpHandler{})
+	server := startMockServer(mockHTTPHandler{})
 
 	port := getServerPort(server)
-	serverUrl := fmt.Sprintf("https://localhost:%d", port)
+	serverURL := fmt.Sprintf("https://localhost:%d", port)
 	defer func() {
 		err := server.Close()
 		if err != nil {
@@ -57,12 +57,12 @@ func TestOutboundHTTPTransport(t *testing.T) {
 		Certificates: nil,
 	}
 	// create a new invalid Outbound transport instance
-	ot, err := NewOutbound()
+	_, err = NewOutbound()
 	require.Error(t, err)
 	require.EqualError(t, err, "Can't create an outbound transport without an HTTP client")
 
 	// now create a new valid Outbound transport instance and test its Send() call
-	ot, err = NewOutbound(WithOutboundTLSConfig(tlsConfig), WithOutboundTimeout(clientTimeout))
+	ot, err := NewOutbound(WithOutboundTLSConfig(tlsConfig), WithOutboundTimeout(clientTimeout))
 	require.NoError(t, err)
 	require.NotNil(t, ot)
 
@@ -78,12 +78,12 @@ func TestOutboundHTTPTransport(t *testing.T) {
 	require.Empty(t, r)
 
 	// and try with a 'bad' payload with a valid url..
-	r, e = ot.Send("bad", serverUrl)
+	r, e = ot.Send("bad", serverURL)
 	require.Error(t, e)
 	require.Empty(t, r)
 
 	// finally using a valid url
-	r, e = ot.Send("Hello World", serverUrl)
+	r, e = ot.Send("Hello World", serverURL)
 	require.NoError(t, e)
 	require.NotEmpty(t, r)
 

--- a/pkg/didcomm/transport/http/support_test.go
+++ b/pkg/didcomm/transport/http/support_test.go
@@ -46,7 +46,7 @@ func addCertsToCertPool(pool *x509.CertPool) error {
 
 func startMockServer(handler http.Handler) net.Listener {
 	// ":0" will make the listener auto assign a free port
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		logger.Fatalf("HTTP listener failed to start: %s", err)
 	}
@@ -59,10 +59,10 @@ func startMockServer(handler http.Handler) net.Listener {
 	return listener
 }
 
-type mockHttpHandler struct {
+type mockHTTPHandler struct {
 }
 
-func (m mockHttpHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+func (m mockHTTPHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	if req.Body != nil {
 		body, err := ioutil.ReadAll(req.Body)
 		if err != nil || string(body) == "bad" {
@@ -74,7 +74,7 @@ func (m mockHttpHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 
 	// mocking successful response
 	res.WriteHeader(http.StatusAccepted) // usually DID-Comm expects StatusAccepted code (202)
-	res.Write([]byte("success"))
+	res.Write([]byte("success"))         // nolint
 }
 
 // decodeCerts will decode a list of pemCertsList (string) into a list of x509 certificates

--- a/pkg/didmethod/peer/resolver_test.go
+++ b/pkg/didmethod/peer/resolver_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const peerDID = "did:peer:1234"
+
 const peerDIDDoc = `{
   "@context": ["https://w3id.org/did/v1","https://w3id.org/did/v2"],
   "id": "did:peer:1234",
@@ -72,28 +74,26 @@ func TestPeerDIDResolver(t *testing.T) {
 	dbstore, err := prov.GetStoreHandle()
 	require.NoError(t, err)
 
-	did1 := "did:peer:1234"
-
 	// save did document
 	store := NewDIDStore(dbstore)
-	err = store.Put(did1, &did.Doc{ID: did1}, nil)
+	err = store.Put(peerDID, &did.Doc{ID: peerDID}, nil)
 	require.NoError(t, err)
 
 	resl := NewDIDResolver(store)
-	doc, err := resl.Read(did1, nil, "", false)
+	doc, err := resl.Read(peerDID, nil, "", false)
 	require.NoError(t, err)
 
 	document := &did.Doc{}
 	err = json.Unmarshal(doc, document)
 	require.NoError(t, err)
-	require.Equal(t, did1, document.ID)
+	require.Equal(t, peerDID, document.ID)
 
 	// empty DID
-	doc, err = resl.Read("", nil, "", false)
+	_, err = resl.Read("", nil, "", false)
 	require.Error(t, err)
 
 	// missing DID
-	doc, err = resl.Read("did:peer:789", nil, "", false)
+	_, err = resl.Read("did:peer:789", nil, "", false)
 	require.Error(t, err)
 
 }
@@ -107,18 +107,16 @@ func TestWithDIDResolveAPI(t *testing.T) {
 	dbstore, err := prov.GetStoreHandle()
 	require.NoError(t, err)
 
-	did1 := "did:peer:1234"
-
 	// save did document
 	store := NewDIDStore(dbstore)
 	peerDoc, err := diddoc.FromBytes([]byte(peerDIDDoc))
 	require.NoError(t, err)
 	require.NotNil(t, peerDoc)
-	err = store.Put(did1, peerDoc, nil)
+	err = store.Put(peerDID, peerDoc, nil)
 	require.NoError(t, err)
 
 	r := didresolver.New(didresolver.WithDidMethod("peer", NewDIDResolver(store)))
-	_, err = r.Resolve("did:peer:1234")
+	_, err = r.Resolve(peerDID)
 	require.NoError(t, err)
 
 	_, err = r.Resolve("did:peer:789")

--- a/pkg/didmethod/peer/store_test.go
+++ b/pkg/didmethod/peer/store_test.go
@@ -22,7 +22,10 @@ func setupLevelDB(t testing.TB) (string, func()) {
 		t.Fatalf("Failed to create leveldb directory: %s", err)
 	}
 	return dbPath, func() {
-		os.RemoveAll(dbPath)
+		err := os.RemoveAll(dbPath)
+		if err != nil {
+			t.Fatalf("Failed to clear leveldb directory: %s", err)
+		}
 	}
 }
 
@@ -54,11 +57,11 @@ func TestPeerDIDStore(t *testing.T) {
 	require.Equal(t, did1, doc.ID)
 
 	// get - empty id
-	doc, err = store.Get("")
+	_, err = store.Get("")
 	require.Error(t, err)
 
 	// get - invalid id
-	doc, err = store.Get("did:peer:789")
+	_, err = store.Get("did:peer:789")
 	require.Error(t, err)
 
 	// put - empty id

--- a/pkg/internal/common/logging/metadata/util_test.go
+++ b/pkg/internal/common/logging/metadata/util_test.go
@@ -30,14 +30,14 @@ func TestParseLevel(t *testing.T) {
 
 func TestParseLevelError(t *testing.T) {
 
-	verifyLevelError := func(expected Level, levels ...string) {
+	verifyLevelError := func(levels ...string) {
 		for _, level := range levels {
 			_, err := ParseLevel(level)
 			require.Error(t, err, "not supposed to succeed while parsing level string [%s]", level)
 		}
 	}
 
-	verifyLevelError(DEBUG, "", "D", "DE BUG", ".")
+	verifyLevelError("", "D", "DE BUG", ".")
 
 }
 


### PR DESCRIPTION
Update golangci to lint test files.
Fix lint warnings in test files.

Closes: #84

Signed-off-by: Troy Ronda <troy@troyronda.com>

