### PR TITLE
remove chacha dependency from crypter interface

### DIFF
--- a/pkg/didcomm/crypto/crypter.go
+++ b/pkg/didcomm/crypto/crypter.go
@@ -6,10 +6,6 @@ SPDX-License-Identifier: Apache-2.0
 
 package crypto
 
-import (
-	chacha "golang.org/x/crypto/chacha20poly1305"
-)
-
 // Crypter is an Aries envelope encrypter to support
 // secure DIDComm exchange of envelopes between Aries agents
 type Crypter interface {
@@ -18,21 +14,23 @@ type Crypter interface {
 	// returns:
 	// 		[]byte containing the encrypted envelope
 	//		error if encryption failed
-	Encrypt(payload []byte, sender KeyPair, recipients []*[chacha.KeySize]byte) ([]byte, error)
+	// TODO add key type of recipients and sender keys to be validated by the implementation
+	Encrypt(payload []byte, sender KeyPair, recipients [][]byte) ([]byte, error)
 	// Decrypt an envelope in an Aries compliant format with the recipient's private key
 	// and the recipient's public key both set in recipientKeyPair
 	// returns:
 	// 		[]byte containing the decrypted payload
 	//		error if decryption failed
+	// TODO add key type of recipients keys to be validated by the implementation
 	Decrypt(envelope []byte, recipientKeyPair KeyPair) ([]byte, error)
 }
 
 // KeyPair represents a private/public key pair each with 32 bytes in size
 type KeyPair struct {
 	// Priv is a private key
-	Priv *[chacha.KeySize]byte
+	Priv []byte
 	// Pub is a public key
-	Pub *[chacha.KeySize]byte
+	Pub []byte
 }
 
 // IsKeyPairValid is a utility function that validates a KeyPair

--- a/pkg/didcomm/crypto/crypter_test.go
+++ b/pkg/didcomm/crypto/crypter_test.go
@@ -7,17 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package crypto
 
 import (
-	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/nacl/box"
 )
 
 func TestIsKeyPairValid(t *testing.T) {
 	require.False(t, IsKeyPairValid(KeyPair{}))
-	pubKey, privKey, err := box.GenerateKey(rand.Reader)
-	require.NoError(t, err)
+	pubKey := []byte("testpublickey")
+	privKey := []byte("testprivatekey")
+
 	require.False(t, IsKeyPairValid(KeyPair{Priv: privKey, Pub: nil}))
 	require.False(t, IsKeyPairValid(KeyPair{Priv: nil, Pub: pubKey}))
 	require.True(t, IsKeyPairValid(KeyPair{Priv: privKey, Pub: pubKey}))

--- a/pkg/didcomm/crypto/jwe/authcrypt/authcrypt.go
+++ b/pkg/didcomm/crypto/jwe/authcrypt/authcrypt.go
@@ -36,6 +36,9 @@ var errEmptyRecipients = errors.New("empty recipients")
 // errInvalidKeypair is used when a keypair is invalid
 var errInvalidKeypair = errors.New("invalid keypair")
 
+// errInvalidKey is used when a key is invalid
+var errInvalidKey = errors.New("invalid key")
+
 // errRecipientNotFound is used when a recipient is not found
 var errRecipientNotFound = errors.New("recipient not found")
 
@@ -98,4 +101,10 @@ func New(alg ContentEncryption) (*Crypter, error) {
 	}
 
 	return c, nil
+}
+
+// IsChachaKeyValid will return true if key size is the same as chacha20poly1035.keySize
+// false otherwise
+func IsChachaKeyValid(key []byte) bool {
+	return len(key) == chacha.KeySize
 }


### PR DESCRIPTION
Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>

the Crypter interface should not reference Golang's crypt/chacha20poly1035 package, it should allow for any crypto implementation to be used instead of being limited 
