### PR TITLE
feat: Verification keys in DIDComm message

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -119,7 +119,7 @@ func (c *Client) HandleInvitation(invitation *didexchange.Invitation) error {
 	if err != nil {
 		return fmt.Errorf("failed marshal invitation: %w", err)
 	}
-	if err = c.didexchangeSvc.Handle(service.DIDCommMsg{Type: invitation.Type, Payload: payload}); err != nil {
+	if err = c.didexchangeSvc.Handle(&service.DIDCommMsg{Type: invitation.Type, Payload: payload}); err != nil {
 		return fmt.Errorf("failed from didexchange service handle: %w", err)
 	}
 	return nil

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -250,7 +250,7 @@ func TestServiceEvents(t *testing.T) {
 		Payload: request,
 	}
 
-	err = didExSvc.Handle(msg)
+	err = didExSvc.Handle(&msg)
 	require.NoError(t, err)
 
 	validateState(t, store, id, "responded", 100*time.Millisecond)

--- a/pkg/didcomm/common/service/event.go
+++ b/pkg/didcomm/common/service/event.go
@@ -33,7 +33,7 @@ type StateMsg struct {
 	StateID string
 
 	// DIDComm message along with message type
-	Msg DIDCommMsg
+	Msg *DIDCommMsg
 
 	// Properties contains value based on specific protocol. The consumers need to cast this to specific interface
 	// based on the protocol event.
@@ -52,7 +52,7 @@ type DIDCommAction struct {
 	ProtocolName string
 
 	// DIDComm message
-	Message DIDCommMsg
+	Message *DIDCommMsg
 
 	// Continue function to be called by the consumer for further processing the message.
 	Continue func()

--- a/pkg/didcomm/common/service/service.go
+++ b/pkg/didcomm/common/service/service.go
@@ -8,7 +8,7 @@ package service
 
 // Handler provides protocol service handle api.
 type Handler interface {
-	Handle(msg DIDCommMsg) error
+	Handle(msg *DIDCommMsg) error
 }
 
 // DIDComm defines service APIs.
@@ -30,6 +30,8 @@ type DIDCommMsg struct {
 	Payload  []byte
 	// TODO : might need refactor as per the issue-226
 	OutboundDestination *Destination
+	// ToVerKeys are recipient keys
+	ToVerKeys []string
 }
 
 // Destination provides the recipientKeys, routingKeys, and serviceEndpoint populated from Invitation

--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -54,7 +54,7 @@ const (
 
 // message type to store data for eventing. This is retrieved during callback.
 type message struct {
-	Msg           service.DIDCommMsg
+	Msg           *service.DIDCommMsg
 	ThreadID      string
 	NextStateName string
 }
@@ -107,7 +107,7 @@ func New(didMaker did.Creator, prov provider) (*Service, error) {
 }
 
 // Handle didexchange msg
-func (s *Service) Handle(msg service.DIDCommMsg) error {
+func (s *Service) Handle(msg *service.DIDCommMsg) error {
 	// throw error if there is no action event registered for inbound messages
 	aEvent := s.GetActionEvent()
 
@@ -224,7 +224,7 @@ func (ex *didExchangeEvent) InvitationID() string {
 
 // sendEvent triggers the action event. This function stores the state of current processing and passes a callback
 // function in the event message.
-func (s *Service) sendActionEvent(msg service.DIDCommMsg, aEvent chan<- service.DIDCommAction,
+func (s *Service) sendActionEvent(msg *service.DIDCommMsg, aEvent chan<- service.DIDCommAction,
 	threadID string, nextState state) error {
 	jsonDoc, err := json.Marshal(&message{
 		Msg:           msg,
@@ -327,7 +327,7 @@ func isNoOp(s state) bool {
 	return ok
 }
 
-func threadID(didCommMsg service.DIDCommMsg) (string, error) {
+func threadID(didCommMsg *service.DIDCommMsg) (string, error) {
 	var thid string
 	if !didCommMsg.Outbound && didCommMsg.Type == ConnectionInvite {
 		return uuid.New().String(), nil

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -141,7 +141,7 @@ func TestService_Handle_Inviter(t *testing.T) {
 		})
 	require.NoError(t, err)
 	msg := service.DIDCommMsg{Type: ConnectionRequest, Payload: payloadBytes}
-	err = s.Handle(msg)
+	err = s.Handle(&msg)
 	require.NoError(t, err)
 
 	select {
@@ -161,7 +161,7 @@ func TestService_Handle_Inviter(t *testing.T) {
 		})
 	require.NoError(t, err)
 	msg = service.DIDCommMsg{Type: ConnectionAck, Payload: payloadBytes}
-	err = s.Handle(msg)
+	err = s.Handle(&msg)
 	require.NoError(t, err)
 
 	select {
@@ -265,7 +265,7 @@ func TestService_Handle_Invitee(t *testing.T) {
 	)
 	require.NoError(t, err)
 	msg := service.DIDCommMsg{Type: ConnectionInvite, Outbound: false, Payload: payloadBytes}
-	err = s.Handle(msg)
+	err = s.Handle(&msg)
 	require.NoError(t, err)
 
 	// Alice automatically sends a Request to Bob and is now in REQUESTED state.
@@ -298,7 +298,7 @@ func TestService_Handle_Invitee(t *testing.T) {
 	)
 	require.NoError(t, err)
 	msg = service.DIDCommMsg{Type: ConnectionResponse, Outbound: false, Payload: payloadBytes}
-	err = s.Handle(msg)
+	err = s.Handle(&msg)
 	require.NoError(t, err)
 
 	// Alice automatically sends an ACK to Bob
@@ -325,7 +325,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		err = s.Handle(service.DIDCommMsg{Type: ConnectionResponse, Payload: response})
+		err = s.Handle(&service.DIDCommMsg{Type: ConnectionResponse, Payload: response})
 		require.Error(t, err)
 	})
 	t.Run("must not start with ACK msg", func(t *testing.T) {
@@ -341,7 +341,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		err = s.Handle(service.DIDCommMsg{Type: ConnectionAck, Payload: ack})
+		err = s.Handle(&service.DIDCommMsg{Type: ConnectionAck, Payload: ack})
 		require.Error(t, err)
 	})
 	t.Run("must not transition to same state", func(t *testing.T) {
@@ -385,7 +385,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		err = s.Handle(service.DIDCommMsg{Type: ConnectionRequest, Outbound: false, Payload: request})
+		err = s.Handle(&service.DIDCommMsg{Type: ConnectionRequest, Outbound: false, Payload: request})
 		require.NoError(t, err)
 
 		select {
@@ -404,7 +404,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		err = s.Handle(service.DIDCommMsg{Type: ConnectionResponse, Outbound: false, Payload: response})
+		err = s.Handle(&service.DIDCommMsg{Type: ConnectionResponse, Outbound: false, Payload: response})
 		require.Error(t, err)
 	})
 	t.Run("error when updating store on first state transition", func(t *testing.T) {
@@ -429,7 +429,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		err = s.Handle(service.DIDCommMsg{Type: ConnectionRequest, Outbound: false, Payload: request})
+		err = s.Handle(&service.DIDCommMsg{Type: ConnectionRequest, Outbound: false, Payload: request})
 		require.Error(t, err)
 	})
 	t.Run("error when updating store on followup state transition", func(t *testing.T) {
@@ -459,7 +459,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		err = s.Handle(service.DIDCommMsg{Type: ConnectionRequest, Outbound: false, Payload: request})
+		err = s.Handle(&service.DIDCommMsg{Type: ConnectionRequest, Outbound: false, Payload: request})
 		require.Error(t, err)
 	})
 
@@ -477,7 +477,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		err = s.Handle(service.DIDCommMsg{Type: "INVALID", Outbound: false, Payload: request})
+		err = s.Handle(&service.DIDCommMsg{Type: "INVALID", Outbound: false, Payload: request})
 		require.Error(t, err)
 	})
 }
@@ -507,18 +507,18 @@ func TestService_Accept(t *testing.T) {
 
 func TestService_threadID(t *testing.T) {
 	t.Run("returns new thid for ", func(t *testing.T) {
-		thid, err := threadID(service.DIDCommMsg{Type: ConnectionInvite, Outbound: false})
+		thid, err := threadID(&service.DIDCommMsg{Type: ConnectionInvite, Outbound: false})
 		require.NoError(t, err)
 		require.NotNil(t, thid)
 	})
 	t.Run("returns unmarshall error", func(t *testing.T) {
-		thid, err := threadID(service.DIDCommMsg{Type: ConnectionRequest, Outbound: true})
+		thid, err := threadID(&service.DIDCommMsg{Type: ConnectionRequest, Outbound: true})
 		require.Error(t, err)
 		require.Equal(t, "", thid)
 	})
 	msg := []byte(`{"~thread": {"thid": "xyz"}}`)
 	t.Run("returns unmarshall error", func(t *testing.T) {
-		thid, err := threadID(service.DIDCommMsg{Type: ConnectionRequest, Outbound: true, Payload: msg})
+		thid, err := threadID(&service.DIDCommMsg{Type: ConnectionRequest, Outbound: true, Payload: msg})
 		require.NoError(t, err)
 		require.Equal(t, "xyz", thid)
 	})
@@ -673,7 +673,7 @@ func TestService_Events(t *testing.T) {
 			Payload: request,
 		}
 
-		err = svc.Handle(msg)
+		err = svc.Handle(&msg)
 		require.NoError(t, err)
 	}()
 
@@ -844,7 +844,7 @@ func handleConnectionAckEvents(t *testing.T, svc *Service, e *service.DIDCommAct
 	}
 }
 
-func writeToDB(t *testing.T, svc *Service, e service.DIDCommMsg) {
+func writeToDB(t *testing.T, svc *Service, e *service.DIDCommMsg) {
 	require.NotEmpty(t, e)
 
 	pl := payload{}
@@ -875,7 +875,7 @@ func validateSuccessCase(t *testing.T, svc *Service) {
 		Payload: invite,
 	}
 
-	err = svc.Handle(msg)
+	err = svc.Handle(&msg)
 	require.NoError(t, err)
 }
 
@@ -901,7 +901,7 @@ func validateUserError(t *testing.T, svc *Service) {
 		Payload: request,
 	}
 
-	err = svc.Handle(msg)
+	err = svc.Handle(&msg)
 	require.NoError(t, err)
 }
 
@@ -931,7 +931,7 @@ func validateStoreError(t *testing.T, svc *Service) {
 		Payload: request,
 	}
 
-	err = svc.Handle(msg)
+	err = svc.Handle(&msg)
 	require.NoError(t, err)
 }
 
@@ -961,7 +961,7 @@ func validateStoreDataCorruptionError(t *testing.T, svc *Service) {
 		Payload: request,
 	}
 
-	err = svc.Handle(msg)
+	err = svc.Handle(&msg)
 	require.NoError(t, err)
 }
 
@@ -991,7 +991,7 @@ func validateHandleError(t *testing.T, svc *Service) {
 		Payload: request,
 	}
 
-	err = svc.Handle(msg)
+	err = svc.Handle(&msg)
 	require.NoError(t, err)
 }
 
@@ -1020,7 +1020,7 @@ func TestService_No_Execution(t *testing.T) {
 		Type: ConnectionResponse,
 	}
 
-	err = svc.Handle(msg)
+	err = svc.Handle(&msg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no clients are registered to handle the message")
 }
@@ -1053,7 +1053,7 @@ func TestServiceErrors(t *testing.T) {
 	require.NoError(t, err)
 
 	// thid error
-	err = svc.Handle(service.DIDCommMsg{Payload: nil})
+	err = svc.Handle(&service.DIDCommMsg{Payload: nil})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot unmarshal @id and ~thread: error=")
 
@@ -1068,7 +1068,7 @@ func TestServiceErrors(t *testing.T) {
 	}}
 	svc.store = mockStore
 	svc.connectionStore = NewConnectionRecorder(mockStore)
-	err = svc.Handle(msg)
+	err = svc.Handle(&msg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot fetch state from store")
 
@@ -1077,13 +1077,13 @@ func TestServiceErrors(t *testing.T) {
 	svc.store, err = mockstorage.NewMockStoreProvider().OpenStore(DIDExchange)
 	svc.connectionStore = NewConnectionRecorder(svc.store)
 	require.NoError(t, err)
-	err = svc.Handle(msg)
+	err = svc.Handle(&msg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unrecognized msgType: invalid")
 
 	// test handle - invalid state name
 	msg.Type = ConnectionResponse
-	message := &message{Msg: msg, ThreadID: randomString()}
+	message := &message{Msg: &msg, ThreadID: randomString()}
 	err = svc.handle(message)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid state name:")

--- a/pkg/didcomm/protocol/didexchange/states.go
+++ b/pkg/didcomm/protocol/didexchange/states.go
@@ -50,7 +50,7 @@ type state interface {
 	CanTransitionTo(next state) bool
 	// Executes this state, returning a followup state to be immediately executed as well.
 	// The 'noOp' state should be returned if the state has no followup.
-	Execute(msg service.DIDCommMsg, thid string, ctx context) (followup state, action stateAction, err error)
+	Execute(msg *service.DIDCommMsg, thid string, ctx context) (followup state, action stateAction, err error)
 }
 
 // Returns the state towards which the protocol will transition to if the msgType is processed.
@@ -101,7 +101,7 @@ func (s *noOp) CanTransitionTo(_ state) bool {
 	return false
 }
 
-func (s *noOp) Execute(_ service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
+func (s *noOp) Execute(_ *service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
 	return nil, nil, errors.New("cannot execute no-op")
 }
 
@@ -117,7 +117,7 @@ func (s *null) CanTransitionTo(next state) bool {
 	return stateNameInvited == next.Name() || stateNameRequested == next.Name()
 }
 
-func (s *null) Execute(msg service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
+func (s *null) Execute(msg *service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
 	return &noOp{}, nil, nil
 }
 
@@ -133,7 +133,7 @@ func (s *invited) CanTransitionTo(next state) bool {
 	return stateNameRequested == next.Name()
 }
 
-func (s *invited) Execute(msg service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
+func (s *invited) Execute(msg *service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
 	if msg.Type != ConnectionInvite {
 		return nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.Type, s.Name())
 	}
@@ -156,7 +156,7 @@ func (s *requested) CanTransitionTo(next state) bool {
 	return stateNameResponded == next.Name()
 }
 
-func (s *requested) Execute(msg service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
+func (s *requested) Execute(msg *service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
 	switch msg.Type {
 	case ConnectionInvite:
 		if msg.Outbound {
@@ -198,7 +198,7 @@ func (s *responded) CanTransitionTo(next state) bool {
 	return stateNameCompleted == next.Name()
 }
 
-func (s *responded) Execute(msg service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
+func (s *responded) Execute(msg *service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
 	switch msg.Type {
 	case ConnectionRequest:
 		if msg.Outbound {
@@ -240,7 +240,7 @@ func (s *completed) CanTransitionTo(next state) bool {
 	return false
 }
 
-func (s *completed) Execute(msg service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
+func (s *completed) Execute(msg *service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
 	switch msg.Type {
 	case ConnectionResponse:
 		if msg.Outbound {
@@ -342,7 +342,7 @@ func (ctx *context) handleInboundRequest(request *Request) (stateAction, error) 
 		return ctx.outboundDispatcher.Send(response, sendVerKey, destination)
 	}, nil
 }
-func (ctx *context) sendOutboundRequest(msg service.DIDCommMsg) (stateAction, error) {
+func (ctx *context) sendOutboundRequest(msg *service.DIDCommMsg) (stateAction, error) {
 	if msg.OutboundDestination == nil {
 		return nil, fmt.Errorf("outboundDestination cannot be empty for outbound Request")
 	}
@@ -368,7 +368,7 @@ func (ctx *context) sendOutboundRequest(msg service.DIDCommMsg) (stateAction, er
 	}, nil
 }
 
-func (ctx *context) sendOutboundResponse(msg service.DIDCommMsg) (stateAction, error) {
+func (ctx *context) sendOutboundResponse(msg *service.DIDCommMsg) (stateAction, error) {
 	if msg.OutboundDestination == nil {
 		return nil, fmt.Errorf("outboundDestination cannot be empty for outbound Request")
 	}
@@ -452,7 +452,7 @@ func prepareConnectionSignature(connection *Connection) (*ConnectionSignature, e
 		SignVerKey: string(pubKey),
 	}, nil
 }
-func (ctx *context) sendOutboundAck(msg service.DIDCommMsg) (stateAction, error) {
+func (ctx *context) sendOutboundAck(msg *service.DIDCommMsg) (stateAction, error) {
 	ack := &model.Ack{}
 	if msg.OutboundDestination == nil {
 		return nil, fmt.Errorf("outboundDestination cannot be empty for outbound Response")

--- a/pkg/didcomm/protocol/introduce/service.go
+++ b/pkg/didcomm/protocol/introduce/service.go
@@ -38,7 +38,7 @@ func New() *Service {
 }
 
 // Handle didexchange msg
-func (s *Service) Handle(msg service.DIDCommMsg) error {
+func (s *Service) Handle(msg *service.DIDCommMsg) error {
 	return nil
 }
 

--- a/pkg/didcomm/protocol/introduce/service_test.go
+++ b/pkg/didcomm/protocol/introduce/service_test.go
@@ -51,7 +51,7 @@ func TestService_Name(t *testing.T) {
 }
 
 func TestService_Handle(t *testing.T) {
-	require.Nil(t, New().Handle(service.DIDCommMsg{}))
+	require.Nil(t, New().Handle(&service.DIDCommMsg{}))
 }
 
 func TestService_Accept(t *testing.T) {

--- a/pkg/didcomm/protocol/introduce/states.go
+++ b/pkg/didcomm/protocol/introduce/states.go
@@ -37,7 +37,7 @@ type state interface {
 	CanTransitionTo(next state) bool
 	// Executes this state, returning a followup state to be immediately executed as well.
 	// The 'noOp' state should be returned if the state has no followup.
-	Execute(msg service.DIDCommMsg) (followup state, err error)
+	Execute(msg *service.DIDCommMsg) (followup state, err error)
 }
 
 // noOp state
@@ -52,7 +52,7 @@ func (s *noOp) CanTransitionTo(_ state) bool {
 	return false
 }
 
-func (s *noOp) Execute(_ service.DIDCommMsg) (state, error) {
+func (s *noOp) Execute(_ *service.DIDCommMsg) (state, error) {
 	return nil, errors.New("cannot execute no-op")
 }
 
@@ -70,7 +70,7 @@ func (s *start) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameArranging || next.Name() == stateNameDelivering || next.Name() == stateNameDeciding
 }
 
-func (s *start) Execute(msg service.DIDCommMsg) (state, error) {
+func (s *start) Execute(msg *service.DIDCommMsg) (state, error) {
 	return nil, errors.New("start execute: not implemented yet")
 }
 
@@ -87,7 +87,7 @@ func (s *done) CanTransitionTo(next state) bool {
 	return false
 }
 
-func (s *done) Execute(msg service.DIDCommMsg) (state, error) {
+func (s *done) Execute(msg *service.DIDCommMsg) (state, error) {
 	return nil, errors.New("done execute: not implemented yet")
 }
 
@@ -103,7 +103,7 @@ func (s *arranging) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameArranging || next.Name() == stateNameDone || next.Name() == stateNameAbandoning
 }
 
-func (s *arranging) Execute(msg service.DIDCommMsg) (state, error) {
+func (s *arranging) Execute(msg *service.DIDCommMsg) (state, error) {
 	return nil, errors.New("arranging execute: not implemented yet")
 }
 
@@ -119,7 +119,7 @@ func (s *delivering) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameConfirming || next.Name() == stateNameDone || next.Name() == stateNameAbandoning
 }
 
-func (s *delivering) Execute(msg service.DIDCommMsg) (state, error) {
+func (s *delivering) Execute(msg *service.DIDCommMsg) (state, error) {
 	return nil, errors.New("delivering execute: not implemented yet")
 }
 
@@ -135,7 +135,7 @@ func (s *confirming) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameDone || next.Name() == stateNameAbandoning
 }
 
-func (s *confirming) Execute(msg service.DIDCommMsg) (state, error) {
+func (s *confirming) Execute(msg *service.DIDCommMsg) (state, error) {
 	return nil, errors.New("confirming execute: not implemented yet")
 }
 
@@ -151,7 +151,7 @@ func (s *abandoning) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameDone
 }
 
-func (s *abandoning) Execute(msg service.DIDCommMsg) (state, error) {
+func (s *abandoning) Execute(msg *service.DIDCommMsg) (state, error) {
 	return nil, errors.New("abandoning execute: not implemented yet")
 }
 
@@ -167,7 +167,7 @@ func (s *deciding) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameWaiting || next.Name() == stateNameDone
 }
 
-func (s *deciding) Execute(msg service.DIDCommMsg) (state, error) {
+func (s *deciding) Execute(msg *service.DIDCommMsg) (state, error) {
 	return nil, errors.New("deciding execute: not implemented yet")
 }
 
@@ -183,6 +183,6 @@ func (s *waiting) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameDone
 }
 
-func (s *waiting) Execute(msg service.DIDCommMsg) (state, error) {
+func (s *waiting) Execute(msg *service.DIDCommMsg) (state, error) {
 	return nil, errors.New("waiting execute: not implemented yet")
 }

--- a/pkg/didcomm/protocol/introduce/states_test.go
+++ b/pkg/didcomm/protocol/introduce/states_test.go
@@ -34,7 +34,7 @@ func TestNoopState(t *testing.T) {
 
 // noOp.Execute() returns nil, error
 func TestNoOpState_Execute(t *testing.T) {
-	followup, err := (&noOp{}).Execute(service.DIDCommMsg{})
+	followup, err := (&noOp{}).Execute(&service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -57,7 +57,7 @@ func TestStartState(t *testing.T) {
 }
 
 func TestStartState_Execute(t *testing.T) {
-	followup, err := (&start{}).Execute(service.DIDCommMsg{})
+	followup, err := (&start{}).Execute(&service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -70,7 +70,7 @@ func TestDoneState(t *testing.T) {
 }
 
 func TestDoneState_Execute(t *testing.T) {
-	followup, err := (&done{}).Execute(service.DIDCommMsg{})
+	followup, err := (&done{}).Execute(&service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -93,7 +93,7 @@ func TestArrangingState(t *testing.T) {
 }
 
 func TestArrangingState_Execute(t *testing.T) {
-	followup, err := (&arranging{}).Execute(service.DIDCommMsg{})
+	followup, err := (&arranging{}).Execute(&service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -116,7 +116,7 @@ func TestDeliveringState(t *testing.T) {
 }
 
 func TestDeliveringState_Execute(t *testing.T) {
-	followup, err := (&delivering{}).Execute(service.DIDCommMsg{})
+	followup, err := (&delivering{}).Execute(&service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -139,7 +139,7 @@ func TestConfirmingState(t *testing.T) {
 }
 
 func TestConfirmingState_Execute(t *testing.T) {
-	followup, err := (&confirming{}).Execute(service.DIDCommMsg{})
+	followup, err := (&confirming{}).Execute(&service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -162,7 +162,7 @@ func TestAbandoningState(t *testing.T) {
 }
 
 func TestAbandoningState_Execute(t *testing.T) {
-	followup, err := (&abandoning{}).Execute(service.DIDCommMsg{})
+	followup, err := (&abandoning{}).Execute(&service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -185,7 +185,7 @@ func TestDecidingState(t *testing.T) {
 }
 
 func TestDecidingState_Execute(t *testing.T) {
-	followup, err := (&deciding{}).Execute(service.DIDCommMsg{})
+	followup, err := (&deciding{}).Execute(&service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -208,7 +208,7 @@ func TestWaitingState(t *testing.T) {
 }
 
 func TestWaitingState_Execute(t *testing.T) {
-	followup, err := (&waiting{}).Execute(service.DIDCommMsg{})
+	followup, err := (&waiting{}).Execute(&service.DIDCommMsg{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }

--- a/pkg/didcomm/transport/http/inbound.go
+++ b/pkg/didcomm/transport/http/inbound.go
@@ -66,7 +66,7 @@ func processPOSTRequest(w http.ResponseWriter, r *http.Request, prov transport.I
 	}
 
 	messageHandler := prov.InboundMessageHandler()
-	err = messageHandler(unpackMsg.Message)
+	err = messageHandler(unpackMsg)
 	if err != nil {
 		// TODO HTTP Response Codes based on errors from service https://github.com/hyperledger/aries-framework-go/issues/271
 		logger.Errorf("incoming msg processing failed: %s", err)

--- a/pkg/didcomm/transport/http/inbound_test.go
+++ b/pkg/didcomm/transport/http/inbound_test.go
@@ -30,8 +30,8 @@ type mockProvider struct {
 }
 
 func (p *mockProvider) InboundMessageHandler() transport.InboundMessageHandler {
-	return func(payload []byte) error {
-		logger.Debugf("Payload received is %s", payload)
+	return func(envelope *wallet.Envelope) error {
+		logger.Debugf("Envelope received is %s", envelope)
 		return nil
 	}
 }

--- a/pkg/didcomm/transport/transport_interface.go
+++ b/pkg/didcomm/transport/transport_interface.go
@@ -19,7 +19,7 @@ type OutboundTransport interface {
 
 // InboundMessageHandler handles the inbound requests. The transport will unpack the payload prior to the
 // message handle invocation.
-type InboundMessageHandler func(payload []byte) error
+type InboundMessageHandler func(envelope *wallet.Envelope) error
 
 // InboundProvider contains dependencies for starting the inbound transport.
 // It is typically created by using aries.Context().

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -83,12 +83,12 @@ func (p *Provider) InboundTransportEndpoint() string {
 
 // InboundMessageHandler return inbound message handler
 func (p *Provider) InboundMessageHandler() transport.InboundMessageHandler {
-	return func(payload []byte) error {
+	return func(envelope *wallet.Envelope) error {
 		// get the message type from the payload and dispatch based on the services
 		msgType := &struct {
 			Type string `json:"@type,omitempty"`
 		}{}
-		err := json.Unmarshal(payload, msgType)
+		err := json.Unmarshal(envelope.Message, msgType)
 		if err != nil {
 			return fmt.Errorf("invalid payload data format: %w", err)
 		}
@@ -96,7 +96,7 @@ func (p *Provider) InboundMessageHandler() transport.InboundMessageHandler {
 		// find the service which accepts the message type
 		for _, svc := range p.services {
 			if svc.Accept(msgType.Type) {
-				return svc.Handle(service.DIDCommMsg{Type: msgType.Type, Payload: payload})
+				return svc.Handle(&service.DIDCommMsg{Type: msgType.Type, Payload: envelope.Message, ToVerKeys: envelope.ToVerKeys})
 			}
 		}
 		return fmt.Errorf("no message handlers found for the message type: %s", msgType.Type)

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -91,38 +91,38 @@ func TestNewProvider(t *testing.T) {
 		inboundHandler := ctx.InboundMessageHandler()
 
 		// valid json and message type
-		err = inboundHandler([]byte(`
+		err = inboundHandler(&wallet.Envelope{Message: []byte(`
 		{
 			"@id": "5678876542345",
 			"@type": "valid-message-type"
-		}`))
+		}`)})
 		require.NoError(t, err)
 
 		// invalid json
-		err = inboundHandler([]byte("invalid json"))
+		err = inboundHandler(&wallet.Envelope{Message: []byte("invalid json")})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid payload data format")
 
 		// invalid json
-		err = inboundHandler([]byte("invalid json"))
+		err = inboundHandler(&wallet.Envelope{Message: []byte("invalid json")})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid payload data format")
 
 		// no handlers
-		err = inboundHandler([]byte(`
+		err = inboundHandler(&wallet.Envelope{Message: []byte(`
 		{
 			"@type": "invalid-message-type",
 			"label": "Bob"
-		}`))
+		}`)})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no message handlers found for the message type: invalid-message-type")
 
 		// valid json, message type but service handlers returns error
-		err = inboundHandler([]byte(`
+		err = inboundHandler(&wallet.Envelope{Message: []byte(`
 		{
 			"label": "Carol",
 			"@type": "valid-message-type"
-		}`))
+		}`)})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error handling the message")
 	})

--- a/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
@@ -26,9 +26,9 @@ type MockDIDExchangeSvc struct {
 }
 
 // Handle msg
-func (m *MockDIDExchangeSvc) Handle(msg service.DIDCommMsg) error {
+func (m *MockDIDExchangeSvc) Handle(msg *service.DIDCommMsg) error {
 	if m.HandleFunc != nil {
-		return m.HandleFunc(msg)
+		return m.HandleFunc(*msg)
 	}
 	return nil
 }

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -139,7 +139,7 @@ func (c *Operation) ReceiveInvitation(rw http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	err = c.service.Handle(service.DIDCommMsg{Type: request.Params.Type, Payload: payload})
+	err = c.service.Handle(&service.DIDCommMsg{Type: request.Params.Type, Payload: payload})
 	if err != nil {
 		c.writeGenericError(rw, err)
 		return

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -343,7 +343,7 @@ func TestServiceEvents(t *testing.T) {
 		Payload: request,
 	}
 
-	err = didExSvc.Handle(msg)
+	err = didExSvc.Handle(&msg)
 	require.NoError(t, err)
 
 	validateState(t, store, id, "responded", 100*time.Millisecond)

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -151,7 +151,7 @@ func (w *BaseWallet) UnpackMessage(encMessage []byte) (*Envelope, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed from decrypt: %w", err)
 		}
-		return &Envelope{Message: bytes}, nil
+		return &Envelope{Message: bytes, ToVerKeys: []string{recipVKeyB58}}, nil
 	}
 	return nil, fmt.Errorf("no corresponding recipient key found in {%s}", keysNotFound)
 }

--- a/pkg/wallet/wallet_test.go
+++ b/pkg/wallet/wallet_test.go
@@ -207,6 +207,7 @@ func TestBaseWallet_PackMessage(t *testing.T) {
 		unpackMsg, err := w.UnpackMessage(packMsg)
 		require.NoError(t, err)
 		require.Equal(t, []byte("msg1"), unpackMsg.Message)
+		require.Equal(t, []string{base58.Encode(pub2[:])}, unpackMsg.ToVerKeys)
 	})
 
 	t.Run("test envelope is nil", func(t *testing.T) {


### PR DESCRIPTION
- added `ToVerKeys` from envelope to DID comm message, so that it can be
accessed inside service handles.
- DID exchange service needs these keys for persistence related changes
- service handle to accept pointer of DIDCommMsg 
( **reason**: `hugeParam: msg is heavy (80 bytes)`)
- closes #462 
Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
