### PR TITLE
ci: codecov to ignore mocks

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -10,3 +10,5 @@ coverage:
     patch:
       default:
         target: 85%
+ignore:
+  - "pkg/internal/mock/**/*"


### PR DESCRIPTION
Updates the codecov configuration to ignore all files and folders under:
pkg/internal/mocks

Closes: #228

Signed-off-by: Troy Ronda <troy@troyronda.com>

