### PR TITLE
refactor: Move messages and events code from dispatcher pkg

### DIFF
--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/common/did"
 	mockprotocol "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
@@ -168,7 +168,7 @@ func TestClient_HandleInvitation(t *testing.T) {
 
 	t.Run("test error from handle msg", func(t *testing.T) {
 		c, err := New(&mockprovider.Provider{StorageProviderValue: mockstore.NewMockStoreProvider(),
-			ServiceValue: &mockprotocol.MockDIDExchangeSvc{HandleFunc: func(msg dispatcher.DIDCommMsg) error {
+			ServiceValue: &mockprotocol.MockDIDExchangeSvc{HandleFunc: func(msg service.DIDCommMsg) error {
 				return fmt.Errorf("handle error")
 			}},
 			WalletValue: &mockwallet.CloseableWallet{CreateEncryptionKeyValue: "sample-key"}, InboundEndpointValue: "endpoint"})
@@ -210,7 +210,7 @@ func TestServiceEvents(t *testing.T) {
 	require.NotNil(t, c)
 
 	// register action event channel
-	aCh := make(chan dispatcher.DIDCommAction, 10)
+	aCh := make(chan service.DIDCommAction, 10)
 	err = c.RegisterActionEvent(aCh)
 	require.NoError(t, err)
 	go func() {
@@ -218,7 +218,7 @@ func TestServiceEvents(t *testing.T) {
 	}()
 
 	// register message event channel
-	mCh := make(chan dispatcher.StateMsg, 10)
+	mCh := make(chan service.StateMsg, 10)
 	err = c.RegisterMsgEvent(mCh)
 	require.NoError(t, err)
 	go func() {
@@ -245,7 +245,7 @@ func TestServiceEvents(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	msg := dispatcher.DIDCommMsg{
+	msg := service.DIDCommMsg{
 		Type:    didexchange.ConnectionRequest,
 		Payload: request,
 	}
@@ -305,12 +305,12 @@ func TestService_ActionEvent(t *testing.T) {
 	require.Nil(t, c.actionEvent)
 
 	// register an action event
-	ch := make(chan dispatcher.DIDCommAction)
+	ch := make(chan service.DIDCommAction)
 	err = c.RegisterActionEvent(ch)
 	require.NoError(t, err)
 
 	// register another action event
-	err = c.RegisterActionEvent(make(chan dispatcher.DIDCommAction))
+	err = c.RegisterActionEvent(make(chan service.DIDCommAction))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "channel is already registered for the action event")
 
@@ -325,7 +325,7 @@ func TestService_ActionEvent(t *testing.T) {
 	require.Nil(t, c.actionEvent)
 
 	// unregister with different channel
-	err = c.UnregisterActionEvent(make(chan dispatcher.DIDCommAction))
+	err = c.UnregisterActionEvent(make(chan service.DIDCommAction))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid channel passed to unregister the action event")
 }
@@ -340,7 +340,7 @@ func TestService_MsgEvents(t *testing.T) {
 	require.Equal(t, 0, len(c.msgEvents))
 
 	// register a status event
-	ch := make(chan dispatcher.StateMsg)
+	ch := make(chan service.StateMsg)
 	err = c.RegisterMsgEvent(ch)
 	require.NoError(t, err)
 
@@ -349,7 +349,7 @@ func TestService_MsgEvents(t *testing.T) {
 	require.Equal(t, 1, len(c.msgEvents))
 
 	// register a new status event
-	err = c.RegisterMsgEvent(make(chan dispatcher.StateMsg))
+	err = c.RegisterMsgEvent(make(chan service.StateMsg))
 	require.NoError(t, err)
 
 	// validate after new register
@@ -365,9 +365,9 @@ func TestService_MsgEvents(t *testing.T) {
 
 	// add channels and remove in opposite order
 	c.msgEvents = nil
-	ch1 := make(chan dispatcher.StateMsg)
-	ch2 := make(chan dispatcher.StateMsg)
-	ch3 := make(chan dispatcher.StateMsg)
+	ch1 := make(chan service.StateMsg)
+	ch2 := make(chan service.StateMsg)
+	ch3 := make(chan service.StateMsg)
 
 	err = c.RegisterMsgEvent(ch1)
 	require.NoError(t, err)

--- a/pkg/didcomm/common/service/event.go
+++ b/pkg/didcomm/common/service/event.go
@@ -1,0 +1,58 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package service
+
+// StateMsgType state msg type
+type StateMsgType int
+
+const (
+	// PreState pre state
+	PreState StateMsgType = iota
+	// PostState post state
+	PostState
+)
+
+// StateMsg msg
+type StateMsg struct {
+	Type    StateMsgType
+	StateID string
+	Msg     DIDCommMsg
+	// Properties contains different values from different protocols
+	Properties map[string]interface{}
+}
+
+// DIDCommAction message type to pass events in go channels.
+type DIDCommAction struct {
+	// DIDComm message
+	Message DIDCommMsg
+	// Continue function to be called by the consumer for further processing the message.
+	Continue func()
+	// Stop invocation notifies the service that the consumer action event processing has failed or the consumer wants
+	// to stop the processing.
+	Stop func(err error)
+	// Properties contains different values from different protocols
+	Properties map[string]interface{}
+}
+
+// Event event related apis.
+type Event interface {
+	// RegisterActionEvent on protocol messages. The events are triggered for incoming message types based on
+	// the protocol service. The consumer need to invoke the callback to resume processing.
+	// Only one channel can be registered for the action events. The function will throw error if a channel is already
+	// registered.
+	RegisterActionEvent(ch chan<- DIDCommAction) error
+
+	// UnregisterActionEvent on protocol messages. Refer RegisterActionEvent().
+	UnregisterActionEvent(ch chan<- DIDCommAction) error
+
+	// RegisterMsgEvent on protocol messages. The message events are triggered for incoming messages. Service
+	// will not expect any callback on these events unlike Action event.
+	RegisterMsgEvent(ch chan<- StateMsg) error
+
+	// UnregisterMsgEvent on protocol messages. Refer RegisterMsgEvent().
+	UnregisterMsgEvent(ch chan<- StateMsg) error
+}

--- a/pkg/didcomm/common/service/service.go
+++ b/pkg/didcomm/common/service/service.go
@@ -1,0 +1,40 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package service
+
+// Handler provides protocol service handle api.
+type Handler interface {
+	Handle(msg DIDCommMsg) error
+}
+
+// DIDComm defines service APIs.
+type DIDComm interface {
+	// service handler
+	Handler
+
+	// event service
+	Event
+}
+
+// DIDCommMsg did comm msg
+type DIDCommMsg struct {
+	// Outbound indicates the direction of this DIDComm message:
+	//   - outgoing (to another agent)
+	//   - incoming (from another agent)
+	Outbound bool
+	Type     string
+	Payload  []byte
+	// TODO : might need refactor as per the issue-226
+	OutboundDestination *Destination
+}
+
+// Destination provides the recipientKeys, routingKeys, and serviceEndpoint populated from Invitation
+type Destination struct {
+	RecipientKeys   []string
+	ServiceEndpoint string
+	RoutingKeys     []string
+}

--- a/pkg/didcomm/dispatcher/outbound.go
+++ b/pkg/didcomm/dispatcher/outbound.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
@@ -26,7 +27,7 @@ func NewOutbound(prov Provider) *OutboundDispatcher {
 }
 
 // Send msg
-func (o *OutboundDispatcher) Send(msg interface{}, senderVerKey string, des *Destination) error {
+func (o *OutboundDispatcher) Send(msg interface{}, senderVerKey string, des *service.Destination) error {
 	for _, v := range o.outboundTransports {
 		if !v.Accept(des.ServiceEndpoint) {
 			continue

--- a/pkg/didcomm/dispatcher/outbound_test.go
+++ b/pkg/didcomm/dispatcher/outbound_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	mockdidcomm "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm"
 	mockwallet "github.com/hyperledger/aries-framework-go/pkg/internal/mock/wallet"
@@ -22,13 +23,13 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
 		o := NewOutbound(&provider{walletValue: &mockwallet.CloseableWallet{},
 			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: true}}})
-		require.NoError(t, o.Send("data", "", &Destination{ServiceEndpoint: "url"}))
+		require.NoError(t, o.Send("data", "", &service.Destination{ServiceEndpoint: "url"}))
 	})
 
 	t.Run("test no outbound transport found", func(t *testing.T) {
 		o := NewOutbound(&provider{walletValue: &mockwallet.CloseableWallet{},
 			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: false}}})
-		err := o.Send("data", "", &Destination{ServiceEndpoint: "url"})
+		err := o.Send("data", "", &service.Destination{ServiceEndpoint: "url"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no outbound transport found for serviceEndpoint: url")
 	})
@@ -36,7 +37,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 	t.Run("test pack msg failure", func(t *testing.T) {
 		o := NewOutbound(&provider{walletValue: &mockwallet.CloseableWallet{PackErr: fmt.Errorf("pack error")},
 			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: true}}})
-		err := o.Send("data", "", &Destination{ServiceEndpoint: "url"})
+		err := o.Send("data", "", &service.Destination{ServiceEndpoint: "url"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "pack error")
 	})
@@ -45,7 +46,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 		o := NewOutbound(&provider{walletValue: &mockwallet.CloseableWallet{},
 			outboundTransportsValue: []transport.OutboundTransport{
 				&mockdidcomm.MockOutboundTransport{AcceptValue: true, SendErr: fmt.Errorf("send error")}}})
-		err := o.Send("data", "", &Destination{ServiceEndpoint: "url"})
+		err := o.Send("data", "", &service.Destination{ServiceEndpoint: "url"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "send error")
 	})

--- a/pkg/didcomm/protocol/didexchange/states_test.go
+++ b/pkg/didcomm/protocol/didexchange/states_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/model"
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	mockdid "github.com/hyperledger/aries-framework-go/pkg/internal/mock/common/did"
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
@@ -170,14 +170,14 @@ func TestStateFromName(t *testing.T) {
 
 // noOp.Execute() returns nil, error
 func TestNoOpState_Execute(t *testing.T) {
-	followup, _, err := (&noOp{}).Execute(dispatcher.DIDCommMsg{}, "", context{})
+	followup, _, err := (&noOp{}).Execute(service.DIDCommMsg{}, "", context{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
 
 // null.Execute() is a no-op
 func TestNullState_Execute(t *testing.T) {
-	followup, _, err := (&null{}).Execute(dispatcher.DIDCommMsg{}, "", context{})
+	followup, _, err := (&null{}).Execute(service.DIDCommMsg{}, "", context{})
 	require.NoError(t, err)
 	require.IsType(t, &noOp{}, followup)
 }
@@ -186,17 +186,17 @@ func TestInvitedState_Execute(t *testing.T) {
 	t.Run("rejects msgs other than invitations", func(t *testing.T) {
 		others := []string{ConnectionRequest, ConnectionResponse, ConnectionAck}
 		for _, o := range others {
-			_, _, err := (&invited{}).Execute(dispatcher.DIDCommMsg{Type: o}, "", context{})
+			_, _, err := (&invited{}).Execute(service.DIDCommMsg{Type: o}, "", context{})
 			require.Error(t, err)
 		}
 	})
 	t.Run("rejects outbound invitations", func(t *testing.T) {
-		_, _, err := (&invited{}).Execute(dispatcher.DIDCommMsg{Type: ConnectionInvite, Outbound: true}, "", context{})
+		_, _, err := (&invited{}).Execute(service.DIDCommMsg{Type: ConnectionInvite, Outbound: true}, "", context{})
 		require.Error(t, err)
 	})
 	t.Run("followup to 'requested' on inbound invitations", func(t *testing.T) {
 		followup, _, err := (&invited{}).Execute(
-			dispatcher.DIDCommMsg{Type: ConnectionInvite, Outbound: false}, "", context{})
+			service.DIDCommMsg{Type: ConnectionInvite, Outbound: false}, "", context{})
 		require.NoError(t, err)
 		require.Equal(t, (&requested{}).Name(), followup.Name())
 	})
@@ -210,12 +210,12 @@ func TestRequestedState_Execute(t *testing.T) {
 	t.Run("rejects msgs other than invitations or requests", func(t *testing.T) {
 		others := []string{ConnectionResponse, ConnectionAck}
 		for _, o := range others {
-			_, _, e := (&requested{}).Execute(dispatcher.DIDCommMsg{Type: o}, "", context{})
+			_, _, e := (&requested{}).Execute(service.DIDCommMsg{Type: o}, "", context{})
 			require.Error(t, e)
 		}
 	})
 	t.Run("rejects outbound invitations", func(t *testing.T) {
-		_, _, e := (&requested{}).Execute(dispatcher.DIDCommMsg{Type: ConnectionInvite, Outbound: true}, "", context{})
+		_, _, e := (&requested{}).Execute(service.DIDCommMsg{Type: ConnectionInvite, Outbound: true}, "", context{})
 		require.Error(t, e)
 	})
 	// Alice receives an invitation from Bob
@@ -232,11 +232,11 @@ func TestRequestedState_Execute(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Run("no followup to inbound invitations", func(t *testing.T) {
-		msg := dispatcher.DIDCommMsg{Type: ConnectionInvite, Payload: invitationPayloadBytes, Outbound: false}
+		msg := service.DIDCommMsg{Type: ConnectionInvite, Payload: invitationPayloadBytes, Outbound: false}
 		thid, er := threadID(msg)
 		require.NoError(t, er)
 		_, _, e := (&requested{}).Execute(
-			dispatcher.DIDCommMsg{Type: ConnectionInvite, Payload: invitationPayloadBytes, Outbound: false}, thid, ctx)
+			service.DIDCommMsg{Type: ConnectionInvite, Payload: invitationPayloadBytes, Outbound: false}, thid, ctx)
 		require.NoError(t, e)
 	})
 	// Bob sends an exchange request to Alice
@@ -251,12 +251,12 @@ func TestRequestedState_Execute(t *testing.T) {
 			},
 		},
 	)
-	dest := &dispatcher.Destination{RecipientKeys: []string{"test", "test2"}, ServiceEndpoint: "xyz"}
+	dest := &service.Destination{RecipientKeys: []string{"test", "test2"}, ServiceEndpoint: "xyz"}
 	require.NoError(t, err)
 	// OutboundDestination needs to be present
 	t.Run("no followup for outbound requests", func(t *testing.T) {
 		followup, _, err := (&requested{}).
-			Execute(dispatcher.DIDCommMsg{
+			Execute(service.DIDCommMsg{
 				Type: ConnectionRequest, Payload: requestPayloadBytes, Outbound: true, OutboundDestination: dest}, "", ctx)
 		require.NoError(t, err)
 		require.IsType(t, &noOp{}, followup)
@@ -279,26 +279,26 @@ func TestRequestedState_Execute(t *testing.T) {
 		)
 		require.NoError(t, err)
 		followup, _, err := (&requested{}).
-			Execute(dispatcher.DIDCommMsg{
+			Execute(service.DIDCommMsg{
 				Type: ConnectionRequest, Payload: requestPayloadBytes, Outbound: true, OutboundDestination: dest}, "", ctx2)
 		require.Error(t, err)
 		require.Nil(t, followup)
 	})
 	t.Run("followup to 'responded' on inbound requests", func(t *testing.T) {
 		followup, _, err := (&requested{}).
-			Execute(dispatcher.DIDCommMsg{Type: ConnectionRequest, Outbound: false}, "", context{})
+			Execute(service.DIDCommMsg{Type: ConnectionRequest, Outbound: false}, "", context{})
 		require.NoError(t, err)
 		require.Equal(t, (&responded{}).Name(), followup.Name())
 	})
 	t.Run("followup to 'responded' on inbound requests", func(t *testing.T) {
 		followup, _, err := (&requested{}).
-			Execute(dispatcher.DIDCommMsg{Type: ConnectionRequest, Payload: nil, Outbound: true}, "", context{})
+			Execute(service.DIDCommMsg{Type: ConnectionRequest, Payload: nil, Outbound: true}, "", context{})
 		require.Error(t, err)
 		require.Nil(t, followup)
 	})
 	t.Run("inbound request error", func(t *testing.T) {
 		followup, _, err := (&requested{}).
-			Execute(dispatcher.DIDCommMsg{Type: ConnectionInvite, Payload: nil, Outbound: false}, "", context{})
+			Execute(service.DIDCommMsg{Type: ConnectionInvite, Payload: nil, Outbound: false}, "", context{})
 		require.Error(t, err)
 		require.Nil(t, followup)
 	})
@@ -313,7 +313,7 @@ func TestRequestedState_Execute(t *testing.T) {
 		ctx2 := context{outboundDispatcher: &mockdispatcher.MockOutbound{SendErr: fmt.Errorf("error")},
 			didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}}
 		followup, action, err := (&requested{}).
-			Execute(dispatcher.DIDCommMsg{Type: ConnectionInvite, Payload: invitationPayloadBytes, Outbound: false}, "", ctx2)
+			Execute(service.DIDCommMsg{Type: ConnectionInvite, Payload: invitationPayloadBytes, Outbound: false}, "", ctx2)
 		require.NoError(t, err)
 		require.NotNil(t, followup)
 		require.Error(t, action())
@@ -322,7 +322,7 @@ func TestRequestedState_Execute(t *testing.T) {
 		ctx2 := context{outboundDispatcher: prov.OutboundDispatcher(),
 			didCreator: &mockdid.MockDIDCreator{Doc: getMockDIDPublicKey()}}
 		followup, _, err := (&requested{}).
-			Execute(dispatcher.DIDCommMsg{Type: ConnectionInvite, Payload: invitationPayloadBytes, Outbound: false}, "", ctx2)
+			Execute(service.DIDCommMsg{Type: ConnectionInvite, Payload: invitationPayloadBytes, Outbound: false}, "", ctx2)
 		require.Error(t, err)
 		require.Nil(t, followup)
 	})
@@ -334,16 +334,16 @@ func TestRespondedState_Execute(t *testing.T) {
 	newDidDoc, err := ctx.didCreator.CreateDID()
 	require.NoError(t, err)
 
-	outboundDestination := &dispatcher.Destination{RecipientKeys: []string{"test", "test2"}, ServiceEndpoint: "xyz"}
+	outboundDestination := &service.Destination{RecipientKeys: []string{"test", "test2"}, ServiceEndpoint: "xyz"}
 	t.Run("rejects msgs other than requests and responses", func(t *testing.T) {
 		others := []string{ConnectionInvite, ConnectionAck}
 		for _, o := range others {
-			_, _, e := (&responded{}).Execute(dispatcher.DIDCommMsg{Type: o}, "", context{})
+			_, _, e := (&responded{}).Execute(service.DIDCommMsg{Type: o}, "", context{})
 			require.Error(t, e)
 		}
 	})
 	t.Run("rejects outbound requests", func(t *testing.T) {
-		_, _, e := (&responded{}).Execute(dispatcher.DIDCommMsg{Type: ConnectionRequest, Outbound: true}, "", context{})
+		_, _, e := (&responded{}).Execute(service.DIDCommMsg{Type: ConnectionRequest, Outbound: true}, "", context{})
 		require.Error(t, e)
 	})
 	// Prepare did-exchange inbound request
@@ -361,12 +361,12 @@ func TestRespondedState_Execute(t *testing.T) {
 	require.NoError(t, err)
 	t.Run("no followup for inbound requests", func(t *testing.T) {
 		followup, _, e := (&responded{}).
-			Execute(dispatcher.DIDCommMsg{Type: ConnectionRequest, Outbound: false, Payload: requestPayloadBytes}, "", ctx)
+			Execute(service.DIDCommMsg{Type: ConnectionRequest, Outbound: false, Payload: requestPayloadBytes}, "", ctx)
 		require.NoError(t, e)
 		require.IsType(t, &noOp{}, followup)
 	})
 	t.Run("followup to 'completed' on inbound responses", func(t *testing.T) {
-		followup, _, e := (&responded{}).Execute(dispatcher.DIDCommMsg{Type: ConnectionResponse, Outbound: false}, "", ctx)
+		followup, _, e := (&responded{}).Execute(service.DIDCommMsg{Type: ConnectionResponse, Outbound: false}, "", ctx)
 		require.NoError(t, e)
 		require.Equal(t, (&completed{}).Name(), followup.Name())
 	})
@@ -388,7 +388,7 @@ func TestRespondedState_Execute(t *testing.T) {
 	require.NoError(t, err)
 	// OutboundDestination needs to be present
 	t.Run("no followup for outbound responses", func(t *testing.T) {
-		m := dispatcher.DIDCommMsg{Type: ConnectionResponse,
+		m := service.DIDCommMsg{Type: ConnectionResponse,
 			Outbound: true, Payload: responsePayloadBytes, OutboundDestination: outboundDestination}
 		followup, _, e := (&responded{}).Execute(m, "", ctx)
 		require.NoError(t, e)
@@ -415,7 +415,7 @@ func TestRespondedState_Execute(t *testing.T) {
 		// Bob sends an exchange request to Alice
 		responsePayloadBytes, err = json.Marshal(response)
 		require.NoError(t, err)
-		m := dispatcher.DIDCommMsg{Type: ConnectionResponse,
+		m := service.DIDCommMsg{Type: ConnectionResponse,
 			Outbound: true, Payload: responsePayloadBytes, OutboundDestination: outboundDestination}
 		followup, _, e := (&responded{}).Execute(m, "", ctx2)
 		require.Error(t, e)
@@ -424,13 +424,13 @@ func TestRespondedState_Execute(t *testing.T) {
 
 	t.Run("no followup for outbound responses error", func(t *testing.T) {
 		followup, _, e := (&responded{}).
-			Execute(dispatcher.DIDCommMsg{Type: ConnectionResponse, Payload: nil, Outbound: true}, "", context{})
+			Execute(service.DIDCommMsg{Type: ConnectionResponse, Payload: nil, Outbound: true}, "", context{})
 		require.Error(t, e)
 		require.Nil(t, followup)
 	})
 	t.Run("inbound request error", func(t *testing.T) {
 		followup, _, e := (&responded{}).
-			Execute(dispatcher.DIDCommMsg{Type: ConnectionRequest, Payload: nil, Outbound: false}, "", context{})
+			Execute(service.DIDCommMsg{Type: ConnectionRequest, Payload: nil, Outbound: false}, "", context{})
 		require.Error(t, e)
 		require.Nil(t, followup)
 	})
@@ -438,7 +438,7 @@ func TestRespondedState_Execute(t *testing.T) {
 		ctx2 := context{outboundDispatcher: &mockdispatcher.MockOutbound{SendErr: fmt.Errorf("error")},
 			didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}}
 		followup, action, e := (&responded{}).
-			Execute(dispatcher.DIDCommMsg{Type: ConnectionRequest, Payload: requestPayloadBytes,
+			Execute(service.DIDCommMsg{Type: ConnectionRequest, Payload: requestPayloadBytes,
 				Outbound: false, OutboundDestination: outboundDestination}, "", ctx2)
 		require.NoError(t, e)
 		require.NotNil(t, followup)
@@ -453,7 +453,7 @@ func TestRespondedState_Execute(t *testing.T) {
 		}
 		responsePayloadBytes, err := json.Marshal(response)
 		require.NoError(t, err)
-		followup, _, err := (&responded{}).Execute(dispatcher.DIDCommMsg{Type: ConnectionResponse, Outbound: true,
+		followup, _, err := (&responded{}).Execute(service.DIDCommMsg{Type: ConnectionResponse, Outbound: true,
 			Payload: responsePayloadBytes, OutboundDestination: outboundDestination}, "", ctx)
 		require.Error(t, err)
 		require.Nil(t, followup)
@@ -462,7 +462,7 @@ func TestRespondedState_Execute(t *testing.T) {
 		ctx2 := context{outboundDispatcher: prov.OutboundDispatcher(),
 			didCreator: &mockdid.MockDIDCreator{Doc: getMockDIDPublicKey()}}
 		followup, _, err := (&responded{}).
-			Execute(dispatcher.DIDCommMsg{Type: ConnectionRequest, Payload: requestPayloadBytes, Outbound: false}, "", ctx2)
+			Execute(service.DIDCommMsg{Type: ConnectionRequest, Payload: requestPayloadBytes, Outbound: false}, "", ctx2)
 		require.Error(t, err)
 		require.Nil(t, followup)
 	})
@@ -474,11 +474,11 @@ func TestCompletedState_Execute(t *testing.T) {
 	ctx := context{outboundDispatcher: prov.OutboundDispatcher(), didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}}
 	newDidDoc, err := ctx.didCreator.CreateDID()
 	require.NoError(t, err)
-	outboundDestination := &dispatcher.Destination{RecipientKeys: []string{"test", "test2"}, ServiceEndpoint: "xyz"}
+	outboundDestination := &service.Destination{RecipientKeys: []string{"test", "test2"}, ServiceEndpoint: "xyz"}
 	t.Run("rejects msgs other than responses and acks", func(t *testing.T) {
 		others := []string{ConnectionInvite, ConnectionRequest}
 		for _, o := range others {
-			_, _, err = (&completed{}).Execute(dispatcher.DIDCommMsg{Type: o}, "", context{})
+			_, _, err = (&completed{}).Execute(service.DIDCommMsg{Type: o}, "", context{})
 			require.Error(t, err)
 		}
 	})
@@ -509,11 +509,11 @@ func TestCompletedState_Execute(t *testing.T) {
 	responsePayloadBytes, err := json.Marshal(response)
 
 	t.Run("rejects outbound responses", func(t *testing.T) {
-		_, _, err = (&completed{}).Execute(dispatcher.DIDCommMsg{Type: ConnectionResponse, Outbound: true}, "", context{})
+		_, _, err = (&completed{}).Execute(service.DIDCommMsg{Type: ConnectionResponse, Outbound: true}, "", context{})
 		require.Error(t, err)
 	})
 	t.Run("no followup for inbound responses", func(t *testing.T) {
-		followup, _, e := (&completed{}).Execute(dispatcher.DIDCommMsg{Type: ConnectionResponse, Outbound: false,
+		followup, _, e := (&completed{}).Execute(service.DIDCommMsg{Type: ConnectionResponse, Outbound: false,
 			Payload: responsePayloadBytes, OutboundDestination: outboundDestination}, "", ctx)
 		require.NoError(t, e)
 		require.IsType(t, &noOp{}, followup)
@@ -529,37 +529,37 @@ func TestCompletedState_Execute(t *testing.T) {
 		}
 		respPayloadBytes, err := json.Marshal(response)
 		require.NoError(t, err)
-		followup, _, err := (&completed{}).Execute(dispatcher.DIDCommMsg{Type: ConnectionResponse, Outbound: false,
+		followup, _, err := (&completed{}).Execute(service.DIDCommMsg{Type: ConnectionResponse, Outbound: false,
 			Payload: respPayloadBytes, OutboundDestination: outboundDestination}, "", ctx)
 		require.Error(t, err)
 		require.Nil(t, followup)
 	})
 	t.Run("no followup for inbound responses error", func(t *testing.T) {
-		followup, _, err := (&completed{}).Execute(dispatcher.DIDCommMsg{Type: ConnectionResponse, Outbound: false},
+		followup, _, err := (&completed{}).Execute(service.DIDCommMsg{Type: ConnectionResponse, Outbound: false},
 			"", context{})
 		require.Error(t, err)
 		require.Nil(t, followup)
 	})
 	t.Run("no followup for inbound acks", func(t *testing.T) {
-		followup, _, err := (&completed{}).Execute(dispatcher.DIDCommMsg{Type: ConnectionAck, Outbound: false}, "", context{})
+		followup, _, err := (&completed{}).Execute(service.DIDCommMsg{Type: ConnectionAck, Outbound: false}, "", context{})
 		require.NoError(t, err)
 		require.IsType(t, &noOp{}, followup)
 	})
 
 	t.Run("no followup for outbound acks error", func(t *testing.T) {
-		followup, _, err := (&completed{}).Execute(dispatcher.DIDCommMsg{Type: ConnectionAck, Outbound: true,
+		followup, _, err := (&completed{}).Execute(service.DIDCommMsg{Type: ConnectionAck, Outbound: true,
 			Payload: ackPayloadBytes, OutboundDestination: outboundDestination}, "", ctx)
 		require.NoError(t, err)
 		require.IsType(t, &noOp{}, followup)
 	})
 	t.Run("no followup for outbound acks outbound destination error", func(t *testing.T) {
-		followup, _, err := (&completed{}).Execute(dispatcher.DIDCommMsg{Type: ConnectionAck, Outbound: true,
+		followup, _, err := (&completed{}).Execute(service.DIDCommMsg{Type: ConnectionAck, Outbound: true,
 			Payload: ackPayloadBytes}, "", ctx)
 		require.Error(t, err)
 		require.Nil(t, followup)
 	})
 	t.Run("no followup for outbound acks error", func(t *testing.T) {
-		followup, _, err := (&completed{}).Execute(dispatcher.DIDCommMsg{Type: ConnectionAck, Outbound: true,
+		followup, _, err := (&completed{}).Execute(service.DIDCommMsg{Type: ConnectionAck, Outbound: true,
 			OutboundDestination: outboundDestination}, "", ctx)
 		require.Error(t, err)
 		require.Nil(t, followup)
@@ -568,7 +568,7 @@ func TestCompletedState_Execute(t *testing.T) {
 		ctx2 := context{outboundDispatcher: &mockdispatcher.MockOutbound{SendErr: fmt.Errorf("error")},
 			didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}}
 		followup, action, err := (&completed{}).
-			Execute(dispatcher.DIDCommMsg{Type: ConnectionResponse, Payload: responsePayloadBytes,
+			Execute(service.DIDCommMsg{Type: ConnectionResponse, Payload: responsePayloadBytes,
 				Outbound: false, OutboundDestination: outboundDestination}, "", ctx2)
 		require.NoError(t, err)
 		require.NotNil(t, followup)
@@ -626,7 +626,7 @@ func TestNewRequestFromInvitation(t *testing.T) {
 		}
 		invitationBytes, err := json.Marshal(invitation)
 		require.NoError(t, err)
-		thid, err := threadID(dispatcher.DIDCommMsg{Type: ConnectionInvite, Payload: invitationBytes, Outbound: false})
+		thid, err := threadID(service.DIDCommMsg{Type: ConnectionInvite, Payload: invitationBytes, Outbound: false})
 		require.NoError(t, err)
 		_, err = ctx.handleInboundInvitation(invitation, thid)
 		require.NoError(t, err)
@@ -638,7 +638,7 @@ func TestNewRequestFromInvitation(t *testing.T) {
 		invitation := &Invitation{}
 		invitationBytes, err := json.Marshal(invitation)
 		require.NoError(t, err)
-		thid, err := threadID(dispatcher.DIDCommMsg{Type: ConnectionInvite, Payload: invitationBytes, Outbound: false})
+		thid, err := threadID(service.DIDCommMsg{Type: ConnectionInvite, Payload: invitationBytes, Outbound: false})
 		require.NoError(t, err)
 		_, err = ctx.handleInboundInvitation(invitation, thid)
 		require.Error(t, err)

--- a/pkg/didcomm/protocol/introduce/states.go
+++ b/pkg/didcomm/protocol/introduce/states.go
@@ -9,7 +9,7 @@ package introduce
 import (
 	"errors"
 
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 )
 
 const (
@@ -37,7 +37,7 @@ type state interface {
 	CanTransitionTo(next state) bool
 	// Executes this state, returning a followup state to be immediately executed as well.
 	// The 'noOp' state should be returned if the state has no followup.
-	Execute(msg dispatcher.DIDCommMsg) (followup state, err error)
+	Execute(msg service.DIDCommMsg) (followup state, err error)
 }
 
 // noOp state
@@ -52,7 +52,7 @@ func (s *noOp) CanTransitionTo(_ state) bool {
 	return false
 }
 
-func (s *noOp) Execute(_ dispatcher.DIDCommMsg) (state, error) {
+func (s *noOp) Execute(_ service.DIDCommMsg) (state, error) {
 	return nil, errors.New("cannot execute no-op")
 }
 
@@ -70,7 +70,7 @@ func (s *start) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameArranging || next.Name() == stateNameDelivering || next.Name() == stateNameDeciding
 }
 
-func (s *start) Execute(msg dispatcher.DIDCommMsg) (state, error) {
+func (s *start) Execute(msg service.DIDCommMsg) (state, error) {
 	return nil, errors.New("start execute: not implemented yet")
 }
 
@@ -87,7 +87,7 @@ func (s *done) CanTransitionTo(next state) bool {
 	return false
 }
 
-func (s *done) Execute(msg dispatcher.DIDCommMsg) (state, error) {
+func (s *done) Execute(msg service.DIDCommMsg) (state, error) {
 	return nil, errors.New("done execute: not implemented yet")
 }
 
@@ -103,7 +103,7 @@ func (s *arranging) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameArranging || next.Name() == stateNameDone || next.Name() == stateNameAbandoning
 }
 
-func (s *arranging) Execute(msg dispatcher.DIDCommMsg) (state, error) {
+func (s *arranging) Execute(msg service.DIDCommMsg) (state, error) {
 	return nil, errors.New("arranging execute: not implemented yet")
 }
 
@@ -119,7 +119,7 @@ func (s *delivering) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameConfirming || next.Name() == stateNameDone || next.Name() == stateNameAbandoning
 }
 
-func (s *delivering) Execute(msg dispatcher.DIDCommMsg) (state, error) {
+func (s *delivering) Execute(msg service.DIDCommMsg) (state, error) {
 	return nil, errors.New("delivering execute: not implemented yet")
 }
 
@@ -135,7 +135,7 @@ func (s *confirming) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameDone || next.Name() == stateNameAbandoning
 }
 
-func (s *confirming) Execute(msg dispatcher.DIDCommMsg) (state, error) {
+func (s *confirming) Execute(msg service.DIDCommMsg) (state, error) {
 	return nil, errors.New("confirming execute: not implemented yet")
 }
 
@@ -151,7 +151,7 @@ func (s *abandoning) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameDone
 }
 
-func (s *abandoning) Execute(msg dispatcher.DIDCommMsg) (state, error) {
+func (s *abandoning) Execute(msg service.DIDCommMsg) (state, error) {
 	return nil, errors.New("abandoning execute: not implemented yet")
 }
 
@@ -167,7 +167,7 @@ func (s *deciding) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameWaiting || next.Name() == stateNameDone
 }
 
-func (s *deciding) Execute(msg dispatcher.DIDCommMsg) (state, error) {
+func (s *deciding) Execute(msg service.DIDCommMsg) (state, error) {
 	return nil, errors.New("deciding execute: not implemented yet")
 }
 
@@ -183,6 +183,6 @@ func (s *waiting) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameDone
 }
 
-func (s *waiting) Execute(msg dispatcher.DIDCommMsg) (state, error) {
+func (s *waiting) Execute(msg service.DIDCommMsg) (state, error) {
 	return nil, errors.New("waiting execute: not implemented yet")
 }

--- a/pkg/didcomm/protocol/introduce/states_test.go
+++ b/pkg/didcomm/protocol/introduce/states_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 )
 
 func notTransition(t *testing.T, st state) {
@@ -34,7 +34,7 @@ func TestNoopState(t *testing.T) {
 
 // noOp.Execute() returns nil, error
 func TestNoOpState_Execute(t *testing.T) {
-	followup, err := (&noOp{}).Execute(dispatcher.DIDCommMsg{})
+	followup, err := (&noOp{}).Execute(service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -57,7 +57,7 @@ func TestStartState(t *testing.T) {
 }
 
 func TestStartState_Execute(t *testing.T) {
-	followup, err := (&start{}).Execute(dispatcher.DIDCommMsg{})
+	followup, err := (&start{}).Execute(service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -70,7 +70,7 @@ func TestDoneState(t *testing.T) {
 }
 
 func TestDoneState_Execute(t *testing.T) {
-	followup, err := (&done{}).Execute(dispatcher.DIDCommMsg{})
+	followup, err := (&done{}).Execute(service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -93,7 +93,7 @@ func TestArrangingState(t *testing.T) {
 }
 
 func TestArrangingState_Execute(t *testing.T) {
-	followup, err := (&arranging{}).Execute(dispatcher.DIDCommMsg{})
+	followup, err := (&arranging{}).Execute(service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -116,7 +116,7 @@ func TestDeliveringState(t *testing.T) {
 }
 
 func TestDeliveringState_Execute(t *testing.T) {
-	followup, err := (&delivering{}).Execute(dispatcher.DIDCommMsg{})
+	followup, err := (&delivering{}).Execute(service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -139,7 +139,7 @@ func TestConfirmingState(t *testing.T) {
 }
 
 func TestConfirmingState_Execute(t *testing.T) {
-	followup, err := (&confirming{}).Execute(dispatcher.DIDCommMsg{})
+	followup, err := (&confirming{}).Execute(service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -162,7 +162,7 @@ func TestAbandoningState(t *testing.T) {
 }
 
 func TestAbandoningState_Execute(t *testing.T) {
-	followup, err := (&abandoning{}).Execute(dispatcher.DIDCommMsg{})
+	followup, err := (&abandoning{}).Execute(service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -185,7 +185,7 @@ func TestDecidingState(t *testing.T) {
 }
 
 func TestDecidingState_Execute(t *testing.T) {
-	followup, err := (&deciding{}).Execute(dispatcher.DIDCommMsg{})
+	followup, err := (&deciding{}).Execute(service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -208,7 +208,7 @@ func TestWaitingState(t *testing.T) {
 }
 
 func TestWaitingState_Execute(t *testing.T) {
-	followup, err := (&waiting{}).Execute(dispatcher.DIDCommMsg{})
+	followup, err := (&waiting{}).Execute(service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
@@ -91,7 +92,7 @@ func TestFramework(t *testing.T) {
 		ctx, err := aries.Context()
 		require.NoError(t, err)
 
-		e := ctx.OutboundDispatcher().Send([]byte("Hello World"), "", &dispatcher.Destination{ServiceEndpoint: serverURL})
+		e := ctx.OutboundDispatcher().Send([]byte("Hello World"), "", &service.Destination{ServiceEndpoint: serverURL})
 		require.NoError(t, e)
 	})
 
@@ -110,7 +111,7 @@ func TestFramework(t *testing.T) {
 		ctx, err := aries.Context()
 		require.NoError(t, err)
 
-		e := ctx.OutboundDispatcher().Send([]byte("Hello World"), "", &dispatcher.Destination{})
+		e := ctx.OutboundDispatcher().Send([]byte("Hello World"), "", &service.Destination{})
 		require.NoError(t, e)
 	})
 

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
@@ -95,7 +96,7 @@ func (p *Provider) InboundMessageHandler() transport.InboundMessageHandler {
 		// find the service which accepts the message type
 		for _, svc := range p.services {
 			if svc.Accept(msgType.Type) {
-				return svc.Handle(dispatcher.DIDCommMsg{Type: msgType.Type, Payload: payload})
+				return svc.Handle(service.DIDCommMsg{Type: msgType.Type, Payload: payload})
 			}
 		}
 		return fmt.Errorf("no message handlers found for the message type: %s", msgType.Type)

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	mockdidcomm "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm"
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
@@ -66,7 +66,7 @@ func TestNewProvider(t *testing.T) {
 			AcceptFunc: func(msgType string) bool {
 				return msgType == "valid-message-type"
 			},
-			HandleFunc: func(msg dispatcher.DIDCommMsg) error {
+			HandleFunc: func(msg service.DIDCommMsg) error {
 				payload := &struct {
 					Label string `json:"label,omitempty"`
 				}{}

--- a/pkg/internal/mock/didcomm/dispatcher/mock_outbound.go
+++ b/pkg/internal/mock/didcomm/dispatcher/mock_outbound.go
@@ -5,7 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 package dispatcher
 
-import "github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+)
 
 // MockOutbound mock outbound dispatcher
 type MockOutbound struct {
@@ -13,6 +15,6 @@ type MockOutbound struct {
 }
 
 // Send msg
-func (m *MockOutbound) Send(msg interface{}, senderVerKey string, des *dispatcher.Destination) error {
+func (m *MockOutbound) Send(msg interface{}, senderVerKey string, des *service.Destination) error {
 	return m.SendErr
 }

--- a/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package protocol
 
 import (
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
 	mockstore "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
@@ -16,7 +17,7 @@ import (
 // MockDIDExchangeSvc mock did exchange service
 type MockDIDExchangeSvc struct {
 	ProtocolName             string
-	HandleFunc               func(dispatcher.DIDCommMsg) error
+	HandleFunc               func(service.DIDCommMsg) error
 	AcceptFunc               func(string) bool
 	RegisterActionEventErr   error
 	UnregisterActionEventErr error
@@ -25,7 +26,7 @@ type MockDIDExchangeSvc struct {
 }
 
 // Handle msg
-func (m *MockDIDExchangeSvc) Handle(msg dispatcher.DIDCommMsg) error {
+func (m *MockDIDExchangeSvc) Handle(msg service.DIDCommMsg) error {
 	if m.HandleFunc != nil {
 		return m.HandleFunc(msg)
 	}
@@ -49,7 +50,7 @@ func (m *MockDIDExchangeSvc) Name() string {
 }
 
 // RegisterActionEvent register action event.
-func (m *MockDIDExchangeSvc) RegisterActionEvent(ch chan<- dispatcher.DIDCommAction) error {
+func (m *MockDIDExchangeSvc) RegisterActionEvent(ch chan<- service.DIDCommAction) error {
 	if m.RegisterActionEventErr != nil {
 		return m.RegisterActionEventErr
 	}
@@ -57,7 +58,7 @@ func (m *MockDIDExchangeSvc) RegisterActionEvent(ch chan<- dispatcher.DIDCommAct
 }
 
 // UnregisterActionEvent unregister action event.
-func (m *MockDIDExchangeSvc) UnregisterActionEvent(ch chan<- dispatcher.DIDCommAction) error {
+func (m *MockDIDExchangeSvc) UnregisterActionEvent(ch chan<- service.DIDCommAction) error {
 	if m.UnregisterActionEventErr != nil {
 		return m.UnregisterActionEventErr
 	}
@@ -65,7 +66,7 @@ func (m *MockDIDExchangeSvc) UnregisterActionEvent(ch chan<- dispatcher.DIDCommA
 }
 
 // RegisterMsgEvent register message event.
-func (m *MockDIDExchangeSvc) RegisterMsgEvent(ch chan<- dispatcher.StateMsg) error {
+func (m *MockDIDExchangeSvc) RegisterMsgEvent(ch chan<- service.StateMsg) error {
 	if m.RegisterMsgEventErr != nil {
 		return m.RegisterMsgEventErr
 	}
@@ -73,7 +74,7 @@ func (m *MockDIDExchangeSvc) RegisterMsgEvent(ch chan<- dispatcher.StateMsg) err
 }
 
 // UnregisterMsgEvent unregister message event.
-func (m *MockDIDExchangeSvc) UnregisterMsgEvent(ch chan<- dispatcher.StateMsg) error {
+func (m *MockDIDExchangeSvc) UnregisterMsgEvent(ch chan<- service.StateMsg) error {
 	if m.UnregisterMsgEventErr != nil {
 		return m.UnregisterMsgEventErr
 	}

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	didexsvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/common/did"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
@@ -278,7 +278,7 @@ func getHandler(t *testing.T, lookup string, handleErr error) operation.Handler 
 	svc, err := New(&mockprovider.Provider{
 		ServiceValue: &protocol.MockDIDExchangeSvc{
 			ProtocolName: "mockProtocolSvc",
-			HandleFunc: func(msg dispatcher.DIDCommMsg) error {
+			HandleFunc: func(msg service.DIDCommMsg) error {
 				return handleErr
 			},
 		},
@@ -338,7 +338,7 @@ func TestServiceEvents(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	msg := dispatcher.DIDCommMsg{
+	msg := service.DIDCommMsg{
 		Type:    didexsvc.ConnectionRequest,
 		Payload: request,
 	}
@@ -375,7 +375,7 @@ func TestOperationEventError(t *testing.T) {
 
 	ops := &Operation{client: client}
 
-	aCh := make(chan dispatcher.DIDCommAction)
+	aCh := make(chan service.DIDCommAction)
 	err = client.RegisterActionEvent(aCh)
 	require.NoError(t, err)
 

--- a/test/bdd/agent_steps.go
+++ b/test/bdd/agent_steps.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/defaults"
 )
@@ -57,7 +57,7 @@ func (a *AgentSteps) createAgent(agentID, inboundHost, inboundPort string) error
 		return fmt.Errorf("failed to create new didexchange client: %w", err)
 	}
 
-	actionCh := make(chan dispatcher.DIDCommAction)
+	actionCh := make(chan service.DIDCommAction)
 	err = didexchangeClient.RegisterActionEvent(actionCh)
 	go func() {
 		if err := didexchange.AutoExecuteActionEvent(actionCh); err != nil {
@@ -77,7 +77,7 @@ func (a *AgentSteps) createAgent(agentID, inboundHost, inboundPort string) error
 }
 
 func (a *AgentSteps) registerPostMsgEvent(agentID, statesValue string) error {
-	statusCh := make(chan dispatcher.StateMsg, 1)
+	statusCh := make(chan service.StateMsg, 1)
 	if err := a.bddContext.DIDExchangeClients[agentID].RegisterMsgEvent(statusCh); err != nil {
 		return fmt.Errorf("failed to register msg event: %w", err)
 	}
@@ -86,7 +86,7 @@ func (a *AgentSteps) registerPostMsgEvent(agentID, statesValue string) error {
 	go func() {
 		for e := range statusCh {
 			a.bddContext.ConnectionID[agentID] = e.Properties[didexchange.ConnectionID].(string)
-			if e.Type == dispatcher.PostState {
+			if e.Type == service.PostState {
 				for _, state := range states {
 					// receive the events
 					if e.StateID == state {


### PR DESCRIPTION
- Move messages and events out of dispatcher pkg to separate pkgs

Closes #342 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
