### PR TITLE
feat: Verifiable Presentation data model

### DIFF
--- a/pkg/doc/verifiable/common.go
+++ b/pkg/doc/verifiable/common.go
@@ -1,0 +1,48 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifiable
+
+import (
+	"fmt"
+
+	"github.com/xeipuuv/gojsonschema"
+)
+
+// jwtDecoding defines if to decode VC from JWT
+type jwtDecoding int
+
+const (
+	// noJwtDecoding not a JWT
+	noJwtDecoding jwtDecoding = iota
+
+	// jwsDecoding indicated to unmarshal from Signed Token
+	jwsDecoding
+
+	// unsecuredJWTDecoding indicates to unmarshal from Unsecured Token
+	unsecuredJWTDecoding
+)
+
+// Proof defines embedded proof of Verifiable Credential
+type Proof interface{}
+
+type typedID struct {
+	ID   string `json:"id,omitempty"`
+	Type string `json:"type,omitempty"`
+}
+
+// RefreshService provides a way to automatic refresh of expired Verifiable Credential
+type RefreshService typedID
+
+// TermsOfUse represents terms of use of Verifiable Credential by Issuer or Verifiable Presentation by Holder.
+type TermsOfUse typedID
+
+func describeSchemaValidationError(result *gojsonschema.Result, what string) string {
+	errMsg := what + " is not valid:\n"
+	for _, desc := range result.Errors() {
+		errMsg += fmt.Sprintf("- %s\n", desc)
+	}
+	return errMsg
+}

--- a/pkg/doc/verifiable/credential.go
+++ b/pkg/doc/verifiable/credential.go
@@ -188,16 +188,8 @@ const jsonSchema2018Type = "JsonSchemaValidator2018"
 //nolint:gochecknoglobals
 var defaultSchemaLoader = gojsonschema.NewStringLoader(defaultSchema)
 
-// Proof defines embedded proof of Verifiable Credential
-type Proof interface{}
-
 // Evidence defines evidence of Verifiable Credential
 type Evidence interface{}
-
-type typedID struct {
-	ID   string `json:"id,omitempty"`
-	Type string `json:"type,omitempty"`
-}
 
 // Issuer of the Verifiable Credential
 type Issuer struct {
@@ -213,12 +205,6 @@ type CredentialStatus typedID
 
 // CredentialSchema defines a link to data schema which enforces a specific structure of Verifiable Credential.
 type CredentialSchema typedID
-
-// RefreshService provides a way to automatic refresh of expired Verifiable Credential
-type RefreshService typedID
-
-// TermsOfUse represents terms of use of Verifiable Credential by Issuer or Verifiable Presentation by Holder.
-type TermsOfUse typedID
 
 // Credential Verifiable Credential definition
 type Credential struct {
@@ -295,22 +281,7 @@ type CredentialTemplate func() *Credential
 // If not defined, JWT encoding is not tested.
 type PublicKeyFetcher func(issuerID, keyID string) (interface{}, error)
 
-// jwtDecoding defines if to decode VC from JWT
-type jwtDecoding int
-
-const (
-	// noJwtDecoding not a JWT
-	noJwtDecoding jwtDecoding = iota
-
-	// jwsDecoding indicated to unmarshal from Signed Token
-	jwsDecoding
-
-	// unsecuredJWTDecoding indicates to unmarshal from Unsecured Token
-	unsecuredJWTDecoding
-)
-
 // credentialOpts holds options for the Verifiable Credential decoding
-// it has a http.Client instance initialized with default parameters
 type credentialOpts struct {
 	schemaDownloadClient   *http.Client
 	disabledCustomSchema   bool
@@ -545,19 +516,11 @@ func validate(data []byte, schemas []CredentialSchema, opts *credentialOpts) err
 	}
 
 	if !result.Valid() {
-		errMsg := describeSchemaValidationError(result)
+		errMsg := describeSchemaValidationError(result, "verifiable credential")
 		return errors.New(errMsg)
 	}
 
 	return nil
-}
-
-func describeSchemaValidationError(result *gojsonschema.Result) string {
-	errMsg := "verifiable credential is not valid:\n"
-	for _, desc := range result.Errors() {
-		errMsg += fmt.Sprintf("- %s\n", desc)
-	}
-	return errMsg
 }
 
 func getSchemaLoader(schemas []CredentialSchema, opts *credentialOpts) (gojsonschema.JSONLoader, error) {

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -164,26 +164,13 @@ func TestValidateVerCredContext(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "Does not match pattern '^https://www.w3.org/2018/credentials/v1$'")
 	})
