### PR TITLE
Add note about GOPROXY in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ make checks
 make unit-test
 ```
 
+**Note: ** setting your `GOPROXY` is highly recommended to avoid the error `failed to load program with go/packages` during the build.
+
 ##### Crypto material generation for tests
 For unit-tests, crypto material is generated under:
 


### PR DESCRIPTION
Add note to README recommending to set the `GOPROXY` environment variable to avoid problems downloading dependencies during the build.

Signed-off-by: George Aristy <george.aristy@securekey.com>