### PR TITLE
refactor: move rest api http handlers out of pkg/didcomm/protocol packages

### DIFF
--- a/pkg/didcomm/protocol/didexchange/exchange.go
+++ b/pkg/didcomm/protocol/didexchange/exchange.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package exchange
+package didexchange
 
 import (
 	"encoding/base64"
@@ -22,7 +22,7 @@ const (
 	connectionResponse = connectionSpec + "response"
 )
 
-// provider contains dependencies for the Exchange protocol and is typically created by using aries.Context()
+// provider contains dependencies for the DID exchange protocol and is typically created by using aries.Context()
 type provider interface {
 	OutboundTransport() transport.OutboundTransport
 }
@@ -45,13 +45,13 @@ func GenerateInviteWithKeyAndEndpoint(invite *Invitation) (string, error) {
 	return encodedExchangeInvitation(invite)
 }
 
-// Protocol for exchange protocol
+// Protocol for DID exchange protocol
 type Protocol struct {
 	outboundTransport transport.OutboundTransport
 }
 
 // New instanstiated new exchange client
-// The argument takes a implementation of transport.OutboundTransport (dependencies required for Exchange protocol) and
+// The argument takes a implementation of transport.OutboundTransport (dependencies required for DID Exchange protocol) and
 // this is typically called by using aries.Context()
 func New(prov provider) *Protocol {
 	return &Protocol{prov.OutboundTransport()}

--- a/pkg/didcomm/protocol/didexchange/exchange_test.go
+++ b/pkg/didcomm/protocol/didexchange/exchange_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package exchange
+package didexchange
 
 import (
 	"testing"

--- a/pkg/didcomm/protocol/didexchange/models.go
+++ b/pkg/didcomm/protocol/didexchange/models.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package exchange
+package didexchange
 
 import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"

--- a/pkg/framework/aries/api/protocol.go
+++ b/pkg/framework/aries/api/protocol.go
@@ -20,7 +20,7 @@ type Handler interface {
 
 // ProtocolSvc interface for protocol service
 type ProtocolSvc interface {
-	GetAPIHandlers() []Handler
+	GetRESTHandlers() []Handler
 }
 
 // Provider interface for protocol ctx

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -7,11 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package aries
 
 import (
-	exchangeService "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/exchange/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didmethod/peer"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/factory/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
+	didexchangerest "github.com/hyperledger/aries-framework-go/pkg/restapi/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/storage/leveldb"
 	errors "golang.org/x/xerrors"
@@ -84,7 +84,7 @@ func defFrameworkOpts() ([]Option, error) {
 	opts = append(opts, WithStoreProvider(storeProv))
 
 	// default protocols
-	newExchangeSvc := func(prv api.Provider) (api.ProtocolSvc, error) { return exchangeService.New(prv), nil }
+	newExchangeSvc := func(prv api.Provider) (api.ProtocolSvc, error) { return didexchangerest.New(prv), nil }
 	opts = append(opts, WithProtocolSvcCreator(newExchangeSvc))
 
 	return opts, nil

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didmethod/peer"
 	"github.com/hyperledger/aries-framework-go/pkg/storage/leveldb"
 
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/exchange"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
@@ -75,11 +75,11 @@ func TestFramework(t *testing.T) {
 		ctx, err := aries.Context()
 		require.NoError(t, err)
 
-		// exchange client
-		exClient := exchange.New(ctx)
+		// did exchange client
+		exClient := didexchange.New(ctx)
 		require.NoError(t, err)
 
-		req := &exchange.Request{
+		req := &didexchange.Request{
 			ID:    "5678876542345",
 			Label: "Bob",
 		}
@@ -229,7 +229,7 @@ type mockProtocolSvc struct {
 	getAPIHandlersValue []api.Handler
 }
 
-func (m mockProtocolSvc) GetAPIHandlers() []api.Handler {
+func (m mockProtocolSvc) GetRESTHandlers() []api.Handler {
 	return m.getAPIHandlersValue
 }
 

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -15,7 +15,7 @@ import (
 // Provider supplies the framework configuration to client objects.
 type Provider struct {
 	outboundTransport   transport.OutboundTransport
-	apiHandlers         []api.Handler
+	restHandlers        []api.Handler
 	protocolSvcCreators []api.ProtocolSvcCreator
 }
 
@@ -35,7 +35,7 @@ func New(opts ...ProviderOption) (*Provider, error) {
 		if err != nil {
 			return nil, errors.Errorf("new protocol service failed: %w", err)
 		}
-		ctxProvider.apiHandlers = append(ctxProvider.apiHandlers, svc.GetAPIHandlers()...)
+		ctxProvider.restHandlers = append(ctxProvider.restHandlers, svc.GetRESTHandlers()...)
 	}
 	return &ctxProvider, nil
 }
@@ -47,7 +47,7 @@ func (p *Provider) OutboundTransport() transport.OutboundTransport {
 
 // RESTHandlers returns the REST API handlers for controller endpoints
 func (p *Provider) RESTHandlers() []api.Handler {
-	return p.apiHandlers
+	return p.restHandlers
 }
 
 // ProviderOption configures the framework.

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -43,7 +43,7 @@ func TestNewProvider(t *testing.T) {
 		prov, err := New(WithProtocolSvcCreator(mockSvcCreator))
 		require.NoError(t, err)
 		exist := false
-		for _, v := range prov.apiHandlers {
+		for _, v := range prov.restHandlers {
 			if v.Path() == "testPath" {
 				exist = true
 				break
@@ -66,6 +66,6 @@ type mockProtocolSvc struct {
 	getAPIHandlersValue []api.Handler
 }
 
-func (m mockProtocolSvc) GetAPIHandlers() []api.Handler {
+func (m mockProtocolSvc) GetRESTHandlers() []api.Handler {
 	return m.getAPIHandlersValue
 }

--- a/pkg/restapi/protocol/didexchange/service.go
+++ b/pkg/restapi/protocol/didexchange/service.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package service
+package didexchange
 
 import (
 	"encoding/json"
@@ -12,7 +12,7 @@ import (
 
 	"github.com/go-openapi/runtime/middleware/denco"
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/exchange"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/common/support"
@@ -41,10 +41,10 @@ type GenericError struct {
 	} `json:"body"`
 }
 
-//New returns new DID Exchange service protocol instance
+//New returns new DID Exchange rest service protocol instance
 func New(ctx provider) *ExchangeService {
 
-	didExchange := exchange.New(ctx)
+	didExchange := didexchange.New(ctx)
 	svc := &ExchangeService{ctx: ctx, didExchange: didExchange}
 	svc.registerHandler()
 
@@ -54,7 +54,7 @@ func New(ctx provider) *ExchangeService {
 //ExchangeService DID Exchange service protocol
 type ExchangeService struct {
 	ctx         provider
-	didExchange *exchange.Protocol
+	didExchange *didexchange.Protocol
 	handlers    []api.Handler
 }
 
@@ -99,8 +99,8 @@ func (e *ExchangeService) writeGenericError(rw http.ResponseWriter, err error) {
 	}
 }
 
-//GetAPIHandlers get all controller API handler available for this protocol service
-func (e *ExchangeService) GetAPIHandlers() []api.Handler {
+//GetRESTHandlers get all controller API handler available for this protocol service
+func (e *ExchangeService) GetRESTHandlers() []api.Handler {
 	return e.handlers
 }
 

--- a/pkg/restapi/protocol/didexchange/service_test.go
+++ b/pkg/restapi/protocol/didexchange/service_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package service
+package didexchange
 
 import (
 	"bytes"
@@ -17,7 +17,7 @@ import (
 	"testing"
 
 	"github.com/go-openapi/runtime/middleware/denco"
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/exchange"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	mocktransport "github.com/hyperledger/aries-framework-go/pkg/internal/didcomm/transport/mock"
@@ -32,7 +32,7 @@ func TestExchangeService_GetAPIHandlers(t *testing.T) {
 	svc := New(&mockProvider{})
 	require.NotNil(t, svc)
 
-	handlers := svc.GetAPIHandlers()
+	handlers := svc.GetRESTHandlers()
 	require.NotEmpty(t, handlers)
 }
 
@@ -40,7 +40,7 @@ func TestExchangeService_CreateInvitation(t *testing.T) {
 	svc := New(&mockProvider{})
 	require.NotNil(t, svc)
 
-	handlers := svc.GetAPIHandlers()
+	handlers := svc.GetRESTHandlers()
 	require.NotEmpty(t, handlers)
 
 	var handler api.Handler
@@ -55,7 +55,7 @@ func TestExchangeService_CreateInvitation(t *testing.T) {
 	buf, err := getResponseFromHandler(handler, nil)
 	require.NoError(t, err)
 
-	response := exchange.InvitationRequest{}
+	response := didexchange.InvitationRequest{}
 	err = json.Unmarshal(buf.Bytes(), &response)
 	require.NoError(t, err)
 
@@ -122,7 +122,7 @@ func getResponseFromHandler(handler api.Handler, requestBody io.Reader) (*bytes.
 	return rr.Body, nil
 }
 
-//mockProvider mocks provider needed for exchange service initialization
+//mockProvider mocks provider needed for did exchange service initialization
 type mockProvider struct {
 }
 


### PR DESCRIPTION
-In order to avoid confusion with transport, moved controller REST API http handle functions out of services package.
-new package: pkg/restapi/didcomm/protocol
-closes #161

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>

