### PR TITLE
feat: Unsecured JWT from Verifiable Credential

### DIFF
--- a/pkg/doc/verifiable/credential.go
+++ b/pkg/doc/verifiable/credential.go
@@ -332,6 +332,7 @@ type credentialOpts struct {
 	decoders               []CredentialDecoder
 	template               CredentialTemplate
 	issuerPublicKeyFetcher PublicKeyFetcher
+	unsecuredJWT           bool
 }
 
 // CredentialOpt is the Verifiable Credential decoding option
@@ -371,6 +372,13 @@ func WithTemplate(template CredentialTemplate) CredentialOpt {
 func WithJWTPublicKeyFetcher(fetcher PublicKeyFetcher) CredentialOpt {
 	return func(opts *credentialOpts) {
 		opts.issuerPublicKeyFetcher = fetcher
+	}
+}
+
+// WithUnsecuredJWT indicates the need to decode Verifiable Credential from unsecured JWT
+func WithUnsecuredJWT() CredentialOpt {
+	return func(opts *credentialOpts) {
+		opts.unsecuredJWT = true
 	}
 }
 
@@ -465,18 +473,25 @@ func NewCredential(vcData []byte, opts ...CredentialOpt) (*Credential, error) {
 	return cred, nil
 }
 
-func decodeRaw(vcData []byte, crOpts *credentialOpts) (vcDataDecoded []byte, raw *rawCredential, err error) {
+func decodeRaw(vcData []byte, crOpts *credentialOpts) ([]byte, *rawCredential, error) {
 	if crOpts.issuerPublicKeyFetcher != nil {
-		var vcDataFromJwt []byte
-		if vcDataFromJwt, raw, err = decodeJWT(vcData, crOpts.issuerPublicKeyFetcher); err != nil {
-			return nil, nil, fmt.Errorf("JWT decoding failed: %w", err)
+		vcDataFromJwt, rawCred, err := decodeCredJWS(vcData, crOpts.issuerPublicKeyFetcher)
+		if err != nil {
+			return nil, nil, fmt.Errorf("JWS decoding failed: %w", err)
 		}
-
-		return vcDataFromJwt, raw, nil
+		return vcDataFromJwt, rawCred, nil
 	}
 
-	raw = &rawCredential{}
-	err = json.Unmarshal(vcData, raw)
+	if crOpts.unsecuredJWT {
+		rawBytes, rawCred, err := decodeCredJWTUnsecured(vcData)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unsecured JWT decoding failed: %w", err)
+		}
+		return rawBytes, rawCred, nil
+	}
+
+	raw := &rawCredential{}
+	err := json.Unmarshal(vcData, raw)
 	if err != nil {
 		return nil, nil, fmt.Errorf("JSON unmarshalling of verifiable credential failed: %w", err)
 	}
@@ -492,137 +507,6 @@ func loadCredentialSchemas(raw *rawCredential, vcDataDecoded []byte) ([]Credenti
 		return schemas, nil
 	}
 	return []CredentialSchema{}, nil
-}
-
-// credentialClaims is JWT Claims extension by Credential.
-type credentialClaims struct {
-	*jwt.Claims
-
-	Credential *rawCredential `json:"vc,omitempty"`
-}
-
-// rawCredentialClaims is used to get raw content of "vc" claim of JWT.
-type rawCredentialClaims struct {
-	*jwt.Claims
-
-	Raw map[string]interface{} `json:"vc,omitempty"`
-}
-
-func decodeJWT(rawJwt []byte, fetcher PublicKeyFetcher) ([]byte, *rawCredential, error) {
-	parsedJwt, err := jwt.ParseSigned(string(rawJwt))
-	if err != nil {
-		return nil, nil, fmt.Errorf("VC is not JWS: %w", err)
-	}
-
-	credClaims := new(credentialClaims)
-	err = parsedJwt.UnsafeClaimsWithoutVerification(credClaims)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse JWT claims: %w", err)
-	}
-
-	if verifyErr := verifyJWTSignature(parsedJwt, fetcher, credClaims); verifyErr != nil {
-		return nil, nil, verifyErr
-	}
-
-	// Apply VC-related claims from JWT.
-	credClaims.refineVCFromJWTClaims()
-
-	// Decode again to get raw content of "vc" claim.
-	rawClaims := new(rawCredentialClaims)
-	err = parsedJwt.UnsafeClaimsWithoutVerification(rawClaims)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse JWT claims: %w", err)
-	}
-
-	// Complement original "vc" JSON claim with data refined from JWT claims.
-	if err = rawClaims.mergeRefinedVC(credClaims.Credential); err != nil {
-		return nil, nil, fmt.Errorf("failed to merge refined VC: %w", err)
-	}
-
-	var vcData []byte
-	if vcData, err = json.Marshal(rawClaims.Raw); err != nil {
-		return nil, nil, errors.New("failed to marshal 'vc' claim of JWT")
-	}
-
-	return vcData, credClaims.Credential, nil
-}
-
-func (credClaims *credentialClaims) refineVCFromJWTClaims() {
-	raw := credClaims.Credential
-
-	if iss := credClaims.Issuer; iss != "" {
-		refineVCIssuerFromJWTClaims(raw, iss)
-	}
-
-	if nbf := credClaims.NotBefore; nbf != nil {
-		nbfTime := nbf.Time().UTC()
-		raw.Issued = &nbfTime
-	}
-
-	if jti := credClaims.ID; jti != "" {
-		raw.ID = credClaims.ID
-	}
-
-	if iat := credClaims.IssuedAt; iat != nil {
-		iatTime := iat.Time().UTC()
-		raw.Issued = &iatTime
-	}
-
-	if exp := credClaims.Expiry; exp != nil {
-		expTime := exp.Time().UTC()
-		raw.Expired = &expTime
-	}
-}
-
-func refineVCIssuerFromJWTClaims(raw *rawCredential, iss string) {
-	// Issuer of Verifiable Credential could be either string (id) or struct (with "id" field).
-	switch issuer := raw.Issuer.(type) {
-	case string:
-		raw.Issuer = iss
-	case map[string]interface{}:
-		issuer["id"] = iss
-	}
-}
-
-func (rawClaims *rawCredentialClaims) mergeRefinedVC(raw *rawCredential) error {
-	rawVCClaims := rawClaims.Raw
-
-	rawData, err := json.Marshal(raw)
-	if err != nil {
-		return err
-	}
-
-	var rawMap map[string]interface{}
-
-	err = json.Unmarshal(rawData, &rawMap)
-	if err != nil {
-		return err
-	}
-
-	// make the merge
-	for k, v := range rawMap {
-		rawVCClaims[k] = v
-	}
-
-	return nil
-}
-
-func verifyJWTSignature(parsedJwt *jwt.JSONWebToken, fetcher PublicKeyFetcher, credClaims *credentialClaims) error {
-	var keyID string
-	for _, h := range parsedJwt.Headers {
-		if h.KeyID != "" {
-			keyID = h.KeyID
-			break
-		}
-	}
-	publicKey, err := fetcher(credClaims.Issuer, keyID)
-	if err != nil {
-		return fmt.Errorf("failed to get public key for JWT signature verification: %w", err)
-	}
-	if err = parsedJwt.Claims(publicKey, credClaims); err != nil {
-		return fmt.Errorf("JWT signature verification failed: %w", err)
-	}
-	return nil
 }
 
 func defaultCredentialOpts() *credentialOpts {
@@ -736,11 +620,12 @@ func loadCredentialSchema(url string, client *http.Client) ([]byte, error) {
 	return gotBody, nil
 }
 
-// JWT serializes Credential to signed JWT.
-func (vc *Credential) JWT(signatureAlg JWTAlgorithm, privateKey interface{}, keyID string, minimizeVc bool) (string, error) { // nolint:lll
+// JWTClaims converts Verifiable Credential into JWT Credential claims, which can be than serialized
+// e.g. into JWS.
+func (vc *Credential) JWTClaims(minimizeVc bool) (*JWTCredClaims, error) {
 	subjectID, err := vc.SubjectID()
 	if err != nil {
-		return "", fmt.Errorf("failed to get VC subject id: %w", err)
+		return nil, fmt.Errorf("failed to get VC subject id: %w", err)
 	}
 
 	// currently jwt encoding supports only single subject (by the spec)
@@ -767,34 +652,12 @@ func (vc *Credential) JWT(signatureAlg JWTAlgorithm, privateKey interface{}, key
 		raw = vc.raw()
 	}
 
-	credClaims := credentialClaims{
+	credClaims := &JWTCredClaims{
 		Claims:     jwtClaims,
 		Credential: raw,
 	}
 
-	key := jose.SigningKey{Algorithm: signatureAlg.Jose(), Key: privateKey}
-
-	var signerOpts = &jose.SignerOptions{}
-	signerOpts.WithType("JWT")
-	signerOpts.WithHeader("kid", keyID)
-
-	rsaSigner, err := jose.NewSigner(key, signerOpts)
-	if err != nil {
-		return "", fmt.Errorf("failed to create signer: %w", err)
-	}
-
-	// create an instance of Builder that uses the rsa signer
-	builder := jwt.Signed(rsaSigner)
-
-	builder = builder.Claims(credClaims)
-
-	// validate all ok, sign with the RSA key, and return a compact JWT
-	rawJWT, err := builder.CompactSerialize()
-	if err != nil {
-		return "", fmt.Errorf("failed to sign JWT: %w", err)
-	}
-
-	return rawJWT, nil
+	return credClaims, nil
 }
 
 // SubjectID gets ID of single subject if present or
@@ -860,11 +723,20 @@ func (vc *Credential) raw() *rawCredential {
 	}
 }
 
-// JSON converts Verifiable Credential to JSON bytes
-func (vc *Credential) JSON() ([]byte, error) {
+func (raw *rawCredential) marshalJSON() ([]byte, error) {
+	byteCred, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("JSON marshalling of raw verifiable credential failed: %w", err)
+	}
+
+	return byteCred, nil
+}
+
+// MarshalJSON converts Verifiable Credential to JSON bytes
+func (vc *Credential) MarshalJSON() ([]byte, error) {
 	byteCred, err := json.Marshal(vc.raw())
 	if err != nil {
-		return nil, fmt.Errorf("JSON unmarshalling of verifiable credential failed: %w", err)
+		return nil, fmt.Errorf("JSON marshalling of verifiable credential failed: %w", err)
 	}
 
 	return byteCred, nil

--- a/pkg/doc/verifiable/credential_jwt.go
+++ b/pkg/doc/verifiable/credential_jwt.go
@@ -1,0 +1,256 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifiable
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/square/go-jose/v3"
+	"github.com/square/go-jose/v3/jwt"
+)
+
+// JWTCredClaims is JWT Claims extension by Verifiable Credential (with custom "vc" claim).
+type JWTCredClaims struct {
+	*jwt.Claims
+
+	Credential *rawCredential `json:"vc,omitempty"`
+}
+
+// MarshalJWS serializes JWT into signed form (JWS)
+func (vcc *JWTCredClaims) MarshalJWS(signatureAlg JWTAlgorithm, privateKey interface{}, keyID string) (string, error) { //nolint:lll
+	key := jose.SigningKey{Algorithm: signatureAlg.Jose(), Key: privateKey}
+
+	var signerOpts = &jose.SignerOptions{}
+	signerOpts.WithType("JWT")
+	signerOpts.WithHeader("kid", keyID)
+
+	signer, err := jose.NewSigner(key, signerOpts)
+	if err != nil {
+		return "", fmt.Errorf("failed to create signer: %w", err)
+	}
+
+	// create an instance of Builder that uses the signer
+	builder := jwt.Signed(signer).Claims(vcc)
+
+	// validate all ok, sign with the key, and return a compact JWT
+	jws, err := builder.CompactSerialize()
+	if err != nil {
+		return "", fmt.Errorf("failed to sign JWT: %w", err)
+	}
+
+	return jws, nil
+}
+
+// MarshalUnsecuredJWT serialized JWT into unsecured JWT.
+func (vcc *JWTCredClaims) MarshalUnsecuredJWT() (string, error) {
+	headers := map[string]string{
+		"alg": "none",
+	}
+	return marshalUnsecuredJWT(headers, vcc)
+}
+
+// jwtVCClaim is used to get content of "vc" claim of JWT.
+type jwtVCClaim struct {
+	VC map[string]interface{} `json:"vc,omitempty"`
+}
+
+func mergeRefinedVC(jsonCred map[string]interface{}, rawCred *rawCredential) error {
+	rawData, err := json.Marshal(rawCred)
+	if err != nil {
+		return err
+	}
+
+	var rawMap map[string]interface{}
+
+	err = json.Unmarshal(rawData, &rawMap)
+	if err != nil {
+		return err
+	}
+
+	// make the merge
+	for k, v := range rawMap {
+		jsonCred[k] = v
+	}
+
+	return nil
+}
+
+// credJWTDecoder parses JWT claims from serialized token into JWTCredClaims struct and JSON object.
+// The implementation depends on the type of serialization, e.g. signed (JWT), unsecured (plain JWT).
+type credJWTDecoder interface {
+	UnmarshalClaims(rawJwt []byte) (*JWTCredClaims, error)
+	UnmarshalVCClaim(rawJwt []byte) (map[string]interface{}, error)
+}
+
+// credJWSDecoder parses and verifies signature of serialized JWT. To verify the signature,
+// Public Key Fetcher is used.
+type credJWSDecoder struct {
+	PKFetcher PublicKeyFetcher
+}
+
+func (jd *credJWSDecoder) UnmarshalClaims(rawJwt []byte) (*JWTCredClaims, error) {
+	parsedJwt, err := jwt.ParseSigned(string(rawJwt))
+	if err != nil {
+		return nil, fmt.Errorf("VC is not valid serialized JWS: %w", err)
+	}
+
+	credClaims := new(JWTCredClaims)
+	err = parsedJwt.UnsafeClaimsWithoutVerification(credClaims)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JWT claims: %w", err)
+	}
+
+	if verifyErr := verifyJWTSignature(parsedJwt, jd.PKFetcher, credClaims); verifyErr != nil {
+		return nil, fmt.Errorf("JWT signature verification failed: %w", verifyErr)
+	}
+
+	return credClaims, nil
+}
+
+func (jd *credJWSDecoder) UnmarshalVCClaim(rawJwt []byte) (map[string]interface{}, error) {
+	parsedJwt, err := jwt.ParseSigned(string(rawJwt))
+	if err != nil {
+		return nil, fmt.Errorf("VC is not valid serialized JWS: %w", err)
+	}
+
+	jsonObjClaims := new(jwtVCClaim)
+	err = parsedJwt.UnsafeClaimsWithoutVerification(jsonObjClaims)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JWT claims: %w", err)
+	}
+
+	return jsonObjClaims.VC, nil
+}
+
+// credUnsecuredJWTDecoder parses serialized unsecured JWT.
+type credUnsecuredJWTDecoder struct{}
+
+func (ud *credUnsecuredJWTDecoder) UnmarshalClaims(rawJwt []byte) (*JWTCredClaims, error) {
+	_, bytesClaim, err := unmarshalUnsecuredJWT(rawJwt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode unsecured JWT")
+	}
+
+	credClaims := new(JWTCredClaims)
+	err = json.Unmarshal(bytesClaim, credClaims)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JWT claims: %w", err)
+	}
+
+	return credClaims, nil
+}
+
+func (ud *credUnsecuredJWTDecoder) UnmarshalVCClaim(rawJwt []byte) (map[string]interface{}, error) {
+	_, bytesClaim, err := unmarshalUnsecuredJWT(rawJwt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode unsecured JWT")
+	}
+
+	rawClaims := new(jwtVCClaim)
+	err = json.Unmarshal(bytesClaim, rawClaims)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JWT claims: %w", err)
+	}
+
+	return rawClaims.VC, nil
+}
+
+// decodeCredJWT parses JWT from the specified bytes array in compact format using jwtDecoder.
+// It returns decoded Verifiable Credential refined by JWT Claims in raw byte array and rawCredential form.
+func decodeCredJWT(rawJWT []byte, jwtDecoder credJWTDecoder) ([]byte, *rawCredential, error) {
+	credClaims, err := jwtDecoder.UnmarshalClaims(rawJWT)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to decode Verifiable Credential JWT claims: %w", err)
+	}
+
+	credJSON, err := jwtDecoder.UnmarshalVCClaim(rawJWT)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to decode raw Verifiable Credential JWT claims: %w", err)
+	}
+
+	// Apply VC-related claims from JWT.
+	credClaims.refineCredFromJWTClaims()
+	// Complement original "vc" JSON claim with data refined from JWT claims.
+	if err = mergeRefinedVC(credJSON, credClaims.Credential); err != nil {
+		return nil, nil, fmt.Errorf("failed to merge refined VC: %w", err)
+	}
+
+	var vcData []byte
+	if vcData, err = json.Marshal(credJSON); err != nil {
+		return nil, nil, errors.New("failed to marshal 'vc' claim of JWT")
+	}
+
+	return vcData, credClaims.Credential, nil
+}
+
+func (vcc *JWTCredClaims) refineCredFromJWTClaims() {
+	raw := vcc.Credential
+
+	if iss := vcc.Issuer; iss != "" {
+		refineVCIssuerFromJWTClaims(raw, iss)
+	}
+
+	if nbf := vcc.NotBefore; nbf != nil {
+		nbfTime := nbf.Time().UTC()
+		raw.Issued = &nbfTime
+	}
+
+	if jti := vcc.ID; jti != "" {
+		raw.ID = vcc.ID
+	}
+
+	if iat := vcc.IssuedAt; iat != nil {
+		iatTime := iat.Time().UTC()
+		raw.Issued = &iatTime
+	}
+
+	if exp := vcc.Expiry; exp != nil {
+		expTime := exp.Time().UTC()
+		raw.Expired = &expTime
+	}
+}
+
+func decodeCredJWS(rawJwt []byte, fetcher PublicKeyFetcher) ([]byte, *rawCredential, error) {
+	decoder := &credJWSDecoder{
+		PKFetcher: fetcher,
+	}
+	return decodeCredJWT(rawJwt, decoder)
+}
+
+func decodeCredJWTUnsecured(rawJwt []byte) ([]byte, *rawCredential, error) {
+	decoder := &credUnsecuredJWTDecoder{}
+	return decodeCredJWT(rawJwt, decoder)
+}
+
+func verifyJWTSignature(parsedJwt *jwt.JSONWebToken, fetcher PublicKeyFetcher, credClaims *JWTCredClaims) error {
+	var keyID string
+	for _, h := range parsedJwt.Headers {
+		if h.KeyID != "" {
+			keyID = h.KeyID
+			break
+		}
+	}
+	publicKey, err := fetcher(credClaims.Issuer, keyID)
+	if err != nil {
+		return fmt.Errorf("failed to get public key for JWT signature verification: %w", err)
+	}
+	if err = parsedJwt.Claims(publicKey, credClaims); err != nil {
+		return fmt.Errorf("JWT signature verification failed: %w", err)
+	}
+	return nil
+}
+
+func refineVCIssuerFromJWTClaims(raw *rawCredential, iss string) {
+	// Issuer of Verifiable Credential could be either string (id) or struct (with "id" field).
+	switch issuer := raw.Issuer.(type) {
+	case string:
+		raw.Issuer = iss
+	case map[string]interface{}:
+		issuer["id"] = iss
+	}
+}

