### PR TITLE
feat: Implement Linked Data Signature Verfication Algorithm

### DIFF
--- a/pkg/doc/signature/proof/data.go
+++ b/pkg/doc/signature/proof/data.go
@@ -53,8 +53,8 @@ func prepareCanonicalProofOptions(suite signatureSuite, proofOptions map[string]
 		return nil, errors.New("creator is missing")
 	}
 
-	_, ok = proofOptions[jsonldCreated]
-	if !ok {
+	value, ok = proofOptions[jsonldCreated]
+	if !ok || value == nil {
 		return nil, errors.New("created is missing")
 	}
 

--- a/pkg/doc/signature/proof/proof.go
+++ b/pkg/doc/signature/proof/proof.go
@@ -77,7 +77,9 @@ func (p *Proof) JSONLdObject() map[string]interface{} {
 	emap := make(map[string]interface{})
 	emap[jsonldType] = p.Type
 	emap[jsonldCreator] = p.Creator
-	emap[jsonldCreated] = p.Created.Format(time.RFC3339)
+	if p.Created != nil {
+		emap[jsonldCreated] = p.Created.Format(time.RFC3339)
+	}
 	emap[jsonldProofValue] = base64.RawURLEncoding.EncodeToString(p.ProofValue)
 	emap[jsonldDomain] = p.Domain
 	emap[jsonldNonce] = base64.RawURLEncoding.EncodeToString(p.Nonce)

--- a/pkg/doc/signature/signer/signer.go
+++ b/pkg/doc/signature/signer/signer.go
@@ -61,7 +61,7 @@ func (signer *DocumentSigner) Sign(context *Context, jsonLdDoc []byte) ([]byte, 
 	var jsonLdObject map[string]interface{}
 	err := json.Unmarshal(jsonLdDoc, &jsonLdObject)
 	if err != nil {
-		return nil, fmt.Errorf("failed tu unmarshall json ld document: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal json ld document: %w", err)
 	}
 
 	err = signer.signObject(context, jsonLdObject)

--- a/pkg/doc/signature/signer/signer_test.go
+++ b/pkg/doc/signature/signer/signer_test.go
@@ -33,7 +33,7 @@ func TestDocumentSigner_SignErrors(t *testing.T) {
 	signedDoc, err := s.Sign(context, []byte("not json"))
 	require.NotNil(t, err)
 	require.Nil(t, signedDoc)
-	require.Contains(t, err.Error(), "failed tu unmarshall json ld document")
+	require.Contains(t, err.Error(), "failed to unmarshal json ld document")
 
 	// test for invalid context
 	context.Creator = ""

--- a/pkg/doc/signature/verifier/verifier.go
+++ b/pkg/doc/signature/verifier/verifier.go
@@ -1,0 +1,104 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifier
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/ed25519signature2018"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/proof"
+)
+
+// signatureSuite encapsulates signature suite methods required for signature verification
+type signatureSuite interface {
+
+	// GetCanonicalDocument will return normalized/canonical version of the document
+	GetCanonicalDocument(doc map[string]interface{}) ([]byte, error)
+
+	// GetDigest returns document digest
+	GetDigest(doc []byte) []byte
+
+	// Verify will verify signature against public key
+	Verify(pubKey []byte, doc []byte, signature []byte) error
+
+	// Accept registers this signature suite with the given signature type
+	Accept(signatureType string) bool
+}
+
+// keyResolver encapsulates key resolution
+type keyResolver interface {
+
+	// Resolve will return public key bytes
+	Resolve(id string) ([]byte, error)
+}
+
+// DocumentVerifier implements JSON LD document proof verification
+type DocumentVerifier struct {
+	signatureSuites []signatureSuite
+	pkResolver      keyResolver
+}
+
+// New returns new instance of document verifier
+func New(resolver keyResolver) *DocumentVerifier {
+	var signatureSuites []signatureSuite
+	signatureSuites = append(signatureSuites, &ed25519signature2018.SignatureSuite{})
+
+	return &DocumentVerifier{signatureSuites: signatureSuites, pkResolver: resolver}
+}
+
+// Verify will verify document proofs
+func (dv *DocumentVerifier) Verify(jsonLdDoc []byte) error {
+	var jsonLdObject map[string]interface{}
+	err := json.Unmarshal(jsonLdDoc, &jsonLdObject)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal json ld document: %w", err)
+	}
+
+	return dv.verifyObject(jsonLdObject)
+}
+
+// verifyObject will verify document proofs for JSON LD object
+func (dv *DocumentVerifier) verifyObject(jsonLdObject map[string]interface{}) error {
+	proofs, err := proof.GetProofs(jsonLdObject)
+	if err != nil {
+		return err
+	}
+
+	for _, p := range proofs {
+		publicKey, err := dv.pkResolver.Resolve(p.Creator)
+		if err != nil {
+			return err
+		}
+
+		suite, err := dv.getSignatureSuite(p.Type)
+		if err != nil {
+			return err
+		}
+
+		message, err := proof.CreateVerifyHashAlgorithm(suite, jsonLdObject, p.JSONLdObject())
+		if err != nil {
+			return err
+		}
+
+		err = suite.Verify(publicKey, message, p.ProofValue)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getSignatureSuite returns signature suite based on signature type
+func (dv *DocumentVerifier) getSignatureSuite(signatureType string) (signatureSuite, error) {
+	for _, s := range dv.signatureSuites {
+		if s.Accept(signatureType) {
+			return s, nil
+		}
+	}
+	return nil, fmt.Errorf("signature type %s not supported", signatureType)
+}

--- a/pkg/doc/signature/verifier/verifier_test.go
+++ b/pkg/doc/signature/verifier/verifier_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifier
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/proof"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/signer"
+)
+
+func TestVerify(t *testing.T) {
+	signedDocBytes, testKeyResolver := getDefaultSignedDoc()
+	v := New(testKeyResolver)
+	err := v.Verify(signedDocBytes)
+	require.Nil(t, err)
+
+	// test invalid json
+	err = v.Verify([]byte("not json"))
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "failed to unmarshal json ld document")
+
+	// test proof not found
+	err = v.Verify([]byte(validDoc))
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "proof not found")
+}
+
+func TestVerifyObject(t *testing.T) {
+	jsonLdObject, tkr := getDefaultSignedDocObject()
+
+	// happy path
+	v := New(tkr)
+	err := v.verifyObject(jsonLdObject)
+	require.Nil(t, err)
+
+	// test invalid signature suite
+	proofs, err := proof.GetProofs(jsonLdObject)
+	require.NoError(t, err)
+	proofs[0].Type = "non-existent"
+	err = proof.AddProof(jsonLdObject, proofs[0])
+	require.NoError(t, err)
+
+	err = v.verifyObject(jsonLdObject)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "signature type non-existent not supported")
+
+	// test key resolver error - key not found
+	v = New(&testKeyResolver{})
+	err = v.verifyObject(jsonLdObject)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "key not found")
+
+	// test signature error - pass in invalid proof value
+	jsonLdObject, tkr = getDefaultSignedDocObject()
+	proofs, err = proof.GetProofs(jsonLdObject)
+	require.NoError(t, err)
+	proofs[0].ProofValue = []byte("invalid")
+	err = proof.AddProof(jsonLdObject, proofs[0])
+	require.NoError(t, err)
+
+	v = New(tkr)
+	err = v.verifyObject(jsonLdObject)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "signature doesn't match")
+}
+
+func getDefaultSignedDoc() ([]byte, keyResolver) {
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+
+	const creator = "key-1"
+	keys := make(map[string][]byte)
+	keys[creator] = pubKey
+
+	context := signer.Context{Creator: creator,
+		SignatureType: "Ed25519Signature2018",
+		Signer:        getSigner(privKey)}
+
+	doc := getDefaultDoc()
+	docBytes, err := json.Marshal(doc)
+	if err != nil {
+		panic(err)
+	}
+
+	s := signer.New()
+	signedDocBytes, err := s.Sign(&context, docBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return signedDocBytes, &testKeyResolver{Keys: keys}
+}
+
+func getDefaultSignedDocObject() (map[string]interface{}, keyResolver) {
+	signedDocBytes, testKeyResolver := getDefaultSignedDoc()
+
+	var jsonLdObject map[string]interface{}
+	err := json.Unmarshal(signedDocBytes, &jsonLdObject)
+	if err != nil {
+		panic(err)
+	}
+
+	return jsonLdObject, testKeyResolver
+}
+
+func getDefaultDoc() map[string]interface{} {
+	var doc map[string]interface{}
+	err := json.Unmarshal([]byte(validDoc), &doc)
+	if err != nil {
+		panic(err)
+	}
+	return doc
+}
+
+func getSigner(privKey []byte) *testSigner {
+	return &testSigner{privateKey: privKey}
+}
+
+type testSigner struct {
+	privateKey []byte
+}
+
+func (s *testSigner) Sign(doc []byte) ([]byte, error) {
+	if l := len(s.privateKey); l != ed25519.PrivateKeySize {
+		return nil, errors.New("ed25519: bad private key length")
+	}
+	return ed25519.Sign(s.privateKey, doc), nil
+}
+
+type testKeyResolver struct {
+	Keys map[string][]byte
+}
+
+func (r *testKeyResolver) Resolve(id string) ([]byte, error) {
+	key, ok := r.Keys[id]
+	if !ok {
+		return nil, errors.New("key not found")
+	}
+	return key, nil
+}
+
+//nolint:lll
+const validDoc = `{
+  "@context": ["https://w3id.org/did/v1"],
+  "id": "did:example:123456789abcdefghi",
+  "publicKey": [
+    {
+      "id": "did:example:123456789abcdefghi#keys-1",
+      "type": "Secp256k1VerificationKey2018",
+      "controller": "did:example:123456789abcdefghi",
+      "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+    }
+  ],
+  "created": "2002-10-10T17:00:00Z"
+}`


### PR DESCRIPTION
Linked Data document signatures are verified using Signature Verification Algorithm:
- fetch and verify the public key in the signature using key resolver
- call the Create Verify Hash Algorithm in order to create data that is used to generate or verify a digital signature
- verify signature in the proof against data created in the step above

Closes #245

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>
