### PR TITLE
refactor: Add DID resolver to didexchange service context

### DIFF
--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/common/metadata"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
@@ -63,6 +64,7 @@ type provider interface {
 	OutboundDispatcher() dispatcher.Outbound
 	StorageProvider() storage.Provider
 	Signer() wallet.Signer
+	DIDResolver() didresolver.Resolver
 }
 
 type connectionStore interface {
@@ -91,6 +93,7 @@ type context struct {
 	outboundDispatcher dispatcher.Outbound
 	didCreator         did.Creator
 	signer             wallet.Signer
+	didResolver        didresolver.Resolver
 }
 
 // New return didexchange service
@@ -104,7 +107,9 @@ func New(didMaker did.Creator, prov provider) (*Service, error) {
 		ctx: context{
 			outboundDispatcher: prov.OutboundDispatcher(),
 			didCreator:         didMaker,
-			signer:             prov.Signer()},
+			signer:             prov.Signer(),
+			didResolver:        prov.DIDResolver(),
+		},
 		store: store,
 		// TODO channel size - https://github.com/hyperledger/aries-framework-go/issues/246
 		callbackChannel: make(chan didCommChMessage, 10),

--- a/pkg/framework/aries/api/protocol.go
+++ b/pkg/framework/aries/api/protocol.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/envelope"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
@@ -30,6 +31,7 @@ type Provider interface {
 	InboundTransportEndpoint() string
 	DIDWallet() wallet.DIDCreator
 	Signer() wallet.Signer
+	DIDResolver() didresolver.Resolver
 }
 
 // ProtocolSvcCreator method to create new protocol service

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -40,7 +40,7 @@ func transportProviderFactory() api.TransportProviderFactory {
 }
 
 // didResolverProvider provides default DID resolver.
-func didResolverProvider(dbprov storage.Provider) (DIDResolver, error) {
+func didResolverProvider(dbprov storage.Provider) (didresolver.Resolver, error) {
 	dbstore, err := dbprov.OpenStore(peer.StoreNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("storage initialization failed : %w", err)

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -13,22 +13,15 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/envelope"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/context"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
-// DIDResolver interface for DID resolver.
-type DIDResolver interface {
-	Resolve(did string, opts ...didresolver.ResolveOpt) (*did.Doc, error)
-}
-
 // Aries provides access to clients being managed by the framework.
 type Aries struct {
 	transport                 api.TransportProviderFactory
-	didResolver               DIDResolver
 	storeProvider             storage.Provider
 	protocolSvcCreators       []api.ProtocolSvcCreator
 	services                  []dispatcher.Service
@@ -41,6 +34,7 @@ type Aries struct {
 	packager                  envelope.Packager
 	crypterCreator            crypto.CrypterCreator
 	crypter                   crypto.Crypter
+	didResolver               didresolver.Resolver
 }
 
 // Option configures the framework.
@@ -123,7 +117,7 @@ func WithInboundTransport(inboundTransport transport.InboundTransport) Option {
 }
 
 // WithDIDResolver injects a DID resolver to the Aries framework
-func WithDIDResolver(didResolver DIDResolver) Option {
+func WithDIDResolver(didResolver didresolver.Resolver) Option {
 	return func(opts *Aries) error {
 		opts.didResolver = didResolver
 		return nil
@@ -179,7 +173,7 @@ func WithPackager(p envelope.PackagerCreator) Option {
 }
 
 // DIDResolver returns the framework configured DID Resolver.
-func (a *Aries) DIDResolver() DIDResolver {
+func (a *Aries) DIDResolver() didresolver.Resolver {
 	return a.didResolver
 }
 

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/envelope"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
@@ -29,6 +30,7 @@ type Provider struct {
 	crypter                  crypto.Crypter
 	inboundTransportEndpoint string
 	outboundTransport        transport.OutboundTransport
+	didResolver              didresolver.Resolver
 }
 
 // New instantiated new context provider
@@ -117,6 +119,11 @@ func (p *Provider) StorageProvider() storage.Provider {
 	return p.storeProvider
 }
 
+// DIDResolver returns did resolver
+func (p *Provider) DIDResolver() didresolver.Resolver {
+	return p.didResolver
+}
+
 // ProviderOption configures the framework.
 type ProviderOption func(opts *Provider) error
 
@@ -164,6 +171,14 @@ func WithInboundTransportEndpoint(endpoint string) ProviderOption {
 func WithStorageProvider(s storage.Provider) ProviderOption {
 	return func(opts *Provider) error {
 		opts.storeProvider = s
+		return nil
+	}
+}
+
+// WithDIDResolver injects did resolver into the context
+func WithDIDResolver(r didresolver.Resolver) ProviderOption {
+	return func(opts *Provider) error {
+		opts.didResolver = r
 		return nil
 	}
 }

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -21,6 +21,7 @@ import (
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
 	mockenvelope "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/envelope"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didresolver"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 	mockwallet "github.com/hyperledger/aries-framework-go/pkg/internal/mock/wallet"
 )
@@ -175,6 +176,13 @@ func TestNewProvider(t *testing.T) {
 		prov, err := New(WithStorageProvider(s))
 		require.NoError(t, err)
 		require.Equal(t, s, prov.StorageProvider())
+	})
+
+	t.Run("test new with did resolver", func(t *testing.T) {
+		r := didresolver.NewMockResolver()
+		prov, err := New(WithDIDResolver(r))
+		require.NoError(t, err)
+		require.Equal(t, r, prov.DIDResolver())
 	})
 
 	t.Run("test new with outbound transport service", func(t *testing.T) {

--- a/pkg/framework/didresolver/api.go
+++ b/pkg/framework/didresolver/api.go
@@ -8,7 +8,14 @@ package didresolver
 import (
 	"errors"
 	"time"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 )
+
+// Resolver interface for DID resolver.
+type Resolver interface {
+	Resolve(did string, opts ...ResolveOpt) (*did.Doc, error)
+}
 
 // ResultType input option can be used to request a certain type of result.
 type ResultType int

--- a/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
@@ -9,7 +9,9 @@ package protocol
 import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
+	mockdidresolver "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didresolver"
 	mockstore "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 	mockwallet "github.com/hyperledger/aries-framework-go/pkg/internal/mock/wallet"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
@@ -104,4 +106,9 @@ func (p *MockProvider) StorageProvider() storage.Provider {
 // Signer is mock signer for DID exchange service
 func (p *MockProvider) Signer() wallet.Signer {
 	return &mockwallet.CloseableWallet{}
+}
+
+// DIDResolver is mock DID resolver
+func (p *MockProvider) DIDResolver() didresolver.Resolver {
+	return &mockdidresolver.MockResolver{}
 }

--- a/pkg/internal/mock/didresolver/mock_didresolver.go
+++ b/pkg/internal/mock/didresolver/mock_didresolver.go
@@ -1,0 +1,25 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didresolver
+
+import (
+	diddoc "github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
+)
+
+// MockResolver is mock did resolver
+type MockResolver struct {
+}
+
+// NewMockResolver return new instance of mock did resolver
+func NewMockResolver() *MockResolver {
+	return &MockResolver{}
+}
+
+// Resolve did document
+func (r *MockResolver) Resolve(did string, opts ...didresolver.ResolveOpt) (*diddoc.Doc, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Expose DID resolver in didexchange service context. It is required for supporting public DIDs.

Closes #489

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>
