### PR TITLE
Enable go linter suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 jobs:
   checks:
     docker:
-      - image: golangci/golangci-lint
+      - image: golangci/golangci-lint:v1.18
     steps:
       - checkout
       - run: make checks

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,7 +60,7 @@ linters-settings:
   unparam:
     check-exported: false
   nakedret:
-    max-func-lines: 30
+    max-func-lines: 0
   gocritic:
     enabled-tags:
       - diagnostic
@@ -69,15 +69,24 @@ linters-settings:
       - opinionated
     disabled-checks:
       - unnamedResult
+  funlen:
+    lines: 60
+    statements: 40
 
 linters:
   enable-all: true
   disable:
     - maligned
     - prealloc
-    - dupl
-    - gochecknoglobals
 
 issues:
   exclude-use-default: false
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - dupl
+        - funlen
 
+  exclude:
+    # Allow package logger variables (for now)
+    - \`logger\` is a global variable

--- a/cmd/aries-agentd/main_test.go
+++ b/cmd/aries-agentd/main_test.go
@@ -64,6 +64,8 @@ func TestStartAriesD(t *testing.T) {
 	validateRequests(t)
 }
 
+// TODO: this method should be refactored (e.g., too many lines).
+//nolint:funlen
 func validateRequests(t *testing.T) {
 	newreq := func(method, url string, body io.Reader, contentType string) *http.Request {
 		r, err := http.NewRequest(method, url, body)

--- a/pkg/common/log/provider.go
+++ b/pkg/common/log/provider.go
@@ -13,8 +13,11 @@ import (
 )
 
 // loggerProviderInstance is logger factory singleton - access only via loggerProvider()
-var loggerProviderInstance LoggerProvider
-var loggerProviderOnce sync.Once
+//nolint:gochecknoglobals
+var (
+	loggerProviderInstance LoggerProvider
+	loggerProviderOnce     sync.Once
+)
 
 // Initialize sets new custom logging provider which takes over logging operations.
 // It is required to call this function before making any loggings for using custom loggers.

--- a/pkg/didcomm/crypto/jwe/authcrypt/authcrypt.go
+++ b/pkg/didcomm/crypto/jwe/authcrypt/authcrypt.go
@@ -27,6 +27,8 @@ const C20P = ContentEncryption("C20P") // Chacha20 encryption + Poly1035 authent
 const XC20P = ContentEncryption("XC20P") // XChacha20 encryption + Poly1035 authenticator cipher (192 bits nonce)
 
 // randReader is a cryptographically secure random number generator.
+// TODO: document usage for tests or find another mechanism.
+//nolint:gochecknoglobals
 var randReader = rand.Reader
 
 type keyPair struct {

--- a/pkg/didcomm/crypto/jwe/authcrypt/encrypt.go
+++ b/pkg/didcomm/crypto/jwe/authcrypt/encrypt.go
@@ -9,7 +9,6 @@ package authcrypt
 import (
 	"crypto"
 	"crypto/cipher"
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
@@ -281,7 +280,7 @@ func (c *Crypter) generateRecipientCEK(apu []byte, recipientKey *[chacha.KeySize
 func encryptOID(pubKey *[chacha.KeySize]byte, msg []byte) ([]byte, error) {
 	var nonce [24]byte
 	// generate ephemeral asymmetric keys
-	epk, esk, err := box.GenerateKey(rand.Reader)
+	epk, esk, err := box.GenerateKey(randReader)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/doc/did/doc.go
+++ b/pkg/doc/did/doc.go
@@ -156,7 +156,7 @@ const (
 }`
 )
 
-var schemaLoader = gojsonschema.NewStringLoader(schema)
+var schemaLoader = gojsonschema.NewStringLoader(schema) //nolint:gochecknoglobals
 
 // Doc DID Document definition
 type Doc struct {

--- a/pkg/doc/verifiable/credential.go
+++ b/pkg/doc/verifiable/credential.go
@@ -141,6 +141,7 @@ const defaultSchema = `
 
 const jsonSchema2018Type = "JsonSchemaValidator2018"
 
+//nolint:gochecknoglobals
 var defaultSchemaLoader = gojsonschema.NewStringLoader(defaultSchema)
 
 // Proof defines embedded proof of Verifiable Credential

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -66,7 +66,7 @@ const validCredential = `
 }
 `
 
-var singleCredentialSubject = `
+const singleCredentialSubject = `
 {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -76,7 +76,7 @@ var singleCredentialSubject = `
 }
 `
 
-var multipleCredentialSubjects = `
+const multipleCredentialSubjects = `
 [{
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "name": "Jayden Doe",
@@ -88,7 +88,7 @@ var multipleCredentialSubjects = `
   }]
 `
 
-var issuerAsObject = `
+const issuerAsObject = `
 {
     "id": "did:example:76e12ec712ebc6f1c221ebfeb1f",
     "name": "Example University"

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -21,9 +21,13 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/storage/leveldb"
 )
 
-// DBPath Level DB Path.
-var dbPath = "/tmp/peerstore/"
-var defaultInboundPort = ":8090"
+// TODO handle the test scenario better (make dbPath constant).
+//nolint:gochecknoglobals
+var (
+	// DBPath Level DB Path.
+	dbPath             = "/tmp/peerstore/"
+	defaultInboundPort = ":8090"
+)
 
 // transportProviderFactory provides default Outbound Transport provider factory
 func transportProviderFactory() api.TransportProviderFactory {

--- a/pkg/internal/common/logging/metadata/opts.go
+++ b/pkg/internal/common/logging/metadata/opts.go
@@ -10,9 +10,12 @@ import (
 	"sync"
 )
 
-var rwmutex = &sync.RWMutex{}
-var levels = newModuledLevels()
-var callerInfos = newCallerInfo()
+//nolint:gochecknoglobals
+var (
+	rwmutex     = &sync.RWMutex{}
+	levels      = newModuledLevels()
+	callerInfos = newCallerInfo()
+)
 
 // SetLevel - setting log level for given module
 func SetLevel(module string, level Level) {

--- a/pkg/internal/common/logging/metadata/utils.go
+++ b/pkg/internal/common/logging/metadata/utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 // levelNames - log level names in string
-var levelNames = []string{
+var levelNames = []string{ //nolint:gochecknoglobals
 	"CRITICAL",
 	"ERROR",
 	"WARNING",

--- a/pkg/internal/common/logging/modlog/logtestutils.go
+++ b/pkg/internal/common/logging/modlog/logtestutils.go
@@ -28,6 +28,8 @@ const (
 	customLevelOutputExpectedRegex = "\\[%s\\] .* CUSTOM LOG OUTPUT"
 )
 
+// TODO Review this variable
+//nolint:gochecknoglobals
 var buf bytes.Buffer
 
 // VerifyDefaultLogging verifies default logging behaviour.

--- a/scripts/check_lint.sh
+++ b/scripts/check_lint.sh
@@ -15,4 +15,4 @@ if [ ! $(command -v ${DOCKER_CMD}) ]; then
     exit 0
 fi
 
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace golangci/golangci-lint golangci-lint run
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace golangci/golangci-lint:v1.18 golangci-lint run


### PR DESCRIPTION
- Upgrade to golangci-lint v1.18
- Enable gochecknoglobals, nolen and dupl
- Disallow naked returns
- Resolve warnings

Noted TODOs to review global usage.

Closes: #205
Closes: #216

Signed-off-by: Troy Ronda <troy@troyronda.com>
