### PR TITLE
feat: Framework Init - base template with Outbound transport config

### DIFF
--- a/pkg/didcomm/protocol/exchange/exchange_test.go
+++ b/pkg/didcomm/protocol/exchange/exchange_test.go
@@ -9,6 +9,8 @@ package exchange
 import (
 	"testing"
 
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
+
 	mocktransport "github.com/hyperledger/aries-framework-go/pkg/internal/didcomm/transport/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -83,19 +85,19 @@ func TestGenerateInviteWithKeyAndEndpoint(t *testing.T) {
 }
 
 func TestSendRequest(t *testing.T) {
-	oTr := mocktransport.NewOutboundTransport(successResponse)
+	prov := New(&mockProvider{})
 
 	req := &Request{
 		ID:    "5678876542345",
 		Label: "Bob",
 	}
 
-	require.NoError(t, SendExchangeRequest(req, destinationURL, oTr))
-	require.Error(t, SendExchangeRequest(nil, destinationURL, oTr))
+	require.NoError(t, prov.SendExchangeRequest(req, destinationURL))
+	require.Error(t, prov.SendExchangeRequest(nil, destinationURL))
 }
 
 func TestSendResponse(t *testing.T) {
-	oTr := mocktransport.NewOutboundTransport(successResponse)
+	prov := New(&mockProvider{})
 
 	resp := &Response{
 		ID: "12345678900987654321",
@@ -104,6 +106,13 @@ func TestSendResponse(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, SendExchangeResponse(resp, destinationURL, oTr))
-	require.Error(t, SendExchangeResponse(nil, destinationURL, oTr))
+	require.NoError(t, prov.SendExchangeResponse(resp, destinationURL))
+	require.Error(t, prov.SendExchangeResponse(nil, destinationURL))
+}
+
+type mockProvider struct {
+}
+
+func (p *mockProvider) OutboundTransport() transport.OutboundTransport {
+	return mocktransport.NewOutboundTransport(successResponse)
 }

--- a/pkg/framework/aries/api/factory.go
+++ b/pkg/framework/aries/api/factory.go
@@ -1,0 +1,16 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
+)
+
+// TransportProviderFactory allows overriding of aries protocol providers
+type TransportProviderFactory interface {
+	CreateOutboundTransport() transport.OutboundTransport
+}

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -1,0 +1,33 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package aries
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/factory/transport"
+)
+
+// defFramework provides default framework configs
+type defFramework struct{}
+
+// transportProviderFactory provides default Outbound Transport provider factory
+func (d defFramework) transportProviderFactory() api.TransportProviderFactory {
+	return transport.NewProviderFactory()
+}
+
+// defFrameworkOpts provides default framework options
+func defFrameworkOpts() []Option {
+	// get the default framework configs
+	def := defFramework{}
+
+	var opts []Option
+	// protocol provider factory
+	opt := WithTransportProviderFactory(def.transportProviderFactory())
+	opts = append(opts, opt)
+
+	return opts
+}

--- a/pkg/framework/aries/factory/transport/transport_factory.go
+++ b/pkg/framework/aries/factory/transport/transport_factory.go
@@ -1,0 +1,27 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package transport
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
+)
+
+// ProviderFactory represents the default transport provider factory.
+type ProviderFactory struct {
+}
+
+// NewProviderFactory returns the default transport provider factory.
+func NewProviderFactory() *ProviderFactory {
+	f := ProviderFactory{}
+	return &f
+}
+
+// CreateOutboundTransport returns a new default implementation of outbound transport provider
+func (f *ProviderFactory) CreateOutboundTransport() transport.OutboundTransport {
+	// TODO - https://github.com/hyperledger/aries-framework-go/issues/83
+	return nil
+}

