### PR TITLE
feat: Universal HTTP DID Resolver

### DIFF
--- a/pkg/didmethod/httpbinding/resolver.go
+++ b/pkg/didmethod/httpbinding/resolver.go
@@ -1,0 +1,121 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httpbinding
+
+import (
+	"crypto/tls"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	errors "golang.org/x/xerrors"
+)
+
+var logger = log.New("aries-framework/didmethod/httpbinding")
+
+// resolverOpts holds options for the DID Resolver
+// it has a http.Client instance initialized with default parameters
+type resolverOpts struct {
+	client *http.Client
+}
+
+// ResolverOpt is the DID Resolver option
+type ResolverOpt func(opts *resolverOpts)
+
+// WithTimeout option is for definition of HTTP(s) timeout value of DID Resolver
+func WithTimeout(timeout time.Duration) ResolverOpt {
+	return func(opts *resolverOpts) {
+		opts.client.Timeout = timeout
+	}
+}
+
+// WithTLSConfig option is for definition of secured HTTP transport using a tls.Config instance
+func WithTLSConfig(tlsConfig *tls.Config) ResolverOpt {
+	return func(opts *resolverOpts) {
+		opts.client.Transport = &http.Transport{
+			TLSClientConfig: tlsConfig,
+		}
+	}
+}
+
+// resolveDID makes DID resolution via HTTP
+func (res *DIDResolver) resolveDID(url string) ([]byte, error) {
+	resp, err := res.client.Get(url)
+	if err != nil {
+		return nil, errors.Errorf("HTTP Get request failed: %w", err)
+	}
+
+	defer func() {
+		e := resp.Body.Close()
+		if e != nil {
+			logger.Errorf("Failed to close response body: %v", e)
+		}
+	}()
+
+	// TODO support for service endpoint URL resolution
+	if containsDIDDocument(resp) {
+		var gotBody []byte
+		gotBody, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, errors.Errorf("Failed to read response body: %w", err)
+		}
+
+		return gotBody, nil
+
+	} else if notExistentDID(resp) {
+		return nil, errors.Errorf("Input DID does not exist: %w", err)
+	}
+
+	return nil, errors.Errorf("Unsupported response from DID Resolver with status code: %v", resp.StatusCode)
+}
+
+// notExistentDID checks if requested DID is not found on remote DID resolver
+func notExistentDID(resp *http.Response) bool {
+	return resp.StatusCode == http.StatusNotFound
+}
+
+// containsDIDDocument checks weather reply from remote DID resolver contains DID document
+func containsDIDDocument(resp *http.Response) bool {
+	return resp.StatusCode == http.StatusOK && resp.Header.Get("Content-type") == "application/did+ld+json"
+}
+
+// New creates new DID Resolver
+func New(endpointURL string, opts ...ResolverOpt) (*DIDResolver, error) {
+	// Apply options
+	clOpts := &resolverOpts{client: &http.Client{}}
+	for _, opt := range opts {
+		opt(clOpts)
+	}
+
+	// Validate host
+	_, err := url.ParseRequestURI(endpointURL)
+	if err != nil {
+		return nil, errors.Errorf("Invalid base url: %w", err)
+	}
+
+	return &DIDResolver{
+		endpointURL: endpointURL,
+		client:      clOpts.client,
+	}, nil
+}
+
+// Read implements didresolver.DidMethod.Read interface (https://w3c-ccg.github.io/did-resolution/#resolving-input)
+func (res *DIDResolver) Read(DID string, versionID interface{}, versionTime string, noCache bool) ([]byte, error) {
+	reqURL, _ := url.ParseRequestURI(res.endpointURL)
+
+	reqURL.Path = path.Join(reqURL.Path, DID)
+
+	return res.resolveDID(reqURL.String())
+}
+
+// DIDResolver DID Resolver via HTTP(s) endpoint
+type DIDResolver struct {
+	endpointURL string
+	client      *http.Client
+}

