### PR TITLE
feat: Webhook notifier now sends JSON

### DIFF
--- a/cmd/aries-agentd/startcmd/start.go
+++ b/cmd/aries-agentd/startcmd/start.go
@@ -172,7 +172,7 @@ func startAgent(parameters *agentParameters) error {
 	}
 
 	// get all HTTP REST API handlers available for controller API
-	restService, err := restapi.New(ctx, parameters.webhookURLs)
+	restService, err := restapi.New(ctx, restapi.WithWebhookURLs(parameters.webhookURLs...))
 	if err != nil {
 		return fmt.Errorf("failed to start aries agentd on port [%s], failed to get rest service api :  %w",
 			parameters.host, err)

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/internal/common/support"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation/didexchange/models"
+	"github.com/hyperledger/aries-framework-go/pkg/restapi/webhook"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
@@ -49,7 +50,7 @@ type provider interface {
 }
 
 // New returns new DID Exchange rest client protocol instance
-func New(ctx provider) (*Operation, error) {
+func New(ctx provider, notifier webhook.Notifier) (*Operation, error) {
 	didExchange, err := didexchange.New(ctx)
 	if err != nil {
 		return nil, err
@@ -61,6 +62,7 @@ func New(ctx provider) (*Operation, error) {
 		// TODO channel size - https://github.com/hyperledger/aries-framework-go/issues/246
 		actionCh: make(chan service.DIDCommAction, 10),
 		msgCh:    make(chan service.StateMsg, 10),
+		notifier: notifier,
 	}
 	svc.registerHandler()
 
@@ -79,6 +81,7 @@ type Operation struct {
 	handlers []operation.Handler
 	actionCh chan service.DIDCommAction
 	msgCh    chan service.StateMsg
+	notifier webhook.Notifier
 }
 
 // CreateInvitation swagger:route POST /connections/create-invitation did-exchange createInvitation

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -30,12 +30,13 @@ import (
 	mockwallet "github.com/hyperledger/aries-framework-go/pkg/internal/mock/wallet"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation/didexchange/models"
+	"github.com/hyperledger/aries-framework-go/pkg/restapi/webhook"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
 func TestOperation_GetAPIHandlers(t *testing.T) {
 	svc, err := New(&mockprovider.Provider{StorageProviderValue: mockstore.NewMockStoreProvider(),
-		ServiceValue: &protocol.MockDIDExchangeSvc{}})
+		ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil))
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 
@@ -44,7 +45,7 @@ func TestOperation_GetAPIHandlers(t *testing.T) {
 }
 
 func TestNew_Fail(t *testing.T) {
-	svc, err := New(&mockprovider.Provider{ServiceErr: errors.New("test-error")})
+	svc, err := New(&mockprovider.Provider{ServiceErr: errors.New("test-error")}, webhook.NewHTTPNotifier(nil))
 	require.Error(t, err)
 	require.Nil(t, svc)
 }
@@ -217,7 +218,7 @@ func TestOperation_WriteGenericError(t *testing.T) {
 	const errMsg = "sample-error-msg"
 
 	svc, err := New(&mockprovider.Provider{StorageProviderValue: mockstore.NewMockStoreProvider(),
-		ServiceValue: &protocol.MockDIDExchangeSvc{}})
+		ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil))
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 
@@ -238,7 +239,7 @@ func TestOperation_WriteGenericError(t *testing.T) {
 
 func TestOperation_WriteResponse(t *testing.T) {
 	svc, err := New(&mockprovider.Provider{StorageProviderValue: mockstore.NewMockStoreProvider(),
-		ServiceValue: &protocol.MockDIDExchangeSvc{}})
+		ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil))
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 	svc.writeResponse(&mockWriter{errors.New("failed to write")}, &models.QueryConnectionResponse{})
@@ -285,6 +286,7 @@ func getHandler(t *testing.T, lookup string, handleErr error) operation.Handler 
 		WalletValue:          &mockwallet.CloseableWallet{CreateEncryptionKeyValue: "sample-key"},
 		InboundEndpointValue: "endpoint",
 		StorageProviderValue: &mockstore.MockStoreProvider{Store: &s}},
+		webhook.NewHTTPNotifier(nil),
 	)
 	require.NoError(t, err)
 	require.NotNil(t, svc)
@@ -316,7 +318,7 @@ func TestServiceEvents(t *testing.T) {
 
 	// create the client
 	op, err := New(&mockprovider.Provider{StorageProviderValue: mockstore.NewMockStoreProvider(),
-		ServiceValue: didExSvc})
+		ServiceValue: didExSvc}, webhook.NewHTTPNotifier(nil))
 	require.NoError(t, err)
 	require.NotNil(t, op)
 

--- a/pkg/restapi/restapi.go
+++ b/pkg/restapi/restapi.go
@@ -13,22 +13,38 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/webhook"
 )
 
+type allOpts struct {
+	webhookURLs []string
+}
+
+// Opt represents a REST Api option.
+type Opt func(opts *allOpts)
+
+// WithWebhookURLs is an option for setting up a webhook dispatcher which will notify clients of events
+func WithWebhookURLs(webhookURLs ...string) Opt {
+	return func(opts *allOpts) {
+		opts.webhookURLs = webhookURLs
+	}
+}
+
 // New returns new controller REST API instance.
-//
 // TODO: Allow customized operations.
