### PR TITLE
refactoring: remove sleep & listen available & random port generation

### DIFF
--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -50,7 +50,7 @@ func New(opts ...Option) (*Aries, error) {
 		err := option(frameworkOpts)
 		if err != nil {
 			closeErr := frameworkOpts.Close()
-			return nil, fmt.Errorf("close err: %s Error in option passed to New: %w", closeErr, err)
+			return nil, fmt.Errorf("close err: %v Error in option passed to New: %w", closeErr, err)
 		}
 	}
 

--- a/pkg/internal/common/logging/metadata/opts_test.go
+++ b/pkg/internal/common/logging/metadata/opts_test.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package metadata
 
 import (
+	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,7 +44,7 @@ func TestLevels(t *testing.T) {
 }
 
 func TestCallerInfos(t *testing.T) {
-	module := "sample-module-caller-info"
+	module := fmt.Sprintf("sample-module-caller-info-%d-%d", rand.Intn(1000), rand.Intn(1000))
 
 	require.True(t, IsCallerInfoEnabled(module, CRITICAL))
 	require.True(t, IsCallerInfoEnabled(module, DEBUG))

--- a/scripts/check_unit.sh
+++ b/scripts/check_unit.sh
@@ -14,4 +14,4 @@ PKGS=`go list github.com/hyperledger/aries-framework-go/... 2> /dev/null | \
 
 go generate ./...
 
-go test $PKGS -count=1 -race -coverprofile=coverage.txt -covermode=atomic -timeout=10m
+go test $PKGS -count=10 -race -coverprofile=coverage.txt -covermode=atomic -timeout=10m


### PR DESCRIPTION
* remove time.Sleep() from tests and listen for port to be available.
* random port generation (allows run tests in parallel)

Issue: https://github.com/hyperledger/aries-framework-go/issues/167

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>