--- a/pkg/framework/aries/factory/transport/transport_factory_test.go
+++ b/pkg/framework/aries/factory/transport/transport_factory_test.go
@@ -1,0 +1,18 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package transport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewProviderFactory(t *testing.T) {
+	f := NewProviderFactory()
+	require.Empty(t, f.CreateOutboundTransport())
+}

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -1,0 +1,52 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package aries
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/context"
+	errors "golang.org/x/xerrors"
+)
+
+// Aries provides access to clients being managed by the framework.
+type Aries struct {
+	transport api.TransportProviderFactory
+}
+
+// Option configures the framework.
+type Option func(opts *Aries) error
+
+// New initializes the Aries framework based on the set of options provided.
+func New(opts ...Option) (*Aries, error) {
+	// get the default framework options
+	defOpts := defFrameworkOpts()
+
+	frameworkOpts := &Aries{}
+
+	// generate framework configs from options
+	for _, option := range append(defOpts, opts...) {
+		err := option(frameworkOpts)
+		if err != nil {
+			return nil, errors.Errorf("Error in option passed to New: %w", err)
+		}
+	}
+
+	return frameworkOpts, nil
+}
+
+// WithTransportProviderFactory injects a protocol provider factory interface to Aries
+func WithTransportProviderFactory(ot api.TransportProviderFactory) Option {
+	return func(opts *Aries) error {
+		opts.transport = ot
+		return nil
+	}
+}
+
+// Context provides handle to framework context
+func (a *Aries) Context() (*context.Provider, error) {
+	return context.New(context.WithOutboundTransport(a.transport.CreateOutboundTransport()))
+}

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package aries
+
+import (
+	"testing"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/exchange"
+	mocktransport "github.com/hyperledger/aries-framework-go/pkg/internal/didcomm/transport/mock"
+	"github.com/stretchr/testify/require"
+	errors "golang.org/x/xerrors"
+)
+
+func TestFramework(t *testing.T) {
+	// framework new - error
+	_, err := New(func(opts *Aries) error {
+		return errors.New("error creating the framework option")
+	})
+	require.Error(t, err)
+
+	// framework new - success
+	aries, err := New(WithTransportProviderFactory(&mockTransportProviderFactory{}))
+	require.NoError(t, err)
+
+	// context
+	ctx, err := aries.Context()
+	require.NoError(t, err)
+
+	// exchange client
+	exClient := exchange.New(ctx)
+	require.NoError(t, err)
+
+	req := &exchange.Request{
+		ID:    "5678876542345",
+		Label: "Bob",
+	}
+	require.NoError(t, exClient.SendExchangeRequest(req, "http://example/didexchange"))
+	require.Error(t, exClient.SendExchangeRequest(req, ""))
+}
+
+type mockTransportProviderFactory struct {
+}
+
+func (f *mockTransportProviderFactory) CreateOutboundTransport() transport.OutboundTransport {
+	return mocktransport.NewOutboundTransport("success")
+}

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -1,0 +1,45 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package context
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
+	errors "golang.org/x/xerrors"
+)
+
+// Provider supplies the framework configuration to client objects.
+type Provider struct {
+	outboundTransport transport.OutboundTransport
+}
+
+// New instantiated new context provider
+func New(opts ...ProviderOption) (*Provider, error) {
+	ctxProvider := Provider{}
+	for _, opt := range opts {
+		err := opt(&ctxProvider)
+		if err != nil {
+			return nil, errors.Errorf("Error in option passed to New: %w", err)
+		}
+	}
+	return &ctxProvider, nil
+}
+
+// OutboundTransport returns the outbound transport provider
+func (p *Provider) OutboundTransport() transport.OutboundTransport {
+	return p.outboundTransport
+}
+
+// ProviderOption configures the framework.
+type ProviderOption func(opts *Provider) error
+
+// WithOutboundTransport injects transport provider into the framework
+func WithOutboundTransport(ot transport.OutboundTransport) ProviderOption {
+	return func(opts *Provider) error {
+		opts.outboundTransport = ot
+		return nil
+	}
+}

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package context
+
+import (
+	"testing"
+
+	mocktransport "github.com/hyperledger/aries-framework-go/pkg/internal/didcomm/transport/mock"
+	"github.com/stretchr/testify/require"
+	errors "golang.org/x/xerrors"
+)
+
+func TestNewProvider(t *testing.T) {
+	prov, err := New()
+	require.NoError(t, err)
+	require.Empty(t, prov.OutboundTransport())
+
+	prov, err = New(WithOutboundTransport(mocktransport.NewOutboundTransport("success")))
+	require.NoError(t, err)
+	require.NotEmpty(t, prov.OutboundTransport())
+
+	_, err = New(func(opts *Provider) error {
+		return errors.New("error creating the framework option")
+	})
+	require.Error(t, err)
+}


### PR DESCRIPTION
- Add New(opts) function which takes in the options to configuration
- Support outbound transport configuration

Closes #78

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>