### PR TITLE
ci: run VC test suite

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,0 +1,51 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+name: test-suite
+on: 
+  push:
+    paths:
+    - 'pkg/doc/verifiable/**'
+    - 'scripts/*_test_suite.sh'
+    - '.github/workflows/test-suite.yml'
+    - 'Makefile'
+  pull_request:
+    paths:
+    - 'pkg/doc/verifiable/**'
+    - 'scripts/*_test_suite.sh'
+    - '.github/workflows/test-suite.yml'
+    - 'Makefile'
+jobs:
+  vcTestSuite:
+    name: VC test suite
+    runs-on: ubuntu-18.04
+    timeout-minutes: 10
+    steps:
+
+    - name: Setup Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Setup node
+      uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+
+    - name: Setup mocha
+      timeout-minutes: 10
+      run: npm install -g mocha
+
+    - uses: actions/checkout@v1
+
+    - name: Run test suite
+      timeout-minutes: 10
+      run: make vc-test-suite
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: vc-report
+        path: build/vc-test-suite/suite/implementations/aries-framework-go-report.json

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ vc-test-suite: clean
 clean:
 	rm -f coverage.txt
 	rm -Rf ./build
-	rm -Rf ./vc_test_suite
 	rm -Rf ./test/bdd/db
 
 .PHONY: generate-openapi-spec

--- a/scripts/run_vc_test_suite.sh
+++ b/scripts/run_vc_test_suite.sh
@@ -13,7 +13,9 @@ VC_TEST_SUITE=vc-test-suite
 REPORT_NAME=aries-framework-go
 DIR=$(pwd)
 GENERATOR_DIR="${DIR}/pkg/doc/verifiable/test-suite"
-SUITE_DIR="${DIR}/${VC_TEST_SUITE}/suite"
+
+BUILD_DIR="${DIR}/build"
+SUITE_DIR="${BUILD_DIR}/${VC_TEST_SUITE}/suite"
 
 # build the app to test
 cd $GENERATOR_DIR
@@ -21,10 +23,10 @@ cd $GENERATOR_DIR
 mkdir tmp
 cp verifiable_suite_test.go tmp/vc_test_suite_app.go
 cd tmp
-go build -o "${DIR}/${VC_TEST_SUITE}/${GENERATOR_NAME}"
+go build -o "${BUILD_DIR}/${VC_TEST_SUITE}/${GENERATOR_NAME}"
 cd ..
 rm -rf tmp
-cd "${DIR}/${VC_TEST_SUITE}"
+cd "${BUILD_DIR}/${VC_TEST_SUITE}"
 export PATH=$PATH:`pwd`
 
 # get the suite
@@ -39,6 +41,12 @@ cp "${GENERATOR_DIR}/config.json" .
 # run the suite
 set +e
 mocha --recursive --timeout 10000 test/vc-data-model-1.0/ -R json > "implementations/${REPORT_NAME}-report.json"
-echo "See test suite results at ${SUITE_DIR}/implementations/${REPORT_NAME}-report.json"
+
+sed '/\"tests\": \[/,$d' < "implementations/${REPORT_NAME}-report.json" > ${BUILD_DIR}/${VC_TEST_SUITE}/summary.json
+echo "}" >> ${BUILD_DIR}/${VC_TEST_SUITE}/summary.json
+
+echo "Test suite summary:"
+cat ${BUILD_DIR}/${VC_TEST_SUITE}/summary.json
+echo "See full test suite results at ${SUITE_DIR}/implementations/${REPORT_NAME}-report.json"
 
 cd $DIR


### PR DESCRIPTION
A workflow is added to GitHub Actions to enable test suite execution.
The VC test suite artifact directory is also moved under build.

Note: the test suite only runs when associated packages are changed.

Signed-off-by: Troy Ronda <troy@troyronda.com>

