### PR TITLE
refactor: Return "http://" uri prefix for HTTP Inbound transport

### DIFF
--- a/pkg/didcomm/transport/http/inbound.go
+++ b/pkg/didcomm/transport/http/inbound.go
@@ -69,6 +69,7 @@ func processPOSTRequest(w http.ResponseWriter, r *http.Request, prov transport.I
 	err = messageHandler(unpackMsg.Message)
 	if err != nil {
 		// TODO HTTP Response Codes based on errors from service https://github.com/hyperledger/aries-framework-go/issues/271
+		logger.Errorf("incoming msg processing failed: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
 	} else {
 		w.WriteHeader(http.StatusAccepted)
@@ -143,5 +144,6 @@ func (i *Inbound) Stop() error {
 
 // Endpoint provides the http connection details.
 func (i *Inbound) Endpoint() string {
-	return i.server.Addr
+	// return http prefix as framework only supports http
+	return "http://" + i.server.Addr
 }

--- a/pkg/didcomm/transport/http/inbound_test.go
+++ b/pkg/didcomm/transport/http/inbound_test.go
@@ -126,9 +126,9 @@ func TestInboundHandler(t *testing.T) {
 
 func TestInboundTransport(t *testing.T) {
 	t.Run("test inbound transport - with host/port", func(t *testing.T) {
-		inbound, err := NewInbound(":26601")
+		inbound, err := NewInbound("example.com:26601")
 		require.NoError(t, err)
-		require.NotEmpty(t, inbound.Endpoint())
+		require.Equal(t, "http://example.com:26601", inbound.Endpoint())
 	})
 
 	t.Run("test inbound transport - without host/port", func(t *testing.T) {


### PR DESCRIPTION
- Update Endpoint() to retun uri prefix (Added http as default framework only supports http)
- Added a Error logger for HTTP 500 cases for easier debugging

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
