### PR TITLE
refactor: move wallet into pkg/crypto, expose keys to crypto ops

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/wallet"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 const (

--- a/pkg/common/did/creator.go
+++ b/pkg/common/did/creator.go
@@ -7,8 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package did
 
 import (
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/didcreator"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 const method = "peer"
@@ -25,7 +25,7 @@ type Creator interface {
 	// did: DID document
 	//
 	// error: error
-	CreateDID(opts ...wallet.DocOpts) (*did.Doc, error)
+	CreateDID(opts ...didcreator.DocOpts) (*did.Doc, error)
 
 	// Gets already created DID document by ID.
 	//
@@ -43,7 +43,7 @@ type Creator interface {
 
 // provider contains dependencies for DID creator and is typically created by using aries.Context()
 type provider interface {
-	DIDWallet() wallet.DIDCreator
+	DIDWallet() didcreator.DIDCreator
 }
 
 // NewPeerDIDCreator returns new Peer DID creator
@@ -53,12 +53,12 @@ func NewPeerDIDCreator(ctx provider) *PeerDIDCreator {
 
 // PeerDIDCreator creates Peer DIDs
 type PeerDIDCreator struct {
-	wallet.DIDCreator
+	didcreator.DIDCreator
 	method string
 }
 
 // CreateDID creates new Peer DID
-func (l *PeerDIDCreator) CreateDID(opts ...wallet.DocOpts) (*did.Doc, error) {
+func (l *PeerDIDCreator) CreateDID(opts ...didcreator.DocOpts) (*did.Doc, error) {
 	return l.DIDCreator.CreateDID(l.method, opts...)
 }
 

--- a/pkg/common/did/creator_test.go
+++ b/pkg/common/did/creator_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/didcreator"
 	d "github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	mockwallet "github.com/hyperledger/aries-framework-go/pkg/internal/mock/wallet"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 func getMockDID() *d.Doc {
@@ -54,6 +54,6 @@ func TestPeerDIDCreator(t *testing.T) {
 type mockProvider struct {
 }
 
-func (m *mockProvider) DIDWallet() wallet.DIDCreator {
+func (m *mockProvider) DIDWallet() didcreator.DIDCreator {
 	return &mockwallet.CloseableWallet{MockDID: getMockDID()}
 }

--- a/pkg/crypto/didcreator/api.go
+++ b/pkg/crypto/didcreator/api.go
@@ -1,0 +1,53 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didcreator
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/internal/didopts"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+)
+
+// DIDCreator provides features to create and query DID document
+type DIDCreator interface {
+	// CreateDID Creates a new DID document.
+	//
+	// Args:
+	//
+	// method: DID method
+	//
+	// opts: options to create DID
+	//
+	// Returns:
+	//
+	// did: DID document
+	//
+	// error: error
+	CreateDID(method string, opts ...DocOpts) (*did.Doc, error)
+
+	// GetDID Gets an already-created DID document by ID.
+	//
+	// Args:
+	//
+	// id: DID identifier
+	//
+	// Returns:
+	//
+	// did: DID document
+	//
+	// error: when document is not found or for any other error conditions
+	GetDID(id string) (*did.Doc, error)
+}
+
+// DocOpts is a create DID option
+type DocOpts func(opts *didopts.CreateDIDOpts)
+
+// WithServiceType service type of DID document to be created
+func WithServiceType(serviceType string) DocOpts {
+	return func(opts *didopts.CreateDIDOpts) {
+		opts.ServiceType = serviceType
+	}
+}

--- a/pkg/crypto/internal/didopts/didopts.go
+++ b/pkg/crypto/internal/didopts/didopts.go
@@ -1,0 +1,12 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didopts
+
+// CreateDIDOpts holds the options for creating DID
+type CreateDIDOpts struct {
+	ServiceType string
+}

--- a/pkg/crypto/operator/operator.go
+++ b/pkg/crypto/operator/operator.go
@@ -1,0 +1,34 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package operator
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/internal/cryptoutil"
+)
+
+// CryptoOperator denotes an object that accesses keys in a KeyHolder
+//
+// Framework CryptoOperators are defined in this package or subpackages.
+// Clients who need to define their own crypto operations can implement
+// this interface.
+type CryptoOperator interface {
+
+	// InjectKeyHolder injects a KeyHolder which will provide private keys
+	// for the CryptoOperator's crypto computations.
+	// Note: KeyHolders defined by the framework are not directly accessible
+	// to clients -
+	InjectKeyHolder(KeyHolder) error
+}
+
+// KeyHolder denotes an object that holds keypairs, indexed by the public key (in base 58)
+type KeyHolder interface {
+	// GetKey gets the keypair associated to the given pubkey
+	GetKey(pub string) (*cryptoutil.KeyPair, error)
+
+	// PutKey persists a keypair in the keystore
+	PutKey(pub string, pair *cryptoutil.KeyPair) error
+}

--- a/pkg/crypto/wallet/wallet.go
+++ b/pkg/crypto/wallet/wallet.go
@@ -1,0 +1,84 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package wallet
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/didcreator"
+	secretwallet "github.com/hyperledger/aries-framework-go/pkg/crypto/internal/wallet"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/operator"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+// provider contains dependencies for the base wallet and is typically created by using aries.Context()
+type provider interface {
+	StorageProvider() storage.Provider
+	InboundTransportEndpoint() string
+}
+
+// BaseWallet wallet implementation
+type BaseWallet struct {
+	secretWallet CloseableWallet
+}
+
+// New return new instance of wallet implementation
+func New(ctx provider) (*BaseWallet, error) {
+	w, err := secretwallet.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &BaseWallet{
+		secretWallet: w,
+	}, nil
+}
+
+// CreateEncryptionKey create a new public/private encryption keypair.
+func (w *BaseWallet) CreateEncryptionKey() (string, error) {
+	return w.secretWallet.CreateEncryptionKey()
+}
+
+// CreateSigningKey create a new public/private signing keypair.
+func (w *BaseWallet) CreateSigningKey() (string, error) {
+	return w.secretWallet.CreateSigningKey()
+}
+
+// SignMessage sign a message using the private key associated with a given verification key.
+func (w *BaseWallet) SignMessage(message []byte, fromVerKey string) ([]byte, error) {
+	return w.secretWallet.SignMessage(message, fromVerKey)
+}
+
+// AttachCryptoOperator attaches a crypto operator to this wallet, so the operator can use its private keys.
+func (w *BaseWallet) AttachCryptoOperator(cryptoOp operator.CryptoOperator) error {
+	return w.secretWallet.AttachCryptoOperator(cryptoOp)
+}
+
+// Close wallet
+func (w *BaseWallet) Close() error {
+	return w.secretWallet.Close()
+}
+
+// CreateDID returns new DID Document
+func (w *BaseWallet) CreateDID(method string, opts ...didcreator.DocOpts) (*did.Doc, error) {
+	return w.secretWallet.CreateDID(method, opts...)
+}
+
+// GetDID gets already created DID document from underlying store
+func (w *BaseWallet) GetDID(id string) (*did.Doc, error) {
+	return w.secretWallet.GetDID(id)
+}
+
+// DeriveKEK will derive an ephemeral symmetric key (kek) using a private key fetched from
+// the wallet corresponding to fromPubKey and derived with toPubKey
+// This implementation is for curve 25519 only
+func (w *BaseWallet) DeriveKEK(alg, apu, fromPubKey, toPubKey []byte) ([]byte, error) { // nolint:lll
+	return w.secretWallet.DeriveKEK(alg, apu, fromPubKey, toPubKey)
+}
+
+// FindVerKey selects a signing key which is present in candidateKeys that is present in the wallet
+func (w *BaseWallet) FindVerKey(candidateKeys []string) (int, error) {
+	return w.secretWallet.FindVerKey(candidateKeys)
+}

--- a/pkg/crypto/wallet/wallet_test.go
+++ b/pkg/crypto/wallet/wallet_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package wallet_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/operator/box"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/wallet"
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+const (
+	serviceEndpoint = "sample-endpoint.com"
+)
+
+func TestBaseWallet_New(t *testing.T) {
+	t.Run("test error from OpenStore for keystore", func(t *testing.T) {
+		const errMsg = "error from OpenStore"
+		_, err := wallet.New(newMockWalletProvider(
+			&mockstorage.MockStoreProvider{ErrOpenStoreHandle: fmt.Errorf(errMsg)}))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errMsg)
+	})
+	t.Run("test error from OpenStore for did store", func(t *testing.T) {
+		_, err := wallet.New(newMockWalletProvider(
+			&mockstorage.MockStoreProvider{FailNameSpace: "didstore"}))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to open store for name space")
+	})
+}
+
+func newMockWalletProvider(storagePvdr *mockstorage.MockStoreProvider) *mockProvider {
+	return &mockProvider{storagePvdr}
+}
+
+// mockProvider mocks provider for wallet
+type mockProvider struct {
+	storage *mockstorage.MockStoreProvider
+}
+
+func (m *mockProvider) StorageProvider() storage.Provider {
+	return m.storage
+}
+
+func (m *mockProvider) InboundTransportEndpoint() string {
+	return serviceEndpoint
+}
+
+func TestBaseWallet_Wrappers(t *testing.T) {
+	bw, err := wallet.New(newMockWalletProvider(&mockstorage.MockStoreProvider{Store: &mockstorage.MockStore{
+		Store: make(map[string][]byte),
+	}}))
+	require.NoError(t, err)
+
+	t.Run("CreateEncryptionKey", func(t *testing.T) {
+		ret, err := bw.CreateEncryptionKey()
+		require.NoError(t, err)
+		require.NotNil(t, ret)
+	})
+
+	t.Run("CreateSigningKey", func(t *testing.T) {
+		ret, err := bw.CreateSigningKey()
+		require.NoError(t, err)
+		require.NotNil(t, ret)
+	})
+
+	t.Run("AttachCryptoOperator", func(t *testing.T) {
+		err := bw.AttachCryptoOperator(&box.CryptoBox{})
+		require.NoError(t, err)
+
+		err = bw.AttachCryptoOperator(nil)
+		require.EqualError(t, err, "cannot attach nil crypto operator")
+	})
+
+	t.Run("FindVerKey", func(t *testing.T) {
+		ret, err := bw.FindVerKey([]string{"test"})
+		require.EqualError(t, err, "key not found")
+		require.Equal(t, -1, ret)
+
+		key, err := bw.CreateSigningKey()
+		require.NoError(t, err)
+
+		ret, err = bw.FindVerKey([]string{"test1", key, "test2"})
+		require.NoError(t, err)
+		require.Equal(t, 1, ret) // key is at index 1
+	})
+
+	t.Run("SignMessage", func(t *testing.T) {
+		_, err := bw.SignMessage([]byte("message"), "key")
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "failed to get key")
+
+		key, err := bw.CreateSigningKey()
+		require.NoError(t, err)
+		sig, err := bw.SignMessage([]byte("message"), key)
+		require.NoError(t, err)
+		require.NotNil(t, sig)
+	})
+
+	t.Run("DeriveKEK", func(t *testing.T) {
+		_, err := bw.DeriveKEK(nil, nil, nil, nil)
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "invalid key")
+	})
+
+	t.Run("CreateDID", func(t *testing.T) {
+		ret, err := bw.CreateDID("peer")
+		require.NoError(t, err)
+		require.NotNil(t, ret)
+	})
+
+	t.Run("GetDID", func(t *testing.T) {
+		did, err := bw.CreateDID("peer")
+		require.NoError(t, err)
+		require.NotNil(t, did)
+		ret, err := bw.GetDID(did.ID)
+		require.NoError(t, err)
+		require.NotNil(t, ret)
+	})
+
+	t.Run("Close", func(t *testing.T) {
+		err := bw.Close()
+		require.NoError(t, err)
+		err = bw.Close()
+		require.NoError(t, err)
+	})
+}

--- a/pkg/didcomm/crypto/crypter.go
+++ b/pkg/didcomm/crypto/crypter.go
@@ -6,7 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 
 package crypto
 
-import "github.com/hyperledger/aries-framework-go/pkg/wallet"
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/wallet"
+)
 
 // Provider interface for Crypter ctx
 type Provider interface {

--- a/pkg/didcomm/crypto/jwe/authcrypt/authcrypt.go
+++ b/pkg/didcomm/crypto/jwe/authcrypt/authcrypt.go
@@ -12,8 +12,8 @@ import (
 
 	chacha "golang.org/x/crypto/chacha20poly1305"
 
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/wallet"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/crypto"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 // This package deals with Authcrypt encryption for Packing/Unpacking DID Comm exchange

--- a/pkg/didcomm/crypto/jwe/authcrypt/authcrypt_test.go
+++ b/pkg/didcomm/crypto/jwe/authcrypt/authcrypt_test.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/crypto/nacl/box"
 
 	"github.com/hyperledger/aries-framework-go/pkg/internal/cryptoutil"
-	mockwallet "github.com/hyperledger/aries-framework-go/pkg/internal/mock/wallet"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/walletprovider"
 )
 
 func TestEncrypt(t *testing.T) {
@@ -49,15 +49,15 @@ func TestEncrypt(t *testing.T) {
 	recipient3Kp := cryptoutil.KeyPair{Priv: ecKeyPriv[:], Pub: ecKeyPub[:]}
 	t.Logf("recipient3Kp pub: %v", base64.RawURLEncoding.EncodeToString(recipient3Kp.Pub))
 	t.Logf("recipient3Kp priv: %v", base64.RawURLEncoding.EncodeToString(recipient3Kp.Priv))
-	senderWalletProvider, err := mockwallet.NewMockProvider(senderKp)
+	senderWalletProvider, err := walletprovider.NewMockProvider(senderKp)
 	require.NoError(t, err)
-	senderAndRec1WalletProvider, err := mockwallet.NewMockProvider(senderKp, recipient1Kp)
+	senderAndRec1WalletProvider, err := walletprovider.NewMockProvider(senderKp, recipient1Kp)
 	require.NoError(t, err)
-	recipient1WalletProvider, err := mockwallet.NewMockProvider(recipient1Kp)
+	recipient1WalletProvider, err := walletprovider.NewMockProvider(recipient1Kp)
 	require.NoError(t, err)
-	recipient2WalletProvider, err := mockwallet.NewMockProvider(recipient2Kp)
+	recipient2WalletProvider, err := walletprovider.NewMockProvider(recipient2Kp)
 	require.NoError(t, err)
-	recipient3WalletProvider, err := mockwallet.NewMockProvider(recipient3Kp)
+	recipient3WalletProvider, err := walletprovider.NewMockProvider(recipient3Kp)
 	require.NoError(t, err)
 	badKey := cryptoutil.KeyPair{
 		Pub:  nil,
@@ -90,7 +90,7 @@ func TestEncrypt(t *testing.T) {
 
 		enc, e := crypter.Encrypt([]byte("lorem ipsum dolor sit amet"),
 			badKey.Pub, [][]byte{recipient1Kp.Pub, recipient2Kp.Pub, recipient3Kp.Pub})
-		require.EqualError(t, e, "failed from getKey: key not found")
+		require.EqualError(t, e, "failed from GetKey: key not found")
 		require.Empty(t, enc)
 
 		// reset badKey
@@ -441,7 +441,7 @@ func TestRefEncrypt(t *testing.T) {
 	require.NoError(t, err)
 
 	// create mockwallet provider with the above keys
-	mockWalletProvider, err := mockwallet.NewMockProvider(cryptoutil.KeyPair{Pub: recipientPub, Priv: recipientPriv})
+	mockWalletProvider, err := walletprovider.NewMockProvider(cryptoutil.KeyPair{Pub: recipientPub, Priv: recipientPriv})
 	require.NoError(t, err)
 
 	// refJWE created by executing PHP test code at:

--- a/pkg/didcomm/crypto/jwe/authcrypt/decrypt_jwk_test.go
+++ b/pkg/didcomm/crypto/jwe/authcrypt/decrypt_jwk_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/stretchr/testify/require"
 	chacha "golang.org/x/crypto/chacha20poly1305"
 
-	mockwallet "github.com/hyperledger/aries-framework-go/pkg/internal/mock/wallet"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/walletprovider"
 )
 
 //nolint:lll
 func TestNilDecryptSenderJwk(t *testing.T) {
-	mockWalletProvider, err := mockwallet.NewMockProvider()
+	mockWalletProvider, err := walletprovider.NewMockProvider()
 	require.NoError(t, err)
 
 	crypter, err := New(mockWalletProvider, XC20P)

--- a/pkg/didcomm/crypto/jwe/authcrypt/encrypt_jwk_test.go
+++ b/pkg/didcomm/crypto/jwe/authcrypt/encrypt_jwk_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 	chacha "golang.org/x/crypto/chacha20poly1305"
 
-	mockwallet "github.com/hyperledger/aries-framework-go/pkg/internal/mock/wallet"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/walletprovider"
 )
 
 func TestNilEncryptSenderJwk(t *testing.T) {
-	mockWalletProvider, err := mockwallet.NewMockProvider()
+	mockWalletProvider, err := walletprovider.NewMockProvider()
 	require.NoError(t, err)
 
 	crypter, err := New(mockWalletProvider, XC20P)

--- a/pkg/didcomm/crypto/legacy/authcrypt/authcrypt.go
+++ b/pkg/didcomm/crypto/legacy/authcrypt/authcrypt.go
@@ -10,18 +10,22 @@ import (
 	"crypto/rand"
 	"io"
 
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/wallet"
 )
 
 // Crypter represents an Authcrypt Encrypter (Decrypter) that outputs/reads legacy Aries envelopes
 type Crypter struct {
 	randSource io.Reader
-	wallet     *wallet.BaseWallet
+	wallet     legacyWallet
+}
+
+type legacyWallet interface {
+	wallet.Crypto
 }
 
 // New will create a Crypter that encrypts messages using the legacy Aries format
 // Note: legacy crypter does not support XChacha20Poly1035 (XC20P), only Chacha20Poly1035 (C20P)
-func New(w *wallet.BaseWallet) *Crypter {
+func New(w legacyWallet) *Crypter {
 	return &Crypter{
 		randSource: rand.Reader,
 		wallet:     w,

--- a/pkg/didcomm/envelope/package_test.go
+++ b/pkg/didcomm/envelope/package_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/nacl/box"
 
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/wallet"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/crypto/jwe/authcrypt"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm"
 	mprovider "github.com/hyperledger/aries-framework-go/pkg/internal/mock/provider"
 	mockstorage "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 func TestBaseWalletInPackager_UnpackMessage(t *testing.T) {

--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -16,11 +16,11 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/common/did"
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	"github.com/hyperledger/aries-framework-go/pkg/common/metadata"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/wallet"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 var logger = log.New("aries-framework/did-exchange/service")

--- a/pkg/didcomm/protocol/didexchange/states.go
+++ b/pkg/didcomm/protocol/didexchange/states.go
@@ -17,11 +17,11 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/didcreator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 const (
@@ -298,7 +298,7 @@ func (ctx *context) handleInboundInvitation(invitation *Invitation, thid string)
 	if err != nil {
 		return nil, err
 	}
-	newDidDoc, err := ctx.didCreator.CreateDID(wallet.WithServiceType(DIDExchangeServiceType))
+	newDidDoc, err := ctx.didCreator.CreateDID(didcreator.WithServiceType(DIDExchangeServiceType))
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +328,7 @@ func (ctx *context) handleInboundInvitation(invitation *Invitation, thid string)
 
 func (ctx *context) handleInboundRequest(request *Request) (stateAction, error) {
 	// create a response from Request
-	newDidDoc, err := ctx.didCreator.CreateDID(wallet.WithServiceType(DIDExchangeServiceType))
+	newDidDoc, err := ctx.didCreator.CreateDID(didcreator.WithServiceType(DIDExchangeServiceType))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/framework/aries/api/protocol.go
+++ b/pkg/framework/aries/api/protocol.go
@@ -9,12 +9,13 @@ package api
 import (
 	"errors"
 
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/didcreator"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/wallet"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/envelope"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 // ErrSvcNotFound is returned when service not found
@@ -29,7 +30,7 @@ type Provider interface {
 	Crypter() crypto.Crypter
 	Packager() envelope.Packager
 	InboundTransportEndpoint() string
-	DIDWallet() wallet.DIDCreator
+	DIDWallet() didcreator.DIDCreator
 	Signer() wallet.Signer
 	DIDResolver() didresolver.Resolver
 }

--- a/pkg/framework/aries/api/wallet.go
+++ b/pkg/framework/aries/api/wallet.go
@@ -9,7 +9,8 @@ package api
 import (
 	"io"
 
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/didcreator"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/wallet"
 )
 
 // CloseableWallet interface
@@ -17,7 +18,7 @@ type CloseableWallet interface {
 	io.Closer
 	wallet.Crypto
 	wallet.Signer
-	wallet.DIDCreator
+	didcreator.DIDCreator
 }
 
 // WalletCreator method to create new wallet service

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/did"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/wallet"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/crypto/jwe/authcrypt"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
@@ -23,7 +24,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/storage/leveldb"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 // TODO handle the test scenario better (make dbPath constant).

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -9,6 +9,8 @@ package context
 import (
 	"fmt"
 
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/didcreator"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/wallet"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
@@ -17,7 +19,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 // Provider supplies the framework configuration to client objects.
@@ -87,7 +88,7 @@ func (p *Provider) Signer() wallet.Signer {
 }
 
 // DIDWallet returns the pack wallet service
-func (p *Provider) DIDWallet() wallet.DIDCreator {
+func (p *Provider) DIDWallet() didcreator.DIDCreator {
 	return p.wallet
 }
 

--- a/pkg/internal/mock/common/did/mock_creator.go
+++ b/pkg/internal/mock/common/did/mock_creator.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/didcreator"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 // MockDIDCreator mock implementation of DID creator
@@ -26,7 +26,7 @@ type MockDIDCreator struct {
 }
 
 // CreateDID mock implementation of create DID
-func (m *MockDIDCreator) CreateDID(opts ...wallet.DocOpts) (*did.Doc, error) {
+func (m *MockDIDCreator) CreateDID(opts ...didcreator.DocOpts) (*did.Doc, error) {
 	if m.Failure != nil {
 		return nil, m.Failure
 	}

--- a/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package protocol
 
 import (
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/wallet"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/didresolver"
@@ -15,7 +16,6 @@ import (
 	mockstore "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 	mockwallet "github.com/hyperledger/aries-framework-go/pkg/internal/mock/wallet"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 // MockDIDExchangeSvc mock did exchange service

--- a/pkg/internal/mock/provider/mock_provider.go
+++ b/pkg/internal/mock/provider/mock_provider.go
@@ -7,9 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package provider
 
 import (
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/wallet"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 // Provider mocks provider needed for did exchange service initialization

--- a/pkg/internal/mock/wallet/mock_wallet.go
+++ b/pkg/internal/mock/wallet/mock_wallet.go
@@ -7,9 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package wallet
 
 import (
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/envelope"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/didcreator"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/operator"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 // CloseableWallet mock wallet
@@ -18,16 +18,13 @@ type CloseableWallet struct {
 	CreateEncryptionKeyErr   error
 	CreateSigningKeyValue    string
 	CreateSigningKeyErr      error
+	AttachCryptoOperatorErr  error
 	FindVerKeyValue          int
 	FindVerKeyErr            error
 	SignMessageValue         []byte
 	SignMessageErr           error
 	DecryptMessageValue      []byte
 	DecryptMessageErr        error
-	PackValue                []byte
-	PackErr                  error
-	UnpackValue              *envelope.Envelope
-	UnpackErr                error
 	MockDID                  *did.Doc
 }
 
@@ -51,6 +48,11 @@ func (m *CloseableWallet) FindVerKey(candidateKeys []string) (int, error) {
 	return m.FindVerKeyValue, m.FindVerKeyErr
 }
 
+// AttachCryptoOperator attaches a crypto operator to this wallet, so the operator can use its private keys.
+func (m *CloseableWallet) AttachCryptoOperator(cryptoOp operator.CryptoOperator) error {
+	return m.AttachCryptoOperatorErr
+}
+
 // SignMessage sign a message using the private key associated with a given verification key.
 func (m *CloseableWallet) SignMessage(message []byte, fromVerKey string) ([]byte, error) {
 	return m.SignMessageValue, m.SignMessageErr
@@ -63,7 +65,7 @@ func (m *CloseableWallet) DeriveKEK(alg, apu, fromKey, toPubKey []byte) ([]byte,
 }
 
 // CreateDID returns new DID Document
-func (m *CloseableWallet) CreateDID(method string, opts ...wallet.DocOpts) (*did.Doc, error) {
+func (m *CloseableWallet) CreateDID(method string, opts ...didcreator.DocOpts) (*did.Doc, error) {
 	return m.MockDID, nil
 }
 

--- a/pkg/internal/mock/walletprovider/mock_wallet_provider.go
+++ b/pkg/internal/mock/walletprovider/mock_wallet_provider.go
@@ -4,18 +4,18 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package wallet
+package walletprovider
 
 import (
 	"encoding/json"
 
 	"github.com/btcsuite/btcutil/base58"
 
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/wallet"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/cryptoutil"
 	mockprovider "github.com/hyperledger/aries-framework-go/pkg/internal/mock/provider"
 	mockstorage "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 // NewMockProvider will create a new mock Wallet Provider that builds a wallet with the keypairs list kp

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -19,13 +19,13 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/wallet"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/common/support"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation/didexchange/models"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/webhook"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
 var logger = log.New("aries-framework/did-exchange")


### PR DESCRIPTION
`pkg/crypto` is now the home for any package that does cryptography requiring
 private keys or any other secret stored in the wallet.

- The wallet API in BaseWallet is unchanged, simply moved to `pkg/crypto/wallet`
- The public wallet APIs are moved to `pkg/crypto/walletapi`
- BaseWallet's implementation is now hidden in `pkg/crypto/internal/wallet`, in SecretWallet, and includes PutKey/GetKey methods, only accessible to other packages in `pkg/crypto`
 - All methods meant for the framework or client to access are wrapped by `pkg/crypto/wallet.BaseWallet`

Fixes #511 

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>

