### PR TITLE
feat: replace oid with spk(JWK) for sender public key

### DIFF
--- a/pkg/didcomm/crypto/jwe/authcrypt/authcrypt.go
+++ b/pkg/didcomm/crypto/jwe/authcrypt/authcrypt.go
@@ -80,7 +80,25 @@ type RecipientHeaders struct {
 	IV  string `json:"iv,omitempty"`
 	Tag string `json:"tag,omitempty"`
 	KID string `json:"kid,omitempty"`
-	OID string `json:"oid,omitempty"`
+	SPK string `json:"spk,omitempty"`
+}
+
+// recipientJWK are the recipient's JWK headers
+type recipientJWKHeaders struct {
+	Typ string `json:"typ,omitempty"`
+	CTY string `json:"cty,omitempty"`
+	Alg string `json:"alg,omitempty"`
+	Enc string `json:"enc,omitempty"`
+	IV  string `json:"iv,omitempty"`
+	Tag string `json:"tag,omitempty"`
+	EPK jwk    `json:"epk,omitempty"`
+}
+
+// jwk is the ephemeral key stored in the JWK header
+type jwk struct {
+	Kty string `json:"kty,omitempty"`
+	Crv string `json:"crv,omitempty"`
+	X   string `json:"x,omitempty"`
 }
 
 // New will create an encrypter instance to 'AuthCrypt' payloads for the given sender and recipients arguments

--- a/pkg/didcomm/crypto/jwe/authcrypt/authcrypt_test.go
+++ b/pkg/didcomm/crypto/jwe/authcrypt/authcrypt_test.go
@@ -292,15 +292,15 @@ func TestEncrypt(t *testing.T) {
 		require.Empty(t, dec)
 		jwe.Tag = validJwe.Tag
 
-		// update jwe with bad recipient oid format
-		jwe.Recipients[0].Header.OID = "badOID!"
+		// update jwe with bad recipient spk (JWE format)
+		jwe.Recipients[0].Header.SPK = "badSPK!"
 		enc, e = json.Marshal(jwe)
 		require.NoError(t, e)
 		// decrypt with bad tag
 		dec, e = crypter.Decrypt(enc, recipient1Key)
-		require.EqualError(t, e, "failed to decrypt message: illegal base64 data at input byte 6")
+		require.EqualError(t, e, "failed to decrypt sender key: bad SPK format")
 		require.Empty(t, dec)
-		jwe.Recipients[0].Header.OID = validJwe.Recipients[0].Header.OID
+		jwe.Recipients[0].Header.SPK = validJwe.Recipients[0].Header.SPK
 
 		// update jwe with bad recipient tag format
 		jwe.Recipients[0].Header.Tag = "badTag!"
@@ -403,7 +403,7 @@ func deepCopy(envelope, envelope2 *Envelope) {
 				APU: r.Header.APU,
 				KID: r.Header.KID,
 				IV:  r.Header.IV,
-				OID: r.Header.OID,
+				SPK: r.Header.SPK,
 				Tag: r.Header.Tag,
 			},
 		}
