### PR TITLE
feat: launching controller REST API

### DIFF
--- a/cmd/aries-agentd/main_test.go
+++ b/cmd/aries-agentd/main_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testURL = "localhost:8080"
+
+func TestStartAriesD(t *testing.T) {
+
+	prev := os.Getenv(agentHostEnvKey)
+	defer func() {
+		err := os.Setenv(agentHostEnvKey, prev)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	err := os.Setenv(agentHostEnvKey, testURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go main()
+
+	newreq := func(method, url string, body io.Reader) *http.Request {
+		r, err := http.NewRequest(method, url, body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return r
+	}
+
+	tests := []struct {
+		name string
+		r    *http.Request
+	}{
+		{name: "1: testing get", r: newreq("GET", fmt.Sprintf("http://%s/create-invitation", testURL), nil)},
+	}
+
+	//give some time for server to start
+	//TODO instead of sleep, listen for port
+	time.Sleep(100 * time.Millisecond)
+
+	for _, tt := range tests {
+
+		resp, err := http.DefaultClient.Do(tt.r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		defer func() {
+			e := resp.Body.Close()
+			if e != nil {
+				panic(err)
+			}
+		}()
+
+		require.Equal(t, resp.Status, "200 OK")
+		require.NotEmpty(t, resp.Body)
+		response, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		require.NotEmpty(t, response)
+		require.True(t, isJSON(response))
+	}
+
+}
+
+//isJSON() checks if response is json
+func isJSON(res []byte) bool {
+	var js map[string]interface{}
+	return json.Unmarshal(res, &js) == nil
+
+}
+
+func TestStartAriesDWithoutHost(t *testing.T) {
+
+	prev := os.Getenv(agentHostEnvKey)
+	defer func() {
+		err := os.Setenv(agentHostEnvKey, prev)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	err := os.Setenv(agentHostEnvKey, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan bool)
+
+	go func() {
+		main()
+		done <- true
+	}()
+
+	select {
+	case res := <-done:
+		require.True(t, res)
+	case <-time.After(5 * time.Second):
+		t.Fatal("agent should fail to start when host address not provided")
+	}
+
+}

--- a/pkg/framework/aries/api/protocol.go
+++ b/pkg/framework/aries/api/protocol.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package api
 
 import (
-	"github.com/go-openapi/runtime/middleware/denco"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	"golang.org/x/xerrors"
@@ -15,13 +14,6 @@ import (
 
 // SvcErrNotFound is returned when service not found
 var SvcErrNotFound = xerrors.New("service not found")
-
-//Handler http handler for each controller API endpoint
-type Handler interface {
-	Path() string
-	Method() string
-	Handle() denco.HandlerFunc
-}
 
 // Provider interface for protocol ctx
 type Provider interface {

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -13,8 +13,8 @@ import (
 	"github.com/go-openapi/runtime/middleware/denco"
 	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
-	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/common/support"
+	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
 )
 
 var logger = log.New("aries-framework/did-exchange")
@@ -41,23 +41,23 @@ type GenericError struct {
 }
 
 //New returns new DID Exchange rest client protocol instance
-func New(ctx provider) (*Client, error) {
+func New(ctx provider) (*Operation, error) {
 
 	didExchange, err := didexchange.New(ctx)
 	if err != nil {
 		return nil, err
 	}
-	svc := &Client{ctx: ctx, didExchangeClient: didExchange}
+	svc := &Operation{ctx: ctx, didExchangeClient: didExchange}
 	svc.registerHandler()
 
 	return svc, nil
 }
 
-//Client DID Exchange rest client
-type Client struct {
+//Operation is controller REST service controller for DID Exchange
+type Operation struct {
 	ctx               provider
 	didExchangeClient *didexchange.Client
-	handlers          []api.Handler
+	handlers          []operation.Handler
 }
 
 // CreateInvitation swagger:route GET /create-invitation did-exchange createInvitation
@@ -67,7 +67,7 @@ type Client struct {
 // Responses:
 //    default: genericError
 //        200: createInvitationResponse
-func (c *Client) CreateInvitation(rw http.ResponseWriter, req *http.Request, param denco.Params) {
+func (c *Operation) CreateInvitation(rw http.ResponseWriter, req *http.Request, param denco.Params) {
 
 	logger.Debugf("Creating connection invitation ")
 
@@ -85,7 +85,7 @@ func (c *Client) CreateInvitation(rw http.ResponseWriter, req *http.Request, par
 }
 
 //writeGenericError writes given error to http response writer as generic error response
-func (c *Client) writeGenericError(rw http.ResponseWriter, err error) {
+func (c *Operation) writeGenericError(rw http.ResponseWriter, err error) {
 	errResponse := GenericError{
 		Body: struct {
 			Code    int32  `json:"code"`
@@ -103,14 +103,14 @@ func (c *Client) writeGenericError(rw http.ResponseWriter, err error) {
 }
 
 //GetRESTHandlers get all controller API handler available for this protocol service
-func (c *Client) GetRESTHandlers() []api.Handler {
+func (c *Operation) GetRESTHandlers() []operation.Handler {
 	return c.handlers
 }
 
 //registerHandler register handlers to be exposed from this protocol service as REST API endpoints
-func (c *Client) registerHandler() {
+func (c *Operation) registerHandler() {
 	//Add more protocol endpoints here to expose them as controller API endpoints
-	c.handlers = []api.Handler{
+	c.handlers = []operation.Handler{
 		support.NewHTTPHandler(createInviationAPIPath, http.MethodGet, c.CreateInvitation),
 	}
 }

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -17,12 +17,12 @@ import (
 	"testing"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
-
 	mocktransport "github.com/hyperledger/aries-framework-go/pkg/internal/didcomm/transport/mock"
+
+	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
 
 	"github.com/go-openapi/runtime/middleware/denco"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
-	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,7 +47,7 @@ func TestExchangeService_CreateInvitation(t *testing.T) {
 	handlers := svc.GetRESTHandlers()
 	require.NotEmpty(t, handlers)
 
-	var handler api.Handler
+	var handler operation.Handler
 	for _, h := range handlers {
 		if h.Path() == createInviationAPIPath {
 			handler = h
@@ -95,7 +95,7 @@ func TestExchangeService_WriteGenericError(t *testing.T) {
 }
 
 //getResponseFromHandler reads response from given http handle func
-func getResponseFromHandler(handler api.Handler, requestBody io.Reader) (*bytes.Buffer, error) {
+func getResponseFromHandler(handler operation.Handler, requestBody io.Reader) (*bytes.Buffer, error) {
 
 	//prepare request
 	req, err := http.NewRequest(handler.Method(), handler.Path(), requestBody)

--- a/pkg/restapi/operation/handler.go
+++ b/pkg/restapi/operation/handler.go
@@ -1,0 +1,16 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package operation
+
+import "github.com/go-openapi/runtime/middleware/denco"
+
+//Handler http handler for each controller API endpoint
+type Handler interface {
+	Path() string
+	Method() string
+	Handle() denco.HandlerFunc
+}

--- a/pkg/restapi/restapi.go
+++ b/pkg/restapi/restapi.go
@@ -1,0 +1,40 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package restapi
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/framework/context"
+	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
+	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation/didexchange"
+)
+
+//New returns new controller REST API instance
+//TODO: Allow customized operations.
+func New(ctx *context.Provider) (*Controller, error) {
+
+	var allHandlers []operation.Handler
+
+	//Add DID Exchange Rest Handlers
+	exchange, err := didexchange.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	allHandlers = append(allHandlers, exchange.GetRESTHandlers()...)
+
+	return &Controller{handlers: allHandlers}, nil
+}
+
+//Controller contains handlers for controller REST API
+type Controller struct {
+	handlers []operation.Handler
+}
+
+//GetOperations returns all controller REST API endpoints
+func (c *Controller) GetOperations() []operation.Handler {
+	return c.handlers
+}

--- a/pkg/restapi/restapi_test.go
+++ b/pkg/restapi/restapi_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package restapi
+
+import (
+	"testing"
+
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/context"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_Failure(t *testing.T) {
+	controller, err := New(&context.Provider{})
+	require.Error(t, err)
+	require.Equal(t, err, api.SvcErrNotFound)
+	require.Nil(t, controller)
+}
+
+func TestNew_Success(t *testing.T) {
+	framework, err := aries.New()
+	require.NoError(t, err)
+	require.NotNil(t, framework)
+
+	defer func() {
+		e := framework.Close()
+		if e != nil {
+			t.Fatal(e)
+		}
+	}()
+
+	ctx, err := framework.Context()
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+
+	controller, err := New(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, controller)
+
+	require.NotEmpty(t, controller.GetOperations())
+
+}


### PR DESCRIPTION
- agentd cmd to use restapi.New() to get all HTTP handlers
- restapi.New() initializes all operations available for controller REST
API and collects all handlers
-closes #164 

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>