-
-	t.Run("test verifiable credential with invalid root context", func(t *testing.T) {
-		raw := &rawCredential{}
-		require.NoError(t, json.Unmarshal([]byte(validCredential), &raw))
-		raw.Context = []interface{}{
-			"https://www.w3.org/2018/credentials/v2",
-			"https://www.w3.org/2018/credentials/examples/v1"}
-		bytes, err := json.Marshal(raw)
-		require.NoError(t, err)
-		err = validate(bytes, []CredentialSchema{}, &credentialOpts{disabledCustomSchema: true})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "Does not match pattern '^https://www.w3.org/2018/credentials/v1$'")
-	})
 }
 
 func TestValidateVerCredID(t *testing.T) {
 	t.Run("test verifiable credential with non-url id", func(t *testing.T) {
 		raw := &rawCredential{}
 		require.NoError(t, json.Unmarshal([]byte(validCredential), &raw))
-		raw.ID = "not url"
+		raw.ID = "not valid credential ID URL"
 		bytes, err := json.Marshal(raw)
 		require.NoError(t, err)
 		err = validate(bytes, []CredentialSchema{}, &credentialOpts{disabledCustomSchema: true})

--- a/pkg/doc/verifiable/presentation.go
+++ b/pkg/doc/verifiable/presentation.go
@@ -1,0 +1,283 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifiable
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/xeipuuv/gojsonschema"
+)
+
+const basePresentationSchema = `
+{
+  "required": [
+    "@context",
+    "type",
+    "verifiableCredential"
+  ],
+  "properties": {
+    "@context": {
+      "type": "array",
+      "items": [
+        {
+          "type": "string",
+          "pattern": "^https://www.w3.org/2018/credentials/v1$"
+        }
+      ],
+      "uniqueItems": true,
+      "additionalItems": {
+        "oneOf": [
+          {
+            "type": "object"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "id": {
+      "type": "string",
+      "format": "uri"
+    },
+    "type": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "pattern": "^VerifiablePresentation$"
+            }
+          ],
+          "minItems": 1
+        },
+        {
+          "type": "string",
+          "pattern": "^VerifiablePresentation$"
+        }
+      ],
+      "additionalItems": {
+        "type": "string"
+      }
+    },
+    "verifiableCredential": {
+      "anyOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "holder": {
+      "type": "string",
+      "format": "uri"
+    },
+    "proof": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": [
+            {
+              "$ref": "#/definitions/proof"
+            }
+          ]
+        },
+        {
+          "$ref": "#/definitions/proof"
+        }
+      ]
+    },
+    "refreshService": {
+      "$ref": "#/definitions/typedID"
+    }
+  },
+  "definitions": {
+    "typedID": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uri"
+        },
+        "type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "proof": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}
+`
+
+//nolint:gochecknoglobals
+var basePresentationSchemaLoader = gojsonschema.NewStringLoader(basePresentationSchema)
+
+// PresentationCredential defines raw Verifiable Credential enclosed into Presentation.
+type PresentationCredential []byte
+
+// Presentation Verifiable Presentation base data model definition
+type Presentation struct {
+	Context        []interface{}
+	ID             string
+	Type           interface{}
+	Credential     interface{}
+	Holder         string
+	Proof          Proof
+	RefreshService *RefreshService
+}
+
+// MarshalJSON converts Verifiable Presentation to JSON bytes.
+func (vp *Presentation) MarshalJSON() ([]byte, error) {
+	byteCred, err := json.Marshal(vp.raw())
+	if err != nil {
+		return nil, fmt.Errorf("JSON marshalling of verifiable credential failed: %w", err)
+	}
+
+	return byteCred, nil
+}
+
+// Credentials provides Verifiable Credentials enclosed into Presentation in raw byte array format.
+func (vp *Presentation) Credentials() ([]PresentationCredential, error) {
+	marshalSingleCredFn := func(cred interface{}) (PresentationCredential, error) {
+		credBytes, err := json.Marshal(cred)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal credentials from presentation: %w", err)
+		}
+		return credBytes, nil
+	}
+
+	switch cred := vp.Credential.(type) {
+	case []interface{}:
+		// 1 or more credentials
+		creds := make([]PresentationCredential, len(cred))
+		for i := range cred {
+			c, err := marshalSingleCredFn(cred[i])
+			if err != nil {
+				return nil, err
+			}
+			creds[i] = c
+		}
+		return creds, nil
+	default:
+		// single credential
+		c, err := marshalSingleCredFn(cred)
+		if err != nil {
+			return nil, err
+		}
+		return []PresentationCredential{c}, nil
+	}
+}
+
+func (vp *Presentation) raw() *rawPresentation {
+	return &rawPresentation{
+		Context:        vp.Context,
+		ID:             vp.ID,
+		Type:           vp.Type,
+		Credential:     vp.Credential,
+		Holder:         vp.Holder,
+		Proof:          vp.Proof,
+		RefreshService: vp.RefreshService,
+	}
+}
+
+// rawPresentation is a basic verifiable credential
+type rawPresentation struct {
+	Context        []interface{}   `json:"@context,omitempty"`
+	ID             string          `json:"id,omitempty"`
+	Type           interface{}     `json:"type,omitempty"`
+	Credential     interface{}     `json:"verifiableCredential,omitempty"`
+	Holder         string          `json:"holder,omitempty"`
+	Proof          Proof           `json:"proof,omitempty"`
+	RefreshService *RefreshService `json:"refreshService,omitempty"`
+}
+
+// NewPresentation creates an instance of Verifiable Presentation by reading a JSON document from bytes.
+func NewPresentation(vpData []byte) (*Presentation, error) {
+	vpDataDecoded, vpRaw, err := decodeRawPresentation(vpData)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validatePresentation(vpDataDecoded)
+	if err != nil {
+		return nil, err
+	}
+
+	vp := &Presentation{
+		Context:        vpRaw.Context,
+		ID:             vpRaw.ID,
+		Type:           vpRaw.Type,
+		Credential:     vpRaw.Credential,
+		Holder:         vpRaw.Holder,
+		Proof:          vpRaw.Proof,
+		RefreshService: vpRaw.RefreshService,
+	}
+
+	return vp, nil
+}
+
+func validatePresentation(data []byte) error {
+	loader := gojsonschema.NewStringLoader(string(data))
+	result, err := gojsonschema.Validate(basePresentationSchemaLoader, loader)
+	if err != nil {
+		return fmt.Errorf("validation of verifiable credential failed: %w", err)
+	}
+
+	if !result.Valid() {
+		errMsg := describeSchemaValidationError(result, "verifiable presentation")
+		return errors.New(errMsg)
+	}
+
+	return nil
+}
+
+func decodeRawPresentation(vpData []byte) ([]byte, *rawPresentation, error) {
+	// unmarshal VP from JSON
+	raw := new(rawPresentation)
+	err := json.Unmarshal(vpData, raw)
+	if err != nil {
+		return nil, nil, fmt.Errorf("JSON unmarshalling of verifiable presentation failed: %w", err)
+	}
+
+	// check that embedded proof is present, if not, it's not a verifiable credential
+	if raw.Proof == nil {
+		return nil, nil, errors.New("embedded proof is missing")
+	}
+
+	return vpData, raw, nil
+}

--- a/pkg/doc/verifiable/presentation_test.go
+++ b/pkg/doc/verifiable/presentation_test.go
@@ -1,0 +1,397 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifiable
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:lll
+const validPresentation = `
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1"
+  ],
+  "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
+  "type": "VerifiablePresentation",
+  "verifiableCredential": [
+    {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/2018/credentials/examples/v1"
+      ],
+      "id": "http://example.edu/credentials/1872",
+      "type": [
+        "VerifiableCredential",
+        "AlumniCredential"
+      ],
+      "issuer": "https://example.edu/issuers/565049",
+      "issuanceDate": "2010-01-01T19:03:24Z",
+      "credentialSubject": {
+        "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+        "alumniOf": {
+          "id": "did:example:c276e12ec21ebfeb1f712ebc6f1",
+          "name": [
+            {
+              "value": "Example University",
+              "lang": "en"
+            }
+          ]
+        }
+      },
+      "proof": {
+        "type": "RsaSignature2018",
+        "created": "2017-06-18T21:19:10Z",
+        "proofPurpose": "assertionMethod",
+        "verificationMethod": "https://example.edu/issuers/keys/1",
+        "jws": "eyJhbGciOiJSUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM"
+      }
+    }
+  ],
+  "holder": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+  "proof": {
+    "type": "RsaSignature2018",
+    "created": "2018-09-14T21:19:10Z",
+    "proofPurpose": "authentication",
+    "verificationMethod": "did:example:ebfeb1f712ebc6f1c276e12ec21#keys-1",
+    "challenge": "1f44d55f-f161-4938-a659-f8026467f126",
+    "domain": "4jt78h47fh47",
+    "jws": "eyJhbGciOiJSUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..kTCYt5XsITJX1CxPCT8yAV-TVIw5WEuts01mq-pQy7UJiN5mgREEMGlv50aqzpqh4Qq_PbChOMqsLfRoPsnsgxD-WUcX16dUOqV0G_zS245-kronKb78cPktb3rk-BuQy72IFLN25DYuNzVBAh4vGHSrQyHUGlcTwLtjPAnKb78"
+  },
+  "refreshService": {
+    "id": "https://example.edu/refresh/3732",
+    "type": "ManualRefreshService2018"
+  }
+}
+`
+
+func TestNewPresentation(t *testing.T) {
+	t.Run("creates a new Verifiable Presentation from JSON with valid structure", func(t *testing.T) {
+		vp, err := NewPresentation([]byte(validPresentation))
+		require.NoError(t, err)
+		require.NotNil(t, vp)
+
+		// validate @context
+		require.Equal(t, vp.Context, []interface{}{
+			"https://www.w3.org/2018/credentials/v1",
+			"https://www.w3.org/2018/credentials/examples/v1"})
+
+		// check id
+		require.Equal(t, vp.ID, "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5")
+
+		// check type
+		require.Equal(t, vp.Type, "VerifiablePresentation")
+
+		// check verifiableCredentials
+		require.NotNil(t, vp.Credential)
+		require.Len(t, vp.Credential, 1)
+
+		// check holder
+		require.Equal(t, vp.Holder, "did:example:ebfeb1f712ebc6f1c276e12ec21")
+
+		// check proof
+		require.NotNil(t, vp.Proof)
+
+		// check refreshService
+		require.NotNil(t, vp.RefreshService)
+		require.Equal(t, vp.RefreshService.ID, "https://example.edu/refresh/3732")
+		require.Equal(t, vp.RefreshService.Type, "ManualRefreshService2018")
+	})
+
+	t.Run("creates a new Verifiable Presentation from JSON with invalid structure", func(t *testing.T) {
+		emptyJSONDoc := "{}"
+		_, err := NewPresentation([]byte(emptyJSONDoc))
+		require.Error(t, err)
+	})
+
+	t.Run("fails to create a new Verifiable Presentation from non-JSON doc", func(t *testing.T) {
+		_, err := NewPresentation([]byte("non json"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "JSON unmarshalling of verifiable presentation failed")
+	})
+}
+
+func TestValidateVP_Context(t *testing.T) {
+	t.Run("rejects verifiable presentation with empty context", func(t *testing.T) {
+		raw := &rawPresentation{}
+		require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+		raw.Context = nil
+		bytes, err := json.Marshal(raw)
+		require.NoError(t, err)
+		_, err = NewPresentation(bytes)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "@context is required")
+	})
+
+	t.Run("rejects verifiable presentation with invalid context", func(t *testing.T) {
+		raw := &rawPresentation{}
+		require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+		raw.Context = []interface{}{
+			"https://www.w3.org/2018/credentials/v2",
+			"https://www.w3.org/2018/credentials/examples/v1"}
+		bytes, err := json.Marshal(raw)
+		require.NoError(t, err)
+		_, err = NewPresentation(bytes)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Does not match pattern '^https://www.w3.org/2018/credentials/v1$'")
+	})
+}
+
+func TestValidateVP_ID(t *testing.T) {
+	t.Run("rejects verifiable presentation with non-url ID", func(t *testing.T) {
+		raw := &rawPresentation{}
+		require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+		raw.ID = "not valid presentation ID URL"
+		bytes, err := json.Marshal(raw)
+		require.NoError(t, err)
+		_, err = NewPresentation(bytes)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "id: Does not match format 'uri'")
+	})
+}
+
+func TestValidateVP_Type(t *testing.T) {
+	t.Run("accepts verifiable presentation with single VerifiablePresentation type", func(t *testing.T) {
+		raw := &rawPresentation{}
+		require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+		raw.Type = "VerifiablePresentation"
+		bytes, err := json.Marshal(raw)
+		require.NoError(t, err)
+		_, err = NewPresentation(bytes)
+		require.NoError(t, err)
+	})
+
+	t.Run("accepts verifiable presentation with multiple types where VerifiablePresentation is a first type",
+		func(t *testing.T) {
+			raw := &rawPresentation{}
+			require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+			raw.Type = []string{"VerifiablePresentation", "CredentialManagerPresentation"}
+			bytes, err := json.Marshal(raw)
+			require.NoError(t, err)
+			_, err = NewPresentation(bytes)
+			require.NoError(t, err)
+		})
+
+	t.Run("rejects verifiable presentation with no type defined", func(t *testing.T) {
+		raw := &rawPresentation{}
+		require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+		raw.Type = nil
+		bytes, err := json.Marshal(raw)
+		require.NoError(t, err)
+		_, err = NewPresentation(bytes)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "type is required")
+	})
+
+	t.Run("rejects verifiable presentation where single type is not VerifiablePresentation", func(t *testing.T) {
+		raw := &rawPresentation{}
+		require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+		raw.Type = "CredentialManagerPresentation"
+		bytes, err := json.Marshal(raw)
+		require.NoError(t, err)
+		_, err = NewPresentation(bytes)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Does not match pattern '^VerifiablePresentation$'")
+	})
+
+	t.Run("rejects verifiable presentation where several types are defined and first one is not VerifiablePresentation", //nolint:lll
+		func(t *testing.T) {
+			raw := &rawPresentation{}
+			require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+			raw.Type = []string{"CredentialManagerPresentation", "VerifiablePresentation"}
+			bytes, err := json.Marshal(raw)
+			require.NoError(t, err)
+			_, err = NewPresentation(bytes)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "Does not match pattern '^VerifiablePresentation$'")
+		})
+}
+
+func TestValidateVP_VerifiableCredential(t *testing.T) {
+	t.Run("rejects verifiable presentation with not defined verifiableCredential", func(t *testing.T) {
+		raw := &rawPresentation{}
+		require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+		raw.Credential = nil
+		bytes, err := json.Marshal(raw)
+		require.NoError(t, err)
+		_, err = NewPresentation(bytes)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "verifiableCredential is required")
+	})
+}
+
+func TestValidateVP_Holder(t *testing.T) {
+	t.Run("rejects verifiable presentation with non-url holder", func(t *testing.T) {
+		raw := &rawPresentation{}
+		require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+		raw.Holder = "not valid presentation Holder URL"
+		bytes, err := json.Marshal(raw)
+		require.NoError(t, err)
+		_, err = NewPresentation(bytes)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "holder: Does not match format 'uri'")
+	})
+}
+
+func TestValidateVP_Proof(t *testing.T) {
+	t.Run("rejects verifiable presentation with missed embedded proof", func(t *testing.T) {
+		raw := &rawPresentation{}
+		require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+		raw.Proof = nil
+		bytes, err := json.Marshal(raw)
+		require.NoError(t, err)
+		_, err = NewPresentation(bytes)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "embedded proof is missing")
+	})
+}
+
+func TestValidateVP_RefreshService(t *testing.T) {
+	t.Run("accepts verifiable presentation with empty refresh service", func(t *testing.T) {
+		raw := &rawPresentation{}
+		require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+		raw.RefreshService = nil
+		bytes, err := json.Marshal(raw)
+		require.NoError(t, err)
+		_, err = NewPresentation(bytes)
+		require.NoError(t, err)
+	})
+
+	t.Run("test verifiable presentation with undefined id of refresh service", func(t *testing.T) {
+		raw := &rawPresentation{}
+		require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+		raw.RefreshService = &RefreshService{Type: "ManualRefreshService2018"}
+		bytes, err := json.Marshal(raw)
+		require.NoError(t, err)
+		_, err = NewPresentation(bytes)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "refreshService: id is required")
+	})
+
+	t.Run("test verifiable presentation with undefined type of refresh service", func(t *testing.T) {
+		raw := &rawPresentation{}
+		require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+		raw.RefreshService = &RefreshService{ID: "https://example.edu/refresh/3732"}
+		bytes, err := json.Marshal(raw)
+		require.NoError(t, err)
+		_, err = NewPresentation(bytes)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "refreshService: type is required")
+	})
+
+	t.Run("test verifiable presentation with invalid URL of id of credential schema", func(t *testing.T) {
+		raw := &rawPresentation{}
+		require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+		raw.RefreshService = &RefreshService{ID: "invalid URL", Type: "ManualRefreshService2018"}
+		bytes, err := json.Marshal(raw)
+		require.NoError(t, err)
+		_, err = NewPresentation(bytes)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "refreshService.id: Does not match format 'uri'")
+	})
+}
+
+func TestPresentation_Credentials(t *testing.T) {
+	t.Run("decode verifiable credential from presentation", func(t *testing.T) {
+		vp, err := NewPresentation([]byte(validPresentation))
+		require.NoError(t, err)
+
+		credsData, err := vp.Credentials()
+		require.NoError(t, err)
+		require.Len(t, credsData, 1)
+
+		// Decode the first verifiable credential
+		vc, err := NewCredential(credsData[0])
+		require.NoError(t, err)
+
+		// check some VC properties to double check that conversion is OK
+		require.Equal(t, "http://example.edu/credentials/1872", vc.ID)
+		require.Equal(t, []string{"VerifiableCredential", "AlumniCredential"}, vc.Type)
+	})
+
+	t.Run("extracts verifiable credentials from list", func(t *testing.T) {
+		vp, err := NewPresentation([]byte(validPresentation))
+		require.NoError(t, err)
+
+		credsData, err := vp.Credentials()
+		require.NoError(t, err)
+		require.Len(t, credsData, 1)
+
+		// Decode the first verifiable credential
+		vc, err := NewCredential(credsData[0])
+		require.NoError(t, err)
+		require.NotNil(t, vc)
+	})
+
+	t.Run("failure handling on extraction of verifiable credentials from list", func(t *testing.T) {
+		vp, err := NewPresentation([]byte(validPresentation))
+		require.NoError(t, err)
+
+		// really artificial case...
+		invalidCredArray := make([]interface{}, 1)
+		invalidCredArray[0] = make(chan int)
+		vp.Credential = invalidCredArray
+
+		_, err = vp.Credentials()
+		require.Error(t, err)
+	})
+
+	t.Run("extracts verifiable credentials from single credential", func(t *testing.T) {
+		vp, err := NewPresentation([]byte(validPresentation))
+		require.NoError(t, err)
+
+		// switch from array to single object
+		creds, ok := vp.Credential.([]interface{})
+		require.True(t, ok)
+		require.Len(t, creds, 1)
+		vp.Credential = creds[0]
+
+		credsData, err := vp.Credentials()
+		require.NoError(t, err)
+		require.Len(t, credsData, 1)
+
+		// Decode the first verifiable credential
+		vc, err := NewCredential(credsData[0])
+		require.NoError(t, err)
+		require.NotNil(t, vc)
+	})
+
+	t.Run("failure handling on extraction of verifiable credentials from object", func(t *testing.T) {
+		vp, err := NewPresentation([]byte(validPresentation))
+		require.NoError(t, err)
+
+		// really artificial case...
+		invalidCred := make(chan int)
+		vp.Credential = invalidCred
+
+		_, err = vp.Credentials()
+		require.Error(t, err)
+	})
+}
+
+func TestPresentation_MarshalJSON(t *testing.T) {
+	vp, err := NewPresentation([]byte(validPresentation))
+	require.NoError(t, err)
+	require.NotEmpty(t, vp)
+
+	// convert verifiable credential to json byte data
+	vpData, err := vp.MarshalJSON()
+	require.NoError(t, err)
+	require.NotEmpty(t, vpData)
+
+	// convert json byte data back to verifiable presentation
+	vp2, err := NewPresentation(vpData)
+	require.NoError(t, err)
+	require.NotEmpty(t, vp2)
+
+	// verify that verifiable presentations created by NewPresentation() and MarshalJSON() matches
+	require.Equal(t, vp, vp2)
+}

