### PR TITLE
refactor: Get public key in didexchange state

### DIFF
--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -603,10 +603,29 @@ func getMockDID() *did.Doc {
 			Controller: "did:example:123456789abcdefghi",
 			Type:       "Secp256k1VerificationKey2018",
 			Value:      base58.Decode("H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV")},
+			{ID: "did:example:123456789abcdefghi#keys-1",
+				Controller: "did:example:123456789abcdefghi",
+				Type:       "Ed25519VerificationKey2018",
+				Value:      base58.Decode("H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV")},
 			{ID: "did:example:123456789abcdefghw#key2",
 				Controller: "did:example:123456789abcdefghw",
 				Type:       "RsaVerificationKey2018",
 				Value:      base58.Decode("H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV")},
+		},
+	}
+}
+func getMockDIDPublicKey() *did.Doc {
+	return &did.Doc{
+		Context: []string{"https://w3id.org/did/v1"},
+		ID:      "did:example:123456789abcdefghi#inbox",
+		Service: []did.Service{{
+			ServiceEndpoint: "https://localhost:8090",
+		}},
+		PublicKey: []did.PublicKey{{
+			ID:         "did:example:123456789abcdefghi#keys-1",
+			Controller: "did:example:123456789abcdefghi",
+			Type:       "Secp256k1VerificationKey2018",
+			Value:      base58.Decode("H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV")},
 		},
 	}
 }


### PR DESCRIPTION
closes #416

Signed-off-by: talwinder.kaur <talwinder.kaur@securekey.com>

This change to remove the directly assessing first public key from the did doc. Instead it will loop through and fetch the key which is supported by the didcomm message protocol.