### PR TITLE
refactor: Split service.Handle function for Inbound/Outbound type

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -125,7 +125,7 @@ func (c *Client) HandleInvitation(invitation *didexchange.Invitation) error {
 		return fmt.Errorf("failed to create DIDCommMsg: %w", err)
 	}
 
-	if err = c.didexchangeSvc.Handle(msg); err != nil {
+	if err = c.didexchangeSvc.HandleInbound(msg); err != nil {
 		return fmt.Errorf("failed from didexchange service handle: %w", err)
 	}
 	return nil

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -246,7 +246,7 @@ func TestServiceEvents(t *testing.T) {
 	require.NoError(t, err)
 	msg, err := service.NewDIDCommMsg(request)
 	require.NoError(t, err)
-	err = didExSvc.Handle(msg)
+	err = didExSvc.HandleInbound(msg)
 	require.NoError(t, err)
 
 	validateState(t, store, id, "responded", 100*time.Millisecond)

--- a/pkg/didcomm/common/service/service.go
+++ b/pkg/didcomm/common/service/service.go
@@ -15,7 +15,8 @@ import (
 
 // Handler provides protocol service handle api.
 type Handler interface {
-	Handle(msg *DIDCommMsg) error
+	// HandleInbound handles inbound didexchange messages.
+	HandleInbound(msg *DIDCommMsg) error
 }
 
 // DIDComm defines service APIs.
@@ -36,14 +37,8 @@ type Header struct {
 
 // DIDCommMsg did comm msg
 type DIDCommMsg struct {
-	// Outbound indicates the direction of this DIDComm message:
-	//   - outgoing (to another agent)
-	//   - incoming (from another agent)
-	Outbound bool
-	Payload  []byte
-	// TODO : might need refactor as per the issue-226
-	OutboundDestination *Destination
-	Header              *Header
+	Header  *Header
+	Payload []byte
 }
 
 // NewDIDCommMsg returns DIDCommMsg with Header

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -78,7 +78,7 @@ func TestService_Handle_Inviter(t *testing.T) {
 	require.NoError(t, err)
 	msg, err := service.NewDIDCommMsg(payloadBytes)
 	require.NoError(t, err)
-	err = s.Handle(msg)
+	err = s.HandleInbound(msg)
 	require.NoError(t, err)
 
 	select {
@@ -99,7 +99,7 @@ func TestService_Handle_Inviter(t *testing.T) {
 	require.NoError(t, err)
 	didMsg, err := service.NewDIDCommMsg(payloadBytes)
 	require.NoError(t, err)
-	err = s.Handle(didMsg)
+	err = s.HandleInbound(didMsg)
 	require.NoError(t, err)
 
 	select {
@@ -204,7 +204,7 @@ func TestService_Handle_Invitee(t *testing.T) {
 	require.NoError(t, err)
 	didMsg, err := service.NewDIDCommMsg(payloadBytes)
 	require.NoError(t, err)
-	err = s.Handle(didMsg)
+	err = s.HandleInbound(didMsg)
 	require.NoError(t, err)
 
 	// Alice automatically sends a Request to Bob and is now in REQUESTED state.
@@ -238,7 +238,7 @@ func TestService_Handle_Invitee(t *testing.T) {
 	require.NoError(t, err)
 	didMsg, err = service.NewDIDCommMsg(payloadBytes)
 	require.NoError(t, err)
-	err = s.Handle(didMsg)
+	err = s.HandleInbound(didMsg)
 	require.NoError(t, err)
 
 	// Alice automatically sends an ACK to Bob
@@ -265,7 +265,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		err = s.Handle(&service.DIDCommMsg{Payload: response})
+		err = s.HandleInbound(&service.DIDCommMsg{Payload: response})
 		require.Error(t, err)
 	})
 	t.Run("must not start with ACK msg", func(t *testing.T) {
@@ -281,7 +281,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		err = s.Handle(&service.DIDCommMsg{Payload: ack})
+		err = s.HandleInbound(&service.DIDCommMsg{Payload: ack})
 		require.Error(t, err)
 	})
 	t.Run("must not transition to same state", func(t *testing.T) {
@@ -327,7 +327,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		didMsg, err := service.NewDIDCommMsg(request)
 		require.NoError(t, err)
-		err = s.Handle(didMsg)
+		err = s.HandleInbound(didMsg)
 		require.NoError(t, err)
 
 		select {
@@ -348,7 +348,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		didMsg, err = service.NewDIDCommMsg(response)
 		require.NoError(t, err)
-		err = s.Handle(didMsg)
+		err = s.HandleInbound(didMsg)
 		require.Error(t, err)
 	})
 	t.Run("error when updating store on first state transition", func(t *testing.T) {
@@ -373,7 +373,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		err = s.Handle(&service.DIDCommMsg{Outbound: false, Payload: request})
+		err = s.HandleInbound(&service.DIDCommMsg{Payload: request})
 		require.Error(t, err)
 	})
 	t.Run("error when updating store on followup state transition", func(t *testing.T) {
@@ -403,7 +403,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		err = s.Handle(&service.DIDCommMsg{Outbound: false, Payload: request})
+		err = s.HandleInbound(&service.DIDCommMsg{Payload: request})
 		require.Error(t, err)
 	})
 
@@ -421,7 +421,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		err = s.Handle(&service.DIDCommMsg{Outbound: false, Payload: request})
+		err = s.HandleInbound(&service.DIDCommMsg{Payload: request})
 		require.Error(t, err)
 	})
 }
@@ -451,12 +451,12 @@ func TestService_Accept(t *testing.T) {
 
 func TestService_threadID(t *testing.T) {
 	t.Run("returns new thid for ", func(t *testing.T) {
-		thid, err := threadID(&service.DIDCommMsg{Header: &service.Header{Type: ConnectionInvite}, Outbound: false})
+		thid, err := threadID(&service.DIDCommMsg{Header: &service.Header{Type: ConnectionInvite}})
 		require.NoError(t, err)
 		require.NotNil(t, thid)
 	})
 	t.Run("returns unmarshall error", func(t *testing.T) {
-		thid, err := threadID(&service.DIDCommMsg{Header: &service.Header{Type: ConnectionRequest}, Outbound: true})
+		thid, err := threadID(&service.DIDCommMsg{Header: &service.Header{Type: ConnectionRequest}})
 		require.Error(t, err)
 		require.Equal(t, "", thid)
 	})
@@ -607,7 +607,7 @@ func TestService_Events(t *testing.T) {
 		require.NoError(t, err)
 		didMsg, err := service.NewDIDCommMsg(request)
 		require.NoError(t, err)
-		err = svc.Handle(didMsg)
+		err = svc.HandleInbound(didMsg)
 		require.NoError(t, err)
 	}()
 
@@ -806,7 +806,7 @@ func validateSuccessCase(t *testing.T, svc *Service) {
 	// send invite
 	didMsg, err := service.NewDIDCommMsg(invite)
 	require.NoError(t, err)
-	err = svc.Handle(didMsg)
+	err = svc.HandleInbound(didMsg)
 	require.NoError(t, err)
 }
 
@@ -829,7 +829,7 @@ func validateUserError(t *testing.T, svc *Service) {
 
 	didMsg, err := service.NewDIDCommMsg(request)
 	require.NoError(t, err)
-	err = svc.Handle(didMsg)
+	err = svc.HandleInbound(didMsg)
 	require.NoError(t, err)
 }
 
@@ -856,7 +856,7 @@ func validateStoreError(t *testing.T, svc *Service) {
 
 	didMsg, err := service.NewDIDCommMsg(request)
 	require.NoError(t, err)
-	err = svc.Handle(didMsg)
+	err = svc.HandleInbound(didMsg)
 	require.NoError(t, err)
 }
 
@@ -883,7 +883,7 @@ func validateStoreDataCorruptionError(t *testing.T, svc *Service) {
 
 	didMsg, err := service.NewDIDCommMsg(request)
 	require.NoError(t, err)
-	err = svc.Handle(didMsg)
+	err = svc.HandleInbound(didMsg)
 	require.NoError(t, err)
 }
 
@@ -910,7 +910,7 @@ func validateHandleError(t *testing.T, svc *Service) {
 
 	didMsg, err := service.NewDIDCommMsg(request)
 	require.NoError(t, err)
-	err = svc.Handle(didMsg)
+	err = svc.HandleInbound(didMsg)
 	require.NoError(t, err)
 }
 
@@ -939,7 +939,7 @@ func TestService_No_Execution(t *testing.T) {
 		Header: &service.Header{Type: ConnectionResponse},
 	}
 
-	err = svc.Handle(&msg)
+	err = svc.HandleInbound(&msg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no clients are registered to handle the message")
 }
@@ -980,7 +980,7 @@ func TestServiceErrors(t *testing.T) {
 	}}
 	svc.store = mockStore
 	svc.connectionStore = NewConnectionRecorder(mockStore)
-	err = svc.Handle(msg)
+	err = svc.HandleInbound(msg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot fetch state from store")
 
@@ -989,7 +989,7 @@ func TestServiceErrors(t *testing.T) {
 	svc.store, err = mockstorage.NewMockStoreProvider().OpenStore(DIDExchange)
 	svc.connectionStore = NewConnectionRecorder(svc.store)
 	require.NoError(t, err)
-	err = svc.Handle(msg)
+	err = svc.HandleInbound(msg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unrecognized msgType: invalid")
 
@@ -1067,7 +1067,7 @@ func TestMsgEventProtocolFailure(t *testing.T) {
 	msg, err := service.NewDIDCommMsg(request)
 	require.NoError(t, err)
 
-	err = svc.Handle(msg)
+	err = svc.HandleInbound(msg)
 	require.NoError(t, err)
 
 	select {
@@ -1079,4 +1079,13 @@ func TestMsgEventProtocolFailure(t *testing.T) {
 	s, err = svc.currentState(id)
 	require.NoError(t, err)
 	require.Equal(t, (&abandoned{}).Name(), s.Name())
+}
+
+func TestHandleOutbound(t *testing.T) {
+	svc, err := New(&mockdid.MockDIDCreator{Doc: getMockDID()}, &protocol.MockProvider{})
+	require.NoError(t, err)
+
+	err = svc.HandleOutbound(&service.DIDCommMsg{}, &service.Destination{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not implemented")
 }

--- a/pkg/didcomm/protocol/introduce/service.go
+++ b/pkg/didcomm/protocol/introduce/service.go
@@ -37,8 +37,8 @@ func New() *Service {
 	return &Service{}
 }
 
-// Handle didexchange msg
-func (s *Service) Handle(msg *service.DIDCommMsg) error {
+// HandleInbound didexchange msg
+func (s *Service) HandleInbound(msg *service.DIDCommMsg) error {
 	return nil
 }
 

--- a/pkg/didcomm/protocol/introduce/service_test.go
+++ b/pkg/didcomm/protocol/introduce/service_test.go
@@ -51,7 +51,7 @@ func TestService_Name(t *testing.T) {
 }
 
 func TestService_Handle(t *testing.T) {
-	require.Nil(t, New().Handle(&service.DIDCommMsg{}))
+	require.Nil(t, New().HandleInbound(&service.DIDCommMsg{}))
 }
 
 func TestService_Accept(t *testing.T) {

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -105,7 +105,7 @@ func (p *Provider) InboundMessageHandler() transport.InboundMessageHandler {
 		// find the service which accepts the message type
 		for _, svc := range p.services {
 			if svc.Accept(msg.Header.Type) {
-				return svc.Handle(msg)
+				return svc.HandleInbound(msg)
 			}
 		}
 		return fmt.Errorf("no message handlers found for the message type: %s", msg.Header.Type)

--- a/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
@@ -27,8 +27,8 @@ type MockDIDExchangeSvc struct {
 	UnregisterMsgEventErr    error
 }
 
-// Handle msg
-func (m *MockDIDExchangeSvc) Handle(msg *service.DIDCommMsg) error {
+// HandleInbound msg
+func (m *MockDIDExchangeSvc) HandleInbound(msg *service.DIDCommMsg) error {
 	if m.HandleFunc != nil {
 		return m.HandleFunc(*msg)
 	}

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -145,7 +145,7 @@ func (c *Operation) ReceiveInvitation(rw http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	err = c.service.Handle(msg)
+	err = c.service.HandleInbound(msg)
 	if err != nil {
 		c.writeGenericError(rw, err)
 		return

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -339,7 +339,7 @@ func TestServiceEvents(t *testing.T) {
 	require.NoError(t, err)
 	msg, err := service.NewDIDCommMsg(request)
 	require.NoError(t, err)
-	err = didExSvc.Handle(msg)
+	err = didExSvc.HandleInbound(msg)
 	require.NoError(t, err)
 
 	validateState(t, store, id, "responded", 100*time.Millisecond)


### PR DESCRIPTION
- Add following APIs to handle the messages in service layer.
	- HandleInbound(DIDCommMsg)
	- HandleOutbound(DIDCommMsg, Destination)
- Remove outbound related fields from DIDCommMsg struct

Closes #490 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
