### PR TITLE
feat: WIP Update the service and state to consume the persistence layer method

### DIFF
--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -245,7 +245,7 @@ func (c *Operation) QueryConnectionByID(rw http.ResponseWriter, req *http.Reques
 	params := mux.Vars(req)
 	logger.Debugf("Querying connection invitation for id [%s]", params["id"])
 
-	result, err := c.client.GetConnection(params["id"])
+	result, err := c.client.GetConnectionRecord(params["id"])
 	if err != nil {
 		c.writeGenericError(rw, err)
 		return

--- a/test/bdd/did_exchange_steps.go
+++ b/test/bdd/did_exchange_steps.go
@@ -61,7 +61,7 @@ func (d *DIDExchangeSteps) waitForPostEvent(agentID, statesValue string) error {
 }
 
 func (d *DIDExchangeSteps) validateConnection(agentID, stateValue string) error {
-	conn, err := d.bddContext.DIDExchangeClients[agentID].GetConnection(d.bddContext.ConnectionID[agentID])
+	conn, err := d.bddContext.DIDExchangeClients[agentID].GetConnectionRecord(d.bddContext.ConnectionID[agentID])
 	if err != nil {
 		return fmt.Errorf("failed to query connection by id: %w", err)
 	}


### PR DESCRIPTION
  Bob -> Invitee: 

1.  Bob receives an invitation from Alice 
2. Bob creates and stores the connection Record {ConnectionID->uuid ,ThreadID -> uuid, Recipient, ServiceEndpoint, state -> invited, Theirlabel: invitation )
3. Store  the mapping of {MyNS+ThreadID to ConnectionID}
4. Sends an automatic Exchange Request to Alice (using the ThreadID created in the step 3. )
5. Update the connectionRecord { state -> requested, Mydid-> from request}

Alice -> Inviter 
1. Alice create the connection Record using the ThreadID in the request plus TheirNS {ConnectionID->uuid ,ThreadID :thid,  state -> requested, TheirDID->did from request, TheirLabel-> from request }
2. Mapping (TheirNS+Thid -> ConnectionID) 
3. Alice prepares the exchange Response to Bob (using the ThreadID created in the step 3. )
4. Update the connectionRecord { state -> responded, MyDID -> from response )
5. Send exchange Response to Bob

Bob -> Invitee
1. Bob receives the Exchange Response 
2. Fetch the connection Record using MyNS+threadID from response 
3. Update connectionRecord {state -> responded, TheirDID->did from response (sig_data)}
4. Bob sends an Ack (using the ThreadID created in the step 3.)
5. Update the connectionRecord {state->completed}


closes #397

Signed-off-by: talwinder.kaur <talwinder.kaur@securekey.com>


