### PR TITLE
test: Update leveldb path for test run

### DIFF
--- a/cmd/aries-agentd/main_test.go
+++ b/cmd/aries-agentd/main_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,6 +24,11 @@ const testURL = "localhost:8080"
 const testInboundURL = "localhost:8081"
 
 func TestStartAriesD(t *testing.T) {
+	// TODO - remove this path manipulation after implementing #175 and #148
+	path, cleanup := generateTempDir(t)
+	defer cleanup()
+	aries.DBPath = path
+
 	// TODO https://github.com/hyperledger/aries-framework-go/issues/167
 	prev := os.Getenv(agentHostEnvKey)
 	defer func() {
@@ -209,4 +215,17 @@ func TestStartAriesWithoutInboundHost(t *testing.T) {
 		t.Fatal("agent should fail to start when inbound host address not provided")
 	}
 
+}
+
+func generateTempDir(t testing.TB) (string, func()) {
+	path, err := ioutil.TempDir("", "db")
+	if err != nil {
+		t.Fatalf("Failed to create leveldb directory: %s", err)
+	}
+	return path, func() {
+		err := os.RemoveAll(path)
+		if err != nil {
+			t.Fatalf("Failed to clear leveldb directory: %s", err)
+		}
+	}
 }

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -18,8 +18,9 @@ import (
 	errors "golang.org/x/xerrors"
 )
 
-// TODO - Need to configure the path externally
-var dbPath = "/tmp/peerstore/"
+// DBPath Level DB Path.
+// TODO - Need to configure the path externally (#148 & #175)
+var DBPath = "/tmp/peerstore/"
 
 // defFramework provides default framework configs
 type defFramework struct {
@@ -53,7 +54,7 @@ func (d *defFramework) storeProvider() (storage.Provider, error) {
 	}
 
 	// TODO - Need to configure the path externally
-	storeProv, err := leveldb.NewProvider(dbPath)
+	storeProv, err := leveldb.NewProvider(DBPath)
 	if err != nil {
 		return nil, errors.Errorf("leveldb provider initialization failed : %w", err)
 	}

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -54,7 +54,7 @@ func TestFramework(t *testing.T) {
 	t.Run("test framework new - returns error", func(t *testing.T) {
 		path, cleanup := setupLevelDB(t)
 		defer cleanup()
-		dbPath = path
+		DBPath = path
 
 		// framework new - error
 		_, err := New(func(opts *Aries) error {
@@ -67,7 +67,7 @@ func TestFramework(t *testing.T) {
 	t.Run("test framework new - returns framework", func(t *testing.T) {
 		path, cleanup := setupLevelDB(t)
 		defer cleanup()
-		dbPath = path
+		DBPath = path
 		aries, err := New(WithTransportProviderFactory(&mockTransportProviderFactory{}))
 		require.NoError(t, err)
 
@@ -90,7 +90,7 @@ func TestFramework(t *testing.T) {
 	t.Run("test framework new - with default transport", func(t *testing.T) {
 		path, cleanup := setupLevelDB(t)
 		defer cleanup()
-		dbPath = path
+		DBPath = path
 
 		// prepare http server
 		server := startMockServer(t, mockHTTPHandler{})
@@ -119,7 +119,7 @@ func TestFramework(t *testing.T) {
 	t.Run("test framework new - failed to create the context : error with user provided transport ", func(t *testing.T) {
 		path, cleanup := setupLevelDB(t)
 		defer cleanup()
-		dbPath = path
+		DBPath = path
 		aries, err := New(WithTransportProviderFactory(&mockTransportProviderFactory{err: errors.New("outbound transport init failed")}))
 		require.NoError(t, err)
 
@@ -151,7 +151,7 @@ func TestFramework(t *testing.T) {
 	// framework new - success
 	t.Run("test DID resolver - with default resolver", func(t *testing.T) {
 		// store peer DID in the store
-		dbprov, err := leveldb.NewProvider(dbPath)
+		dbprov, err := leveldb.NewProvider(DBPath)
 		require.NoError(t, err)
 
 		dbstore, err := dbprov.GetStoreHandle()

--- a/pkg/restapi/restapi_test.go
+++ b/pkg/restapi/restapi_test.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package restapi
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
@@ -23,6 +25,11 @@ func TestNew_Failure(t *testing.T) {
 }
 
 func TestNew_Success(t *testing.T) {
+	// TODO - remove this path manipulation after implementing #175 and #148
+	path, cleanup := generateTempDir(t)
+	defer cleanup()
+	aries.DBPath = path
+
 	framework, err := aries.New()
 	require.NoError(t, err)
 	require.NotNil(t, framework)
@@ -44,4 +51,17 @@ func TestNew_Success(t *testing.T) {
 
 	require.NotEmpty(t, controller.GetOperations())
 
+}
+
+func generateTempDir(t testing.TB) (string, func()) {
+	path, err := ioutil.TempDir("", "db")
+	if err != nil {
+		t.Fatalf("Failed to create leveldb directory: %s", err)
+	}
+	return path, func() {
+		err := os.RemoveAll(path)
+		if err != nil {
+			t.Fatalf("Failed to clear leveldb directory: %s", err)
+		}
+	}
 }


### PR DESCRIPTION
Intermittently the test cases fail due to levelDB resource unavailability as parallel tests lock on file system.
Updated test cases to update path through global variable. This global variable will be removed once config are handled through struct (#148 and #175).

Closes #191 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>