### PR TITLE
Enable go linter suite (stylecheck / critic)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,7 @@ linters-settings:
   gofmt:
     simplify: true
   goimports:
-    local-prefixes:
+    local-prefixes: github.com/hyperledger/aries-framework-go
   gocyclo:
     min-complexity: 10
   maligned:
@@ -60,32 +60,13 @@ linters-settings:
     max-func-lines: 30
 
 linters:
-  disable-all: true
-  enable:
-    - deadcode
-    - gocyclo
-    - gofmt
-    - goimports
-    - golint
-    - gosimple
-    - ineffassign
-    - misspell
-    - unconvert
-    - unused
-    - vet
-    - varcheck
+  enable-all: true
+  disable:
     - maligned
-    - errcheck
-    - megacheck
-    - goconst
-    - gas
-    - structcheck
-  enable-all: false
-  disable: []
-  presets:
-    - bugs
-    - unused
-  fast: false
+    - prealloc
+    - dupl
+    - gochecknoglobals
+    - lll
 
 issues:
   exclude-use-default: false

--- a/cmd/aries-agentd/main.go
+++ b/cmd/aries-agentd/main.go
@@ -29,6 +29,7 @@ import (
 	"os"
 
 	"github.com/gorilla/mux"
+
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	didcommtrans "github.com/hyperledger/aries-framework-go/pkg/didcomm/transport/http"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -10,10 +10,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	mocktransport "github.com/hyperledger/aries-framework-go/pkg/internal/didcomm/transport/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {

--- a/pkg/didcomm/crypto/jwe/authcrypt/encrypt.go
+++ b/pkg/didcomm/crypto/jwe/authcrypt/encrypt.go
@@ -110,9 +110,9 @@ func extractCipherText(symOutput []byte) string {
 func createCipher(nonceSize int, symKey []byte) (cipher.AEAD, error) {
 	switch nonceSize {
 	case chacha20poly1305.NonceSize:
-		return chacha20poly1305.New(symKey[:])
+		return chacha20poly1305.New(symKey)
 	case chacha20poly1305.NonceSizeX:
-		return chacha20poly1305.NewX(symKey[:])
+		return chacha20poly1305.NewX(symKey)
 	default:
 		return nil, errors.New("cipher cannot be created with bad nonce size and shared symmetric Key combo")
 	}

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -15,14 +15,14 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	mocktransport "github.com/hyperledger/aries-framework-go/pkg/internal/didcomm/transport/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
+	mocktransport "github.com/hyperledger/aries-framework-go/pkg/internal/didcomm/transport/mock"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/storage/leveldb"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -329,9 +329,9 @@ func TestService_currentState(t *testing.T) {
 				get: func(string) ([]byte, error) { return nil, errors.New("not found") },
 			},
 		}
-		state, err := svc.currentState("ignored")
+		s, err := svc.currentState("ignored")
 		require.NoError(t, err)
-		require.Equal(t, (&null{}).Name(), state.Name())
+		require.Equal(t, (&null{}).Name(), s.Name())
 	})
 	t.Run("returns state from store", func(t *testing.T) {
 		expected := &requested{}
@@ -348,7 +348,7 @@ func TestService_currentState(t *testing.T) {
 
 func TestService_update(t *testing.T) {
 	const thid = "123"
-	state := &responded{}
+	s := &responded{}
 	data := make(map[string][]byte)
 	store := &mockStore{
 		put: func(k string, v []byte) error {
@@ -356,8 +356,8 @@ func TestService_update(t *testing.T) {
 			return nil
 		},
 	}
-	require.NoError(t, (&Service{store: store}).update("123", state))
-	require.Equal(t, state.Name(), string(data[thid]))
+	require.NoError(t, (&Service{store: store}).update("123", s))
+	require.Equal(t, s.Name(), string(data[thid]))
 }
 
 type mockStore struct {

--- a/pkg/didcomm/transport/http/inbound.go
+++ b/pkg/didcomm/transport/http/inbound.go
@@ -32,7 +32,7 @@ type provider interface {
 func NewInboundHandler(prov provider) (http.Handler, error) {
 	if prov == nil || prov.InboundMessageHandler() == nil {
 		logger.Errorf("Error creating a new inbound handler: message handler function is nil")
-		return nil, errors.New("Failed to create NewInboundHandler")
+		return nil, errors.New("creation of inbound handler failed")
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/didcomm/transport/http/inbound_test.go
+++ b/pkg/didcomm/transport/http/inbound_test.go
@@ -14,8 +14,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 )
 
 type mockProvider struct {

--- a/pkg/didcomm/transport/http/outbound.go
+++ b/pkg/didcomm/transport/http/outbound.go
@@ -68,7 +68,7 @@ func NewOutbound(opts ...OutboundHTTPOpt) (*OutboundHTTPClient, error) {
 	}
 
 	if clOpts.client == nil {
-		return nil, errors.New("Can't create an outbound transport without an HTTP client")
+		return nil, errors.New("creation of outbound transport requires an HTTP client")
 	}
 
 	cs := &OutboundHTTPClient{
@@ -81,7 +81,7 @@ func NewOutbound(opts ...OutboundHTTPOpt) (*OutboundHTTPClient, error) {
 func (cs *OutboundHTTPClient) Send(data string, url string) (string, error) {
 	resp, err := cs.client.Post(url, commContentType, bytes.NewBuffer([]byte(data)))
 	if err != nil {
-		logger.Errorf("HTTP Transport - Error posting did envelope to agent at [%s]: %v", url, err)
+		logger.Errorf("posting DID envelope to agent failed [%s, %v]", url, err)
 		return "", err
 	}
 
@@ -89,13 +89,13 @@ func (cs *OutboundHTTPClient) Send(data string, url string) (string, error) {
 	if resp != nil {
 		isStatusSuccess := resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusOK
 		if !isStatusSuccess {
-			return "", fmt.Errorf("Warning - Received non success POST HTTP status from agent at [%s]: status : %v", url, resp.Status)
+			return "", fmt.Errorf("received unsuccessful POST HTTP status from agent [%s, %v]", url, resp.Status)
 		}
 		// handle response
 		defer func() {
 			e := resp.Body.Close()
 			if e != nil {
-				logger.Errorf("HTTP Transport - Error closing response body: %v", e)
+				logger.Errorf("closing response body failed: %v", e)
 			}
 		}()
 		buf := new(bytes.Buffer)

--- a/pkg/didcomm/transport/http/outbound_test.go
+++ b/pkg/didcomm/transport/http/outbound_test.go
@@ -59,7 +59,7 @@ func TestOutboundHTTPTransport(t *testing.T) {
 	// create a new invalid Outbound transport instance
 	_, err = NewOutbound()
 	require.Error(t, err)
-	require.EqualError(t, err, "Can't create an outbound transport without an HTTP client")
+	require.EqualError(t, err, "creation of outbound transport requires an HTTP client")
 
 	// now create a new valid Outbound transport instance and test its Send() call
 	ot, err := NewOutbound(WithOutboundTLSConfig(tlsConfig), WithOutboundTimeout(clientTimeout))

--- a/pkg/didmethod/httpbinding/resolver.go
+++ b/pkg/didmethod/httpbinding/resolver.go
@@ -64,16 +64,16 @@ func (res *DIDResolver) resolveDID(url string) ([]byte, error) {
 		var gotBody []byte
 		gotBody, err = ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to read response body: %w", err)
+			return nil, fmt.Errorf("reading response body failed: %w", err)
 		}
 
 		return gotBody, nil
 
 	} else if notExistentDID(resp) {
-		return nil, fmt.Errorf("Input DID does not exist: %w", err)
+		return nil, fmt.Errorf("DID does not exist: %w", err)
 	}
 
-	return nil, fmt.Errorf("Unsupported response from DID Resolver with status code: %v", resp.StatusCode)
+	return nil, fmt.Errorf("unsupported response from DID resolver [%v]", resp.StatusCode)
 }
 
 // notExistentDID checks if requested DID is not found on remote DID resolver
@@ -97,7 +97,7 @@ func New(endpointURL string, opts ...ResolverOpt) (*DIDResolver, error) {
 	// Validate host
 	_, err := url.ParseRequestURI(endpointURL)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid base url: %w", err)
+		return nil, fmt.Errorf("base URL invalid: %w", err)
 	}
 
 	return &DIDResolver{
@@ -107,13 +107,13 @@ func New(endpointURL string, opts ...ResolverOpt) (*DIDResolver, error) {
 }
 
 // Read implements didresolver.DidMethod.Read interface (https://w3c-ccg.github.io/did-resolution/#resolving-input)
-func (res *DIDResolver) Read(DID string, _ ...didresolver.ResolveOpt) ([]byte, error) {
+func (res *DIDResolver) Read(did string, _ ...didresolver.ResolveOpt) ([]byte, error) {
 	reqURL, err := url.ParseRequestURI(res.endpointURL)
 	if err != nil {
-		return nil, fmt.Errorf("url parse request uri failed %w", err)
+		return nil, fmt.Errorf("url parse request uri failed: %w", err)
 	}
 
-	reqURL.Path = path.Join(reqURL.Path, DID)
+	reqURL.Path = path.Join(reqURL.Path, did)
 
 	return res.resolveDID(reqURL.String())
 }

--- a/pkg/didmethod/httpbinding/resolver_test.go
+++ b/pkg/didmethod/httpbinding/resolver_test.go
@@ -50,7 +50,7 @@ func TestNew(t *testing.T) {
 	// Invalid URL
 	_, err = New("invalid url")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Invalid base url")
+	require.Contains(t, err.Error(), "base URL invalid")
 }
 
 func TestRead_DIDDoc(t *testing.T) {
@@ -117,7 +117,7 @@ func TestRead_DIDDocNotFound(t *testing.T) {
 	require.NoError(t, err)
 	_, err = resolver.Read("did:example:334455")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Input DID does not exist")
+	require.Contains(t, err.Error(), "DID does not exist")
 }
 
 func TestRead_UnsupportedStatus(t *testing.T) {
@@ -130,7 +130,7 @@ func TestRead_UnsupportedStatus(t *testing.T) {
 	require.NoError(t, err)
 	_, err = resolver.Read("did:example:334455")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Unsupported response from DID Resolver with status code")
+	require.Contains(t, err.Error(), "unsupported response from DID resolver")
 }
 
 func TestRead_HTTPGetFailed(t *testing.T) {

--- a/pkg/didmethod/peer/did_test.go
+++ b/pkg/didmethod/peer/did_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestComputeDID(t *testing.T) {

--- a/pkg/didmethod/peer/resolver.go
+++ b/pkg/didmethod/peer/resolver.go
@@ -27,7 +27,7 @@ func (resl *DIDResolver) Read(did string, _ ...didresolver.ResolveOpt) ([]byte, 
 	// get the document from the store
 	doc, err := resl.store.Get(did)
 	if err != nil {
-		return nil, fmt.Errorf("Fetching data from store failed: %w", err)
+		return nil, fmt.Errorf("fetching data from store failed: %w", err)
 	}
 
 	if doc == nil {
@@ -37,7 +37,7 @@ func (resl *DIDResolver) Read(did string, _ ...didresolver.ResolveOpt) ([]byte, 
 	// convert the doc to JSON as DID Resolver expects byte result.
 	jsonDoc, err := doc.JSONBytes()
 	if err != nil {
-		return nil, fmt.Errorf("Json marshalling of document failed: %w", err)
+		return nil, fmt.Errorf("JSON marshalling of document failed: %w", err)
 	}
 
 	return jsonDoc, nil

--- a/pkg/didmethod/peer/resolver_test.go
+++ b/pkg/didmethod/peer/resolver_test.go
@@ -10,11 +10,12 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	diddoc "github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
 	"github.com/hyperledger/aries-framework-go/pkg/storage/leveldb"
-	"github.com/stretchr/testify/require"
 )
 
 const peerDID = "did:peer:1234"

--- a/pkg/didmethod/peer/store.go
+++ b/pkg/didmethod/peer/store.go
@@ -44,7 +44,7 @@ func NewDIDStore(s storage.Store) *DIDStore {
 // Put saves Peer DID Document along with user key/signature
 func (s *DIDStore) Put(did string, doc *did.Doc, by *[]DIDModifiedBy) error {
 	if did == "" || doc == nil {
-		return errors.New("DID and Document are mandatory")
+		return errors.New("DID and document are mandatory")
 	}
 
 	var deltas []docDelta
@@ -54,7 +54,7 @@ func (s *DIDStore) Put(did string, doc *did.Doc, by *[]DIDModifiedBy) error {
 	// For now, assume the doc is a genesis document
 	jsonDoc, err := json.Marshal(doc)
 	if err != nil {
-		return fmt.Errorf("Json marshalling of document failed: %w", err)
+		return fmt.Errorf("JSON marshalling of document failed: %w", err)
 	}
 
 	docDelta := &docDelta{
@@ -67,7 +67,7 @@ func (s *DIDStore) Put(did string, doc *did.Doc, by *[]DIDModifiedBy) error {
 
 	val, err := json.Marshal(deltas)
 	if err != nil {
-		return fmt.Errorf("Json marshalling of document deltas failed: %w", err)
+		return fmt.Errorf("JSON marshalling of document deltas failed: %w", err)
 	}
 
 	return s.store.Put(did, val)
@@ -81,7 +81,7 @@ func (s *DIDStore) Get(id string) (*did.Doc, error) {
 
 	deltas, err := s.getDeltas(id)
 	if err != nil {
-		return nil, fmt.Errorf("Delta data fetch from store failed : %w", err)
+		return nil, fmt.Errorf("delta data fetch from store failed: %w", err)
 	}
 
 	// TODO construct document from all the deltas (https://github.com/hyperledger/aries-framework-go/issues/54)
@@ -90,13 +90,13 @@ func (s *DIDStore) Get(id string) (*did.Doc, error) {
 
 	doc, err := base64.URLEncoding.DecodeString(delta.Change)
 	if err != nil {
-		return nil, fmt.Errorf("Decoding of document delta failed: %w", err)
+		return nil, fmt.Errorf("decoding of document delta failed: %w", err)
 	}
 
 	document := &did.Doc{}
 	err = json.Unmarshal(doc, document)
 	if err != nil {
-		return nil, fmt.Errorf("Json unmarshalling of document failed: %w", err)
+		return nil, fmt.Errorf("JSON unmarshalling of document failed: %w", err)
 	}
 
 	return document, nil
@@ -105,13 +105,13 @@ func (s *DIDStore) Get(id string) (*did.Doc, error) {
 func (s *DIDStore) getDeltas(id string) ([]docDelta, error) {
 	val, err := s.store.Get(id)
 	if err != nil {
-		return nil, fmt.Errorf("Fetching data from store failed: %w", err)
+		return nil, fmt.Errorf("fetching data from store failed: %w", err)
 	}
 
 	var deltas []docDelta
 	err = json.Unmarshal(val, &deltas)
 	if err != nil {
-		return nil, fmt.Errorf("Json unmarshalling of document deltas failed: %w", err)
+		return nil, fmt.Errorf("JSON unmarshalling of document deltas failed: %w", err)
 	}
 
 	return deltas, nil

--- a/pkg/didmethod/peer/store_test.go
+++ b/pkg/didmethod/peer/store_test.go
@@ -11,9 +11,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/storage/leveldb"
-	"github.com/stretchr/testify/require"
 )
 
 func setupLevelDB(t testing.TB) (string, func()) {

--- a/pkg/doc/did/doc.go
+++ b/pkg/doc/did/doc.go
@@ -222,7 +222,7 @@ func FromBytes(data []byte) (*Doc, error) {
 	raw := &rawDoc{}
 	err := json.Unmarshal(data, &raw)
 	if err != nil {
-		return nil, fmt.Errorf("Json marshalling of did doc bytes bytes failed: %w", err)
+		return nil, fmt.Errorf("JSON marshalling of did doc bytes bytes failed: %w", err)
 	}
 
 	publicKeys, err := populatePublicKeys(raw.PublicKey)
@@ -335,13 +335,13 @@ func validate(data []byte) error {
 	documentLoader := gojsonschema.NewStringLoader(string(data))
 	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
 	if err != nil {
-		return fmt.Errorf("Validation of did doc failed: %w", err)
+		return fmt.Errorf("validation of DID doc failed: %w", err)
 	}
 
 	if !result.Valid() {
 		errMsg := "did document not valid:\n"
 		for _, desc := range result.Errors() {
-			errMsg = errMsg + fmt.Sprintf("- %s\n", desc)
+			errMsg += fmt.Sprintf("- %s\n", desc)
 		}
 		return errors.New(errMsg)
 	}
@@ -371,7 +371,7 @@ func (doc *Doc) JSONBytes() ([]byte, error) {
 
 	byteDoc, err := json.Marshal(raw)
 	if err != nil {
-		return nil, fmt.Errorf("Json unmarshalling of document failed: %w", err)
+		return nil, fmt.Errorf("JSON unmarshalling of document failed: %w", err)
 	}
 
 	return byteDoc, nil

--- a/pkg/doc/did/doc_test.go
+++ b/pkg/doc/did/doc_test.go
@@ -161,7 +161,7 @@ func TestFromBytes(t *testing.T) {
 	// test error from Unmarshal
 	_, err := FromBytes([]byte("wrongData"))
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Validation of did doc failed")
+	require.Contains(t, err.Error(), "validation of DID doc failed")
 }
 
 func TestValidateDidDocContext(t *testing.T) {

--- a/pkg/doc/verifiable/credential.go
+++ b/pkg/doc/verifiable/credential.go
@@ -13,8 +13,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	"github.com/xeipuuv/gojsonschema"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 )
 
 var logger = log.New("aries-framework/doc/verifiable")
@@ -250,7 +251,7 @@ func NewCredential(data []byte, opts ...CredentialOpt) (*Credential, error) {
 	raw := &rawCredential{}
 	err := json.Unmarshal(data, &raw)
 	if err != nil {
-		return nil, fmt.Errorf("Json unmarshalling of Verifiable Credential bytes failed: %w", err)
+		return nil, fmt.Errorf("JSON unmarshalling of verifiable credential failed: %w", err)
 	}
 
 	if err = validate(data, raw.Schema, clOpts); err != nil {
@@ -259,7 +260,7 @@ func NewCredential(data []byte, opts ...CredentialOpt) (*Credential, error) {
 
 	issuerID, issuerName, err := issuerFromBytes(data)
 	if err != nil {
-		return nil, fmt.Errorf("Json unmarshalling of Verifiable Credential bytes failed: %w", err)
+		return nil, fmt.Errorf("JSON unmarshalling of verifiable credential failed: %w", err)
 	}
 
 	return &Credential{
@@ -297,7 +298,7 @@ func issuerFromBytes(data []byte) (string, string, error) {
 		return eci.CompositeIssuer.ID, eci.CompositeIssuer.Name, nil
 	}
 
-	return "", "", fmt.Errorf("Verifiable Credential's Issuer is not valid")
+	return "", "", fmt.Errorf("verifiable credential issuer is not valid")
 
 }
 
@@ -319,7 +320,7 @@ func validate(data []byte, schema *CredentialSchema, opts *credentialOpts) error
 	loader := gojsonschema.NewStringLoader(string(data))
 	result, err := gojsonschema.Validate(schemaLoader, loader)
 	if err != nil {
-		return fmt.Errorf("Validation of Verifiable Credential failed: %w", err)
+		return fmt.Errorf("validation of verifiable credential failed: %w", err)
 	}
 
 	if !result.Valid() {
@@ -330,9 +331,9 @@ func validate(data []byte, schema *CredentialSchema, opts *credentialOpts) error
 }
 
 func describeSchemaValidationError(result *gojsonschema.Result) string {
-	errMsg := "Verifiable Credential is not valid:\n"
+	errMsg := "verifiable credential is not valid:\n"
 	for _, desc := range result.Errors() {
-		errMsg = errMsg + fmt.Sprintf("- %s\n", desc)
+		errMsg += fmt.Sprintf("- %s\n", desc)
 	}
 	return errMsg
 }
@@ -345,10 +346,10 @@ func getCredentialSchema(schema *CredentialSchema, opts *credentialOpts) (gojson
 			if customSchemaData, err := loadCredentialSchema(schema.ID, opts.schemaDownloadClient); err == nil {
 				schemaLoader = gojsonschema.NewBytesLoader(customSchemaData)
 			} else {
-				return nil, fmt.Errorf("Failed to load custom credential schema from %s: %w", schema.ID, err)
+				return nil, fmt.Errorf("loading custom credential schema from %s failed: %w", schema.ID, err)
 			}
 		default:
-			logger.Warnf("Unsupported credential schema: %s. Using default schema for validation", schema.Type)
+			logger.Warnf("unsupported credential schema: %s. Using default schema for validation", schema.Type)
 		}
 	}
 	return schemaLoader, nil
@@ -358,24 +359,24 @@ func getCredentialSchema(schema *CredentialSchema, opts *credentialOpts) (gojson
 func loadCredentialSchema(url string, client *http.Client) ([]byte, error) {
 	resp, err := client.Get(url)
 	if err != nil {
-		return nil, fmt.Errorf("HTTP GET request failed: %w", err)
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}
 
 	defer func() {
 		e := resp.Body.Close()
 		if e != nil {
-			logger.Errorf("Failed to close response body: %v", e)
+			logger.Errorf("closing response body failed [%v]", e)
 		}
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Returned status is not OK as expected: %v", resp.StatusCode)
+		return nil, fmt.Errorf("credential schema endpoint HTTP failure [%v]", resp.StatusCode)
 	}
 
 	var gotBody []byte
 	gotBody, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read response body: %w", err)
+		return nil, fmt.Errorf("reading response body failed: %w", err)
 	}
 
 	return gotBody, nil
@@ -399,7 +400,7 @@ func (vc *Credential) JSONBytes() ([]byte, error) {
 
 	byteCred, err := json.Marshal(rawCred)
 	if err != nil {
-		return nil, fmt.Errorf("Json unmarshalling of Verifiable Credential failed: %w", err)
+		return nil, fmt.Errorf("JSON unmarshalling of verifiable credential failed: %w", err)
 	}
 
 	return byteCred, nil

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -154,13 +154,13 @@ func TestNew(t *testing.T) {
 		emptyJSONDoc := "{}"
 		_, err := NewCredential([]byte(emptyJSONDoc))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "Verifiable Credential is not valid")
+		require.Contains(t, err.Error(), "verifiable credential is not valid")
 	})
 
 	t.Run("test a try to create a new Verifiable Credential from non-JSON doc", func(t *testing.T) {
 		_, err := NewCredential([]byte("non json"))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "Json unmarshalling of Verifiable Credential bytes failed")
+		require.Contains(t, err.Error(), "JSON unmarshalling of verifiable credential failed")
 	})
 }
 
@@ -673,7 +673,7 @@ func TestCustomCredentialJsonSchemaValidator2018(t *testing.T) {
 
 		_, err = NewCredential(schemaWithInvalidURLToCredentialSchema, WithSchemaDownloadClient(&http.Client{}))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "Failed to load custom credential schema")
+		require.Contains(t, err.Error(), "loading custom credential schema")
 	})
 
 	t.Run("Uses default schema if custom credentialSchema is not of 'JsonSchemaValidator2018' type", func(t *testing.T) {
@@ -728,7 +728,7 @@ func TestDownloadCustomSchema(t *testing.T) {
 
 		_, err := loadCredentialSchema(testServer.URL, &http.Client{})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "HTTP GET request failed")
+		require.Contains(t, err.Error(), "HTTP request failed")
 	})
 
 	t.Run("HTTP GET request to download custom credentialSchema returns not OK", func(t *testing.T) {
@@ -740,7 +740,7 @@ func TestDownloadCustomSchema(t *testing.T) {
 
 		_, err := loadCredentialSchema(testServer.URL, &http.Client{})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "Returned status is not OK as expected")
+		require.Contains(t, err.Error(), "credential schema endpoint HTTP failure")
 	})
 }
 

--- a/pkg/framework/aries/defaults/defaults_test.go
+++ b/pkg/framework/aries/defaults/defaults_test.go
@@ -11,8 +11,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
 )
 
 func TestWithDBPath(t *testing.T) {

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
@@ -25,7 +27,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
 	mocktransport "github.com/hyperledger/aries-framework-go/pkg/internal/didcomm/transport/mock"
 	"github.com/hyperledger/aries-framework-go/pkg/storage/leveldb"
-	"github.com/stretchr/testify/require"
 )
 
 var doc = `{

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -27,7 +27,7 @@ func New(opts ...ProviderOption) (*Provider, error) {
 	for _, opt := range opts {
 		err := opt(&ctxProvider)
 		if err != nil {
-			return nil, fmt.Errorf("Error in option passed to New: %w", err)
+			return nil, fmt.Errorf("option failed: %w", err)
 		}
 	}
 

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -12,9 +12,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	mocktransport "github.com/hyperledger/aries-framework-go/pkg/internal/didcomm/transport/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewProvider(t *testing.T) {

--- a/pkg/framework/didresolver/didresolver_test.go
+++ b/pkg/framework/didresolver/didresolver_test.go
@@ -105,7 +105,7 @@ func TestResolve(t *testing.T) {
 		}}))
 		_, err := r.Resolve("did:example:1234")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "Validation of did doc failed")
+		require.Contains(t, err.Error(), "validation of DID doc failed")
 	})
 
 	t.Run("test result type resolution-result", func(t *testing.T) {

--- a/pkg/internal/common/logging/modlog/logtestutils.go
+++ b/pkg/internal/common/logging/modlog/logtestutils.go
@@ -13,8 +13,9 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hyperledger/aries-framework-go/pkg/internal/common/logging/metadata"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/internal/common/logging/metadata"
 )
 
 const (

--- a/pkg/internal/didcomm/transport/mock/mock_transport.go
+++ b/pkg/internal/didcomm/transport/mock/mock_transport.go
@@ -20,7 +20,7 @@ func NewOutboundTransport(expectedResponse string) *OutboundTransport {
 // Send implementation of OutboundTransport.Send api
 func (transport *OutboundTransport) Send(data string, destination string) (string, error) {
 	if data == "" || destination == "" {
-		return "", errors.New("Data or destination can't be empty")
+		return "", errors.New("data and destination are mandatory")
 	}
 
 	return transport.ExpectedResponse, nil

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -9,16 +9,16 @@ package didexchange
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"time"
 
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
-
-	didexchange2 "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
-
 	"github.com/gorilla/mux"
+
 	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	didexchange2 "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/common/support"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation/didexchange/models"
@@ -179,8 +179,8 @@ func (c *Operation) AcceptInvitation(rw http.ResponseWriter, req *http.Request) 
 	}
 }
 
-//writeGenericError writes given error to http response writer as generic error response
-func (c *Operation) writeGenericError(rw http.ResponseWriter, err error) {
+//writeGenericError writes given error to writer as generic error response
+func (c *Operation) writeGenericError(rw io.Writer, err error) {
 	errResponse := models.GenericError{
 		Body: struct {
 			Code    int32  `json:"code"`

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -16,12 +16,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
-
 	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation/didexchange/models"
-	"github.com/stretchr/testify/require"
 )
 
 func TestOperation_GetAPIHandlers(t *testing.T) {

--- a/pkg/restapi/restapi_test.go
+++ b/pkg/restapi/restapi_test.go
@@ -11,11 +11,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/defaults"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/context"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNew_Failure(t *testing.T) {

--- a/pkg/storage/leveldb/leveldb_store.go
+++ b/pkg/storage/leveldb/leveldb_store.go
@@ -9,8 +9,9 @@ package leveldb
 import (
 	"errors"
 
-	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/syndtr/goleveldb/leveldb"
+
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
 // Provider leveldb implementation of storage.Provider interface
@@ -48,7 +49,7 @@ func newLeveldbStore(db *leveldb.DB) *leveldbStore {
 // Put stores the key and the record
 func (s *leveldbStore) Put(k string, v []byte) error {
 	if k == "" || v == nil {
-		return errors.New("Key and value are mandatory")
+		return errors.New("key and value are mandatory")
 	}
 
 	return s.db.Put([]byte(k), v, nil)
@@ -57,7 +58,7 @@ func (s *leveldbStore) Put(k string, v []byte) error {
 // Get fetches the record based on key
 func (s *leveldbStore) Get(k string) ([]byte, error) {
 	if k == "" {
-		return nil, errors.New("Key is mandatory")
+		return nil, errors.New("key is mandatory")
 	}
 
 	data, err := s.db.Get([]byte(k), nil)


### PR DESCRIPTION
The golangci configuration is updated to include missing linters. Linter
warnings are resolved.

For this change, we continue to disable some linters to decrease the scope
of linter fixes. Upcoming changes will continue to increase linter scope.

Story: #205

Signed-off-by: Troy Ronda <troy@troyronda.com>
