### PR TITLE
refactor: split wallet CreateKey into CreateSigningKey & CreateEncryptionKey

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -84,7 +84,7 @@ func New(ctx provider) (*Client, error) {
 
 // CreateInvitation create invitation
 func (c *Client) CreateInvitation(label string) (*didexchange.Invitation, error) {
-	verKey, err := c.wallet.CreateKey()
+	verKey, err := c.wallet.CreateEncryptionKey()
 	if err != nil {
 		return nil, fmt.Errorf("failed CreateSigningKey: %w", err)
 	}

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -48,7 +48,7 @@ func TestNew(t *testing.T) {
 func TestClient_CreateInvitation(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
 		c, err := New(&mockprovider.Provider{ServiceValue: didexchange.New(nil, &did.MockDIDCreator{}, &mockProvider{}),
-			WalletValue: &mockwallet.CloseableWallet{CreateSigningKeyValue: "sample-key"}, InboundEndpointValue: "endpoint"})
+			WalletValue: &mockwallet.CloseableWallet{CreateEncryptionKeyValue: "sample-key"}, InboundEndpointValue: "endpoint"})
 		require.NoError(t, err)
 		inviteReq, err := c.CreateInvitation("agent")
 		require.NoError(t, err)
@@ -58,13 +58,13 @@ func TestClient_CreateInvitation(t *testing.T) {
 		require.Equal(t, "endpoint", inviteReq.ServiceEndpoint)
 	})
 
-	t.Run("test error from createSigningKey", func(t *testing.T) {
+	t.Run("test error from createEncryptionKey", func(t *testing.T) {
 		c, err := New(&mockprovider.Provider{ServiceValue: didexchange.New(nil, &did.MockDIDCreator{}, &mockProvider{}),
-			WalletValue: &mockwallet.CloseableWallet{CreateSigningKeyErr: fmt.Errorf("createSigningKeyErr")}})
+			WalletValue: &mockwallet.CloseableWallet{CreateEncryptionKeyErr: fmt.Errorf("createEncryptionKeyErr")}})
 		require.NoError(t, err)
 		_, err = c.CreateInvitation("agent")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "createSigningKeyErr")
+		require.Contains(t, err.Error(), "createEncryptionKeyErr")
 	})
 
 	t.Run("test error from save record", func(t *testing.T) {
@@ -98,7 +98,7 @@ func TestClient_RemoveConnection(t *testing.T) {
 func TestClient_HandleInvitation(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
 		c, err := New(&mockprovider.Provider{ServiceValue: &mockprotocol.MockDIDExchangeSvc{},
-			WalletValue: &mockwallet.CloseableWallet{CreateSigningKeyValue: "sample-key"}, InboundEndpointValue: "endpoint"})
+			WalletValue: &mockwallet.CloseableWallet{CreateEncryptionKeyValue: "sample-key"}, InboundEndpointValue: "endpoint"})
 		require.NoError(t, err)
 		inviteReq, err := c.CreateInvitation("agent")
 		require.NoError(t, err)
@@ -110,7 +110,7 @@ func TestClient_HandleInvitation(t *testing.T) {
 			ServiceValue: &mockprotocol.MockDIDExchangeSvc{HandleFunc: func(msg dispatcher.DIDCommMsg) error {
 				return fmt.Errorf("handle error")
 			}},
-			WalletValue: &mockwallet.CloseableWallet{CreateSigningKeyValue: "sample-key"}, InboundEndpointValue: "endpoint"})
+			WalletValue: &mockwallet.CloseableWallet{CreateEncryptionKeyValue: "sample-key"}, InboundEndpointValue: "endpoint"})
 		require.NoError(t, err)
 		inviteReq, err := c.CreateInvitation("agent")
 		require.NoError(t, err)

