### PR TITLE
feat:added missing endpoints in controller API

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -78,3 +78,9 @@ func (c *Client) QueryConnectionByID(id string) (*QueryConnectionResult, error) 
 		ConnectionID: uuid.New().String(), CreatedTime: time.Now(),
 	}, nil
 }
+
+// RemoveConnection removes connection record for given id
+func (c *Client) RemoveConnection(id string) error {
+	// TODO sample response, to be implemented as part of #226
+	return nil
+}

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -72,6 +72,14 @@ func TestClient_QueryConnectionByID(t *testing.T) {
 	require.NotNil(t, result.ConnectionID)
 }
 
+func TestClient_RemoveConnection(t *testing.T) {
+	c, err := New(&mockprovider.Provider{ServiceValue: didexchange.New(nil, &mockOutboundTransport{})})
+	require.NoError(t, err)
+
+	err = c.RemoveConnection("sample-id")
+	require.NoError(t, err)
+}
+
 func TestClient_QueryConnectionsByParams(t *testing.T) {
 	c, err := New(&mockprovider.Provider{ServiceValue: didexchange.New(nil, &mockOutboundTransport{})})
 	require.NoError(t, err)

--- a/pkg/restapi/operation/didexchange/models/invitation.go
+++ b/pkg/restapi/operation/didexchange/models/invitation.go
@@ -209,7 +209,7 @@ type QueryConnections struct {
 	//
 	// in: path
 	// required: true
-	didexchange.QueryConnectionsParams
+	*didexchange.QueryConnectionsParams
 }
 
 // QueryConnectionResponse model
@@ -318,4 +318,25 @@ type ExchangeResponse struct {
 
 	// Connection invitation accept mode
 	Accept string `json:"accept,omitempty"`
+}
+
+// RemoveConnectionRequest model
+//
+// This is used for removing connection request
+//
+// swagger:parameters removeConnection
+type RemoveConnectionRequest struct {
+	// The ID of the connection record to remove
+	//
+	// in: path
+	// required: true
+	ID string `json:"id"`
+}
+
+// RemoveConnectionResponse model
+//
+// response of remove connection action
+//
+// swagger:response removeConnectionResponse
+type RemoveConnectionResponse struct {
 }


### PR DESCRIPTION
 - added connection.remove() endpoint in client and rest API
 - all except connection query endpoints are changed to HTTP POST
 - improved test coverage for `pkg/restapi/operation/didexchange`
 - related to #247

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>

