### PR TITLE
feat: Default Outbound Transport Provider

### DIFF
--- a/pkg/framework/aries/api/factory.go
+++ b/pkg/framework/aries/api/factory.go
@@ -12,5 +12,5 @@ import (
 
 // TransportProviderFactory allows overriding of aries protocol providers
 type TransportProviderFactory interface {
-	CreateOutboundTransport() transport.OutboundTransport
+	CreateOutboundTransport() (transport.OutboundTransport, error)
 }

--- a/pkg/framework/aries/factory/transport/transport_factory.go
+++ b/pkg/framework/aries/factory/transport/transport_factory.go
@@ -7,7 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package transport
 
 import (
+	"net/http"
+
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
+	httptransport "github.com/hyperledger/aries-framework-go/pkg/didcomm/transport/http"
 )
 
 // ProviderFactory represents the default transport provider factory.
@@ -21,7 +24,6 @@ func NewProviderFactory() *ProviderFactory {
 }
 
 // CreateOutboundTransport returns a new default implementation of outbound transport provider
-func (f *ProviderFactory) CreateOutboundTransport() transport.OutboundTransport {
-	// TODO - https://github.com/hyperledger/aries-framework-go/issues/83
-	return nil
+func (f *ProviderFactory) CreateOutboundTransport() (transport.OutboundTransport, error) {
+	return httptransport.NewOutbound(httptransport.WithOutboundHTTPClient(&http.Client{}))
 }

--- a/pkg/framework/aries/factory/transport/transport_factory_test.go
+++ b/pkg/framework/aries/factory/transport/transport_factory_test.go
@@ -14,5 +14,7 @@ import (
 
 func TestNewProviderFactory(t *testing.T) {
 	f := NewProviderFactory()
-	require.Empty(t, f.CreateOutboundTransport())
+	ot, err := f.CreateOutboundTransport()
+	require.NoError(t, err)
+	require.NotEmpty(t, ot)
 }

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -83,8 +83,13 @@ func (a *Aries) DIDResolver() DIDResolver {
 
 // Context provides handle to framework context
 func (a *Aries) Context() (*context.Provider, error) {
+	ot, err := a.transport.CreateOutboundTransport()
+	if err != nil {
+		return nil, errors.Errorf("outbound transport initialization failed: %w", err)
+	}
+
 	return context.New(
-		context.WithOutboundTransport(a.transport.CreateOutboundTransport()),
+		context.WithOutboundTransport(ot),
 	)
 }
 


### PR DESCRIPTION
Add HTTP Client as the default transport provider

Closes #83 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>