### PR TITLE
feat: Inbound Message Handler/Dispatcher

### DIFF
--- a/cmd/aries-agentd/main_test.go
+++ b/cmd/aries-agentd/main_test.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,9 +20,10 @@ import (
 )
 
 const testURL = "localhost:8080"
+const testInboundURL = "localhost:8081"
 
 func TestStartAriesD(t *testing.T) {
-
+	// TODO https://github.com/hyperledger/aries-framework-go/issues/167
 	prev := os.Getenv(agentHostEnvKey)
 	defer func() {
 		err := os.Setenv(agentHostEnvKey, prev)
@@ -35,10 +37,30 @@ func TestStartAriesD(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	prevInboundPort := os.Getenv(agentHTTPInboundEnvKey)
+	defer func() {
+		inboundConfigErr := os.Setenv(agentHTTPInboundEnvKey, prevInboundPort)
+		if inboundConfigErr != nil {
+			t.Fatal(inboundConfigErr)
+		}
+	}()
+
+	err = os.Setenv(agentHTTPInboundEnvKey, testInboundURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	go main()
 
-	newreq := func(method, url string, body io.Reader) *http.Request {
+	validateRequests(t)
+}
+
+func validateRequests(t *testing.T) {
+	newreq := func(method, url string, body io.Reader, contentType string) *http.Request {
 		r, err := http.NewRequest(method, url, body)
+		if contentType != "" {
+			r.Header.Add("Content-Type", contentType)
+		}
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -46,10 +68,33 @@ func TestStartAriesD(t *testing.T) {
 	}
 
 	tests := []struct {
-		name string
-		r    *http.Request
+		name               string
+		r                  *http.Request
+		expectedStatus     int
+		expectResponseData bool
 	}{
-		{name: "1: testing get", r: newreq("GET", fmt.Sprintf("http://%s/create-invitation", testURL), nil)},
+		// controller API test
+		{
+			name:               "1: testing get",
+			r:                  newreq("GET", fmt.Sprintf("http://%s/create-invitation", testURL), nil, ""),
+			expectedStatus:     http.StatusOK,
+			expectResponseData: true,
+		},
+
+		// DIDComm inbound API test
+		{
+			name: "200: testing didcomm inbound",
+			r: newreq("POST",
+				fmt.Sprintf("http://%s", testInboundURL),
+				strings.NewReader(`
+							{
+								"@id": "5678876542345",
+								"@type": "valid-message-type"
+							}`),
+				"application/didcomm-envelope-enc"),
+			expectedStatus:     http.StatusAccepted,
+			expectResponseData: false,
+		},
 	}
 
 	//give some time for server to start
@@ -70,14 +115,16 @@ func TestStartAriesD(t *testing.T) {
 			}
 		}()
 
-		require.Equal(t, resp.Status, "200 OK")
-		require.NotEmpty(t, resp.Body)
-		response, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			t.Fatal(err)
+		require.Equal(t, tt.expectedStatus, resp.StatusCode)
+		if tt.expectResponseData {
+			require.NotEmpty(t, resp.Body)
+			response, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			require.NotEmpty(t, response)
+			require.True(t, isJSON(response))
 		}
-		require.NotEmpty(t, response)
-		require.True(t, isJSON(response))
 	}
 
 }
@@ -116,6 +163,50 @@ func TestStartAriesDWithoutHost(t *testing.T) {
 		require.True(t, res)
 	case <-time.After(5 * time.Second):
 		t.Fatal("agent should fail to start when host address not provided")
+	}
+
+}
+
+func TestStartAriesWithoutInboundHost(t *testing.T) {
+
+	prev := os.Getenv(agentHostEnvKey)
+	defer func() {
+		err := os.Setenv(agentHostEnvKey, prev)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	err := os.Setenv(agentHostEnvKey, testURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prevInboundHost := os.Getenv(agentHTTPInboundEnvKey)
+	defer func() {
+		inboundConfigErr := os.Setenv(agentHTTPInboundEnvKey, prevInboundHost)
+		if inboundConfigErr != nil {
+			t.Fatal(inboundConfigErr)
+		}
+	}()
+
+	err = os.Setenv(agentHTTPInboundEnvKey, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan bool)
+
+	go func() {
+		main()
+		done <- true
+	}()
+
+	select {
+	case res := <-done:
+		require.True(t, res)
+	case <-time.After(5 * time.Second):
+		t.Fatal("agent should fail to start when inbound host address not provided")
 	}
 
 }

--- a/pkg/didcomm/dispatcher/dispatcher.go
+++ b/pkg/didcomm/dispatcher/dispatcher.go
@@ -8,11 +8,13 @@ package dispatcher
 
 // Service protocol service
 type Service interface {
-	Handle(msg DIDCommMsg)
+	Handle(msg DIDCommMsg) error
 	Accept(msgType string) bool
 	Name() string
 }
 
 // DIDCommMsg did comm msg
 type DIDCommMsg struct {
+	Type    string
+	Payload []byte
 }

--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -45,8 +45,9 @@ func New(store storage.Store, prov provider) *Service {
 }
 
 // Handle didexchange msg
-func (s *Service) Handle(msg dispatcher.DIDCommMsg) {
+func (s *Service) Handle(msg dispatcher.DIDCommMsg) error {
 	// TODO add Handle logic
+	return nil
 }
 
 // Accept msg

--- a/pkg/didcomm/transport/http/inbound_test.go
+++ b/pkg/didcomm/transport/http/inbound_test.go
@@ -14,13 +14,18 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	"github.com/stretchr/testify/require"
 )
 
-// mockMsgHandler is an http.msgHandler type, it is similar to MockHandler struct
-// but will be injected in WithInboundSetting() directly, will be used by each transport comm handle function
-func mockMsgHandler(payload []byte) {
-	logger.Debugf("Payload received is %s", payload)
+type mockProvider struct {
+}
+
+func (p *mockProvider) InboundMessageHandler() transport.InboundMessageHandler {
+	return func(payload []byte) error {
+		logger.Debugf("Payload received is %s", payload)
+		return nil
+	}
 }
 
 func TestInboundHandler(t *testing.T) {
@@ -30,7 +35,7 @@ func TestInboundHandler(t *testing.T) {
 	require.Nil(t, inHandler)
 
 	// now create a valid inboundHandler to continue testing..
-	inHandler, err = NewInboundHandler(mockMsgHandler)
+	inHandler, err = NewInboundHandler(&mockProvider{})
 
 	require.NoError(t, err)
 	require.NotNil(t, inHandler)

--- a/pkg/didcomm/transport/transport_interface.go
+++ b/pkg/didcomm/transport/transport_interface.go
@@ -12,3 +12,7 @@ type OutboundTransport interface {
 	// Send send a2a exchange data
 	Send(data string, destination string) (string, error)
 }
+
+// InboundMessageHandler handles the inbound requests. The transport will unpack the payload prior to the
+// message handle invocation.
+type InboundMessageHandler func(payload []byte) error

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -220,8 +220,8 @@ func TestFramework(t *testing.T) {
 type mockProtocolSvc struct {
 }
 
-func (m mockProtocolSvc) Handle(msg dispatcher.DIDCommMsg) {
-
+func (m mockProtocolSvc) Handle(msg dispatcher.DIDCommMsg) error {
+	return nil
 }
 
 func (m mockProtocolSvc) Accept(msgType string) bool {


### PR DESCRIPTION
- Message handler routes the messages to Protocol services depending on the message type
- The handler uses dispatcher.Service.Accept to redirect the inbound transfer
- HTTP server in main() uses inbound handlers from context

Closes #141 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