--- a/pkg/didmethod/httpbinding/resolver_test.go
+++ b/pkg/didmethod/httpbinding/resolver_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+package httpbinding
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithOutboundOpts(t *testing.T) {
+	opt := WithTimeout(1 * time.Second)
+	require.NotNil(t, opt)
+	clOpts := &resolverOpts{}
+	// opt.client is nil, so setting timeout should panic
+	require.Panics(t, func() { opt(clOpts) })
+
+	opt = WithTLSConfig(nil)
+	require.NotNil(t, opt)
+	clOpts = &resolverOpts{}
+	// opt.client is nil, so setting TLS config should panic
+	require.Panics(t, func() { opt(clOpts) })
+}
+
+func TestNew(t *testing.T) {
+	var err error
+
+	// OK with no options
+	_, err = New("https://uniresolver.io/")
+	require.NoError(t, err)
+
+	// All options are applied
+	i := 0
+	_, err = New("https://uniresolver.io/",
+		func(opts *resolverOpts) {
+			i += 1 // nolint
+		},
+		func(opts *resolverOpts) {
+			i += 2
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1+2, i)
+
+	// Invalid URL
+	_, err = New("invalid url")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Invalid base url")
+}
+
+func TestRead_DIDDoc(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		require.Equal(t, "/did:example:334455", req.URL.String())
+		res.Header().Add("Content-type", "application/did+ld+json")
+		res.WriteHeader(http.StatusOK)
+		_, _ = res.Write([]byte("did doc body"))
+	}))
+	defer func() { testServer.Close() }()
+
+	resolver, _ := New(testServer.URL)
+	gotDocument, err := resolver.Read("did:example:334455", nil, "", false)
+	require.NoError(t, err)
+	require.Equal(t, []byte("did doc body"), gotDocument)
+}
+
+func TestRead_DIDDocWithBasePath(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		require.Equal(t, "/document/did:example:334455", req.URL.String())
+		res.Header().Add("Content-type", "application/did+ld+json")
+		res.WriteHeader(http.StatusOK)
+		_, _ = res.Write([]byte("did doc body"))
+	}))
+	defer func() { testServer.Close() }()
+
+	resolver, _ := New(testServer.URL + "/document")
+	gotDocument, err := resolver.Read("did:example:334455", nil, "", false)
+	require.NoError(t, err)
+	require.Equal(t, []byte("did doc body"), gotDocument)
+}
+
+func TestRead_DIDDocWithBasePathWithSlashes(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		require.Equal(t, "/document/did:example:334455", req.URL.String())
+		res.Header().Add("Content-type", "application/did+ld+json")
+		res.WriteHeader(http.StatusOK)
+		_, _ = res.Write([]byte("did doc body"))
+	}))
+	defer func() { testServer.Close() }()
+
+	resolver, _ := New(testServer.URL + "/document/")
+	gotDocument, err := resolver.Read("did:example:334455", nil, "", false)
+	require.NoError(t, err)
+	require.Equal(t, []byte("did doc body"), gotDocument)
+}
+
+func TestRead_DIDDocNotFound(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		require.Equal(t, "/did:example:334455", req.URL.String())
+		res.WriteHeader(http.StatusNotFound)
+		_, _ = res.Write([]byte("did doc body"))
+	}))
+	defer func() { testServer.Close() }()
+
+	resolver, _ := New(testServer.URL)
+	_, err := resolver.Read("did:example:334455", nil, "", false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Input DID does not exist")
+}
+
+func TestRead_UnsupportedStatus(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusForbidden)
+	}))
+	defer func() { testServer.Close() }()
+
+	resolver, _ := New(testServer.URL)
+	_, err := resolver.Read("did:example:334455", nil, "", false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Unsupported response from DID Resolver with status code")
+}
+
+func TestRead_HTTPGetFailed(t *testing.T) {
+	// HTTP GET failed
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusSeeOther)
+	}))
+	defer func() { testServer.Close() }()
+
+	resolver, _ := New(testServer.URL)
+	_, err := resolver.Read("did:example:334455", nil, "", false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "HTTP Get request failed")
+}


### PR DESCRIPTION
```
This change adds support of Universal  HTTP DID Resolver
```

Signed-off-by: Dima <dkinoshenko@gmail.com>

**Title:**
Universal  HTTP DID Resolver

**Description:**
This is a part of #99 and allows for Universal HTTP DID Resolver.

**Summary:**
This PR adds a definition of Universal  HTTP(s) DID Resolver which is based on standard `http.Client` HTTP client. It's used for making HTTP GET request and reading the DID document from the reply.

