### PR TITLE
feat: Preapare the connection signature raw data as per the spec

### DIFF
--- a/pkg/didcomm/protocol/didexchange/states_test.go
+++ b/pkg/didcomm/protocol/didexchange/states_test.go
@@ -516,7 +516,6 @@ func TestPrepareConnectionSignature(t *testing.T) {
 		connectionSignature, err := prepareConnectionSignature(connection)
 		require.NoError(t, err)
 		require.NotNil(t, connectionSignature)
-		require.Equal(t, connectionSignature.Type, "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single")
 	})
 }
 


### PR DESCRIPTION
closes: #345

Signed-off-by: talwinder.kaur <talwinder.kaur@securekey.com>
