### PR TITLE
refactor: inbound message handlers to access messages only

### DIFF
--- a/pkg/didcomm/common/service/service.go
+++ b/pkg/didcomm/common/service/service.go
@@ -30,8 +30,6 @@ type DIDCommMsg struct {
 	Payload  []byte
 	// TODO : might need refactor as per the issue-226
 	OutboundDestination *Destination
-	// ToVerKeys are recipient keys
-	ToVerKeys []string
 }
 
 // Destination provides the recipientKeys, routingKeys, and serviceEndpoint populated from Invitation

--- a/pkg/didcomm/transport/http/inbound.go
+++ b/pkg/didcomm/transport/http/inbound.go
@@ -66,7 +66,7 @@ func processPOSTRequest(w http.ResponseWriter, r *http.Request, prov transport.I
 	}
 
 	messageHandler := prov.InboundMessageHandler()
-	err = messageHandler(unpackMsg)
+	err = messageHandler(unpackMsg.Message)
 	if err != nil {
 		// TODO HTTP Response Codes based on errors from service https://github.com/hyperledger/aries-framework-go/issues/271
 		logger.Errorf("incoming msg processing failed: %s", err)

--- a/pkg/didcomm/transport/http/inbound_test.go
+++ b/pkg/didcomm/transport/http/inbound_test.go
@@ -30,8 +30,8 @@ type mockProvider struct {
 }
 
 func (p *mockProvider) InboundMessageHandler() transport.InboundMessageHandler {
-	return func(envelope *wallet.Envelope) error {
-		logger.Debugf("Envelope received is %s", envelope)
+	return func(message []byte) error {
+		logger.Debugf("message received is %s", message)
 		return nil
 	}
 }

--- a/pkg/didcomm/transport/transport_interface.go
+++ b/pkg/didcomm/transport/transport_interface.go
@@ -19,7 +19,7 @@ type OutboundTransport interface {
 
 // InboundMessageHandler handles the inbound requests. The transport will unpack the payload prior to the
 // message handle invocation.
-type InboundMessageHandler func(envelope *wallet.Envelope) error
+type InboundMessageHandler func(message []byte) error
 
 // InboundProvider contains dependencies for starting the inbound transport.
 // It is typically created by using aries.Context().

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -83,12 +83,12 @@ func (p *Provider) InboundTransportEndpoint() string {
 
 // InboundMessageHandler return inbound message handler
 func (p *Provider) InboundMessageHandler() transport.InboundMessageHandler {
-	return func(envelope *wallet.Envelope) error {
+	return func(message []byte) error {
 		// get the message type from the payload and dispatch based on the services
 		msgType := &struct {
 			Type string `json:"@type,omitempty"`
 		}{}
-		err := json.Unmarshal(envelope.Message, msgType)
+		err := json.Unmarshal(message, msgType)
 		if err != nil {
 			return fmt.Errorf("invalid payload data format: %w", err)
 		}
@@ -96,7 +96,7 @@ func (p *Provider) InboundMessageHandler() transport.InboundMessageHandler {
 		// find the service which accepts the message type
 		for _, svc := range p.services {
 			if svc.Accept(msgType.Type) {
-				return svc.Handle(&service.DIDCommMsg{Type: msgType.Type, Payload: envelope.Message, ToVerKeys: envelope.ToVerKeys})
+				return svc.Handle(&service.DIDCommMsg{Type: msgType.Type, Payload: message})
 			}
 		}
 		return fmt.Errorf("no message handlers found for the message type: %s", msgType.Type)

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -91,38 +91,38 @@ func TestNewProvider(t *testing.T) {
 		inboundHandler := ctx.InboundMessageHandler()
 
 		// valid json and message type
-		err = inboundHandler(&wallet.Envelope{Message: []byte(`
+		err = inboundHandler([]byte(`
 		{
 			"@id": "5678876542345",
 			"@type": "valid-message-type"
-		}`)})
+		}`))
 		require.NoError(t, err)
 
 		// invalid json
-		err = inboundHandler(&wallet.Envelope{Message: []byte("invalid json")})
+		err = inboundHandler([]byte("invalid json"))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid payload data format")
 
 		// invalid json
-		err = inboundHandler(&wallet.Envelope{Message: []byte("invalid json")})
+		err = inboundHandler([]byte("invalid json"))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid payload data format")
 
 		// no handlers
-		err = inboundHandler(&wallet.Envelope{Message: []byte(`
+		err = inboundHandler([]byte(`
 		{
 			"@type": "invalid-message-type",
 			"label": "Bob"
-		}`)})
+		}`))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no message handlers found for the message type: invalid-message-type")
 
 		// valid json, message type but service handlers returns error
-		err = inboundHandler(&wallet.Envelope{Message: []byte(`
+		err = inboundHandler([]byte(`
 		{
 			"label": "Carol",
 			"@type": "valid-message-type"
-		}`)})
+		}`))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error handling the message")
 	})


### PR DESCRIPTION
- reverted recent changes due to which inbound message handler had
access to whole envelope
- closes #478

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
