### PR TITLE
feat: Controller API for Accept Exchange Request

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -25,6 +25,8 @@ type provider interface {
 }
 
 // Client enable access to didexchange api
+// TODO add support for Accept Exchange Request & Accept Invitation
+//  using events & callback (#198 & #238)
 type Client struct {
 	didexchangeSvc dispatcher.Service
 	wallet         wallet.Crypto
@@ -66,8 +68,8 @@ func (c *Client) CreateInvitation() (*InvitationRequest, error) {
 func (c *Client) QueryConnections(request *QueryConnectionsParams) ([]*QueryConnectionResult, error) {
 	// TODO sample response, to be implemented as part of #226
 	return []*QueryConnectionResult{
-		{ConnectionID: uuid.New().String(), CreateTime: time.Now()},
-		{ConnectionID: uuid.New().String(), CreateTime: time.Now()},
+		{ConnectionID: uuid.New().String(), CreatedTime: time.Now()},
+		{ConnectionID: uuid.New().String(), CreatedTime: time.Now()},
 	}, nil
 }
 
@@ -75,6 +77,6 @@ func (c *Client) QueryConnections(request *QueryConnectionsParams) ([]*QueryConn
 func (c *Client) QueryConnectionByID(id string) (*QueryConnectionResult, error) {
 	// TODO sample response, to be implemented as part of #226
 	return &QueryConnectionResult{
-		ConnectionID: uuid.New().String(), CreateTime: time.Now(),
+		ConnectionID: uuid.New().String(), CreatedTime: time.Now(),
 	}, nil
 }

--- a/pkg/client/didexchange/models.go
+++ b/pkg/client/didexchange/models.go
@@ -45,7 +45,7 @@ type QueryConnectionsParams struct {
 	// Invitation key
 	InvitationKey string `json:"invitation_key,omitempty"`
 
-	// TheirDID is other party's DID
+	// MyDID is DID of the agent
 	MyDID string `json:"my_did,omitempty"`
 
 	// State of the connection invitation
@@ -73,7 +73,7 @@ type QueryConnectionResult struct {
 	TheirDID string `json:"their_did"`
 
 	// Created time
-	CreateTime time.Time `json:"created_at,omitempty"`
+	CreatedTime time.Time `json:"created_at,omitempty"`
 
 	// Connection invitation accept mode
 	Accept string `json:"accept,omitempty"`
@@ -87,7 +87,7 @@ type QueryConnectionResult struct {
 	// Initiator is Connection invitation initiator
 	Initiator string `json:"initiator,omitempty"`
 
-	// Created time
+	// Updated time
 	UpdatedTime time.Time `json:"updated_at,omitempty"`
 
 	// Invitation key

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -157,7 +157,7 @@ func TestOperation_ReceiveInvitationFailure(t *testing.T) {
 func TestOperation_AcceptInvitation(t *testing.T) {
 
 	handler := getHandler(t, acceptInvitationPath)
-	buf, err := getResponseFromHandler(handler, bytes.NewBuffer([]byte("test-id")), operationID+"/accept-invitation/1234")
+	buf, err := getResponseFromHandler(handler, bytes.NewBuffer([]byte("test-id")), operationID+"/1111/accept-invitation")
 	require.NoError(t, err)
 
 	response := models.AcceptInvitationResponse{}
@@ -171,6 +171,22 @@ func TestOperation_AcceptInvitation(t *testing.T) {
 	require.NotEmpty(t, response.UpdateTime)
 	require.NotEmpty(t, response.RequestID)
 	require.NotEmpty(t, response.DID)
+}
+
+func TestOperation_AcceptExchangeRequest(t *testing.T) {
+
+	handler := getHandler(t, acceptExchangeRequest)
+	buf, err := getResponseFromHandler(handler, bytes.NewBuffer([]byte("test-id")), operationID+"/4444/accept-request")
+	require.NoError(t, err)
+
+	response := models.AcceptExchangeResult{}
+	err = json.Unmarshal(buf.Bytes(), &response)
+	require.NoError(t, err)
+
+	// verify response
+	require.NotEmpty(t, response)
+	require.NotEmpty(t, response.Result.ConnectionID)
+	require.NotEmpty(t, response.Result.CreatedTime)
 }
 
 func TestOperation_WriteGenericError(t *testing.T) {

--- a/pkg/restapi/operation/didexchange/models/invitation.go
+++ b/pkg/restapi/operation/didexchange/models/invitation.go
@@ -235,3 +235,87 @@ type QueryConnectionsResponse struct {
 		Results []*didexchange.QueryConnectionResult `json:"results"`
 	}
 }
+
+// AcceptExchangeRequestParams model
+//
+// This is used for accepting connection request
+//
+// swagger:parameters acceptRequest
+type AcceptExchangeRequestParams struct {
+	// The ID of the connection request to accept
+	//
+	// in: path
+	// required: true
+	ID string `json:"id"`
+}
+
+// AcceptExchangeResult model
+//
+// This is used for returning response for accept exchange request
+//
+// swagger:response acceptExchangeResponse
+type AcceptExchangeResult struct {
+
+	// in: body
+	Result *ExchangeResponse `json:""`
+}
+
+// ExchangeResponse model
+//
+// response of accept exchange request
+// TODO: this model is not final, to be updated as part of (issue #238)
+//
+// swagger:model ExchangeResponse
+type ExchangeResponse struct {
+
+	// Routing state of connection invitation
+	RoutingState string `json:"routing_state,omitempty"`
+
+	// the connection ID of the connection invitation
+	InboundConnectionID string `json:"inbound_connection_id,omitempty"`
+
+	// Invitation key
+	InvitationKey string `json:"invitation_key,omitempty"`
+
+	// TheirDID is other party's DID
+	TheirDID string `json:"their_did"`
+
+	// Request ID of the connection request
+	RequestID string `json:"request_id"`
+
+	// Invitation mode
+	Mode string `json:"invitation_mode,omitempty"`
+
+	// TheirRole is other party's role
+	TheirRole string `json:"their_role,omitempty"`
+
+	// TheirRole is other party's role
+	TheirLabel string `json:"their_label,omitempty"`
+
+	// the connection ID of the connection invitation
+	ConnectionID string `json:"connection_id,omitempty"`
+
+	// Initiator is Connection invitation initiator
+	Initiator string `json:"initiator,omitempty"`
+
+	// MyDID is DID of the agent
+	MyDID string `json:"my_did,omitempty"`
+
+	// Updated time
+	UpdatedTime time.Time `json:"updated_at,omitempty"`
+
+	// Created time
+	CreatedTime time.Time `json:"created_at,omitempty"`
+
+	// Error message
+	Error string `json:"error_msg,omitempty"`
+
+	// Alias of connection invitation
+	Alias string `json:"alias,omitempty"`
+
+	// State of the connection invitation
+	State string `json:"state"`
+
+	// Connection invitation accept mode
+	Accept string `json:"accept,omitempty"`
+}


### PR DESCRIPTION
- added `/connections/{id}/accept-request` controller rest-api endpoint
- added accept exchange request in did-exchange client
- closes #170

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
