### PR TITLE
feat: Update Protocol Service API with Event handling functions (Register/Unregister)

### DIFF
--- a/pkg/didcomm/dispatcher/api.go
+++ b/pkg/didcomm/dispatcher/api.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package dispatcher
 
+// TODO https://github.com/hyperledger/aries-framework-go/issues/342 - refactor the pkg, currently contains dispatcher,
+//  messages and events fuctionalities. (need to avoid cyclical dependecy)
 import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/wallet"
@@ -67,3 +69,31 @@ type DIDCommCallback struct {
 
 // Callback type to pass service callbacks.
 type Callback func(DIDCommCallback)
+
+// Event related apis.
+type Event interface {
+	// RegisterActionEvent on protocol messages. The events are triggered for incoming message types based on
+	// the protocol service. The consumer need to invoke the callback to resume processing.
+	// Only one channel can be registered for the action events. The function will throw error if a channel is already
+	// registered.
+	RegisterActionEvent(ch chan<- DIDCommAction) error
+
+	// UnregisterActionEvent on protocol messages. Refer RegisterActionEvent().
+	UnregisterActionEvent(ch chan<- DIDCommAction) error
+
+	// RegisterMsgEvent on protocol messages. The message events are triggered for incoming messages. Service
+	// will not expect any callback on these events unlike Action event.
+	RegisterMsgEvent(ch chan<- DIDCommMsg) error
+
+	// UnregisterMsgEvent on protocol messages. Refer RegisterMsgEvent().
+	UnregisterMsgEvent(ch chan<- DIDCommMsg) error
+}
+
+// DIDCommService defines service APIs.
+type DIDCommService interface {
+	// dispatcher service
+	Service
+
+	// event service
+	Event
+}

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -351,6 +351,22 @@ func (m mockProtocolSvc) Name() string {
 	return "mockProtocolSvc"
 }
 
+func (m mockProtocolSvc) RegisterActionEvent(ch chan<- dispatcher.DIDCommAction) error {
+	return nil
+}
+
+func (m mockProtocolSvc) UnregisterActionEvent(ch chan<- dispatcher.DIDCommAction) error {
+	return nil
+}
+
+func (m mockProtocolSvc) RegisterMsgEvent(ch chan<- dispatcher.DIDCommMsg) error {
+	return nil
+}
+
+func (m mockProtocolSvc) UnregisterMsgEvent(ch chan<- dispatcher.DIDCommMsg) error {
+	return nil
+}
+
 type mockTransportProviderFactory struct {
 	err error
 }

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -173,3 +173,19 @@ func (m mockProtocolSvc) Accept(msgType string) bool {
 func (m mockProtocolSvc) Name() string {
 	return "mockProtocolSvc"
 }
+
+func (m mockProtocolSvc) RegisterActionEvent(ch chan<- dispatcher.DIDCommAction) error {
+	return nil
+}
+
+func (m mockProtocolSvc) UnregisterActionEvent(ch chan<- dispatcher.DIDCommAction) error {
+	return nil
+}
+
+func (m mockProtocolSvc) RegisterMsgEvent(ch chan<- dispatcher.DIDCommMsg) error {
+	return nil
+}
+
+func (m mockProtocolSvc) UnregisterMsgEvent(ch chan<- dispatcher.DIDCommMsg) error {
+	return nil
+}

--- a/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
@@ -28,3 +28,23 @@ func (m *MockDIDExchangeSvc) Accept(msgType string) bool {
 func (m *MockDIDExchangeSvc) Name() string {
 	return "didexchange"
 }
+
+// RegisterActionEvent register action event.
+func (m *MockDIDExchangeSvc) RegisterActionEvent(ch chan<- dispatcher.DIDCommAction) error {
+	return nil
+}
+
+// UnregisterActionEvent unregister action event.
+func (m *MockDIDExchangeSvc) UnregisterActionEvent(ch chan<- dispatcher.DIDCommAction) error {
+	return nil
+}
+
+// RegisterMsgEvent register message event.
+func (m *MockDIDExchangeSvc) RegisterMsgEvent(ch chan<- dispatcher.DIDCommMsg) error {
+	return nil
+}
+
+// UnregisterMsgEvent unregister message event.
+func (m *MockDIDExchangeSvc) UnregisterMsgEvent(ch chan<- dispatcher.DIDCommMsg) error {
+	return nil
+}

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -297,6 +297,22 @@ func (m mockProtocolSvc) Name() string {
 	return "mockProtocolSvc"
 }
 
+func (m mockProtocolSvc) RegisterActionEvent(ch chan<- dispatcher.DIDCommAction) error {
+	return nil
+}
+
+func (m mockProtocolSvc) UnregisterActionEvent(ch chan<- dispatcher.DIDCommAction) error {
+	return nil
+}
+
+func (m mockProtocolSvc) RegisterMsgEvent(ch chan<- dispatcher.DIDCommMsg) error {
+	return nil
+}
+
+func (m mockProtocolSvc) UnregisterMsgEvent(ch chan<- dispatcher.DIDCommMsg) error {
+	return nil
+}
+
 type mockWriter struct {
 	failure error
 }


### PR DESCRIPTION
Added Register/Unregister Action/Msg event APIs to Protocol Services. These were implemented in as part of Issue #276 and PR #327.

Closes #332 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
