### PR TITLE
feat: Implement Create Verify Hash Algorithm

### DIFF
--- a/pkg/doc/signature/ed25519signature2018/suite.go
+++ b/pkg/doc/signature/ed25519signature2018/suite.go
@@ -12,6 +12,7 @@ SPDX-License-Identifier: Apache-2.0
 package ed25519signature2018
 
 import (
+	"crypto/sha512"
 	"errors"
 
 	"crypto/ed25519"
@@ -52,9 +53,8 @@ func (s *SignatureSuite) GetCanonicalDocument(doc map[string]interface{}) ([]byt
 
 // GetDigest returns document digest
 func (s *SignatureSuite) GetDigest(doc []byte) []byte {
-	// Nothing to do for Ed25519Signature2018 since ed25519.Verify does sha512 internally
-	// and it throws an error if it has already been done
-	return doc
+	digest := sha512.Sum512(doc)
+	return digest[:]
 }
 
 // Verify will verify ed25519 signature against public key

--- a/pkg/doc/signature/proof/data.go
+++ b/pkg/doc/signature/proof/data.go
@@ -1,0 +1,100 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package proof
+
+import "errors"
+
+const jsonldContext = "@context"
+
+// signatureSuite encapsulates signature suite methods required for normalizing document
+type signatureSuite interface {
+
+	// GetCanonicalDocument will return normalized/canonical version of the document
+	GetCanonicalDocument(doc map[string]interface{}) ([]byte, error)
+
+	// GetDigest returns document digest
+	GetDigest(doc []byte) []byte
+}
+
+// CreateVerifyHashAlgorithm returns data that is used to generate or verify a digital signature
+// Algorithm steps are described here https://w3c-dvcg.github.io/ld-signatures/#create-verify-hash-algorithm
+func CreateVerifyHashAlgorithm(suite signatureSuite, jsonldDoc, proofOptions map[string]interface{}) ([]byte, error) {
+	// in  order to generate canonical form we need context
+	// if context is not passed, use document's context
+	_, ok := proofOptions[jsonldContext]
+	if !ok {
+		proofOptions[jsonldContext] = jsonldDoc[jsonldContext]
+	}
+
+	canonicalProofOptions, err := prepareCanonicalProofOptions(suite, proofOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	proofOptionsDigest := suite.GetDigest(canonicalProofOptions)
+
+	canonicalDoc, err := prepareCanonicalDocument(suite, jsonldDoc)
+	if err != nil {
+		return nil, err
+	}
+
+	docDigest := suite.GetDigest(canonicalDoc)
+
+	return append(proofOptionsDigest, docDigest...), nil
+}
+
+func prepareCanonicalProofOptions(suite signatureSuite, proofOptions map[string]interface{}) ([]byte, error) {
+	_, ok := proofOptions[jsonldCreator]
+	if !ok {
+		return nil, errors.New("creator is missing")
+	}
+
+	_, ok = proofOptions[jsonldCreated]
+	if !ok {
+		return nil, errors.New("created is missing")
+	}
+
+	// copy from the original proof options map without specific keys
+	proofOptionsCopy := make(map[string]interface{})
+	for key, value := range proofOptions {
+		if excludedKeyFromString(key) == 0 {
+			proofOptionsCopy[key] = value
+		}
+	}
+
+	// build canonical proof options
+	return suite.GetCanonicalDocument(proofOptionsCopy)
+}
+
+func prepareCanonicalDocument(suite signatureSuite, jsonldObject map[string]interface{}) ([]byte, error) {
+	// copy document object without proof
+	docCopy := GetCopyWithoutProof(jsonldObject)
+
+	// build canonical document
+	return suite.GetCanonicalDocument(docCopy)
+}
+
+// excludedKey defines keys that are excluded for proof options
+type excludedKey uint
+
+const (
+	proofType excludedKey = iota + 1
+	proofID
+	proofValue
+)
+
+func (ek excludedKey) String() string {
+	return [...]string{"type", "id", "proofValue"}[ek-1]
+}
+
+func excludedKeyFromString(s string) excludedKey {
+	for _, ek := range [...]excludedKey{proofType, proofID, proofValue} {
+		if ek.String() == s {
+			return ek
+		}
+	}
+	return 0
+}

--- a/pkg/doc/signature/proof/data_test.go
+++ b/pkg/doc/signature/proof/data_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package proof
+
+import (
+	"crypto/sha512"
+	"encoding/json"
+	"testing"
+
+	"github.com/piprate/json-gold/ld"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateVerifyHashAlgorithm(t *testing.T) {
+	proofOptions := map[string]interface{}{
+		"type":    "type",
+		"creator": "key1",
+		"created": "2018-03-15T00:00:00Z",
+	}
+
+	var doc map[string]interface{}
+	err := json.Unmarshal([]byte(validDoc), &doc)
+	require.NoError(t, err)
+
+	normalizedDoc, err := CreateVerifyHashAlgorithm(&mockSignatureSuite{}, doc, proofOptions)
+	require.NoError(t, err)
+	require.NotEmpty(t, normalizedDoc)
+
+	// test error due to missing proof option
+	delete(proofOptions, jsonldCreator)
+	normalizedDoc, err = CreateVerifyHashAlgorithm(&mockSignatureSuite{}, doc, proofOptions)
+	require.NotNil(t, err)
+	require.Nil(t, normalizedDoc)
+	require.Contains(t, err.Error(), "creator is missing")
+}
+
+func TestPrepareCanonicalDocument(t *testing.T) {
+	var doc map[string]interface{}
+	err := json.Unmarshal([]byte(test1), &doc)
+	require.NoError(t, err)
+
+	normalizedDoc, err := prepareCanonicalDocument(&mockSignatureSuite{}, doc)
+	require.NoError(t, err)
+	require.NotEmpty(t, normalizedDoc)
+	require.Equal(t, test1Result, string(normalizedDoc))
+}
+
+func TestPrepareCanonicalProofOptions(t *testing.T) {
+	proofOptions := map[string]interface{}{
+		"@context": []interface{}{"https://w3id.org/did/v1"},
+		"type":     "type",
+		"creator":  "key1",
+		"created":  "2018-03-15T00:00:00Z",
+		"domain":   "abc.com",
+		"nonce":    "nonce",
+	}
+
+	canonicalProofOptions, err := prepareCanonicalProofOptions(&mockSignatureSuite{}, proofOptions)
+	require.NoError(t, err)
+	require.NotEmpty(t, canonicalProofOptions)
+
+	// test missing created
+	delete(proofOptions, jsonldCreated)
+	canonicalProofOptions, err = prepareCanonicalProofOptions(&mockSignatureSuite{}, proofOptions)
+	require.NotNil(t, err)
+	require.Nil(t, canonicalProofOptions)
+	require.Contains(t, err.Error(), "created is missing")
+
+	// test missing creator
+	proofOptions[jsonldCreated] = "2018-03-15T00:00:00Z"
+	delete(proofOptions, jsonldCreator)
+	canonicalProofOptions, err = prepareCanonicalProofOptions(&mockSignatureSuite{}, proofOptions)
+	require.NotNil(t, err)
+	require.Nil(t, canonicalProofOptions)
+	require.Contains(t, err.Error(), "creator is missing")
+}
+
+type mockSignatureSuite struct {
+}
+
+// GetCanonicalDocument will return normalized/canonical version of the document
+func (s *mockSignatureSuite) GetCanonicalDocument(doc map[string]interface{}) ([]byte, error) {
+	proc := ld.NewJsonLdProcessor()
+	options := ld.NewJsonLdOptions("")
+	options.ProcessingMode = ld.JsonLd_1_1
+	options.Format = "application/n-quads"
+	options.ProduceGeneralizedRdf = true
+
+	canonicalDoc, err := proc.Normalize(doc, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(canonicalDoc.(string)), nil
+}
+
+// GetDigest returns document digest
+func (s *mockSignatureSuite) GetDigest(doc []byte) []byte {
+	digest := sha512.Sum512(doc)
+	return digest[:]
+}
+
+//nolint:lll
+const validDoc = `{
+  "@context": ["https://w3id.org/did/v1"],
+  "id": "did:example:21tDAKCERh95uGgKbJNHYp",
+  "publicKey": [
+    {
+      "id": "did:example:123456789abcdefghi#keys-1",
+      "type": "Secp256k1VerificationKey2018",
+      "controller": "did:example:123456789abcdefghi",
+      "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+    },
+    {
+      "id": "did:example:123456789abcdefghw#key2",
+      "type": "RsaVerificationKey2018",
+      "controller": "did:example:123456789abcdefghw",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAryQICCl6NZ5gDKrnSztO\n3Hy8PEUcuyvg/ikC+VcIo2SFFSf18a3IMYldIugqqqZCs4/4uVW3sbdLs/6PfgdX\n7O9D22ZiFWHPYA2k2N744MNiCD1UE+tJyllUhSblK48bn+v1oZHCM0nYQ2NqUkvS\nj+hwUU3RiWl7x3D2s9wSdNt7XUtW05a/FXehsPSiJfKvHJJnGOX0BgTvkLnkAOTd\nOrUZ/wK69Dzu4IvrN4vs9Nes8vbwPa/ddZEzGR0cQMt0JBkhk9kU/qwqUseP1QRJ\n5I1jR4g8aYPL/ke9K35PxZWuDp3U0UPAZ3PjFAh+5T+fc7gzCs9dPzSHloruU+gl\nFQIDAQAB\n-----END PUBLIC KEY-----"
+    }
+  ],
+  "created": "2002-10-10T17:00:00Z"
+}`
+
+// from https://json-ld.org/test-suite/reports/#test_a5ebfe589bd62d1029790695808f8ff9
+const test1 = `{
+  "@id": "http://greggkellogg.net/foaf#me",
+  "http://xmlns.com/foaf/0.1/name": "Gregg Kellogg"
+}`
+
+const test1Result = `<http://greggkellogg.net/foaf#me> <http://xmlns.com/foaf/0.1/name> "Gregg Kellogg" .
+`

--- a/pkg/doc/signature/proof/proof.go
+++ b/pkg/doc/signature/proof/proof.go
@@ -1,0 +1,86 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package proof
+
+import (
+	"encoding/base64"
+	"time"
+)
+
+const (
+	// jsonldType is key for proof type
+	jsonldType = "type"
+	// jsonldCreator is key for creator
+	jsonldCreator = "creator"
+	// jsonldCreated is key for time proof created
+	jsonldCreated = "created"
+	// jsonldDomain is key for domain name
+	jsonldDomain = "domain"
+	// jsonldNonce is key for nonce
+	jsonldNonce = "nonce"
+	// jsonldProofValue is key for proof value
+	jsonldProofValue = "proofValue"
+)
+
+// Proof is cryptographic proof of the integrity of the DID Document
+type Proof struct {
+	Type       string
+	Created    *time.Time
+	Creator    string
+	ProofValue []byte
+	Domain     string
+	Nonce      []byte
+}
+
+// NewProof creates new proof
+func NewProof(emap map[string]interface{}) (*Proof, error) {
+	created := stringEntry(emap[jsonldCreated])
+
+	timeValue, err := time.Parse(time.RFC3339, created)
+	if err != nil {
+		return nil, err
+	}
+
+	proofValue, err := base64.RawURLEncoding.DecodeString(stringEntry(emap[jsonldProofValue]))
+	if err != nil {
+		return nil, err
+	}
+
+	nonce, err := base64.RawURLEncoding.DecodeString(stringEntry(emap[jsonldNonce]))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Proof{
+		Type:       stringEntry(emap[jsonldType]),
+		Created:    &timeValue,
+		Creator:    stringEntry(emap[jsonldCreator]),
+		ProofValue: proofValue,
+		Domain:     stringEntry(emap[jsonldDomain]),
+		Nonce:      nonce,
+	}, nil
+}
+
+// stringEntry
+func stringEntry(entry interface{}) string {
+	if entry == nil {
+		return ""
+	}
+	return entry.(string)
+}
+
+// JSONLdObject returns map that represents JSON LD Object
+func (p *Proof) JSONLdObject() map[string]interface{} {
+	emap := make(map[string]interface{})
+	emap[jsonldType] = p.Type
+	emap[jsonldCreator] = p.Creator
+	emap[jsonldCreated] = p.Created.Format(time.RFC3339)
+	emap[jsonldProofValue] = base64.RawURLEncoding.EncodeToString(p.ProofValue)
+	emap[jsonldDomain] = p.Domain
+	emap[jsonldNonce] = base64.RawURLEncoding.EncodeToString(p.Nonce)
+
+	return emap
+}

--- a/pkg/doc/signature/proof/proof_test.go
+++ b/pkg/doc/signature/proof/proof_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package proof
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const proofValueBase64 = "6mdES87erjP5r1qCSRW__otj-A_Rj0YgRO7XU_0Amhwdfa7AAmtGUSFGflR_fZqPYrY9ceLRVQCJ49s0q7-LBA"
+
+func TestProof(t *testing.T) {
+	p, err := NewProof(map[string]interface{}{
+		"type":       "type",
+		"creator":    "didID",
+		"created":    "2018-03-15T00:00:00Z",
+		"domain":     "abc.com",
+		"nonce":      "",
+		"proofValue": proofValueBase64,
+	})
+	require.NoError(t, err)
+
+	// test proof
+	created, err := time.Parse(time.RFC3339, "2018-03-15T00:00:00Z")
+	require.NoError(t, err)
+
+	proofValueBytes, err := base64.RawURLEncoding.DecodeString(proofValueBase64)
+	require.NoError(t, err)
+
+	require.Equal(t, "type", p.Type)
+	require.Equal(t, "didID", p.Creator)
+	require.Equal(t, &created, p.Created)
+	require.Equal(t, "abc.com", p.Domain)
+	require.Equal(t, []byte(""), p.Nonce)
+	require.Equal(t, proofValueBytes, p.ProofValue)
+}
+
+func TestInvalidProofValue(t *testing.T) {
+	p, err := NewProof(map[string]interface{}{
+		"type":       "Ed25519Signature2018",
+		"creator":    "creator",
+		"created":    "2011-09-23T20:21:34Z",
+		"proofValue": "hello",
+	})
+	require.Error(t, err)
+
+	require.Nil(t, p)
+	require.Contains(t, err.Error(), "illegal base64 data")
+}
+
+func TestInvalidNonce(t *testing.T) {
+	p, err := NewProof(map[string]interface{}{
+		"type":       "Ed25519Signature2018",
+		"creator":    "creator",
+		"created":    "2011-09-23T20:21:34Z",
+		"nonce":      "hello",
+		"proofValue": proofValueBase64,
+	})
+	require.Error(t, err)
+
+	require.Nil(t, p)
+	require.Contains(t, err.Error(), "illegal base64 data")
+}

--- a/pkg/doc/signature/proof/utils.go
+++ b/pkg/doc/signature/proof/utils.go
@@ -1,0 +1,81 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package proof
+
+import (
+	"errors"
+)
+
+const (
+	jsonldProof = "proof"
+)
+
+// GetProofs gets proof(s) from LD Object
+func GetProofs(jsonLdObject map[string]interface{}) ([]*Proof, error) {
+	entry, ok := jsonLdObject[jsonldProof]
+	if !ok {
+		return nil, ErrProofNotFound
+	}
+
+	typedEntry, ok := entry.([]interface{})
+	if !ok {
+		return nil, errors.New("expecting []interface{}, got something else")
+	}
+
+	var result []*Proof
+	for _, e := range typedEntry {
+		emap, ok := e.(map[string]interface{})
+		if !ok {
+			return nil, errors.New("wrong interface, expecting []interface{}")
+		}
+
+		proof, err := NewProof(emap)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, proof)
+	}
+
+	return result, nil
+}
+
+// AddProof adds a proof to LD Object
+func AddProof(jsonLdObject map[string]interface{}, proof *Proof) error {
+	var proofs []interface{}
+	entry, exists := jsonLdObject[jsonldProof]
+	if exists {
+		var ok bool
+		proofs, ok = entry.([]interface{})
+		if !ok {
+			return errors.New("expecting []interface{}, got something else")
+		}
+	}
+
+	proofs = append(proofs, proof.JSONLdObject())
+	jsonLdObject[jsonldProof] = proofs
+
+	return nil
+}
+
+// GetCopyWithoutProof gets copy of JSON LD Object without proofs (signatures)
+func GetCopyWithoutProof(jsonLdObject map[string]interface{}) map[string]interface{} {
+	if jsonLdObject == nil {
+		return nil
+	}
+
+	dest := make(map[string]interface{})
+	for k, v := range jsonLdObject {
+		if k != jsonldProof {
+			dest[k] = v
+		}
+	}
+
+	return dest
+}
+
+// ErrProofNotFound is returned when proof is not found
+var ErrProofNotFound = errors.New("proof not found")

--- a/pkg/doc/signature/proof/utils_test.go
+++ b/pkg/doc/signature/proof/utils_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package proof
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddProof(t *testing.T) {
+	doc := getDefaultDoc()
+	proofs, err := GetProofs(doc)
+	require.Equal(t, err, ErrProofNotFound)
+	require.Nil(t, proofs)
+
+	now := time.Now()
+	proof1 := Proof{Creator: "creator-1",
+		Created:    &now,
+		ProofValue: []byte("proof"),
+		Type:       "Ed25519Signature2018"}
+
+	err = AddProof(doc, &proof1)
+	require.NoError(t, err)
+
+	proofs, err = GetProofs(doc)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(proofs))
+
+	proof2 := Proof{Creator: "creator-2",
+		Created:    &now,
+		ProofValue: []byte("proof"),
+		Type:       "Ed25519Signature2018"}
+	err = AddProof(doc, &proof2)
+	require.NoError(t, err)
+
+	proofs, err = GetProofs(doc)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(proofs))
+	require.Equal(t, "creator-1", proofs[0].Creator)
+	require.Equal(t, "creator-2", proofs[1].Creator)
+}
+
+func TestGetCopyWithoutProof(t *testing.T) {
+	doc := getDefaultDocWithSignature()
+	proofs, err := GetProofs(doc)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(proofs))
+
+	docCopy := GetCopyWithoutProof(doc)
+
+	proofs, err = GetProofs(docCopy)
+	require.Equal(t, err, ErrProofNotFound)
+	require.Nil(t, proofs)
+
+	require.True(t, reflect.DeepEqual(docCopy, getDefaultDoc()))
+}
+
+func TestInvalidProofFormat(t *testing.T) {
+	doc := map[string]interface{}{
+		"test": "test",
+		"proof": map[string]interface{}{
+			"type":       "Ed25519Signature2018",
+			"creator":    "creator",
+			"created":    "2011-09-23T20:21:34Z",
+			"proofValue": "ABC",
+		},
+	}
+	proofs, err := GetProofs(doc)
+	require.NotNil(t, err)
+	require.Nil(t, proofs)
+	require.Contains(t, err.Error(), "expecting []interface{}")
+
+	now := time.Now()
+	proof := Proof{Creator: "creator-2",
+		Created:    &now,
+		ProofValue: []byte("proof #2"),
+		Type:       "Ed25519Signature2018"}
+
+	err = AddProof(doc, &proof)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "expecting []interface{}")
+}
+
+func getDefaultDoc() map[string]interface{} {
+	return map[string]interface{}{
+		"test": "test",
+	}
+}
+
+func getDefaultDocWithSignature() map[string]interface{} {
+	return map[string]interface{}{
+		"test":  "test",
+		"proof": getProofs(),
+	}
+}
+
+func getProofs() []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"type":       "Ed25519Signature2018",
+			"creator":    "creator",
+			"created":    "2011-09-23T20:21:34Z",
+			"proofValue": "ABC",
+		},
+	}
+}


### PR DESCRIPTION
The following algorithm specifies how to create the data that is used to generate or verify a digital signature.

Closes #243
