### PR TITLE
test: example selecting VC template based on basic one

### DIFF
--- a/pkg/doc/verifiable/credential.go
+++ b/pkg/doc/verifiable/credential.go
@@ -187,7 +187,7 @@ type Credential struct {
 	RefreshService *RefreshService
 }
 
-// rawCredential
+// rawCredential is a basic verifiable credential
 type rawCredential struct {
 	Context        []string          `json:"@context,omitempty"`
 	ID             string            `json:"id,omitempty"`
@@ -294,7 +294,7 @@ func NewCredential(dataJSON []byte, opts ...CredentialOpt) (*Credential, error) 
 		return nil, err
 	}
 
-	var cred = crOpts.template()
+	cred := crOpts.template()
 	cred.Context = raw.Context
 	cred.ID = raw.ID
 	cred.Type = raw.Type

--- a/pkg/doc/verifiable/credential_extension_switch_test.go
+++ b/pkg/doc/verifiable/credential_extension_switch_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifiable
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	validCred1 = `
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/ext/type1"
+  ],
+  "id": "http://example.edu/credentials/1872",
+  "type": [
+    "VerifiableCredential",
+    "CredType1"
+  ],
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "s1": "custom subject 1"
+  },
+
+  "c1": "custom field 1",
+
+  "issuer": {
+    "id": "did:example:76e12ec712ebc6f1c221ebfeb1f",
+    "name": "Example University"
+  },
+
+  "issuanceDate": "2010-01-01T19:23:24Z"
+}
+`
+
+	validCred2 = `
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/ext/type2"
+  ],
+  "id": "http://example.edu/credentials/1872",
+  "type": [
+    "VerifiableCredential",
+    "CredType2"
+  ],
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "s2": "custom subject 2"
+  },
+
+  "c2": "custom field 2",
+
+  "issuer": {
+    "id": "did:example:76e12ec712ebc6f1c221ebfeb1f",
+    "name": "Example University"
+  },
+
+  "issuanceDate": "2010-01-01T19:23:24Z"
+}`
+
+	credMissingMandatoryFields = `
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/ext/type2"
+  ],
+  "id": "http://example.edu/credentials/1872",
+  "type": [
+    "VerifiableCredential"
+  ]
+}`
+)
+
+type CustomCredentialProducer struct {
+	Accept func(cred *Credential) bool
+	Apply  func(dataJSON []byte) (interface{}, error)
+}
+
+type Cred1 struct {
+	Base    Credential
+	Subject struct {
+		ID                 string `json:"id,omitempty"`
+		CustomSubjectField string `json:"s1,omitempty"`
+	} `json:"credentialSubject,omitempty"`
+	CustomField string `json:"c1,omitempty"`
+}
+
+type Cred2 struct {
+	Base    Credential
+	Subject struct {
+		ID                 string `json:"id,omitempty"`
+		CustomSubjectField string `json:"s2,omitempty"`
+	} `json:"credentialSubject,omitempty"`
+	CustomField string `json:"c2,omitempty"`
+}
+
+func Cred1Producer() CustomCredentialProducer {
+	return CustomCredentialProducer{
+		Apply: func(dataJSON []byte) (interface{}, error) {
+			cred1 := &Cred1{}
+
+			_, err := NewCredential(
+				dataJSON,
+				WithDecoders([]CredentialDecoder{func(dataJSON []byte, c *Credential) error {
+					return json.Unmarshal(dataJSON, cred1)
+				}}),
+				WithTemplate(func() *Credential {
+					return &cred1.Base
+				}),
+			)
+			if err == nil {
+				return cred1, nil
+			}
+			return nil, err
+		},
+		Accept: func(vc *Credential) bool {
+			return containsString(vc.Context, "https://www.w3.org/2018/credentials/examples/ext/type1") &&
+				containsString(vc.Type, "CredType1")
+		},
+	}
+}
+
+func Cred2Producer() CustomCredentialProducer {
+	return CustomCredentialProducer{
+		Apply: func(dataJSON []byte) (interface{}, error) {
+			cred2 := &Cred2{}
+
+			_, err := NewCredential(
+				dataJSON,
+				WithDecoders([]CredentialDecoder{func(dataJSON []byte, c *Credential) error {
+					return json.Unmarshal(dataJSON, cred2)
+				}}),
+				WithTemplate(func() *Credential {
+					return &cred2.Base
+				}),
+			)
+			if err == nil {
+				return cred2, nil
+			}
+			return nil, err
+		},
+		Accept: func(vc *Credential) bool {
+			return containsString(vc.Context, "https://www.w3.org/2018/credentials/examples/ext/type2") &&
+				containsString(vc.Type, "CredType2")
+		},
+	}
+}
+
+func DecodeCredentials(dataJSON []byte, producers ...CustomCredentialProducer) (interface{}, error) {
+	var baseCred *Credential
+	var credErr error
+	if baseCred, credErr = NewCredential(dataJSON); credErr != nil {
+		return nil, fmt.Errorf("failed to build base verifiable credential: %w", credErr)
+	}
+
+	for _, p := range producers {
+		if p.Accept(baseCred) {
+			var customCred interface{}
+			var jsonErr error
+
+			if customCred, jsonErr = p.Apply(dataJSON); jsonErr == nil {
+				return customCred, nil
+			}
+			return nil, fmt.Errorf("error occurred when building custom verifiable credential: %w", jsonErr)
+		}
+	}
+
+	// return base credential no producers accepted the dataJSON
+	return baseCred, nil
+}
+
+func containsString(credentialTypes []string, targetType string) bool {
+	for _, thatType := range credentialTypes {
+		if thatType == targetType {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCredentialExtensibilitySwitch(t *testing.T) {
+	producers := []CustomCredentialProducer{Cred1Producer(), Cred2Producer()}
+
+	i1, err := DecodeCredentials([]byte(validCred1), producers...)
+	require.NoError(t, err)
+	require.IsType(t, &Cred1{}, i1)
+	cred1, correct := i1.(*Cred1)
+	require.True(t, correct)
+	require.NotNil(t, cred1.Base)
+	require.Equal(t, []string{"VerifiableCredential", "CredType1"}, cred1.Base.Type)
+	require.Equal(t, "custom field 1", cred1.CustomField)
+	require.Equal(t, "custom subject 1", cred1.Subject.CustomSubjectField)
+
+	i2, err := DecodeCredentials([]byte(validCred2), producers...)
+	require.NoError(t, err)
+	require.IsType(t, &Cred2{}, i2)
+	cred2, correct := i2.(*Cred2)
+	require.True(t, correct)
+	require.NotNil(t, cred2.Base)
+	require.Equal(t, []string{"VerifiableCredential", "CredType2"}, cred2.Base.Type)
+	require.Equal(t, "custom field 2", cred2.CustomField)
+	require.Equal(t, "custom subject 2", cred2.Subject.CustomSubjectField)
+
+	i3, err := DecodeCredentials([]byte(validCredential), producers...)
+	require.NoError(t, err)
+	require.IsType(t, &Credential{}, i3)
+
+	_, err = DecodeCredentials([]byte(credMissingMandatoryFields), producers...)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to build base verifiable credential")
+}

--- a/pkg/doc/verifiable/credential_extension_test.go
+++ b/pkg/doc/verifiable/credential_extension_test.go
@@ -31,13 +31,13 @@ type UniversityDegreeSubject struct {
 
 // UniversityDegreeCredential University Degree credential, from examples of https://w3c.github.io/vc-data-model
 type UniversityDegreeCredential struct {
-	c Credential
+	Base Credential
 
 	Subject *UniversityDegreeSubject `json:"credentialSubject,omitempty"`
 }
 
 func (udc *UniversityDegreeCredential) credential() *Credential {
-	return &udc.c
+	return &udc.Base
 }
 
 func (udc *UniversityDegreeCredential) decode(dataJSON []byte, credential *Credential) error {
@@ -54,7 +54,7 @@ func TestCredentialExtensibility(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, cred)
-	require.Equal(t, &udc.c, cred)
+	require.Equal(t, &udc.Base, cred)
 
 	// default issuer credential decoder is applied (i.e. not re-written by new custom decoder)
 	require.NotNil(t, cred.Issuer)


### PR DESCRIPTION
According to @troyronda:
we should add an additional test case to provide an illustration of how a developer could choose which template to use.

decode into a basic verifiable credential
based on type info in the basic verifiable credential, decode into the more specialized type.
i.e., keep this test function that you created in this PR and add another one to illustrate the above.

Story: #218

Signed-off-by: Dima <dkinoshenko@gmail.com>