--- a/pkg/internal/mock/wallet/mock_wallet.go
+++ b/pkg/internal/mock/wallet/mock_wallet.go
@@ -13,15 +13,17 @@ import (
 
 // CloseableWallet mock wallet
 type CloseableWallet struct {
-	CreateSigningKeyValue string
-	CreateSigningKeyErr   error
-	SignMessageValue      []byte
-	SignMessageErr        error
-	PackValue             []byte
-	PackErr               error
-	UnpackValue           *wallet.Envelope
-	UnpackErr             error
-	MockDID               *did.Doc
+	CreateEncryptionKeyValue string
+	CreateEncryptionKeyErr   error
+	CreateSigningKeyValue    string
+	CreateSigningKeyErr      error
+	SignMessageValue         []byte
+	SignMessageErr           error
+	PackValue                []byte
+	PackErr                  error
+	UnpackValue              *wallet.Envelope
+	UnpackErr                error
+	MockDID                  *did.Doc
 }
 
 // Close previously-opened wallet, removing it if so configured.
@@ -29,8 +31,13 @@ func (m *CloseableWallet) Close() error {
 	return nil
 }
 
-// CreateKey create a new public/private signing keypair.
-func (m *CloseableWallet) CreateKey() (string, error) {
+// CreateEncryptionKey create a new public/private encryption keypair.
+func (m *CloseableWallet) CreateEncryptionKey() (string, error) {
+	return m.CreateEncryptionKeyValue, m.CreateEncryptionKeyErr
+}
+
+// CreateSigningKey create a new public/private signing keypair.
+func (m *CloseableWallet) CreateSigningKey() (string, error) {
 	return m.CreateSigningKeyValue, m.CreateSigningKeyErr
 }
 

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -271,7 +271,7 @@ func getHandler(t *testing.T, lookup string, handleErr error) operation.Handler 
 				return handleErr
 			},
 		},
-		WalletValue:          &mockwallet.CloseableWallet{CreateSigningKeyValue: "sample-key"},
+		WalletValue:          &mockwallet.CloseableWallet{CreateEncryptionKeyValue: "sample-key"},
 		InboundEndpointValue: "endpoint",
 	},
 	)

--- a/pkg/wallet/api.go
+++ b/pkg/wallet/api.go
@@ -22,14 +22,23 @@ type Wallet interface {
 // Crypto interface
 type Crypto interface {
 
-	// CreateKey create a new public/private signing keypair.
+	// CreateEncryptionKey create a new public/private encryption keypair.
 	//
 	// Returns:
 	//
 	// string: verKey
 	//
 	// error: error
-	CreateKey() (string, error)
+	CreateEncryptionKey() (string, error)
+
+	// CreateSigningKey create a new public/private signing keypair.
+	//
+	// Returns:
+	//
+	// string: verKey
+	//
+	// error: error
+	CreateSigningKey() (string, error)
 
 	// SignMessage sign a message using the private key associated with a given verification key.
 	//

--- a/pkg/wallet/wallet_test.go
+++ b/pkg/wallet/wallet_test.go
@@ -44,7 +44,11 @@ func TestBaseWallet_CreateKey(t *testing.T) {
 			Store: make(map[string][]byte),
 		}}))
 		require.NoError(t, err)
-		verKey, err := w.CreateKey()
+		encKey, err := w.CreateEncryptionKey()
+		require.NoError(t, err)
+		require.NotEmpty(t, encKey)
+
+		verKey, err := w.CreateSigningKey()
 		require.NoError(t, err)
 		require.NotEmpty(t, verKey)
 	})
@@ -54,7 +58,10 @@ func TestBaseWallet_CreateKey(t *testing.T) {
 			Store: make(map[string][]byte), ErrPut: fmt.Errorf("put error"),
 		}}))
 		require.NoError(t, err)
-		_, err = w.CreateKey()
+		_, err = w.CreateEncryptionKey()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "put error")
+		_, err = w.CreateSigningKey()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "put error")
 	})


### PR DESCRIPTION
Replaced wallet.CreateKey with CreateEncryptionKey, since it's an encryption key (curve25519) and introduced a new CreateSigningKey method that actually creates signing keys (ed25519).

Updated references/usages to use correct keys.

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>