### PR TITLE
refactor: Add signer to did exchange service context

### DIFF
--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 var logger = log.New("aries-framework/did-exchange/service")
@@ -62,6 +63,7 @@ type message struct {
 type provider interface {
 	OutboundDispatcher() dispatcher.Outbound
 	StorageProvider() storage.Provider
+	Signer() wallet.Signer
 }
 
 type connectionStore interface {
@@ -81,6 +83,7 @@ type Service struct {
 type context struct {
 	outboundDispatcher dispatcher.Outbound
 	didCreator         did.Creator
+	signer             wallet.Signer
 }
 
 // New return didexchange service
@@ -93,7 +96,8 @@ func New(didMaker did.Creator, prov provider) (*Service, error) {
 	svc := &Service{
 		ctx: context{
 			outboundDispatcher: prov.OutboundDispatcher(),
-			didCreator:         didMaker},
+			didCreator:         didMaker,
+			signer:             prov.Signer()},
 		store: store,
 		// TODO channel size - https://github.com/hyperledger/aries-framework-go/issues/246
 		callbackChannel: make(chan didCommChMessage, 10),

--- a/pkg/didcomm/protocol/didexchange/states_test.go
+++ b/pkg/didcomm/protocol/didexchange/states_test.go
@@ -204,7 +204,9 @@ func TestInvitedState_Execute(t *testing.T) {
 
 func TestRequestedState_Execute(t *testing.T) {
 	prov := protocol.MockProvider{}
-	ctx := context{outboundDispatcher: prov.OutboundDispatcher(), didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}}
+	ctx := context{outboundDispatcher: prov.OutboundDispatcher(),
+		didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()},
+		signer:     &mockSigner{}}
 	newDidDoc, err := ctx.didCreator.CreateDID()
 	require.NoError(t, err)
 	t.Run("rejects msgs other than invitations or requests", func(t *testing.T) {
@@ -263,7 +265,8 @@ func TestRequestedState_Execute(t *testing.T) {
 	})
 	t.Run("err in sendind outbound requests", func(t *testing.T) {
 		ctx2 := context{outboundDispatcher: prov.OutboundDispatcher(),
-			didCreator: &mockdid.MockDIDCreator{Doc: getMockDIDPublicKey()}}
+			didCreator: &mockdid.MockDIDCreator{Doc: getMockDIDPublicKey()},
+			signer:     &mockSigner{}}
 		newDidDoc, err := ctx2.didCreator.CreateDID()
 		require.NoError(t, err)
 		requestPayloadBytes, err := json.Marshal(
@@ -311,7 +314,7 @@ func TestRequestedState_Execute(t *testing.T) {
 	})
 	t.Run("handle inbound invitation  error", func(t *testing.T) {
 		ctx2 := context{outboundDispatcher: &mockdispatcher.MockOutbound{SendErr: fmt.Errorf("error")},
-			didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}}
+			didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}, signer: &mockSigner{}}
 		followup, action, err := (&requested{}).
 			Execute(&service.DIDCommMsg{Type: ConnectionInvite, Payload: invitationPayloadBytes, Outbound: false}, "", ctx2)
 		require.NoError(t, err)
@@ -320,7 +323,8 @@ func TestRequestedState_Execute(t *testing.T) {
 	})
 	t.Run("handle inbound invitation public key error", func(t *testing.T) {
 		ctx2 := context{outboundDispatcher: prov.OutboundDispatcher(),
-			didCreator: &mockdid.MockDIDCreator{Doc: getMockDIDPublicKey()}}
+			didCreator: &mockdid.MockDIDCreator{Doc: getMockDIDPublicKey()},
+			signer:     &mockSigner{}}
 		followup, _, err := (&requested{}).
 			Execute(&service.DIDCommMsg{Type: ConnectionInvite, Payload: invitationPayloadBytes, Outbound: false}, "", ctx2)
 		require.Error(t, err)
@@ -330,7 +334,9 @@ func TestRequestedState_Execute(t *testing.T) {
 
 func TestRespondedState_Execute(t *testing.T) {
 	prov := protocol.MockProvider{}
-	ctx := context{outboundDispatcher: prov.OutboundDispatcher(), didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}}
+	ctx := context{outboundDispatcher: prov.OutboundDispatcher(),
+		didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()},
+		signer:     &mockSigner{}}
 	newDidDoc, err := ctx.didCreator.CreateDID()
 	require.NoError(t, err)
 
@@ -397,7 +403,8 @@ func TestRespondedState_Execute(t *testing.T) {
 
 	t.Run("error for outbound responses", func(t *testing.T) {
 		ctx2 := context{outboundDispatcher: prov.OutboundDispatcher(),
-			didCreator: &mockdid.MockDIDCreator{Doc: getMockDIDPublicKey()}}
+			didCreator: &mockdid.MockDIDCreator{Doc: getMockDIDPublicKey()},
+			signer:     &mockSigner{}}
 		newDidDoc, err = ctx2.didCreator.CreateDID()
 		require.NoError(t, err)
 		connection := &Connection{
@@ -436,7 +443,7 @@ func TestRespondedState_Execute(t *testing.T) {
 	})
 	t.Run("handle inbound request  error", func(t *testing.T) {
 		ctx2 := context{outboundDispatcher: &mockdispatcher.MockOutbound{SendErr: fmt.Errorf("error")},
-			didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}}
+			didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}, signer: &mockSigner{}}
 		followup, action, e := (&responded{}).
 			Execute(&service.DIDCommMsg{Type: ConnectionRequest, Payload: requestPayloadBytes,
 				Outbound: false, OutboundDestination: outboundDestination}, "", ctx2)
@@ -460,7 +467,7 @@ func TestRespondedState_Execute(t *testing.T) {
 	})
 	t.Run("handle inbound request public key error", func(t *testing.T) {
 		ctx2 := context{outboundDispatcher: prov.OutboundDispatcher(),
-			didCreator: &mockdid.MockDIDCreator{Doc: getMockDIDPublicKey()}}
+			didCreator: &mockdid.MockDIDCreator{Doc: getMockDIDPublicKey()}, signer: &mockSigner{}}
 		followup, _, err := (&responded{}).
 			Execute(&service.DIDCommMsg{Type: ConnectionRequest, Payload: requestPayloadBytes, Outbound: false}, "", ctx2)
 		require.Error(t, err)
@@ -471,7 +478,9 @@ func TestRespondedState_Execute(t *testing.T) {
 // completed is an end state
 func TestCompletedState_Execute(t *testing.T) {
 	prov := protocol.MockProvider{}
-	ctx := context{outboundDispatcher: prov.OutboundDispatcher(), didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}}
+	ctx := context{outboundDispatcher: prov.OutboundDispatcher(),
+		didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()},
+		signer:     &mockSigner{}}
 	newDidDoc, err := ctx.didCreator.CreateDID()
 	require.NoError(t, err)
 	outboundDestination := &service.Destination{RecipientKeys: []string{"test", "test2"}, ServiceEndpoint: "xyz"}
@@ -566,7 +575,7 @@ func TestCompletedState_Execute(t *testing.T) {
 	})
 	t.Run("handle inbound response  error", func(t *testing.T) {
 		ctx2 := context{outboundDispatcher: &mockdispatcher.MockOutbound{SendErr: fmt.Errorf("error")},
-			didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}}
+			didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}, signer: &mockSigner{}}
 		followup, action, err := (&completed{}).
 			Execute(&service.DIDCommMsg{Type: ConnectionResponse, Payload: responsePayloadBytes,
 				Outbound: false, OutboundDestination: outboundDestination}, "", ctx2)
@@ -580,7 +589,6 @@ func TestPrepareConnectionSignature(t *testing.T) {
 		prov := protocol.MockProvider{}
 		ctx := context{outboundDispatcher: prov.OutboundDispatcher(), didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}}
 		newDidDoc, err := ctx.didCreator.CreateDID()
-		require.NoError(t, err)
 		require.NoError(t, err)
 		connection := &Connection{
 			DID:    newDidDoc.ID,
@@ -649,7 +657,8 @@ func TestNewRequestFromInvitation(t *testing.T) {
 func TestNewResponseFromRequest(t *testing.T) {
 	t.Run("successful new response from request", func(t *testing.T) {
 		prov := protocol.MockProvider{}
-		ctx := context{outboundDispatcher: prov.OutboundDispatcher(), didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}}
+		ctx := context{outboundDispatcher: prov.OutboundDispatcher(),
+			didCreator: &mockdid.MockDIDCreator{Doc: getMockDID()}, signer: &mockSigner{}}
 		newDidDoc, err := ctx.didCreator.CreateDID()
 		require.NoError(t, err)
 		request := &Request{
@@ -671,6 +680,7 @@ func TestNewResponseFromRequest(t *testing.T) {
 		request := &Request{}
 		_, err := ctx.handleInboundRequest(request)
 		require.Error(t, err)
+		require.Equal(t, "create DID error", err.Error())
 	})
 }
 
@@ -692,6 +702,15 @@ func TestGetPublicKey(t *testing.T) {
 		require.NoError(t, err)
 		pubkey, err := getPublicKeys(newDidDoc, "invalid key")
 		require.Error(t, err)
+		require.Contains(t, err.Error(), "public key not supported")
 		require.Nil(t, pubkey)
 	})
+}
+
+type mockSigner struct {
+	Err error
+}
+
+func (s *mockSigner) SignMessage(message []byte, fromVerKey string) ([]byte, error) {
+	return nil, s.Err
 }

--- a/pkg/framework/aries/api/protocol.go
+++ b/pkg/framework/aries/api/protocol.go
@@ -29,6 +29,7 @@ type Provider interface {
 	Packager() envelope.Packager
 	InboundTransportEndpoint() string
 	DIDWallet() wallet.DIDCreator
+	Signer() wallet.Signer
 }
 
 // ProtocolSvcCreator method to create new protocol service

--- a/pkg/framework/aries/api/wallet.go
+++ b/pkg/framework/aries/api/wallet.go
@@ -16,6 +16,7 @@ import (
 type CloseableWallet interface {
 	io.Closer
 	wallet.Crypto
+	wallet.Signer
 	wallet.DIDCreator
 }
 

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -342,7 +342,7 @@ func TestFramework(t *testing.T) {
 		ctx, err := aries.Context()
 		require.NoError(t, err)
 
-		v, err := ctx.CryptoWallet().SignMessage(nil, "")
+		v, err := ctx.Signer().SignMessage(nil, "")
 		require.NoError(t, err)
 		require.Equal(t, []byte("mockValue"), v)
 		err = aries.Close()

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -80,6 +80,11 @@ func (p *Provider) Crypter() crypto.Crypter {
 	return p.crypter
 }
 
+// Signer returns the wallet signing service
+func (p *Provider) Signer() wallet.Signer {
+	return p.wallet
+}
+
 // DIDWallet returns the pack wallet service
 func (p *Provider) DIDWallet() wallet.DIDCreator {
 	return p.wallet

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -134,9 +134,12 @@ func TestNewProvider(t *testing.T) {
 			WithPackager(&mockenvelope.BasePackager{PackValue: []byte("data")}),
 		)
 		require.NoError(t, err)
-		v, err := prov.CryptoWallet().SignMessage(nil, "")
+		v, err := prov.Signer().SignMessage(nil, "")
 		require.NoError(t, err)
 		require.Equal(t, []byte("mockValue"), v)
+		index, err := prov.CryptoWallet().FindVerKey([]string{"non-existent"})
+		require.Error(t, err)
+		require.Equal(t, -1, index)
 		v, err = prov.packager.PackMessage(&envelope.Envelope{})
 		require.NoError(t, err)
 		require.Equal(t, []byte("data"), v)
@@ -153,7 +156,7 @@ func TestNewProvider(t *testing.T) {
 			WithPackager(&mockenvelope.BasePackager{PackValue: []byte("data")}),
 		)
 		require.NoError(t, err)
-		v, err := prov.CryptoWallet().SignMessage(nil, "")
+		v, err := prov.Signer().SignMessage(nil, "")
 		require.NoError(t, err)
 		require.Equal(t, []byte("mockValue"), v)
 		didDoc, err := prov.DIDWallet().CreateDID("example")

--- a/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
@@ -11,7 +11,9 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
 	mockstore "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
+	mockwallet "github.com/hyperledger/aries-framework-go/pkg/internal/mock/wallet"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 // MockDIDExchangeSvc mock did exchange service
@@ -97,4 +99,9 @@ func (p *MockProvider) StorageProvider() storage.Provider {
 		return mockstore.NewMockCustomStoreProvider(p.CustomStore)
 	}
 	return mockstore.NewMockStoreProvider()
+}
+
+// Signer is mock signer for DID exchange service
+func (p *MockProvider) Signer() wallet.Signer {
+	return &mockwallet.CloseableWallet{}
 }

--- a/pkg/internal/mock/wallet/mock_wallet.go
+++ b/pkg/internal/mock/wallet/mock_wallet.go
@@ -21,6 +21,8 @@ type CloseableWallet struct {
 	CreateSigningKeyErr      error
 	SignMessageValue         []byte
 	SignMessageErr           error
+	DecryptMessageValue      []byte
+	DecryptMessageErr        error
 	PackValue                []byte
 	PackErr                  error
 	UnpackValue              *envelope.Envelope

--- a/pkg/wallet/api.go
+++ b/pkg/wallet/api.go
@@ -13,6 +13,7 @@ import (
 // Wallet interface
 type Wallet interface {
 	Crypto
+	Signer
 	DIDCreator
 }
 
@@ -37,21 +38,6 @@ type Crypto interface {
 	// error: error
 	CreateSigningKey() (string, error)
 
-	// SignMessage sign a message using the private key associated with a given verification key.
-	//
-	// Args:
-	//
-	// message: The message to sign
-	//
-	// fromVerKey: Sign using the private key related to this verification key
-	//
-	// Returns:
-	//
-	// []byte: The signature
-	//
-	// error: error
-	SignMessage(message []byte, fromVerKey string) ([]byte, error)
-
 	// DeriveKEK will derive an ephemeral symmetric key (kek) using a private from key fetched from
 	// from the wallet corresponding to fromPubKey and derived with toPubKey.
 	//
@@ -70,6 +56,25 @@ type Crypto interface {
 	//
 	//		in case of error, the index will be -1
 	FindVerKey(candidateKeys []string) (int, error)
+}
+
+// Signer interface provides signing capabilities
+type Signer interface {
+
+	// SignMessage sign a message using the private key associated with a given verification key.
+	//
+	// Args:
+	//
+	// message: The message to sign
+	//
+	// fromVerKey: Sign using the private key related to this verification key
+	//
+	// Returns:
+	//
+	// []byte: The signature
+	//
+	// error: error
+	SignMessage(message []byte, fromVerKey string) ([]byte, error)
 }
 
 // DIDCreator provide method to create DID document


### PR DESCRIPTION
Did exchange service has to sign connection response. Add signer to did exchange service context.

Closes #476

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>
