### PR TITLE
refactor: made threadID function part of service.DIDCommMsg

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -119,7 +119,13 @@ func (c *Client) HandleInvitation(invitation *didexchange.Invitation) error {
 	if err != nil {
 		return fmt.Errorf("failed marshal invitation: %w", err)
 	}
-	if err = c.didexchangeSvc.Handle(&service.DIDCommMsg{Type: invitation.Type, Payload: payload}); err != nil {
+
+	msg, err := service.NewDIDCommMsg(payload)
+	if err != nil {
+		return fmt.Errorf("failed to create DIDCommMsg: %w", err)
+	}
+
+	if err = c.didexchangeSvc.Handle(msg); err != nil {
 		return fmt.Errorf("failed from didexchange service handle: %w", err)
 	}
 	return nil

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -244,13 +244,9 @@ func TestServiceEvents(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-
-	msg := service.DIDCommMsg{
-		Type:    didexchange.ConnectionRequest,
-		Payload: request,
-	}
-
-	err = didExSvc.Handle(&msg)
+	msg, err := service.NewDIDCommMsg(request)
+	require.NoError(t, err)
+	err = didExSvc.Handle(msg)
 	require.NoError(t, err)
 
 	validateState(t, store, id, "responded", 100*time.Millisecond)

--- a/pkg/didcomm/common/service/errors.go
+++ b/pkg/didcomm/common/service/errors.go
@@ -11,6 +11,9 @@ const (
 	ErrChannelRegistered = serviceError("channel is already registered for the action event")
 	ErrNilChannel        = serviceError("cannot pass nil channel")
 	ErrInvalidChannel    = serviceError("invalid channel passed to unregister the action event")
+	ErrThreadIDNotFound  = serviceError("threadID not found")
+	ErrInvalidMessage    = serviceError("invalid message")
+	ErrNoHeader          = serviceError("the header is not provided")
 )
 
 // serviceError defines service error

--- a/pkg/didcomm/common/service/service.go
+++ b/pkg/didcomm/common/service/service.go
@@ -6,6 +6,13 @@ SPDX-License-Identifier: Apache-2.0
 
 package service
 
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+)
+
 // Handler provides protocol service handle api.
 type Handler interface {
 	Handle(msg *DIDCommMsg) error
@@ -20,16 +27,57 @@ type DIDComm interface {
 	Event
 }
 
+// Header helper structure which keeps reusable fields
+type Header struct {
+	ID     string           `json:"@id"`
+	Thread decorator.Thread `json:"~thread"`
+	Type   string           `json:"@type,omitempty"`
+}
+
 // DIDCommMsg did comm msg
 type DIDCommMsg struct {
 	// Outbound indicates the direction of this DIDComm message:
 	//   - outgoing (to another agent)
 	//   - incoming (from another agent)
 	Outbound bool
-	Type     string
 	Payload  []byte
 	// TODO : might need refactor as per the issue-226
 	OutboundDestination *Destination
+	Header              *Header
+}
+
+// NewDIDCommMsg returns DIDCommMsg with Header
+func NewDIDCommMsg(payload []byte) (*DIDCommMsg, error) {
+	msg := &DIDCommMsg{Payload: payload}
+	if err := json.Unmarshal(msg.Payload, &msg.Header); err != nil {
+		return nil, fmt.Errorf("invalid payload data format: %w", err)
+	}
+	return msg, nil
+}
+
+// ThreadID returns msg ~thread.thid if there is no ~thread.thid returns msg @id
+// message is invalid if ~thread.thid exist and @id is absent
+// NOTE: Header field should be filled before calling ThreadID func
+// it can be done by using NewDIDCommMsg([]byte) func or directly set a Header value
+func (m *DIDCommMsg) ThreadID() (string, error) {
+	if m.Header == nil {
+		return "", ErrNoHeader
+	}
+	// if message has ~thread.thid but @id is absent this is invalid message
+	if len(m.Header.Thread.ID) > 0 && m.Header.ID == "" {
+		return "", ErrInvalidMessage
+	}
+
+	if len(m.Header.Thread.ID) > 0 {
+		return m.Header.Thread.ID, nil
+	}
+
+	// we need to return it only if there is no ~thread.thid
+	if len(m.Header.ID) > 0 {
+		return m.Header.ID, nil
+	}
+
+	return "", ErrThreadIDNotFound
 }
 
 // Destination provides the recipientKeys, routingKeys, and serviceEndpoint populated from Invitation

--- a/pkg/didcomm/common/service/service_test.go
+++ b/pkg/didcomm/common/service/service_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+)
+
+func TestNewDIDCommMsg(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		err     string
+	}{{
+		name: "No payload",
+		err:  "invalid payload data format: unexpected end of JSON input",
+	}, {
+		name:    "Happy path",
+		payload: []byte(`{"@id":"ID"}`),
+		err:     "",
+	}, {
+		name:    "Empty payload (JSON)",
+		payload: []byte(`{}`),
+		err:     "",
+	}, {
+		name:    "Array payload",
+		payload: []byte(`[]`),
+		err:     `invalid payload data format: json: cannot unmarshal array into Go value of type service.Header`,
+	}}
+	t.Parallel()
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := NewDIDCommMsg(tc.payload)
+			if err != nil {
+				require.Contains(t, err.Error(), tc.err)
+				require.Nil(t, val)
+			} else {
+				require.NotNil(t, val)
+			}
+		})
+	}
+}
+
+func TestDIDCommMsg_ThreadID(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  DIDCommMsg
+		val  string
+		err  string
+	}{{
+		name: "No header",
+		msg:  DIDCommMsg{},
+		err:  ErrNoHeader.Error(),
+	}, {
+		name: "ID without Thread ID",
+		msg:  DIDCommMsg{Header: &Header{ID: "ID"}},
+		val:  "ID",
+		err:  "",
+	}, {
+		name: "Thread ID with ID",
+		msg:  DIDCommMsg{Header: &Header{ID: "ID", Thread: decorator.Thread{ID: "thID"}}},
+		val:  "thID",
+		err:  "",
+	}, {
+		name: "Thread ID without ID",
+		msg:  DIDCommMsg{Header: &Header{Thread: decorator.Thread{ID: "thID"}}},
+		val:  "",
+		err:  ErrInvalidMessage.Error(),
+	}}
+	t.Parallel()
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := tc.msg.ThreadID()
+			if err != nil {
+				require.Contains(t, err.Error(), tc.err)
+			}
+			require.Equal(t, tc.val, val)
+		})
+	}
+}