@@ -434,10 +434,10 @@ func TestBadCreateCipher(t *testing.T) {
 func TestRefEncrypt(t *testing.T) {
 	// reference php crypto material similar to
 	// https://github.com/hyperledger/aries-rfcs/issues/133#issuecomment-518922447
-	var recipientPrivStr = "texhAAu5uu7mCc32DDEM5hYYPaVBbF-J2B-oX0hpRLc"
+	var recipientPrivStr = "c8CSJr_27PN9xWCpzXNmepRndD6neQcnO9DS0YWjhNs"
 	recipientPriv, err := base64.RawURLEncoding.DecodeString(recipientPrivStr)
 	require.NoError(t, err)
-	var recipientPubStr = "JxOLbl4tfU1JnfwULiaHBES8ph2D7Fc1THedj9sMyH4"
+	var recipientPubStr = "AAjrHjiFLw6kf6CZ5zqH1ooG3y2aQhuqxmUvqJnIvDI"
 	recipientPub, err := base64.RawURLEncoding.DecodeString(recipientPubStr)
 	require.NoError(t, err)
 
@@ -448,20 +448,20 @@ func TestRefEncrypt(t *testing.T) {
     "protected": "eyJ0eXAiOiJwcnMuaHlwZXJsZWRnZXIuYXJpZXMtYXV0aC1tZXNzYWdlIiwiYWxnIjoiRUNESC1TUytYQzIwUEtXIiwiZW5jIjoiWEMyMFAifQ",
     "recipients": [
         {
-            "encrypted_key": "zidjLr239dr_UL5eMGheiOqw4z7R2fQpa3Ty5hC-9EQ",
+            "encrypted_key": "46R0uW5KUbaZYt5PpIW5j1v_H8BS2SLrdPEzUaK8V0U",
             "header": {
-                "apu": "aOAAGdeWD-aTyIHq4qaKkS3AsQSBN0HwAr-auPh8GV-UB1fctHWNmDD_E2t-ihwnTjrsifaZTTzeWRPoYZsO-A",
-                "iv": "6MDVdecPSjcTisLDzaxgwHnmXBjUMvcM",
-                "tag": "Jr5IFbE1fYIP5kElavZlyw",
-                "kid": "3dYBmNKZeq8XwM8fXgzcznFqo2FtUezogkJFZwhKrPvV",
-                "oid": "psnFXtlA6Nhi50-Rr3RJ3YUuVy3pDNB8sffCSI5GBzgFPl5MkGqBC02rDdN892fygJKNvcdMj7QSd4AT93EDdblTZfNL1K3ZEZRg0v2jQxqFvAmtH50QF7cebRs"
+                "apu": "tDzm-bgMblZUgzONI7NTHcSqObP9NX21Vkeid8RFf-PzbJrdU3ApC_f0fDfZVxTwyw-5OZQcTti1H1esIfBFvg",
+                "iv": "5HTxplQx5sOfwWtfR5oK416ahbRChh-b",
+                "tag": "qrtr29m4EKh5WV6l47fcCw",
+                "kid": "18tUZoFCoRVEHdxTyNLRxzcKYV7ZyBm98gunvcChKr1",
+                "spk": "eyJ0eXAiOiJqb3NlIiwiY3R5IjoiandrK2pzb24iLCJhbGciOiJFQ0RILUVTK1hDMjBQS1ciLCJlbmMiOiJYQzIwUCIsImVwayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJYMjU1MTkiLCJ4IjoiT0ZkRlN3bTR5Sm5oZmxZNUNZZ1FSVG9ra2ExNHQ0VnNCM216M0N4XzZuayJ9LCJpdiI6Ik5SZkp6Z1N5UE9JU3dOMURSR3lTSERXcXVqdUVXQmgtIiwidGFnIjoibTFsekRSTTl5VEp5cEJOYkVnSE5adyJ9.KIcpv4hUlq0gAb8FpWkSWFnlcshrdNRz51iVoTFyy7E.53YTian9wG5u-S2J2YTjI1TayqW-YMuL.uw6ucr25OIZTfsGQRp8t9fllV0ClBmuhblnTHG6hlh0EEqAWal9jgd6jDbf6Xb_HPzpLSfX7uwYTA11Ui7jZloP8aRjnAKsiEO1-4d-R.GTwXUgcy89zjIAi1Z4WpIA"
             }
         }
     ],
-    "aad": "garDa2wX7AT2gU1eKTj2ajb4A-ikwNAZ3oyDJmlPzzc",
-    "iv": "iHrFLuOAYr_k8_tNlPUNDUEpn2U2k3H6",
-    "tag": "wtqLqrAfzWO4pmvCCJ6iBw",
-    "ciphertext": "YtXeQDYlSr-9NI4O"
+    "aad": "rC0KS-IDOnn39WJvPXJQmP3M5qd_Ax4sYidWXdXSIek",
+    "iv": "JS2FxjEKdndnt-J7QX5pEnVwyBTu0_3d",
+    "tag": "2FqZMMQuNPYfL0JsSkj8LQ",
+    "ciphertext": "qQyzvajdvCDJbwxM"
 }`
 
 	crypter, err := New(XC20P)

--- a/pkg/didcomm/crypto/jwe/authcrypt/common.go
+++ b/pkg/didcomm/crypto/jwe/authcrypt/common.go
@@ -40,7 +40,10 @@ func lengthPrefix(array []byte) []byte {
 // generateKEK will generate an ephemeral symmetric key (kek) for the privKey/pubKey set to
 // be used for encrypting a cek.
 // it will return this new key along with the corresponding APU or an error if it fails.
-func (c *Crypter) generateKEK(apu []byte, privKey, pubKey *[chacha.KeySize]byte) ([]byte, error) {
+func (c *Crypter) generateKEK(alg, apu []byte, privKey, pubKey *[chacha.KeySize]byte) ([]byte, error) {
+	if privKey == nil || pubKey == nil {
+		return nil, errInvalidKey
+	}
 	// generating Z is inspired by sodium_crypto_scalarmult()
 	// https://github.com/gamringer/php-authcrypt/blob/master/src/Crypt.php#L80
 
@@ -60,7 +63,7 @@ func (c *Crypter) generateKEK(apu []byte, privKey, pubKey *[chacha.KeySize]byte)
 	// as per https://tools.ietf.org/html/rfc7518#section-4.6.2
 	// concatKDF requires info data to be length prefixed with BigEndian 32 bits type
 	// length prefix alg
-	algInfo := lengthPrefix([]byte(c.alg))
+	algInfo := lengthPrefix(alg)
 
 	// length prefix apu
 	apuInfo := lengthPrefix(apu)

--- a/pkg/didcomm/crypto/jwe/authcrypt/decrypt_jwk.go
+++ b/pkg/didcomm/crypto/jwe/authcrypt/decrypt_jwk.go
@@ -1,0 +1,149 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package authcrypt
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	chacha "golang.org/x/crypto/chacha20poly1305"
+
+	jwecrypto "github.com/hyperledger/aries-framework-go/pkg/didcomm/crypto"
+)
+
+// decryptSPK will decrypt a recipient's encrypted SPK (in the case of this package, it is represented as
+// the sender's public key as a jwk). It uses the recipent's private/public keypair for decryption
+// the returned decrypted value is the sender's public key
+func (c *Crypter) decryptSPK(recipientKeyPair jwecrypto.KeyPair, spk string) ([]byte, error) {
+	var recPubKey [chacha.KeySize]byte
+	copy(recPubKey[:], recipientKeyPair.Pub)
+
+	recPrivKey := new([chacha.KeySize]byte)
+	copy(recPrivKey[:], recipientKeyPair.Priv)
+
+	jwe := strings.Split(spk, ".")
+	if len(jwe) != 5 {
+		return nil, fmt.Errorf("bad SPK format")
+	}
+
+	headersEncoded := jwe[0]
+	headers, err := base64.RawURLEncoding.DecodeString(headersEncoded)
+	if err != nil {
+		return nil, err
+	}
+
+	headersJSON := &recipientJWKHeaders{
+		EPK: jwk{},
+	}
+	err = json.Unmarshal(headers, headersJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	cipherKEK, err := base64.RawURLEncoding.DecodeString(jwe[1])
+	if err != nil {
+		return nil, err
+	}
+
+	nonce, err := base64.RawURLEncoding.DecodeString(jwe[2])
+	if err != nil {
+		return nil, err
+	}
+
+	cipherJWK, err := base64.RawURLEncoding.DecodeString(jwe[3])
+	if err != nil {
+		return nil, err
+	}
+
+	tag, err := base64.RawURLEncoding.DecodeString(jwe[4])
+	if err != nil {
+		return nil, err
+	}
+
+	sharedKey, err := c.decryptJWKSharedKey(cipherKEK, headersJSON, recPrivKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// now that we have sharedKey, let's decrypt the sender JWK (cipherJWK)
+	return c.decryptSenderJWK(nonce, sharedKey, []byte(headersEncoded), cipherJWK, tag)
+}
+
+// decryptJWKSharedKey will decrypt the cek using recPrivKey for decryption and rebuild the cipher text, nonce
+// kek from headersJSON, the result is the sharedKey to be used for decrypting the sender JWK
+func (c *Crypter) decryptJWKSharedKey(cipherKEK []byte, headersJSON *recipientJWKHeaders, recPrivKey *[chacha.KeySize]byte) ([]byte, error) { //nolint:lll
+	epk, err := base64.RawURLEncoding.DecodeString(headersJSON.EPK.X)
+	if err != nil {
+		return nil, err
+	}
+
+	epKey := new([chacha.KeySize]byte)
+	copy(epKey[:], epk)
+	kek, err := c.generateKEK([]byte(c.alg+"KW"), nil, recPrivKey, epKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// create a cipher for the given nonceSize and generated kek above
+	// to decrypt the symmetric shared key (by decrypting cipherKEK)
+	crypter, err := createCipher(c.nonceSize, kek)
+	if err != nil {
+		return nil, err
+	}
+
+	// fetch symmetric shared key crypto info (kek's tag and nonce)
+	kekTag, err := base64.RawURLEncoding.DecodeString(headersJSON.Tag)
+	if err != nil {
+		return nil, err
+	}
+
+	kekNonce, err := base64.RawURLEncoding.DecodeString(headersJSON.IV)
+	if err != nil {
+		return nil, err
+	}
+
+	// assemble kek for decryption
+	cipherKEK = append(cipherKEK, kekTag...)
+
+	symKey, err := crypter.Open(nil, kekNonce, cipherKEK, nil)
+	if err != nil {
+		return nil, err
+	}
+	return symKey, nil
+}
+
+// decryptSenderJWK will decrypt and extract the sender key from cipherJwk, tag and nonce using symKey for decryption
+// and headersEncoded as AAD for the aead (chacha20poly1035) cipher
+func (c *Crypter) decryptSenderJWK(nonce, symKey, headersEncoded, cipherJWK, tag []byte) ([]byte, error) {
+	// now that we have symKey, let's decrypt the sender JWK (cipherJWK)
+	jwkCrypter, err := createCipher(c.nonceSize, symKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// assemble cipher JWK for decryption
+	cipherTxt := append(cipherJWK, tag...)
+
+	senderJWKJSONEncoded, err := jwkCrypter.Open(nil, nonce, cipherTxt, headersEncoded)
+	if err != nil {
+		return nil, err
+	}
+
+	senderJWK := &jwk{}
+	err = json.Unmarshal(senderJWKJSONEncoded, senderJWK)
+	if err != nil {
+		return nil, err
+	}
+
+	senderKey, err := base64.RawURLEncoding.DecodeString(senderJWK.X)
+	if err != nil {
+		return nil, err
+	}
+	return senderKey, nil
+}

--- a/pkg/didcomm/crypto/jwe/authcrypt/decrypt_jwk_test.go
+++ b/pkg/didcomm/crypto/jwe/authcrypt/decrypt_jwk_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package authcrypt
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	chacha "golang.org/x/crypto/chacha20poly1305"
+
+	jwecrypto "github.com/hyperledger/aries-framework-go/pkg/didcomm/crypto"
+)
+
+//nolint:lll
+func TestNilDecryptSenderJwk(t *testing.T) {
+	crypter, err := New(XC20P)
+	require.NoError(t, err)
+
+	spk, err := crypter.decryptSPK(jwecrypto.KeyPair{}, "!-.t.t.t.t")
+	require.Error(t, err)
+	require.Empty(t, spk)
+
+	spk, err = crypter.decryptSPK(jwecrypto.KeyPair{}, "eyJ0eXAiOiJqb3NlIiwiY3R5IjoiandrK2pzb24iLCJhbGciOiJFQ0RILUVTK1hDMjBQS1ciLCJlbmMiOiJYQzIwUCIsIml2IjoiNWhwNEVrWGtqSHR0SFlmY1IySXQ4d2dnZndjanNQaWwiLCJ0YWciOiJuMjg1OGplTXhZVE0tYzRZc2J0ZlBRIiwiZXBrIjp7Imt0eSI6Ik9LUCIsImNydiI6IlgyNTUxOSIsIngiOiJ3OW1EZ1FENnJVdWkyLVMyRjV6SVNqZXBua1FOZWEwMGtvTnRBOUhEeUIwIn19.!-.t.t.t")
+	require.Error(t, err)
+	require.Empty(t, spk)
+
+	spk, err = crypter.decryptSPK(jwecrypto.KeyPair{}, "eyJ0eXAiOiJqb3NlIiwiY3R5IjoiandrK2pzb24iLCJhbGciOiJFQ0RILUVTK1hDMjBQS1ciLCJlbmMiOiJYQzIwUCIsIml2IjoiNWhwNEVrWGtqSHR0SFlmY1IySXQ4d2dnZndjanNQaWwiLCJ0YWciOiJuMjg1OGplTXhZVE0tYzRZc2J0ZlBRIiwiZXBrIjp7Imt0eSI6Ik9LUCIsImNydiI6IlgyNTUxOSIsIngiOiJ3OW1EZ1FENnJVdWkyLVMyRjV6SVNqZXBua1FOZWEwMGtvTnRBOUhEeUIwIn19.U-AXyneFJ5x4QayrZ3GcuDCg1yHYHC9Kn1s8gtd7O4c.!-.t.t")
+	require.Error(t, err)
+	require.Empty(t, spk)
+
+	spk, err = crypter.decryptSPK(jwecrypto.KeyPair{}, "eyJ0eXAiOiJqb3NlIiwiY3R5IjoiandrK2pzb24iLCJhbGciOiJFQ0RILUVTK1hDMjBQS1ciLCJlbmMiOiJYQzIwUCIsIml2IjoiNWhwNEVrWGtqSHR0SFlmY1IySXQ4d2dnZndjanNQaWwiLCJ0YWciOiJuMjg1OGplTXhZVE0tYzRZc2J0ZlBRIiwiZXBrIjp7Imt0eSI6Ik9LUCIsImNydiI6IlgyNTUxOSIsIngiOiJ3OW1EZ1FENnJVdWkyLVMyRjV6SVNqZXBua1FOZWEwMGtvTnRBOUhEeUIwIn19.U-AXyneFJ5x4QayrZ3GcuDCg1yHYHC9Kn1s8gtd7O4c.aigDJrko05dw-9Hk4LQbfOCCG9Dzskw6.!-.t")
+	require.Error(t, err)
+	require.Empty(t, spk)
+
+	spk, err = crypter.decryptSPK(jwecrypto.KeyPair{}, "eyJ0eXAiOiJqb3NlIiwiY3R5IjoiandrK2pzb24iLCJhbGciOiJFQ0RILUVTK1hDMjBQS1ciLCJlbmMiOiJYQzIwUCIsIml2IjoiNWhwNEVrWGtqSHR0SFlmY1IySXQ4d2dnZndjanNQaWwiLCJ0YWciOiJuMjg1OGplTXhZVE0tYzRZc2J0ZlBRIiwiZXBrIjp7Imt0eSI6Ik9LUCIsImNydiI6IlgyNTUxOSIsIngiOiJ3OW1EZ1FENnJVdWkyLVMyRjV6SVNqZXBua1FOZWEwMGtvTnRBOUhEeUIwIn19.U-AXyneFJ5x4QayrZ3GcuDCg1yHYHC9Kn1s8gtd7O4c.aigDJrko05dw-9Hk4LQbfOCCG9Dzskw6.tY10QY9fXvqV_vfhzBKkqw.!-")
+	require.Error(t, err)
+	require.Empty(t, spk)
+	headersJSON := &recipientJWKHeaders{EPK: jwk{
+		X: "test",
+	}}
+	spk, err = crypter.decryptJWKSharedKey([]byte(""), headersJSON, nil)
+	require.Error(t, err)
+	require.Empty(t, spk)
+
+	headersJSON.EPK.X = "!-"
+	spk, err = crypter.decryptJWKSharedKey([]byte(""), headersJSON, nil)
+	require.Error(t, err)
+	require.Empty(t, spk)
+
+	headersJSON.EPK.X = "test"
+	headersJSON.Tag = "!-"
+	someKey := new([chacha.KeySize]byte)
+	spk, err = crypter.decryptJWKSharedKey([]byte(""), headersJSON, someKey)
+	require.Error(t, err)
+	require.Empty(t, spk)
+
+	headersJSON.Tag = "test"
+	headersJSON.IV = "!-"
+	spk, err = crypter.decryptJWKSharedKey([]byte(""), headersJSON, someKey)
+	require.Error(t, err)
+	require.Empty(t, spk)
+
+	headersJSON.IV = "aigDJrko05dw-9Hk4LQbfOCCG9Dzskw6"
+
+	// set broken reader
+	randReader = &badReader{}
+	defer resetRandReader()
+
+	nonce, err := base64.RawURLEncoding.DecodeString(headersJSON.IV)
+	require.NoError(t, err)
+
+	spk, err = crypter.decryptSenderJWK(nonce, nil, nil, nil, nil)
+	require.Error(t, err)
+	require.Empty(t, spk)
+
+	spk, err = crypter.decryptSenderJWK(nonce, someKey[:], nil, nil, nil)
+	require.Error(t, err)
+	require.Empty(t, spk)
+}

--- a/pkg/didcomm/crypto/jwe/authcrypt/encrypt_jwk.go
+++ b/pkg/didcomm/crypto/jwe/authcrypt/encrypt_jwk.go
@@ -1,0 +1,119 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package authcrypt
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	chacha "golang.org/x/crypto/chacha20poly1305"
+	"golang.org/x/crypto/nacl/box"
+)
+
+// generateSPK will encrypt a msg (in the case of this package, it will be
+// the sender's public key) using the recipient's pubKey, the output will be
+// a full JWE wrapping a JWK containing the (encrypted) sender's public key
+func (c *Crypter) generateSPK(recipientPubKey, senderPubKey *[chacha.KeySize]byte) (string, error) {
+	if recipientPubKey == nil {
+		return "", errInvalidKey
+	}
+
+	// generate ephemeral asymmetric keys
+	epk, esk, err := box.GenerateKey(randReader)
+	if err != nil {
+		return "", err
+	}
+
+	// create a new ephemeral key for the recipient
+	kek, err := c.generateKEK([]byte(c.alg+"KW"), nil, esk, recipientPubKey)
+	if err != nil {
+		return "", err
+	}
+
+	// generate a sharedSymKey for encryption
+	sharedSymKey := &[chacha.KeySize]byte{}
+	_, err = randReader.Read(sharedSymKey[:])
+	if err != nil {
+		return "", err
+	}
+
+	kCipherEncoded, kTagEncoded, kNonceEncoded, err := c.encryptSymKey(kek, sharedSymKey[:])
+	if err != nil {
+		return "", err
+	}
+
+	headersEncoded, err := c.buildJWKHeaders(epk, kNonceEncoded, kTagEncoded)
+	if err != nil {
+		return "", err
+	}
+
+	// build sender key as jwk header
+	senderJWK := jwk{
+		Kty: "OKP", // OPK not 0PK
+		Crv: "X25519",
+		X:   base64.RawURLEncoding.EncodeToString(senderPubKey[:]),
+	}
+	// senderJWKJSON is the payload to be encrypted with sharedSymKey
+	senderJWKJSON, err := json.Marshal(senderJWK)
+	if err != nil {
+		return "", err
+	}
+
+	return c.encryptSenderJWK(kCipherEncoded, headersEncoded, senderJWKJSON, sharedSymKey[:])
+}
+
+func (c *Crypter) buildJWKHeaders(epk *[32]byte, kNonceEncoded, kTagEncoded string) (string, error) {
+	headers := recipientJWKHeaders{
+		Typ: "jose",
+		CTY: "jwk+json",
+		Alg: "ECDH-ES+" + string(c.alg) + "KW",
+		Enc: string(c.alg),
+		EPK: jwk{
+			Kty: "OKP", // OPK not 0PK
+			Crv: "X25519",
+			X:   base64.RawURLEncoding.EncodeToString(epk[:]),
+		},
+		IV:  kNonceEncoded,
+		Tag: kTagEncoded,
+	}
+
+	headersJSON, err := json.Marshal(headers)
+	if err != nil {
+		return "", err
+	}
+
+	return base64.RawURLEncoding.EncodeToString(headersJSON), nil
+}
+
+func (c *Crypter) encryptSenderJWK(encKey, headers string, senderJWKJSON, sharedSymKey []byte) (string, error) {
+	// create a new nonce
+	nonce := make([]byte, c.nonceSize)
+	_, err := randReader.Read(nonce)
+	if err != nil {
+		return "", err
+	}
+
+	// create a cipher for the given nonceSize and generated sharedSymKey above
+	crypter, err := createCipher(c.nonceSize, sharedSymKey)
+	if err != nil {
+		return "", err
+	}
+
+	// encrypt the sender's encoded JWK using generated nonce and JWK encoded headers as AAD
+	// the output is a []byte containing the cipherText + tag
+	symOutput := crypter.Seal(nil, nonce, senderJWKJSON, []byte(headers))
+
+	tagEncoded := extractTag(symOutput)
+	cipherJWKEncoded := extractCipherText(symOutput)
+
+	return headers + "." +
+			encKey + "." +
+			base64.RawURLEncoding.EncodeToString(nonce) + "." +
+			cipherJWKEncoded + "." +
+			tagEncoded,
+		nil
+}

--- a/pkg/didcomm/crypto/jwe/authcrypt/encrypt_jwk_test.go
+++ b/pkg/didcomm/crypto/jwe/authcrypt/encrypt_jwk_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package authcrypt
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	chacha "golang.org/x/crypto/chacha20poly1305"
+)
+
+func TestNilEncryptSenderJwk(t *testing.T) {
+	crypter, err := New(XC20P)
+	require.NoError(t, err)
+
+	spk, err := crypter.generateSPK(nil, nil)
+	require.Error(t, err)
+	require.Empty(t, spk)
+
+	s, l, m, err := crypter.encryptSymKey(nil, nil)
+	require.Error(t, err)
+	require.Empty(t, s)
+	require.Empty(t, l)
+	require.Empty(t, m)
+
+	s, err = crypter.encryptSenderJWK("", "", nil, nil)
+	require.Error(t, err)
+	require.Empty(t, s)
+
+	// set broken reader
+	randReader = &badReader{}
+	defer resetRandReader()
+	s, err = crypter.encryptSenderJWK("", "", nil, nil)
+	require.Error(t, err)
+	require.Empty(t, s)
+
+	someKey := new([chacha.KeySize]byte)
+	spk, err = crypter.generateSPK(someKey, nil)
+	require.Error(t, err)
+	require.Empty(t, spk)
+
+	spk, err = crypter.generateSPK(someKey, someKey)
+	require.Error(t, err)
+	require.Empty(t, spk)
+}
+
+// Reset random reader to original value
+func resetRandReader() {
+	randReader = rand.Reader
+}
+
+type badReader struct{}
+
+func (r *badReader) Read(arr []byte) (int, error) {
+	return 0, fmt.Errorf("bad reader")
+}


### PR DESCRIPTION
Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>

closes #302 

with this change, the Envelope encryption RFC can be updated to reflect the new (JWE compliment) format.

[aries issue  # 133](https://github.com/hyperledger/aries-rfcs/issues/133) will be updated to reflect the updated JWE format.