--- a/pkg/doc/verifiable/credential_jwt_test.go
+++ b/pkg/doc/verifiable/credential_jwt_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifiable
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/square/go-jose/v3"
+	"github.com/square/go-jose/v3/jwt"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialJWTClaimsMarshallingToJWS(t *testing.T) {
+	privateKey, err := readPrivateKey(filepath.Join(certPrefix, "issuer_private.pem"))
+	require.NoError(t, err)
+
+	vc, err := NewCredential([]byte(validCredential))
+	require.NoError(t, err)
+
+	jwtClaims, err := vc.JWTClaims(true)
+	require.NoError(t, err)
+
+	t.Run("Marshal signed JWT", func(t *testing.T) {
+		jws, err := jwtClaims.MarshalJWS(RS256, privateKey, "any")
+		require.NoError(t, err)
+
+		_, rawVC, err := decodeCredJWS([]byte(jws), func(issuerID, keyID string) (i interface{}, e error) {
+			publicKey, pcErr := readPublicKey(filepath.Join(certPrefix, "issuer_public.pem"))
+			require.NoError(t, pcErr)
+			require.NotNil(t, publicKey)
+
+			return publicKey, nil
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, vc.raw().stringJSON(t), rawVC.stringJSON(t))
+	})
+
+	t.Run("Marshal signed JWT failed with invalid private key", func(t *testing.T) {
+		_, err := jwtClaims.MarshalJWS(RS256, "invalid private key", "any")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to create signer")
+	})
+
+	t.Run("Marshal plain (unsecured) JWT", func(t *testing.T) {
+		sJWT, err := jwtClaims.MarshalUnsecuredJWT()
+		require.NoError(t, err)
+		require.NotNil(t, sJWT)
+
+		_, rawVC, err := decodeCredJWTUnsecured([]byte(sJWT))
+
+		require.NoError(t, err)
+		require.Equal(t, vc.raw().stringJSON(t), rawVC.stringJSON(t))
+	})
+}
+
+type badParseJWTClaims struct{}
+
+func (b badParseJWTClaims) UnmarshalClaims(rawJwt []byte) (*JWTCredClaims, error) {
+	return nil, errors.New("cannot parse JWT claims")
+}
+
+func (b badParseJWTClaims) UnmarshalVCClaim(rawJwt []byte) (map[string]interface{}, error) {
+	return new(jwtVCClaim).VC, nil
+}
+
+type badParseJWTRawClaims struct{}
+
+func (b badParseJWTRawClaims) UnmarshalClaims(rawJwt []byte) (*JWTCredClaims, error) {
+	return new(JWTCredClaims), nil
+}
+
+func (b badParseJWTRawClaims) UnmarshalVCClaim(rawJwt []byte) (map[string]interface{}, error) {
+	return nil, errors.New("cannot parse raw JWT claims")
+}
+
+func TestDecodeJWT(t *testing.T) {
+	_, _, err := decodeCredJWT([]byte{}, &badParseJWTClaims{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot parse JWT claims")
+
+	_, _, err = decodeCredJWT([]byte{}, &badParseJWTRawClaims{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot parse raw JWT claims")
+}
+
+type invalidCredClaims struct {
+	*jwt.Claims
+
+	Credential int `json:"vc,omitempty"`
+}
+
+func TestCredJWSDecoderParseJWTClaims(t *testing.T) {
+	privateKey, err := readPrivateKey(filepath.Join(certPrefix, "issuer_private.pem"))
+	require.NoError(t, err)
+
+	t.Run("Successful JWS decoding", func(t *testing.T) {
+		jws := createJWS(t, []byte(jwtTestCredential), false)
+
+		decoder := &credJWSDecoder{
+			PKFetcher: func(issuerID, keyID string) (i interface{}, e error) {
+				publicKey, err := readPublicKey(filepath.Join(certPrefix, "issuer_public.pem"))
+				require.NoError(t, err)
+				require.NotNil(t, publicKey)
+
+				return publicKey, nil
+			},
+		}
+
+		decodedCred, err := decoder.UnmarshalClaims(jws)
+		require.NoError(t, err)
+
+		vc, err := NewCredential([]byte(jwtTestCredential))
+		require.NoError(t, err)
+		require.Equal(t, vc.raw().stringJSON(t), decodedCred.Credential.stringJSON(t))
+	})
+
+	t.Run("Invalid serialized JWS", func(t *testing.T) {
+		decoder := new(credJWSDecoder)
+
+		_, err := decoder.UnmarshalClaims([]byte("invalid JWS"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "VC is not valid serialized JWS")
+
+		_, err = decoder.UnmarshalVCClaim([]byte("invalid JWS"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "VC is not valid serialized JWS")
+	})
+
+	t.Run("Invalid format of \"vc\" claim", func(t *testing.T) {
+		key := jose.SigningKey{Algorithm: jose.RS256, Key: privateKey}
+
+		signer, err := jose.NewSigner(key, &jose.SignerOptions{})
+		require.NoError(t, err)
+
+		claims := &invalidCredClaims{
+			Claims:     &jwt.Claims{},
+			Credential: 55, // "vc" claim of invalid format
+		}
+
+		rawJWT, err := jwt.Signed(signer).Claims(claims).CompactSerialize()
+		require.NoError(t, err)
+
+		decoder := new(credJWSDecoder)
+
+		_, err = decoder.UnmarshalClaims([]byte(rawJWT))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse JWT claims")
+
+		_, err = decoder.UnmarshalVCClaim([]byte(rawJWT))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse JWT claims")
+	})
+
+	t.Run("Invalid signature of JWS", func(t *testing.T) {
+		jws := createJWS(t, []byte(jwtTestCredential), false)
+
+		decoder := &credJWSDecoder{
+			PKFetcher: func(issuerID, keyID string) (i interface{}, e error) {
+				// use public key of VC Holder (while expecting to use the ones of Issuer)
+				publicKey, err := readPublicKey(filepath.Join(certPrefix, "holder_public.pem"))
+				require.NoError(t, err)
+				require.NotNil(t, publicKey)
+
+				return publicKey, nil
+			},
+		}
+
+		_, err := decoder.UnmarshalClaims(jws)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "JWT signature verification failed")
+	})
+}
+
+func TestCredUnsecuredJWTDecoderParseJWTClaims(t *testing.T) {
+	t.Run("Successful unsecured JWT decoding", func(t *testing.T) {
+		vc, err := NewCredential([]byte(validCredential))
+		require.NoError(t, err)
+
+		jwtClaims, err := vc.JWTClaims(true)
+		require.NoError(t, err)
+
+		sJWT, err := jwtClaims.MarshalUnsecuredJWT()
+		require.NoError(t, err)
+
+		decoder := &credUnsecuredJWTDecoder{}
+
+		decodedCred, err := decoder.UnmarshalClaims([]byte(sJWT))
+		require.NoError(t, err)
+		require.NotNil(t, decodedCred)
+	})
+
+	t.Run("Invalid serialized unsecured JWT", func(t *testing.T) {
+		decoder := new(credUnsecuredJWTDecoder)
+
+		_, err := decoder.UnmarshalClaims([]byte("invalid JWS"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to decode unsecured JWT")
+
+		_, err = decoder.UnmarshalVCClaim([]byte("invalid JWS"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to decode unsecured JWT")
+	})
+
+	t.Run("Invalid format of \"vc\" claim", func(t *testing.T) {
+		claims := &invalidCredClaims{
+			Claims:     &jwt.Claims{},
+			Credential: 55, // "vc" claim of invalid format
+		}
+
+		rawJWT, err := marshalUnsecuredJWT(map[string]string{}, claims)
+		require.NoError(t, err)
+
+		decoder := new(credUnsecuredJWTDecoder)
+
+		_, err = decoder.UnmarshalClaims([]byte(rawJWT))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse JWT claims")
+
+		_, err = decoder.UnmarshalVCClaim([]byte(rawJWT))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse JWT claims")
+	})
+}

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -17,91 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:lll
-const validCredential = `
-{
-  "@context": [
-    "https://www.w3.org/2018/credentials/v1",
-    "https://www.w3.org/2018/credentials/examples/v1"
-  ],
-  "id": "http://example.edu/credentials/1872",
-  "type": [
-    "VerifiableCredential",
-    "UniversityDegreeCredential"
-  ],
-  "credentialSubject": {
-    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-    "degree": {
-      "type": "BachelorDegree",
-      "university": "MIT"
-    },
-    "name": "Jayden Doe",
-    "spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
-  },
-
-  "issuer": {
-    "id": "did:example:76e12ec712ebc6f1c221ebfeb1f",
-    "name": "Example University"
-  },
-
-  "issuanceDate": "2010-01-01T19:23:24Z",
-
-  "proof": {
-    "type": "RsaSignature2018",
-    "created": "2018-06-18T21:19:10Z",
-    "proofPurpose": "assertionMethod",
-    "verificationMethod": "https://example.com/jdoe/keys/1",
-    "jws": "eyJhbGciOiJQUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DJBMvvFAIC00nSGB6Tn0XKbbF9XrsaJZREWvR2aONYTQQxnyXirtXnlewJMBBn2h9hfcGZrvnC1b6PgWmukzFJ1IiH1dWgnDIS81BH-IxXnPkbuYDeySorc4QU9MJxdVkY5EL4HYbcIfwKj6X4LBQ2_ZHZIu1jdqLcRZqHcsDF5KKylKc1THn5VRWy5WhYg_gBnyWny8E6Qkrze53MR7OuAmmNJ1m1nN8SxDrG6a08L78J0-Fbas5OjAQz3c17GY8mVuDPOBIOVjMEghBlgl3nOi1ysxbRGhHLEK4s0KKbeRogZdgt1DkQxDFxxn41QWDw_mmMCjs9qxg0zcZzqEJw"
-  },
-
-  "expirationDate": "2020-01-01T19:23:24Z",
-
-  "credentialStatus": {
-    "id": "https://example.edu/status/24",
-    "type": "CredentialStatusList2017"
-  },
-
-  "evidence": [{
-    "id": "https://example.edu/evidence/f2aeec97-fc0d-42bf-8ca7-0548192d4231",
-    "type": ["DocumentVerification"],
-    "verifier": "https://example.edu/issuers/14",
-    "evidenceDocument": "DriversLicense",
-    "subjectPresence": "Physical",
-    "documentPresence": "Physical"
-  },{
-    "id": "https://example.edu/evidence/f2aeec97-fc0d-42bf-8ca7-0548192dxyzab",
-    "type": ["SupportingActivity"],
-    "verifier": "https://example.edu/issuers/14",
-    "evidenceDocument": "Fluid Dynamics Focus",
-    "subjectPresence": "Digital",
-    "documentPresence": "Digital"
-  }],
-
-  "termsOfUse": [
-    {
-      "type": "IssuerPolicy",
-      "id": "http://example.com/policies/credential/4",
-      "profile": "http://example.com/profiles/credential",
-      "prohibition": [
-        {
-          "assigner": "https://example.edu/issuers/14",
-          "assignee": "AllVerifiers",
-          "target": "http://example.edu/credentials/3732",
-          "action": [
-            "Archival"
-          ]
-        }
-      ]
-    }
-  ],
-
-  "refreshService": {
-    "id": "https://example.edu/refresh/3732",
-    "type": "ManualRefreshService2018"
-  }
-}
-`
-
 const singleCredentialSubject = `
 {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
@@ -614,7 +529,7 @@ func TestJSONConversionWithPlainIssuer(t *testing.T) {
 	require.NotEmpty(t, vc)
 
 	// convert verifiable credential to json byte data
-	byteCred, err := vc.JSON()
+	byteCred, err := vc.MarshalJSON()
 	require.NoError(t, err)
 	require.NotEmpty(t, byteCred)
 
@@ -638,7 +553,7 @@ func TestJSONConversionCompositeIssuer(t *testing.T) {
 	vc.Issuer.Name = ""
 
 	// convert verifiable credential to json byte data
-	byteCred, err := vc.JSON()
+	byteCred, err := vc.MarshalJSON()
 	require.NoError(t, err)
 	require.NotEmpty(t, byteCred)
 

--- a/pkg/doc/verifiable/jwt_unsecured.go
+++ b/pkg/doc/verifiable/jwt_unsecured.go
@@ -1,0 +1,68 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifiable
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// marshalUnsecuredJWT serializes JWT in unsecured form
+func marshalUnsecuredJWT(headers map[string]string, claims interface{}) (string, error) {
+	bHeader, err := json.Marshal(headers)
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize JOSE headers: %w", err)
+	}
+
+	bPayload, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize JWT claims: %w", err)
+	}
+
+	return fmt.Sprintf("%s.%s.",
+			base64.RawURLEncoding.EncodeToString(bHeader),
+			base64.RawURLEncoding.EncodeToString(bPayload)),
+		nil
+}
+
+// unmarshalUnsecuredJWT unmarshals serialized JWT in unsecured form into jose headers and claims body.
+func unmarshalUnsecuredJWT(rawJWT []byte) (joseHeaders map[string]string, bytesClaim []byte, err error) {
+	parts := strings.Split(string(rawJWT), ".")
+
+	if len(parts) != 3 {
+		return nil, nil, fmt.Errorf("JWT format must have three parts")
+	}
+
+	if parts[2] != "" {
+		return nil, nil, fmt.Errorf("unsecured JWT must have empty signature part")
+	}
+
+	bytesHeader, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, nil, err
+	}
+
+	headers := make(map[string]string)
+	err = json.Unmarshal(bytesHeader, &headers)
+	if err != nil {
+		return nil, nil, fmt.Errorf("JOSE headers must be JSON document: %w", err)
+	}
+
+	bytesPayload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, nil, err
+	}
+
+	claims := make(map[string]interface{})
+	err = json.Unmarshal(bytesPayload, &claims)
+	if err != nil {
+		return nil, nil, fmt.Errorf("JWT Claims must be JSON document: %w", err)
+	}
+
+	return headers, bytesPayload, nil
+}

--- a/pkg/doc/verifiable/jwt_unsecured_test.go
+++ b/pkg/doc/verifiable/jwt_unsecured_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifiable
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// nolint:gochecknoglobals
+var (
+	joseHeaders   = map[string]string{"alg": "none"}
+	jwtClaims     = map[string]interface{}{"sub": "user123", "productIds": []int{1, 2}}
+	jwtSerialized = "eyJhbGciOiJub25lIn0.eyJwcm9kdWN0SWRzIjpbMSwyXSwic3ViIjoidXNlcjEyMyJ9."
+)
+
+func TestMarshalUnsecuredJWT(t *testing.T) {
+	t.Run("serialize unsecured JWT", func(t *testing.T) {
+		unsecuredJWT, err := marshalUnsecuredJWT(joseHeaders, jwtClaims)
+		require.NoError(t, err)
+		require.Equal(t, jwtSerialized, unsecuredJWT)
+	})
+
+	t.Run("incorrect JWT payload", func(t *testing.T) {
+		unmarshallable := make(chan bool)
+
+		_, err := marshalUnsecuredJWT(joseHeaders, unmarshallable)
+		require.Error(t, err)
+	})
+}
+
+func TestUnmarshalUnsecuredJWT(t *testing.T) {
+	jwtClaimsBytes, serError := json.Marshal(jwtClaims)
+	require.NoError(t, serError)
+
+	notBase64 := "[not base64]"
+	notJSON := base64.RawURLEncoding.EncodeToString([]byte("Not JSON!"))
+
+	t.Run("decodes unsecured JWT", func(t *testing.T) {
+		decodedHeaders, decodedClaims, err := unmarshalUnsecuredJWT([]byte(jwtSerialized))
+		require.NoError(t, err)
+		require.Equal(t, joseHeaders, decodedHeaders)
+		require.Equal(t, jwtClaimsBytes, decodedClaims)
+	})
+
+	t.Run("rejects serialized JWT of invalid format", func(t *testing.T) {
+		_, _, err := unmarshalUnsecuredJWT([]byte("invalid JWT"))
+		require.EqualError(t, err, "JWT format must have three parts")
+	})
+
+	t.Run("rejects signed JWT", func(t *testing.T) {
+		_, _, err := unmarshalUnsecuredJWT([]byte("headers.payload.signature"))
+		require.EqualError(t, err, "unsecured JWT must have empty signature part")
+	})
+
+	t.Run("rejects serialized JWT headers not in base64 format", func(t *testing.T) {
+		invalidJWT := fmt.Sprintf("%s.eyJwcm9kdWN0SWRzIjpbMSwyXSwic3ViIjoidXNlcjEyMyJ9.", notBase64)
+		_, _, err := unmarshalUnsecuredJWT([]byte(invalidJWT))
+		require.Error(t, err)
+	})
+
+	t.Run("rejects JWT headers which are not JSON", func(t *testing.T) {
+		invalidJWT := fmt.Sprintf("%s.eyJwcm9kdWN0SWRzIjpbMSwyXSwic3ViIjoidXNlcjEyMyJ9.", notJSON)
+		_, _, err := unmarshalUnsecuredJWT([]byte(invalidJWT))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "JOSE headers must be JSON document")
+	})
+
+	t.Run("rejects serialized JWT claims not in base64 format", func(t *testing.T) {
+		invalidJWT := fmt.Sprintf("eyJhbGciOiJub25lIn0.%s.", notBase64)
+		_, _, err := unmarshalUnsecuredJWT([]byte(invalidJWT))
+		require.Error(t, err)
+	})
+
+	t.Run("rejects JWT headers which are not JSON", func(t *testing.T) {
+		invalidJWT := fmt.Sprintf("eyJhbGciOiJub25lIn0.%s.", notJSON)
+		_, _, err := unmarshalUnsecuredJWT([]byte(invalidJWT))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "JWT Claims must be JSON document")
+	})
+}

--- a/pkg/doc/verifiable/support_test.go
+++ b/pkg/doc/verifiable/support_test.go
@@ -13,7 +13,97 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+const certPrefix = "testdata/crypto"
+
+//nolint:lll
+const validCredential = `
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1"
+  ],
+  "id": "http://example.edu/credentials/1872",
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ],
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "BachelorDegree",
+      "university": "MIT"
+    },
+    "name": "Jayden Doe",
+    "spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
+  },
+
+  "issuer": {
+    "id": "did:example:76e12ec712ebc6f1c221ebfeb1f",
+    "name": "Example University"
+  },
+
+  "issuanceDate": "2010-01-01T19:23:24Z",
+
+  "proof": {
+    "type": "RsaSignature2018",
+    "created": "2018-06-18T21:19:10Z",
+    "proofPurpose": "assertionMethod",
+    "verificationMethod": "https://example.com/jdoe/keys/1",
+    "jws": "eyJhbGciOiJQUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DJBMvvFAIC00nSGB6Tn0XKbbF9XrsaJZREWvR2aONYTQQxnyXirtXnlewJMBBn2h9hfcGZrvnC1b6PgWmukzFJ1IiH1dWgnDIS81BH-IxXnPkbuYDeySorc4QU9MJxdVkY5EL4HYbcIfwKj6X4LBQ2_ZHZIu1jdqLcRZqHcsDF5KKylKc1THn5VRWy5WhYg_gBnyWny8E6Qkrze53MR7OuAmmNJ1m1nN8SxDrG6a08L78J0-Fbas5OjAQz3c17GY8mVuDPOBIOVjMEghBlgl3nOi1ysxbRGhHLEK4s0KKbeRogZdgt1DkQxDFxxn41QWDw_mmMCjs9qxg0zcZzqEJw"
+  },
+
+  "expirationDate": "2020-01-01T19:23:24Z",
+
+  "credentialStatus": {
+    "id": "https://example.edu/status/24",
+    "type": "CredentialStatusList2017"
+  },
+
+  "evidence": [{
+    "id": "https://example.edu/evidence/f2aeec97-fc0d-42bf-8ca7-0548192d4231",
+    "type": ["DocumentVerification"],
+    "verifier": "https://example.edu/issuers/14",
+    "evidenceDocument": "DriversLicense",
+    "subjectPresence": "Physical",
+    "documentPresence": "Physical"
+  },{
+    "id": "https://example.edu/evidence/f2aeec97-fc0d-42bf-8ca7-0548192dxyzab",
+    "type": ["SupportingActivity"],
+    "verifier": "https://example.edu/issuers/14",
+    "evidenceDocument": "Fluid Dynamics Focus",
+    "subjectPresence": "Digital",
+    "documentPresence": "Digital"
+  }],
+
+  "termsOfUse": [
+    {
+      "type": "IssuerPolicy",
+      "id": "http://example.com/policies/credential/4",
+      "profile": "http://example.com/profiles/credential",
+      "prohibition": [
+        {
+          "assigner": "https://example.edu/issuers/14",
+          "assignee": "AllVerifiers",
+          "target": "http://example.edu/credentials/3732",
+          "action": [
+            "Archival"
+          ]
+        }
+      ]
+    }
+  ],
+
+  "refreshService": {
+    "id": "https://example.edu/refresh/3732",
+    "type": "ManualRefreshService2018"
+  }
+}
+`
 
 func readPublicKey(keyFilePath string) (*rsa.PublicKey, error) {
 	pub, err := ioutil.ReadFile(filepath.Clean(keyFilePath))
@@ -56,4 +146,10 @@ func readPrivateKey(keyFilePath string) (*rsa.PrivateKey, error) {
 	}
 
 	return privKey, nil
+}
+
+func (raw *rawCredential) stringJSON(t *testing.T) string {
+	bytes, err := raw.marshalJSON()
+	require.NoError(t, err)
+	return string(bytes)
 }


### PR DESCRIPTION
closes #372

Signed-off-by: Dima <dkinoshenko@gmail.com>

As a result, 2 VC Test Suite tests are passing.

As go-jose does not support unsecured JWT serialization, a workaround solution is used. [#264](https://github.com/square/go-jose/issues/264)is filed but was rejected by the authors of the go-jose.