### PR TITLE
Removed some duplicated code

### DIFF
--- a/cmd/aries-agentd/startcmd/start_test.go
+++ b/cmd/aries-agentd/startcmd/start_test.go
@@ -106,13 +106,7 @@ func TestStartAriesDRequests(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	// give some time for server to start
-	if err := listenFor(testHostURL, time.Second); err != nil {
-		t.Fatal(err)
-	}
-	if err := listenFor(testInboundHostURL, time.Second); err != nil {
-		t.Fatal(err)
-	}
+	waitForServerToStart(t, testHostURL, testInboundHostURL)
 
 	validateRequests(t, testHostURL, testInboundHostURL)
 }


### PR DESCRIPTION
Small fix related to https://github.com/hyperledger/aries-framework-go/pull/290

While merging master into my own branch it looks like I missed some duplicated code which I had already refactored into a function to be used in a few different places. This duplicated code also had the wrong timeout (1 second instead of 2).

Signed-off-by: Derek Trider <derek.trider@securekey.com>