--- a/pkg/didcomm/protocol/didexchange/states.go
+++ b/pkg/didcomm/protocol/didexchange/states.go
@@ -134,8 +134,8 @@ func (s *invited) CanTransitionTo(next state) bool {
 }
 
 func (s *invited) Execute(msg *service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
-	if msg.Type != ConnectionInvite {
-		return nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.Type, s.Name())
+	if msg.Header.Type != ConnectionInvite {
+		return nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.Header.Type, s.Name())
 	}
 	if msg.Outbound {
 		// illegal
@@ -157,7 +157,7 @@ func (s *requested) CanTransitionTo(next state) bool {
 }
 
 func (s *requested) Execute(msg *service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
-	switch msg.Type {
+	switch msg.Header.Type {
 	case ConnectionInvite:
 		if msg.Outbound {
 			return nil, nil, fmt.Errorf("outbound invitations are not allowed for state %s", s.Name())
@@ -182,7 +182,7 @@ func (s *requested) Execute(msg *service.DIDCommMsg, thid string, ctx context) (
 		}
 		return &responded{}, func() error { return nil }, nil
 	default:
-		return nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.Type, s.Name())
+		return nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.Header.Type, s.Name())
 	}
 }
 
@@ -199,7 +199,7 @@ func (s *responded) CanTransitionTo(next state) bool {
 }
 
 func (s *responded) Execute(msg *service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
-	switch msg.Type {
+	switch msg.Header.Type {
 	case ConnectionRequest:
 		if msg.Outbound {
 			return nil, nil, fmt.Errorf("outbound requests are not allowed for state %s", s.Name())
@@ -224,7 +224,7 @@ func (s *responded) Execute(msg *service.DIDCommMsg, thid string, ctx context) (
 		}
 		return &completed{}, func() error { return nil }, nil
 	default:
-		return nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.Type, s.Name())
+		return nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.Header.Type, s.Name())
 	}
 }
 
@@ -241,7 +241,7 @@ func (s *completed) CanTransitionTo(next state) bool {
 }
 
 func (s *completed) Execute(msg *service.DIDCommMsg, thid string, ctx context) (state, stateAction, error) {
-	switch msg.Type {
+	switch msg.Header.Type {
 	case ConnectionResponse:
 		if msg.Outbound {
 			return nil, nil, fmt.Errorf("outbound responses are not allowed for state %s", s.Name())
@@ -268,7 +268,7 @@ func (s *completed) Execute(msg *service.DIDCommMsg, thid string, ctx context) (
 		//TODO: issue-333 otherwise save did-exchange connection
 		return &noOp{}, action, nil
 	default:
-		return nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.Type, s.Name())
+		return nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.Header.Type, s.Name())
 	}
 }
 func (ctx *context) handleInboundInvitation(invitation *Invitation, thid string) (stateAction, error) {

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -139,7 +139,13 @@ func (c *Operation) ReceiveInvitation(rw http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	err = c.service.Handle(&service.DIDCommMsg{Type: request.Params.Type, Payload: payload})
+	msg, err := service.NewDIDCommMsg(payload)
+	if err != nil {
+		c.writeGenericError(rw, err)
+		return
+	}
+
+	err = c.service.Handle(msg)
 	if err != nil {
 		c.writeGenericError(rw, err)
 		return

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -337,13 +337,9 @@ func TestServiceEvents(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-
-	msg := service.DIDCommMsg{
-		Type:    didexsvc.ConnectionRequest,
-		Payload: request,
-	}
-
-	err = didExSvc.Handle(&msg)
+	msg, err := service.NewDIDCommMsg(request)
+	require.NoError(t, err)
+	err = didExSvc.Handle(msg)
 	require.NoError(t, err)
 
 	validateState(t, store, id, "responded", 100*time.Millisecond)


### PR DESCRIPTION
This function will be reusable for introduce protocol as well

* threadID function as part of service.DIDCommMsg

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>