### PR TITLE
feat: DIDComm Inbound Transport Initiation in framework.New()

### DIFF
--- a/pkg/didcomm/transport/transport_interface.go
+++ b/pkg/didcomm/transport/transport_interface.go
@@ -16,3 +16,20 @@ type OutboundTransport interface {
 // InboundMessageHandler handles the inbound requests. The transport will unpack the payload prior to the
 // message handle invocation.
 type InboundMessageHandler func(payload []byte) error
+
+// InboundProvider contains dependencies for starting the inbound transport and is typically created by using aries.Context()
+type InboundProvider interface {
+	InboundMessageHandler() InboundMessageHandler
+}
+
+// InboundTransport interface definition for inbound transport layer
+type InboundTransport interface {
+	// starts the inbound transport
+	Start(prov InboundProvider) error
+
+	// stops the inbound transport
+	Stop() error
+
+	// returns the endpoint
+	Endpoint() string
+}

--- a/pkg/framework/aries/defaults/defaults.go
+++ b/pkg/framework/aries/defaults/defaults.go
@@ -9,6 +9,7 @@ package defaults
 import (
 	"fmt"
 
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport/http"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
 	"github.com/hyperledger/aries-framework-go/pkg/storage/leveldb"
 )
@@ -21,5 +22,16 @@ func WithStorePath(storePath string) aries.Option {
 			return fmt.Errorf("leveldb provider initialization failed : %w", err)
 		}
 		return aries.WithStoreProvider(storeProv)(opts)
+	}
+}
+
+// WithInboundHTTPAddr return new default inbound transport.
+func WithInboundHTTPAddr(addr string) aries.Option {
+	return func(opts *aries.Aries) error {
+		inbound, err := http.NewInbound(addr)
+		if err != nil {
+			return fmt.Errorf("http inbound transport initialization failed : %w", err)
+		}
+		return aries.WithInboundTransport(inbound)(opts)
 	}
 }

--- a/pkg/framework/aries/defaults/defaults_test.go
+++ b/pkg/framework/aries/defaults/defaults_test.go
@@ -24,16 +24,34 @@ func TestWithDBPath(t *testing.T) {
 	})
 
 	t.Run("test with db path success", func(t *testing.T) {
-		path, cleanup := setupLevelDB(t)
+		path, cleanup := generateTempDir(t)
 		defer cleanup()
-		a, err := aries.New(WithStorePath(path))
+		a, err := aries.New(WithStorePath(path), WithInboundHTTPAddr(":26502"))
 		require.NoError(t, err)
 		require.NoError(t, a.Close())
 	})
 
 }
 
-func setupLevelDB(t testing.TB) (string, func()) {
+func TestWithInboundHTTPPort(t *testing.T) {
+	t.Run("test inbound with http port - success", func(t *testing.T) {
+		path, cleanup := generateTempDir(t)
+		defer cleanup()
+
+		a, err := aries.New(WithStorePath(path), WithInboundHTTPAddr(":26503"))
+		require.NoError(t, err)
+		require.NoError(t, a.Close())
+	})
+
+	t.Run("test inbound with http port - empty address", func(t *testing.T) {
+		_, err := aries.New(WithInboundHTTPAddr(""))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "http inbound transport initialization failed")
+	})
+
+}
+
+func generateTempDir(t testing.TB) (string, func()) {
 	path, err := ioutil.TempDir("", "db")
 	if err != nil {
 		t.Fatalf("Failed to create leveldb directory: %s", err)

--- a/pkg/restapi/restapi_test.go
+++ b/pkg/restapi/restapi_test.go
@@ -29,7 +29,7 @@ func TestNew_Failure(t *testing.T) {
 func TestNew_Success(t *testing.T) {
 	path, cleanup := generateTempDir(t)
 	defer cleanup()
-	framework, err := aries.New(defaults.WithStorePath(path))
+	framework, err := aries.New(defaults.WithStorePath(path), defaults.WithInboundHTTPAddr(":26508"))
 	require.NoError(t, err)
 	require.NotNil(t, framework)
 


### PR DESCRIPTION
- Create interface for InboundTransport
- Provide HTTP InboundTransport based on the new interface
- Add HTTPInboundTransport as the default inbound transport provider
- Start the inbound transport in while creating a new framework
- Remove code from reference agent to build and start the HTTP inbound transport

Closes #188 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
