### PR TITLE
feat: Introduce protocol service implementation

### DIFF
--- a/pkg/didcomm/common/service/service.go
+++ b/pkg/didcomm/common/service/service.go
@@ -32,7 +32,7 @@ type DIDComm interface {
 type Header struct {
 	ID     string           `json:"@id"`
 	Thread decorator.Thread `json:"~thread"`
-	Type   string           `json:"@type,omitempty"`
+	Type   string           `json:"@type"`
 }
 
 // DIDCommMsg did comm msg

--- a/pkg/didcomm/protocol/introduce/service.go
+++ b/pkg/didcomm/protocol/introduce/service.go
@@ -7,8 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package introduce
 
 import (
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	"github.com/hyperledger/aries-framework-go/pkg/common/metadata"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
 const (
@@ -26,20 +31,164 @@ const (
 	AckMsgType = IntroduceSpec + "ack"
 )
 
+var logger = log.New("aries-framework/introduce/service")
+
+// eventMetadata type to store data for eventing. This is retrieved during callback.
+type eventMetadata struct {
+	Msg           *service.DIDCommMsg
+	NextStateName string
+}
+
 // Service for introduce protocol
 type Service struct {
 	service.Action
 	service.Message
+	store storage.Store
 }
 
 // New returns introduce service
-func New() *Service {
-	return &Service{}
+func New(s storage.Provider) (*Service, error) {
+	store, err := s.OpenStore(Introduce)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Service{store: store}, nil
 }
 
-// HandleInbound didexchange msg
+// HandleInbound handles inbound message (introduce protocol)
 func (s *Service) HandleInbound(msg *service.DIDCommMsg) error {
+	aEvent := s.GetActionEvent()
+
+	logger.Infof("entered into Handle: %v", msg.Header)
+	// throw error if there is no action event registered for inbound messages
+	if aEvent == nil {
+		return errors.New("no clients are registered to handle the message")
+	}
+
+	thID, err := msg.ThreadID()
+	if err != nil {
+		return err
+	}
+	logger.Infof("thread id value for the message: %s", thID)
+
+	current, err := s.currentState(thID)
+	if err != nil {
+		return err
+	}
+	logger.Infof("current state : %s", current.Name())
+
+	next, err := nextState(msg)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("state will transition from %q to %q if the msgType is processed", current.Name(), next.Name())
+
+	if !current.CanTransitionTo(next) {
+		return fmt.Errorf("invalid state transition: %s -> %s", current.Name(), next.Name())
+	}
+
+	// trigger message events
+	s.sendMsgEvents(service.StateMsg{
+		Type:         service.PreState,
+		Msg:          msg,
+		ProtocolName: Introduce,
+		StateID:      next.Name(),
+		Properties:   nil,
+	})
+
+	logger.Infof("sent pre event for state %s", next.Name())
+
+	// trigger action event based on message type for inbound messages
+	if canTriggerActionEvents(msg) {
+		return s.sendActionEvent(msg, aEvent, next)
+	}
+
+	// if no action event is triggered, continue the execution
+	return s.handle(eventMetadata{
+		Msg:           msg,
+		NextStateName: next.Name(),
+	})
+}
+
+// HandleOutbound handles outbound message (introduce protocol)
+func (s *Service) HandleOutbound(msg *service.DIDCommMsg, destination *service.Destination) error {
+	return errors.New("not implemented yet")
+}
+
+// sendMsgEvents triggers the message events.
+func (s *Service) sendMsgEvents(msg service.StateMsg) {
+	// trigger the message events
+	for _, handler := range s.GetMsgEvents() {
+		handler <- msg
+	}
+}
+
+// sendEvent triggers the action event. This function stores the state of current processing and passes a callback
+// function in the event message.
+func (s *Service) sendActionEvent(msg *service.DIDCommMsg, aEvent chan<- service.DIDCommAction, nextState state) error {
 	return nil
+}
+
+func nextState(msg *service.DIDCommMsg) (state, error) {
+	switch msg.Header.Type {
+	case ProposalMsgType:
+		return &arranging{}, nil
+	case ResponseMsgType:
+		return &delivering{}, nil
+	default:
+		return nil, fmt.Errorf("unrecognized msgType: %s", msg.Header.Type)
+	}
+}
+
+func (s *Service) currentState(thID string) (state, error) {
+	name, err := s.store.Get(thID)
+	if err != nil {
+		if errors.Is(err, storage.ErrDataNotFound) {
+			return &start{}, nil
+		}
+		return nil, fmt.Errorf("cannot fetch state from store: thid=%s err=%s", thID, err)
+	}
+
+	return stateFromName(string(name))
+}
+
+// nolint: gocyclo
+// stateFromName returns the state by given name.
+func stateFromName(name string) (state, error) {
+	switch name {
+	case stateNameNoop:
+		return &noOp{}, nil
+	case stateNameStart:
+		return &start{}, nil
+	case stateNameDone:
+		return &done{}, nil
+	case stateNameArranging:
+		return &arranging{}, nil
+	case stateNameDelivering:
+		return &delivering{}, nil
+	case stateNameConfirming:
+		return &confirming{}, nil
+	case stateNameAbandoning:
+		return &abandoning{}, nil
+	case stateNameDeciding:
+		return &deciding{}, nil
+	case stateNameWaiting:
+		return &waiting{}, nil
+	default:
+		return nil, fmt.Errorf("invalid state name %s", name)
+	}
+}
+
+// canTriggerActionEvents checks if the incoming message can trigger an action event
+func canTriggerActionEvents(msg *service.DIDCommMsg) bool {
+	// TODO: need to check more msg.Header.Type
+	return msg.Header.Type == ProposalMsgType
+}
+
+func (s *Service) handle(_ eventMetadata) error {
+	return errors.New("not implemented yet")
 }
 
 // Name returns service name
@@ -49,5 +198,9 @@ func (s *Service) Name() string {
 
 // Accept msg checks the msg type
 func (s *Service) Accept(msgType string) bool {
+	switch msgType {
+	case ProposalMsgType, RequestMsgType, ResponseMsgType, AckMsgType:
+		return true
+	}
 	return false
 }

--- a/pkg/didcomm/protocol/introduce/service_test.go
+++ b/pkg/didcomm/protocol/introduce/service_test.go
@@ -7,15 +7,33 @@ SPDX-License-Identifier: Apache-2.0
 package introduce
 
 import (
+	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	mockstore "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 )
 
+// this line checks that Service satisfies service.Handler interface
+var _ service.Handler = &Service{}
+
+func TestService_New(t *testing.T) {
+	const errMsg = "test err"
+	store := mockstore.NewMockStoreProvider()
+	store.ErrOpenStoreHandle = errors.New(errMsg)
+	svc, err := New(store)
+	require.EqualError(t, err, "test err")
+	require.Nil(t, svc)
+}
+
 func TestService_Action(t *testing.T) {
-	svc := New()
+	store := mockstore.NewMockStoreProvider()
+	svc, err := New(store)
+	require.NoError(t, err)
 	ch := make(chan<- service.DIDCommAction)
 
 	// by default
@@ -31,7 +49,9 @@ func TestService_Action(t *testing.T) {
 }
 
 func TestService_Message(t *testing.T) {
-	svc := New()
+	store := mockstore.NewMockStoreProvider()
+	svc, err := New(store)
+	require.NoError(t, err)
 	ch := make(chan<- service.StateMsg)
 
 	// by default
@@ -47,13 +67,159 @@ func TestService_Message(t *testing.T) {
 }
 
 func TestService_Name(t *testing.T) {
-	require.Equal(t, Introduce, New().Name())
+	store := mockstore.NewMockStoreProvider()
+	svc, err := New(store)
+	require.NoError(t, err)
+	require.Equal(t, Introduce, svc.Name())
 }
 
-func TestService_Handle(t *testing.T) {
-	require.Nil(t, New().HandleInbound(&service.DIDCommMsg{}))
+func TestService_HandleOutbound(t *testing.T) {
+	store := mockstore.NewMockStoreProvider()
+	svc, err := New(store)
+	require.NoError(t, err)
+	msg, err := service.NewDIDCommMsg([]byte(fmt.Sprintf(`{"@id":"ID","@type":%q}`, ResponseMsgType)))
+	require.NoError(t, err)
+	require.EqualError(t, svc.HandleOutbound(msg, nil), "not implemented yet")
+}
+
+func TestService_HandleInbound(t *testing.T) {
+	t.Parallel()
+
+	t.Run("No clients", func(t *testing.T) {
+		store := mockstore.NewMockStoreProvider()
+		svc, err := New(store)
+		require.NoError(t, err)
+		require.EqualError(t, svc.HandleInbound(&service.DIDCommMsg{}), "no clients are registered to handle the message")
+	})
+
+	t.Run("ThreadID Error", func(t *testing.T) {
+		store := mockstore.NewMockStoreProvider()
+		svc, err := New(store)
+		require.NoError(t, err)
+		msg, err := service.NewDIDCommMsg([]byte(`{}`))
+		require.NoError(t, err)
+		ch := make(chan service.DIDCommAction)
+		require.NoError(t, svc.RegisterActionEvent(ch))
+		require.EqualError(t, svc.HandleInbound(msg), service.ErrThreadIDNotFound.Error())
+	})
+
+	t.Run("Storage error", func(t *testing.T) {
+		const errMsg = "test err"
+		store := mockstore.NewMockStoreProvider()
+		store.Store.ErrGet = errors.New(errMsg)
+		require.NoError(t, store.Store.Put("ID", nil))
+		svc, err := New(store)
+		require.NoError(t, err)
+		msg, err := service.NewDIDCommMsg([]byte(fmt.Sprintf(`{"@id":"ID","@type":%q}`, ProposalMsgType)))
+		require.NoError(t, err)
+		ch := make(chan service.DIDCommAction)
+		require.NoError(t, svc.RegisterActionEvent(ch))
+		require.EqualError(t, svc.HandleInbound(msg), "cannot fetch state from store: thid=ID err=test err")
+	})
+
+	t.Run("Bad transition", func(t *testing.T) {
+		store := mockstore.NewMockStoreProvider()
+		require.NoError(t, store.Store.Put("ID", []byte(stateNameNoop)))
+		svc, err := New(store)
+		require.NoError(t, err)
+		msg, err := service.NewDIDCommMsg([]byte(fmt.Sprintf(`{"@id":"ID","@type":%q}`, ProposalMsgType)))
+		require.NoError(t, err)
+		ch := make(chan service.DIDCommAction)
+		require.NoError(t, svc.RegisterActionEvent(ch))
+		require.EqualError(t, svc.HandleInbound(msg), "invalid state transition: noop -> arranging")
+	})
+
+	t.Run("Unknown msg type error", func(t *testing.T) {
+		store := mockstore.NewMockStoreProvider()
+		svc, err := New(store)
+		require.NoError(t, err)
+		msg, err := service.NewDIDCommMsg([]byte(`{"@id":"ID","@type":"unknown"}`))
+		require.NoError(t, err)
+		ch := make(chan service.DIDCommAction)
+		require.NoError(t, svc.RegisterActionEvent(ch))
+		require.EqualError(t, svc.HandleInbound(msg), "unrecognized msgType: unknown")
+	})
+
+	t.Run("Happy path (send an action event)", func(t *testing.T) {
+		store := mockstore.NewMockStoreProvider()
+		svc, err := New(store)
+		require.NoError(t, err)
+		msg, err := service.NewDIDCommMsg([]byte(fmt.Sprintf(`{"@id":"ID","@type":%q}`, ProposalMsgType)))
+		require.NoError(t, err)
+		aCh := make(chan service.DIDCommAction)
+		require.NoError(t, svc.RegisterActionEvent(aCh))
+		sCh := make(chan service.StateMsg)
+		require.NoError(t, svc.RegisterMsgEvent(sCh))
+		go func() { require.NoError(t, svc.HandleInbound(msg)) }()
+
+		select {
+		case <-sCh:
+		case <-time.After(time.Second):
+			t.Error("timeout")
+		}
+	})
+
+	t.Run("Happy path (execute handle)", func(t *testing.T) {
+		store := mockstore.NewMockStoreProvider()
+		svc, err := New(store)
+		require.NoError(t, err)
+		msg, err := service.NewDIDCommMsg([]byte(fmt.Sprintf(`{"@id":"ID","@type":%q}`, ResponseMsgType)))
+		require.NoError(t, err)
+		ch := make(chan service.DIDCommAction)
+		require.NoError(t, svc.RegisterActionEvent(ch))
+		require.EqualError(t, svc.HandleInbound(msg), "not implemented yet")
+	})
 }
 
 func TestService_Accept(t *testing.T) {
-	require.Equal(t, false, New().Accept(""))
+	store := mockstore.NewMockStoreProvider()
+	svc, err := New(store)
+	require.NoError(t, err)
+	require.False(t, svc.Accept(""))
+	require.True(t, svc.Accept(ProposalMsgType))
+	require.True(t, svc.Accept(RequestMsgType))
+	require.True(t, svc.Accept(ResponseMsgType))
+	require.True(t, svc.Accept(AckMsgType))
+}
+
+func Test_stateFromName(t *testing.T) {
+	st, err := stateFromName(stateNameNoop)
+	require.NoError(t, err)
+	require.Equal(t, &noOp{}, st)
+
+	st, err = stateFromName(stateNameStart)
+	require.NoError(t, err)
+	require.Equal(t, &start{}, st)
+
+	st, err = stateFromName(stateNameDone)
+	require.NoError(t, err)
+	require.Equal(t, &done{}, st)
+
+	st, err = stateFromName(stateNameArranging)
+	require.NoError(t, err)
+	require.Equal(t, &arranging{}, st)
+
+	st, err = stateFromName(stateNameDelivering)
+	require.NoError(t, err)
+	require.Equal(t, &delivering{}, st)
+
+	st, err = stateFromName(stateNameConfirming)
+	require.NoError(t, err)
+	require.Equal(t, &confirming{}, st)
+
+	st, err = stateFromName(stateNameAbandoning)
+	require.NoError(t, err)
+	require.Equal(t, &abandoning{}, st)
+
+	st, err = stateFromName(stateNameDeciding)
+	require.NoError(t, err)
+	require.Equal(t, &deciding{}, st)
+
+	st, err = stateFromName(stateNameWaiting)
+	require.NoError(t, err)
+	require.Equal(t, &waiting{}, st)
+
+	st, err = stateFromName("unknown")
+	require.EqualError(t, err, "invalid state name unknown")
+	require.Nil(t, st)
 }

--- a/pkg/didcomm/protocol/introduce/states.go
+++ b/pkg/didcomm/protocol/introduce/states.go
@@ -37,7 +37,8 @@ type state interface {
 	CanTransitionTo(next state) bool
 	// Executes this state, returning a followup state to be immediately executed as well.
 	// The 'noOp' state should be returned if the state has no followup.
-	Execute(msg *service.DIDCommMsg) (followup state, err error)
+	ExecuteInbound(msg *service.DIDCommMsg) (followup state, err error)
+	ExecuteOutbound(msg *service.DIDCommMsg, destination *service.Destination) (followup state, err error)
 }
 
 // noOp state
@@ -52,7 +53,11 @@ func (s *noOp) CanTransitionTo(_ state) bool {
 	return false
 }
 
-func (s *noOp) Execute(_ *service.DIDCommMsg) (state, error) {
+func (s *noOp) ExecuteInbound(_ *service.DIDCommMsg) (state, error) {
+	return nil, errors.New("cannot execute no-op")
+}
+
+func (s *noOp) ExecuteOutbound(_ *service.DIDCommMsg, destination *service.Destination) (state, error) {
 	return nil, errors.New("cannot execute no-op")
 }
 
@@ -70,8 +75,12 @@ func (s *start) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameArranging || next.Name() == stateNameDelivering || next.Name() == stateNameDeciding
 }
 
-func (s *start) Execute(msg *service.DIDCommMsg) (state, error) {
-	return nil, errors.New("start execute: not implemented yet")
+func (s *start) ExecuteInbound(msg *service.DIDCommMsg) (state, error) {
+	return nil, errors.New("start ExecuteInbound: not implemented yet")
+}
+
+func (s *start) ExecuteOutbound(_ *service.DIDCommMsg, destination *service.Destination) (state, error) {
+	return nil, errors.New("start ExecuteOutbound: not implemented yet")
 }
 
 // done state
@@ -87,8 +96,12 @@ func (s *done) CanTransitionTo(next state) bool {
 	return false
 }
 
-func (s *done) Execute(msg *service.DIDCommMsg) (state, error) {
-	return nil, errors.New("done execute: not implemented yet")
+func (s *done) ExecuteInbound(msg *service.DIDCommMsg) (state, error) {
+	return nil, errors.New("done ExecuteInbound: not implemented yet")
+}
+
+func (s *done) ExecuteOutbound(_ *service.DIDCommMsg, destination *service.Destination) (state, error) {
+	return nil, errors.New("done ExecuteOutbound: not implemented yet")
 }
 
 // arranging state
@@ -103,8 +116,12 @@ func (s *arranging) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameArranging || next.Name() == stateNameDone || next.Name() == stateNameAbandoning
 }
 
-func (s *arranging) Execute(msg *service.DIDCommMsg) (state, error) {
-	return nil, errors.New("arranging execute: not implemented yet")
+func (s *arranging) ExecuteInbound(msg *service.DIDCommMsg) (state, error) {
+	return nil, errors.New("arranging ExecuteInbound: not implemented yet")
+}
+
+func (s *arranging) ExecuteOutbound(_ *service.DIDCommMsg, destination *service.Destination) (state, error) {
+	return nil, errors.New("arranging ExecuteOutbound: not implemented yet")
 }
 
 // delivering state
@@ -119,8 +136,12 @@ func (s *delivering) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameConfirming || next.Name() == stateNameDone || next.Name() == stateNameAbandoning
 }
 
-func (s *delivering) Execute(msg *service.DIDCommMsg) (state, error) {
-	return nil, errors.New("delivering execute: not implemented yet")
+func (s *delivering) ExecuteInbound(msg *service.DIDCommMsg) (state, error) {
+	return nil, errors.New("delivering ExecuteInbound: not implemented yet")
+}
+
+func (s *delivering) ExecuteOutbound(_ *service.DIDCommMsg, destination *service.Destination) (state, error) {
+	return nil, errors.New("delivering ExecuteOutbound: not implemented yet")
 }
 
 // confirming state
@@ -135,8 +156,12 @@ func (s *confirming) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameDone || next.Name() == stateNameAbandoning
 }
 
-func (s *confirming) Execute(msg *service.DIDCommMsg) (state, error) {
-	return nil, errors.New("confirming execute: not implemented yet")
+func (s *confirming) ExecuteInbound(msg *service.DIDCommMsg) (state, error) {
+	return nil, errors.New("confirming ExecuteInbound: not implemented yet")
+}
+
+func (s *confirming) ExecuteOutbound(_ *service.DIDCommMsg, destination *service.Destination) (state, error) {
+	return nil, errors.New("confirming ExecuteOutbound: not implemented yet")
 }
 
 // abandoning state
@@ -151,8 +176,12 @@ func (s *abandoning) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameDone
 }
 
-func (s *abandoning) Execute(msg *service.DIDCommMsg) (state, error) {
-	return nil, errors.New("abandoning execute: not implemented yet")
+func (s *abandoning) ExecuteInbound(msg *service.DIDCommMsg) (state, error) {
+	return nil, errors.New("abandoning ExecuteInbound: not implemented yet")
+}
+
+func (s *abandoning) ExecuteOutbound(_ *service.DIDCommMsg, destination *service.Destination) (state, error) {
+	return nil, errors.New("abandoning ExecuteOutbound: not implemented yet")
 }
 
 // deciding state
@@ -167,8 +196,12 @@ func (s *deciding) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameWaiting || next.Name() == stateNameDone
 }
 
-func (s *deciding) Execute(msg *service.DIDCommMsg) (state, error) {
-	return nil, errors.New("deciding execute: not implemented yet")
+func (s *deciding) ExecuteInbound(msg *service.DIDCommMsg) (state, error) {
+	return nil, errors.New("deciding ExecuteInbound: not implemented yet")
+}
+
+func (s *deciding) ExecuteOutbound(_ *service.DIDCommMsg, destination *service.Destination) (state, error) {
+	return nil, errors.New("deciding ExecuteOutbound: not implemented yet")
 }
 
 // waiting state
@@ -183,6 +216,10 @@ func (s *waiting) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameDone
 }
 
-func (s *waiting) Execute(msg *service.DIDCommMsg) (state, error) {
-	return nil, errors.New("waiting execute: not implemented yet")
+func (s *waiting) ExecuteInbound(msg *service.DIDCommMsg) (state, error) {
+	return nil, errors.New("waiting ExecuteInbound: not implemented yet")
+}
+
+func (s *waiting) ExecuteOutbound(_ *service.DIDCommMsg, destination *service.Destination) (state, error) {
+	return nil, errors.New("waiting ExecuteOutbound: not implemented yet")
 }

--- a/pkg/didcomm/protocol/introduce/states_test.go
+++ b/pkg/didcomm/protocol/introduce/states_test.go
@@ -32,9 +32,14 @@ func TestNoopState(t *testing.T) {
 	notTransition(t, noop)
 }
 
-// noOp.Execute() returns nil, error
-func TestNoOpState_Execute(t *testing.T) {
-	followup, err := (&noOp{}).Execute(&service.DIDCommMsg{})
+func TestNoOpState_ExecuteInbound(t *testing.T) {
+	followup, err := (&noOp{}).ExecuteInbound(&service.DIDCommMsg{})
+	require.Error(t, err)
+	require.Nil(t, followup)
+}
+
+func TestNoOpState_ExecuteOutbound(t *testing.T) {
+	followup, err := (&noOp{}).ExecuteOutbound(&service.DIDCommMsg{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -56,8 +61,14 @@ func TestStartState(t *testing.T) {
 	require.False(t, st.CanTransitionTo(&waiting{}))
 }
 
-func TestStartState_Execute(t *testing.T) {
-	followup, err := (&start{}).Execute(&service.DIDCommMsg{})
+func TestStartState_ExecuteInbound(t *testing.T) {
+	followup, err := (&start{}).ExecuteInbound(&service.DIDCommMsg{})
+	require.Error(t, err)
+	require.Nil(t, followup)
+}
+
+func TestStartState_ExecuteOutbound(t *testing.T) {
+	followup, err := (&start{}).ExecuteOutbound(&service.DIDCommMsg{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -69,8 +80,14 @@ func TestDoneState(t *testing.T) {
 	notTransition(t, done)
 }
 
-func TestDoneState_Execute(t *testing.T) {
-	followup, err := (&done{}).Execute(&service.DIDCommMsg{})
+func TestDoneState_ExecuteInbound(t *testing.T) {
+	followup, err := (&done{}).ExecuteInbound(&service.DIDCommMsg{})
+	require.Error(t, err)
+	require.Nil(t, followup)
+}
+
+func TestDoneState_ExecuteOutbound(t *testing.T) {
+	followup, err := (&done{}).ExecuteOutbound(&service.DIDCommMsg{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -92,8 +109,14 @@ func TestArrangingState(t *testing.T) {
 	require.False(t, st.CanTransitionTo(&waiting{}))
 }
 
-func TestArrangingState_Execute(t *testing.T) {
-	followup, err := (&arranging{}).Execute(&service.DIDCommMsg{})
+func TestArrangingState_ExecuteInbound(t *testing.T) {
+	followup, err := (&arranging{}).ExecuteInbound(&service.DIDCommMsg{})
+	require.Error(t, err)
+	require.Nil(t, followup)
+}
+
+func TestArrangingState_ExecuteOutbound(t *testing.T) {
+	followup, err := (&arranging{}).ExecuteOutbound(&service.DIDCommMsg{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -115,8 +138,14 @@ func TestDeliveringState(t *testing.T) {
 	require.False(t, st.CanTransitionTo(&waiting{}))
 }
 
-func TestDeliveringState_Execute(t *testing.T) {
-	followup, err := (&delivering{}).Execute(&service.DIDCommMsg{})
+func TestDeliveringState_ExecuteInbound(t *testing.T) {
+	followup, err := (&delivering{}).ExecuteInbound(&service.DIDCommMsg{})
+	require.Error(t, err)
+	require.Nil(t, followup)
+}
+
+func TestDeliveringState_ExecuteOutbound(t *testing.T) {
+	followup, err := (&delivering{}).ExecuteOutbound(&service.DIDCommMsg{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -138,8 +167,14 @@ func TestConfirmingState(t *testing.T) {
 	require.False(t, st.CanTransitionTo(&waiting{}))
 }
 
-func TestConfirmingState_Execute(t *testing.T) {
-	followup, err := (&confirming{}).Execute(&service.DIDCommMsg{})
+func TestConfirmingState_ExecuteInbound(t *testing.T) {
+	followup, err := (&confirming{}).ExecuteInbound(&service.DIDCommMsg{})
+	require.Error(t, err)
+	require.Nil(t, followup)
+}
+
+func TestConfirmingState_ExecuteOutbound(t *testing.T) {
+	followup, err := (&confirming{}).ExecuteOutbound(&service.DIDCommMsg{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -161,8 +196,14 @@ func TestAbandoningState(t *testing.T) {
 	require.False(t, st.CanTransitionTo(&waiting{}))
 }
 
-func TestAbandoningState_Execute(t *testing.T) {
-	followup, err := (&abandoning{}).Execute(&service.DIDCommMsg{})
+func TestAbandoningState_ExecuteInbound(t *testing.T) {
+	followup, err := (&abandoning{}).ExecuteInbound(&service.DIDCommMsg{})
+	require.Error(t, err)
+	require.Nil(t, followup)
+}
+
+func TestAbandoningState_ExecuteOutbound(t *testing.T) {
+	followup, err := (&abandoning{}).ExecuteOutbound(&service.DIDCommMsg{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -184,8 +225,14 @@ func TestDecidingState(t *testing.T) {
 	require.False(t, st.CanTransitionTo(&abandoning{}))
 }
 
-func TestDecidingState_Execute(t *testing.T) {
-	followup, err := (&deciding{}).Execute(&service.DIDCommMsg{})
+func TestDecidingState_ExecuteInbound(t *testing.T) {
+	followup, err := (&deciding{}).ExecuteInbound(&service.DIDCommMsg{})
+	require.Error(t, err)
+	require.Nil(t, followup)
+}
+
+func TestDecidingState_ExecuteOutbound(t *testing.T) {
+	followup, err := (&deciding{}).ExecuteOutbound(&service.DIDCommMsg{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -207,8 +254,14 @@ func TestWaitingState(t *testing.T) {
 	require.False(t, st.CanTransitionTo(&waiting{}))
 }
 
-func TestWaitingState_Execute(t *testing.T) {
-	followup, err := (&waiting{}).Execute(&service.DIDCommMsg{})
+func TestWaitingState_ExecuteInbound(t *testing.T) {
+	followup, err := (&waiting{}).ExecuteInbound(&service.DIDCommMsg{})
+	require.Error(t, err)
+	require.Nil(t, followup)
+}
+
+func TestWaitingState_ExecuteOutbound(t *testing.T) {
+	followup, err := (&waiting{}).ExecuteOutbound(&service.DIDCommMsg{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }


### PR DESCRIPTION
* `HandleInbound` and `stateFromName` methods implementation
* state interface was changed (Execute function was separated into ExecuteInbound and ExecuteOutbound)

Issue: https://github.com/hyperledger/aries-framework-go/issues/464

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>