### PR TITLE
fix: VC data model and JWT to pass the test suite

### DIFF
--- a/pkg/doc/verifiable/credential_extension_switch_test.go
+++ b/pkg/doc/verifiable/credential_extension_switch_test.go
@@ -117,14 +117,14 @@ func Cred1Producer() CustomCredentialProducer {
 					return &cred1.Base
 				}),
 			)
-			if err == nil {
-				return cred1, nil
+			if err != nil {
+				return nil, err
 			}
-			return nil, err
+			return cred1, nil
 		},
 		Accept: func(vc *Credential) bool {
-			return containsString(vc.Context, "https://www.w3.org/2018/credentials/examples/ext/type1") &&
-				containsString(vc.Type, "CredType1")
+			return hasContext(vc.Context, "https://www.w3.org/2018/credentials/examples/ext/type1") &&
+				hasType(vc.Types(), "CredType1")
 		},
 	}
 }
@@ -143,14 +143,14 @@ func Cred2Producer() CustomCredentialProducer {
 					return &cred2.Base
 				}),
 			)
-			if err == nil {
-				return cred2, nil
+			if err != nil {
+				return nil, err
 			}
-			return nil, err
+			return cred2, nil
 		},
 		Accept: func(vc *Credential) bool {
-			return containsString(vc.Context, "https://www.w3.org/2018/credentials/examples/ext/type2") &&
-				containsString(vc.Type, "CredType2")
+			return hasContext(vc.Context, "https://www.w3.org/2018/credentials/examples/ext/type2") &&
+				hasType(vc.Types(), "CredType2")
 		},
 	}
 }
@@ -178,8 +178,17 @@ func DecodeCredentials(dataJSON []byte, producers ...CustomCredentialProducer) (
 	return baseCred, nil
 }
 
-func containsString(credentialTypes []string, targetType string) bool {
-	for _, thatType := range credentialTypes {
+func hasContext(allContexts []interface{}, targetContext string) bool {
+	for _, thatType := range allContexts {
+		if thatType == targetContext {
+			return true
+		}
+	}
+	return false
+}
+
+func hasType(allTypes []string, targetType string) bool {
+	for _, thatType := range allTypes {
 		if thatType == targetType {
 			return true
 		}

--- a/pkg/doc/verifiable/test-suite/config.json
+++ b/pkg/doc/verifiable/test-suite/config.json
@@ -1,8 +1,8 @@
 {
   "generator": "aries-framework-go-gen",
-  "presentationGenerator": "aries-framework-go-gen",
+  "presentationGenerator": "aries-framework-go-gen --presentation",
   "generatorOptions": "",
-  "sectionsNotSupported": [],
+  "sectionsNotSupported": ["zkp"],
   "jwt": {
     "es256kPrivateKeyJwk": {
       "kty": "EC",

--- a/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
+++ b/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
@@ -34,7 +34,14 @@ func main() {
 	jwtNoJws := flag.Bool("jwt-no-jws", false, "indication to suppress the JWS although keys are present")
 	jwtPresentation := flag.Bool("jwt-presentation", false, "indication to generate a verifiable presentation")
 	jwtDecode := flag.Bool("jwt-decode", false, "indication to generate a credential from a JWT verifiable credential. The input file will be a JWT instead of a JSON-LD file.") // nolint: lll
+	isPresentation := flag.Bool("presentation", false, "presentation is passed")
 	flag.Parse()
+
+	if *isPresentation {
+		// todo support Verifiable Presentations #371
+		log.Println("verifiable presentations are not supported")
+		abort()
+	}
 
 	if *jwt == "" {
 		encodeVCToJSON(vcBytes)
@@ -49,7 +56,8 @@ func main() {
 
 	if *jwtPresentation {
 		// TODO Encode Verifiable Presentation #371
-		return
+		log.Println("verifiable presentations are not supported")
+		abort()
 	}
 
 	if *jwtNoJws {
@@ -142,7 +150,7 @@ func parseKeys(packedKeys string) (private, public interface{}) {
 }
 
 func encodeVCToJSON(vcBytes []byte) {
-	credential, err := verifiable.NewCredential(vcBytes)
+	credential, err := verifiable.NewCredential(vcBytes, verifiable.WithNoCustomSchemaCheck())
 	if err != nil {
 		log.Println(fmt.Errorf("failed to decode credential: %w", err))
 		abort()


### PR DESCRIPTION
closes #358

Signed-off-by: Dima <dkinoshenko@gmail.com>

VC Test Suite statistics:
- 57 passing
- 19 pending
- 18 failing

The reasons for failing:
- JWT suite errors, ES256K support required (#381 )
- Cannot generate JWT from Verifiable Credential without the signature (#372 )
- Support of Verifiable Presentation (#371 )
- Several inconsistencies in VC Test Suite: [#96](https://github.com/w3c/vc-test-suite/issues/96), [#97](https://github.com/w3c/vc-test-suite/issues/97), [#98](https://github.com/w3c/vc-test-suite/issues/98)

The reasons for pending:
- Not implemented support of Zero Knowledge Proof (#180 ), `zkp` test suite is disabled for now.

