### PR TITLE
feature: Add support for multiple proofs to DID Document

### DIFF
--- a/pkg/didmethod/peer/resolver_test.go
+++ b/pkg/didmethod/peer/resolver_test.go
@@ -58,12 +58,12 @@ const peerDIDDoc = `{
     }
   ],
   "created": "2002-10-10T17:00:00Z",
-  "proof": {
+  "proof": [{
     "type": "LinkedDataSignature2015",
     "created": "2016-02-08T16:02:20Z",
     "creator": "did:example:8uQhQMGzWxR8vw5P3UWH1ja#keys-1",
-    "signatureValue": "QNB13Y7Q9...1tzjn4w=="
-  }
+    "proofValue": "6mdES87erjP5r1qCSRW__otj-A_Rj0YgRO7XU_0Amhwdfa7AAmtGUSFGflR_fZqPYrY9ceLRVQCJ49s0q7-LBA"
+  }]
 }`
 
 func TestPeerDIDResolver(t *testing.T) {
@@ -71,16 +71,18 @@ func TestPeerDIDResolver(t *testing.T) {
 	dbstore, err := prov.GetStoreHandle()
 	require.NoError(t, err)
 
+	context := []string{"https://w3id.org/did/v1"}
+
 	// save did document
 	store := NewDIDStore(dbstore)
-	err = store.Put(&did.Doc{ID: peerDID}, nil)
+	err = store.Put(&did.Doc{Context: context, ID: peerDID}, nil)
 	require.NoError(t, err)
 
 	resl := NewDIDResolver(store)
 	doc, err := resl.Read(peerDID)
 	require.NoError(t, err)
 
-	document := &did.Doc{}
+	document := &did.Doc{Context: context}
 	err = json.Unmarshal(doc, document)
 	require.NoError(t, err)
 	require.Equal(t, peerDID, document.ID)

--- a/pkg/didmethod/peer/store.go
+++ b/pkg/didmethod/peer/store.go
@@ -49,10 +49,11 @@ func (s *DIDStore) Put(doc *did.Doc, by *[]DIDModifiedBy) error {
 
 	var deltas []docDelta
 
+	// TODO : Revisit comment bellow; usually delta's are not derived from two documents
 	// TODO - Need to derive the docDelta if its not a genesis document(DID already exists)
 	// (https://github.com/hyperledger/aries-framework-go/issues/54)
 	// For now, assume the doc is a genesis document
-	jsonDoc, err := json.Marshal(doc)
+	jsonDoc, err := doc.JSONBytes()
 	if err != nil {
 		return fmt.Errorf("JSON marshalling of document failed: %w", err)
 	}
@@ -93,10 +94,9 @@ func (s *DIDStore) Get(id string) (*did.Doc, error) {
 		return nil, fmt.Errorf("decoding of document delta failed: %w", err)
 	}
 
-	document := &did.Doc{}
-	err = json.Unmarshal(doc, document)
+	document, err := did.FromBytes(doc)
 	if err != nil {
-		return nil, fmt.Errorf("JSON unmarshalling of document failed: %w", err)
+		return nil, fmt.Errorf("document FromBytes() failed: %w", err)
 	}
 
 	return document, nil

--- a/pkg/didmethod/peer/store_test.go
+++ b/pkg/didmethod/peer/store_test.go
@@ -20,17 +20,19 @@ func TestPeerDIDStore(t *testing.T) {
 	dbstore, err := prov.GetStoreHandle()
 	require.NoError(t, err)
 
+	context := []string{"https://w3id.org/did/v1"}
+
 	did1 := "did:peer:1234"
 	did2 := "did:peer:4567"
 
 	store := NewDIDStore(dbstore)
 
 	// put
-	err = store.Put(&did.Doc{ID: did1}, nil)
+	err = store.Put(&did.Doc{Context: context, ID: did1}, nil)
 	require.NoError(t, err)
 
 	// put
-	err = store.Put(&did.Doc{ID: did2}, nil)
+	err = store.Put(&did.Doc{Context: context, ID: did2}, nil)
 	require.NoError(t, err)
 
 	// get

--- a/pkg/framework/didresolver/didresolver_test.go
+++ b/pkg/framework/didresolver/didresolver_test.go
@@ -51,12 +51,12 @@ const doc = `{
     }
   ],
   "created": "2002-10-10T17:00:00Z",
-  "proof": {
+  "proof": [{
     "type": "LinkedDataSignature2015",
     "created": "2016-02-08T16:02:20Z",
     "creator": "did:example:8uQhQMGzWxR8vw5P3UWH1ja#keys-1",
-    "signatureValue": "QNB13Y7Q9...1tzjn4w=="
-  }
+    "proofValue": "6mdES87erjP5r1qCSRW__otj-A_Rj0YgRO7XU_0Amhwdfa7AAmtGUSFGflR_fZqPYrY9ceLRVQCJ49s0q7-LBA"
+  }]
 }`
 
 func TestNew(t *testing.T) {


### PR DESCRIPTION
Currently DID Document supports only one proof. Add support for multiple proofs to DID Document. Also, change signatureValue to proofValue.

Closes #324

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>