-// TODO: Make webhookURLs an optional parameter (#472)
-func New(ctx *context.Provider, webhookURLs []string) (*Controller, error) {
+func New(ctx *context.Provider, opts ...Opt) (*Controller, error) {
+	restAPIOpts := &allOpts{}
+	// Apply options
+	for _, opt := range opts {
+		opt(restAPIOpts)
+	}
+
 	var allHandlers []operation.Handler
 
 	// Add DID Exchange Rest Handlers
-	exchange, err := didexchange.New(ctx)
+	exchange, err := didexchange.New(ctx, webhook.NewHTTPNotifier(restAPIOpts.webhookURLs))
 	if err != nil {
 		return nil, err
 	}
 
 	allHandlers = append(allHandlers, exchange.GetRESTHandlers()...)
-
-	webhook.StartWebhookDispatcher(webhookURLs)
 
 	return &Controller{handlers: allHandlers}, nil
 }

--- a/pkg/restapi/restapi_test.go
+++ b/pkg/restapi/restapi_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestNew_Failure(t *testing.T) {
-	controller, err := New(&context.Provider{}, nil)
+	controller, err := New(&context.Provider{})
 	require.Error(t, err)
 	require.Equal(t, err, api.ErrSvcNotFound)
 	require.Nil(t, controller)
@@ -44,11 +44,22 @@ func TestNew_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ctx)
 
-	controller, err := New(ctx, nil)
+	controller, err := New(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, controller)
 
 	require.NotEmpty(t, controller.GetOperations())
+}
+
+func TestAddWebhookNotifierOption(t *testing.T) {
+	restAPIOpts := &allOpts{}
+
+	webhookURLs := []string{"localhost:8080"}
+	webhookNotifierOpt := WithWebhookURLs(webhookURLs...)
+
+	webhookNotifierOpt(restAPIOpts)
+
+	require.Equal(t, webhookURLs, restAPIOpts.webhookURLs)
 }
 
 func generateTempDir(t testing.TB) (string, func()) {

--- a/pkg/restapi/webhook/payloads.go
+++ b/pkg/restapi/webhook/payloads.go
@@ -1,0 +1,74 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package webhook
+
+// ConnectionMsg is sent when a pairwise connection record is updated.
+// TODO: This model is not final and was simply copied from ACA-Py for now (see #540).
+type ConnectionMsg struct {
+	ConnectionID        string `json:"connection_id"`
+	State               string `json:"state"`
+	MyDid               string `json:"myDid"`
+	TheirDid            string `json:"theirDid"`
+	TheirLabel          string `json:"theirLabel"`
+	TheirRole           string `json:"theirRole"`
+	InboundConnectionID string `json:"inbound_connection_id"`
+	Initiator           string `json:"initiator"`
+	InvitationKey       string `json:"invitation_key"`
+	RequestID           string `json:"request_id"`
+	RoutingState        string `json:"routing_state"`
+	Accept              string `json:"accept"`
+	ErrorMsg            string `json:"error_msg"`
+	InvitationMode      string `json:"invitation_mode"`
+	Alias               string `json:"alias"`
+}
+
+// BasicMsg is used for receiving basic messages.
+// TODO: This model is not final and was simply copied from ACA-Py for now (see #541).
+type BasicMsg struct {
+	ConnectionID string `json:"connection_id"`
+	MessageID    string `json:"message_id"`
+	Content      string `json:"content"`
+	State        string `json:"state"`
+}
+
+// IssueCredentialMsg is sent when a credential exchange record is updated.
+// TODO: This model is not final and was simply copied from ACA-Py for now (see #558).
+type IssueCredentialMsg struct {
+	CredentialExchangeID      string `json:"credential_exchange_id"`
+	ConnectionID              string `json:"connection_id"`
+	ThreadID                  string `json:"thread_id"`
+	ParentThreadID            string `json:"parent_thread_id"`
+	Initiator                 string `json:"initiator"`
+	State                     string `json:"state"`
+	CredentialDefinitionID    string `json:"credential_definition_id"`
+	SchemaID                  string `json:"schema_id"`
+	CredentialProposalDict    string `json:"credential_proposal_dict"`
+	CredentialOffer           string `json:"credential_offer"`
+	CredentialRequest         string `json:"credential_request"`
+	CredentialRequestMetadata string `json:"credential_request_metadata"`
+	CredentialID              string `json:"credential_id"`
+	RawCredential             string `json:"raw_credential"`
+	Credential                string `json:"credential"`
+	AutoOffer                 string `json:"auto_offer"`
+	AutoIssue                 string `json:"auto_issue"`
+	ErrorMsg                  string `json:"error_msg"`
+}
+
+// PresentProofMsg is sent when a presentation exchange record is updated.
+// TODO: This model is not final and was simply copied from ACA-Py for now (see #559).
+type PresentProofMsg struct {
+	PresentationExchangeID   string `json:"presentation_exchange_id"`
+	ConnectionID             string `json:"connection_id"`
+	ThreadID                 string `json:"thread_id"`
+	Initiator                string `json:"initiator"`
+	State                    string `json:"state"`
+	PresentationProposalDict string `json:"presentation_proposal_dict"`
+	PresentationRequest      string `json:"presentation_request"`
+	Presentation             string `json:"presentation"`
+	Verified                 string `json:"verified"`
+	AutoPresent              string `json:"auto_present"`
+	ErrorMsg                 string `json:"error_msg"`
+}


### PR DESCRIPTION
Closes #472 

Webhook notifier now sends arbitrary JSON messages. The ticker was removed.

The actual triggering of webhook notifications has to be done in another story since the REST Api is still in-progress.

Signed-off-by: Derek Trider <derek.trider@securekey.com>