### PR TITLE
refactor: #65 DidMethod.Read()

### DIFF
--- a/pkg/didmethod/peer/resolver.go
+++ b/pkg/didmethod/peer/resolver.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package peer
 
 import (
+	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
 	errors "golang.org/x/xerrors"
 )
 
@@ -21,11 +22,15 @@ func NewDIDResolver(store *DIDStore) *DIDResolver {
 }
 
 // Read implements didresolver.DidMethod.Read interface (https://w3c-ccg.github.io/did-resolution/#resolving-input)
-func (resl *DIDResolver) Read(did string, versionID interface{}, versionTime string, noCache bool) ([]byte, error) {
+func (resl *DIDResolver) Read(did string, _ ...didresolver.ResolveOpt) ([]byte, error) {
 	// get the document from the store
 	doc, err := resl.store.Get(did)
 	if err != nil {
 		return nil, errors.Errorf("Fetching data from store failed: %w", err)
+	}
+
+	if doc == nil {
+		return nil, didresolver.ErrNotFound
 	}
 
 	// convert the doc to JSON as DID Resolver expects byte result.

--- a/pkg/didmethod/peer/resolver_test.go
+++ b/pkg/didmethod/peer/resolver_test.go
@@ -80,7 +80,7 @@ func TestPeerDIDResolver(t *testing.T) {
 	require.NoError(t, err)
 
 	resl := NewDIDResolver(store)
-	doc, err := resl.Read(peerDID, nil, "", false)
+	doc, err := resl.Read(peerDID)
 	require.NoError(t, err)
 
 	document := &did.Doc{}
@@ -89,13 +89,15 @@ func TestPeerDIDResolver(t *testing.T) {
 	require.Equal(t, peerDID, document.ID)
 
 	// empty DID
-	_, err = resl.Read("", nil, "", false)
+	_, err = resl.Read("")
 	require.Error(t, err)
 
 	// missing DID
-	_, err = resl.Read("did:peer:789", nil, "", false)
+	// TODO this test should assert that didresolver.ErrNotFound is returned.
+	//      that is currently impossible since the underlying store returns a
+	//      generic error when the object is not found.
+	_, err = resl.Read("did:peer:789")
 	require.Error(t, err)
-
 }
 
 func TestWithDIDResolveAPI(t *testing.T) {

--- a/pkg/framework/didresolver/api.go
+++ b/pkg/framework/didresolver/api.go
@@ -7,6 +7,8 @@ package didresolver
 
 import (
 	"time"
+
+	"golang.org/x/xerrors"
 )
 
 // ResultType input option can be used to request a certain type of result.
@@ -19,9 +21,16 @@ const (
 	ResolutionResult
 )
 
-// DidMethod operations
+// ErrNotFound is returned when a DID resolver does not find the DID.
+var ErrNotFound = xerrors.New("DID not found")
+
+// DidMethod resolves a DID into a result type (default: DidDocumentResult).
+// See the DID resolution spec: https://w3c-ccg.github.io/did-resolution.
 type DidMethod interface {
-	Read(did string, versionID interface{}, versionTime string, noCache bool) ([]byte, error)
+	// Read implements the 'DID Resolution' algorithm defined in
+	// https://w3c-ccg.github.io/did-resolution/#resolving.
+	Read(did string, opts ...ResolveOpt) ([]byte, error)
+	// Accept registers this DID method resolver with the given method.
 	Accept(method string) bool
 }
 

--- a/pkg/framework/didresolver/didresolver.go
+++ b/pkg/framework/didresolver/didresolver.go
@@ -34,7 +34,6 @@ func (r *DIDResolver) Resolve(did string, opts ...ResolveOpt) (*diddoc.Doc, erro
 	for _, opt := range opts {
 		opt(resolveOpts)
 	}
-
 	// TODO Validate that the input DID conforms to the did rule of the Generic DID Syntax (https://w3c-ccg.github.io/did-spec/#generic-did-syntax)
 	// For now we do simple validation
 	didParts := strings.SplitN(did, ":", 3)
@@ -51,14 +50,16 @@ func (r *DIDResolver) Resolve(did string, opts ...ResolveOpt) (*diddoc.Doc, erro
 	}
 
 	// Obtain the DID Document
-	didDocBytes, err := method.Read(did, resolveOpts.versionID, resolveOpts.versionTime, resolveOpts.noCache)
+	didDocBytes, err := method.Read(did, opts...)
 	if err != nil {
+		if err == ErrNotFound {
+			return nil, err
+		}
 		return nil, errors.Errorf("did method read failed failed: %w", err)
 	}
 
-	// If the input DID does not exist, return a nil
 	if len(didDocBytes) == 0 {
-		return nil, nil
+		return nil, ErrNotFound
 	}
 
 	// Validate that the output DID Document conforms to the serialization of the DID Document data model

--- a/pkg/framework/didresolver/didresolver_test.go
+++ b/pkg/framework/didresolver/didresolver_test.go
@@ -90,11 +90,12 @@ func TestResolve(t *testing.T) {
 	})
 
 	t.Run("test did input not found", func(t *testing.T) {
-		r := New(WithDidMethod(mockDidMethod{acceptFunc: func(method string) bool {
+		r := New(WithDidMethod(mockDidMethod{readErr: ErrNotFound, acceptFunc: func(method string) bool {
 			return true
 		}}))
 		didDoc, err := r.Resolve("did:example:1234")
-		require.NoError(t, err)
+		require.Error(t, err)
+		require.EqualValues(t, ErrNotFound, err)
 		require.Nil(t, didDoc)
 	})
 
@@ -133,11 +134,11 @@ func TestResolve(t *testing.T) {
 		}}))
 		didMethod, err := r.resolveDidMethod("did1")
 		require.NoError(t, err)
-		v, _ := didMethod.Read("", nil, "", false)
+		v, _ := didMethod.Read("")
 		require.Equal(t, "did1", string(v))
 		didMethod, err = r.resolveDidMethod("did2")
 		require.NoError(t, err)
-		v, _ = didMethod.Read("", nil, "", false)
+		v, _ = didMethod.Read("")
 		require.Equal(t, "did2", string(v))
 
 	})
@@ -150,7 +151,7 @@ type mockDidMethod struct {
 	acceptFunc func(method string) bool
 }
 
-func (m mockDidMethod) Read(did string, versionID interface{}, versionTime string, noCache bool) ([]byte, error) {
+func (m mockDidMethod) Read(did string, opts ...ResolveOpt) ([]byte, error) {
 	return m.readValue, m.readErr
 }
 


### PR DESCRIPTION
Closes #65

* Make optional all args to DidMethod.Read() (aside from the DID)
* Add didresolver.ErrNotFound sentinel error to indicate when DID was not found
* Add GoDocs to `didresolver.DidMethod`

Signed-off-by: George Aristy <george.aristy@securekey.com>