--- a/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
+++ b/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
@@ -34,7 +34,7 @@ func main() {
 	}
 
 	jwt := flag.String("jwt", "", "base64encoded JSON object containing es256kPrivateKeyJwk and rs256PrivateKeyJwk.")
-	// todo use jwtAud #371
+	// todo use jwtAud #483
 	flag.String("jwt-aud", "", "indication to use aud attribute in all JWTs")
 	jwtNoJws := flag.Bool("jwt-no-jws", false, "indication to suppress the JWS although keys are present")
 	jwtPresentation := flag.Bool("jwt-presentation", false, "indication to generate a verifiable presentation")
@@ -42,25 +42,24 @@ func main() {
 	isPresentation := flag.Bool("presentation", false, "presentation is passed")
 	flag.Parse()
 
-	if *isPresentation {
-		// todo support Verifiable Presentations #371
-		abort("verifiable presentations are not supported")
+	if *jwt == "" {
+		if *isPresentation {
+			encodeVPToJSON(vcBytes)
+		} else {
+			encodeVCToJSON(vcBytes)
+		}
+		return
 	}
 
-	if *jwt == "" {
-		encodeVCToJSON(vcBytes)
-		return
+	if *jwtPresentation {
+		// TODO Encode Verifiable Presentation #483
+		abort("verifiable presentations are not supported")
 	}
 
 	privateKey, publicKey := parseKeys(*jwt)
 
 	if *jwtDecode {
 		decodeVCJWTToJSON(vcBytes, publicKey)
-	}
-
-	if *jwtPresentation {
-		// TODO Encode Verifiable Presentation #371
-		abort("verifiable presentations are not supported")
 	}
 
 	if *jwtNoJws {
@@ -175,6 +174,18 @@ func encodeVCToJSON(vcBytes []byte) {
 	encoded, err := credential.MarshalJSON()
 	if err != nil {
 		abort("failed to encode credential: %v", err)
+	}
+	fmt.Println(string(encoded))
+}
+
+func encodeVPToJSON(vcBytes []byte) {
+	vp, err := verifiable.NewPresentation(vcBytes)
+	if err != nil {
+		abort("failed to decode presentation: %v", err)
+	}
+	encoded, err := vp.MarshalJSON()
+	if err != nil {
+		abort("failed to encode presentation: %v", err)
 	}
 	fmt.Println(string(encoded))
 }


### PR DESCRIPTION
closes #371

Signed-off-by: Dima <dkinoshenko@gmail.com>

In this PR, the data model of Verifiable Credential is defined. It's checked by VC Test Suite to pass tests from **basic**  suite.
In the follow-up PR #483 , JWT proof support will be added to the Verifiable Presentations.