### PR TITLE
test: Increase main startup timeout to 2 seconds

### DIFF
--- a/cmd/aries-agentd/main_test.go
+++ b/cmd/aries-agentd/main_test.go
@@ -92,10 +92,10 @@ func TestStartAriesD(t *testing.T) {
 
 	go main()
 	// give some time for server to start
-	if err := listenFor(testURL, time.Second); err != nil {
+	if err := listenFor(testURL, 2*time.Second); err != nil {
 		t.Fatal(err)
 	}
-	if err := listenFor(testInboundURL, time.Second); err != nil {
+	if err := listenFor(testInboundURL, 2*time.Second); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
The unit-test build in ubuntu fails with timeout error, where as it passes in macOS build. Increased the server timeout check to 2seconds from 1seconds.

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
