### PR TITLE
refactor: Properties variable in Action/Msg event struct

### DIFF
--- a/pkg/didcomm/common/service/event.go
+++ b/pkg/didcomm/common/service/event.go
@@ -12,30 +12,61 @@ type StateMsgType int
 const (
 	// PreState pre state
 	PreState StateMsgType = iota
+
 	// PostState post state
 	PostState
 )
 
-// StateMsg msg
+// StateMsg is used in MsgEvent to pass the state details to the consumer. Refer service.Event.RegisterMsgEvent
+// for more details.
 type StateMsg struct {
-	Type    StateMsgType
+	// Name of the protocol.
+	//
+	// Supported protocols
+	//   - DID Exchange :  didexchange.DIDExchange
+	ProtocolName string
+
+	// type of the message (pre or post), refer service.StateMsgType
+	Type StateMsgType
+
+	// current state. Refer protocol RFC for possible states.
 	StateID string
-	Msg     DIDCommMsg
-	// Properties contains different values from different protocols
-	Properties map[string]interface{}
+
+	// DIDComm message along with message type
+	Msg DIDCommMsg
+
+	// Properties contains value based on specific protocol. The consumers need to cast this to specific interface
+	// based on the protocol event.
+	//
+	// Cast to following interfaces based on protocol
+	//   - DID Exchange :  service.DIDExchangeEvent
+	Properties interface{}
 }
 
 // DIDCommAction message type to pass events in go channels.
 type DIDCommAction struct {
+	// Name of the protocol.
+	//
+	// Supported protocols
+	//   - DID Exchange :  didexchange.DIDExchange
+	ProtocolName string
+
 	// DIDComm message
 	Message DIDCommMsg
+
 	// Continue function to be called by the consumer for further processing the message.
 	Continue func()
+
 	// Stop invocation notifies the service that the consumer action event processing has failed or the consumer wants
 	// to stop the processing.
 	Stop func(err error)
-	// Properties contains different values from different protocols
-	Properties map[string]interface{}
+
+	// Properties contains value based on specific protocol. The consumers need to cast this to specific interface
+	// based on the protocol event.
+	//
+	// Cast to following interfaces based on protocol
+	//   - DID Exchange :  service.DIDExchangeEvent
+	Properties interface{}
 }
 
 // Event event related apis.

--- a/pkg/didcomm/protocol/didexchange/event.go
+++ b/pkg/didcomm/protocol/didexchange/event.go
@@ -1,0 +1,16 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didexchange
+
+// Event properties related api.
+type Event interface {
+	// connection ID
+	ConnectionID() string
+
+	// invitation ID
+	InvitationID() string
+}

--- a/test/bdd/agent_steps.go
+++ b/test/bdd/agent_steps.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	didexsvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/defaults"
 )
@@ -85,7 +86,12 @@ func (a *AgentSteps) registerPostMsgEvent(agentID, statesValue string) error {
 	a.initializeStates(agentID, states)
 	go func() {
 		for e := range statusCh {
-			a.bddContext.ConnectionID[agentID] = e.Properties[didexchange.ConnectionID].(string)
+			props, ok := e.Properties.(didexsvc.Event)
+			if !ok {
+				panic("cast event properties to DIDExchange Props failed")
+			}
+
+			a.bddContext.ConnectionID[agentID] = props.ConnectionID()
 			if e.Type == service.PostState {
 				for _, state := range states {
 					// receive the events


### PR DESCRIPTION
- Currently the type of that is map[string]interface{}. The consumer would need to know the keys for each protocol and also they would need to cast to a type for each of those keys.
- Update this to interface{} type. That would require the consumers to know the type for each protocol. The each protocol can have an interface that will have functions for different properties.

Closes #457 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
