### PR TITLE
fix: Remove DIDExchange service dependency from consumers (BDD/RestAPI)

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -100,7 +100,7 @@ func New(ctx provider) (*Client, error) {
 }
 
 // CreateInvitation create invitation
-func (c *Client) CreateInvitation(label string) (*didexchange.Invitation, error) {
+func (c *Client) CreateInvitation(label string) (*Invitation, error) {
 	verKey, err := c.wallet.CreateEncryptionKey()
 	if err != nil {
 		return nil, fmt.Errorf("failed CreateSigningKey: %w", err)
@@ -119,11 +119,11 @@ func (c *Client) CreateInvitation(label string) (*didexchange.Invitation, error)
 		return nil, fmt.Errorf("failed to save invitation: %w", err)
 	}
 
-	return invitation, nil
+	return &Invitation{*invitation}, nil
 }
 
 // CreateInvitationWithDID creates invitation with specified public DID
-func (c *Client) CreateInvitationWithDID(label, did string) (*didexchange.Invitation, error) {
+func (c *Client) CreateInvitationWithDID(label, did string) (*Invitation, error) {
 	invitation := &didexchange.Invitation{
 		ID:    uuid.New().String(),
 		Label: label,
@@ -136,11 +136,11 @@ func (c *Client) CreateInvitationWithDID(label, did string) (*didexchange.Invita
 		return nil, fmt.Errorf("failed to save invitation with DID: %w", err)
 	}
 
-	return invitation, nil
+	return &Invitation{*invitation}, nil
 }
 
 // HandleInvitation handle incoming invitation
-func (c *Client) HandleInvitation(invitation *didexchange.Invitation) error {
+func (c *Client) HandleInvitation(invitation *Invitation) error {
 	payload, err := json.Marshal(invitation)
 	if err != nil {
 		return fmt.Errorf("failed marshal invitation: %w", err)

--- a/pkg/client/didexchange/event.go
+++ b/pkg/client/didexchange/event.go
@@ -1,0 +1,16 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didexchange
+
+// Event properties related api. This can be used to cast Generic event properties to DID Exchange specific props.
+type Event interface {
+	// connection ID
+	ConnectionID() string
+
+	// invitation ID
+	InvitationID() string
+}

--- a/pkg/client/didexchange/models.go
+++ b/pkg/client/didexchange/models.go
@@ -46,3 +46,8 @@ type QueryConnectionsParams struct {
 type Connection struct {
 	didexchange.ConnectionRecord
 }
+
+// Invitation model for DID Exchange invitation.
+type Invitation struct {
+	didexchange.Invitation
+}

--- a/pkg/didcomm/common/service/event.go
+++ b/pkg/didcomm/common/service/event.go
@@ -39,7 +39,7 @@ type StateMsg struct {
 	// functions to get the data.
 	//
 	// Clients function to retrieve data based on protocol.
-	//   - DID Exchange :  didexchange.EventProperties
+	//   - DID Exchange :  didexchange.Event
 	Properties EventProperties
 }
 

--- a/pkg/didcomm/protocol/didexchange/event.go
+++ b/pkg/didcomm/protocol/didexchange/event.go
@@ -6,15 +6,6 @@ SPDX-License-Identifier: Apache-2.0
 
 package didexchange
 
-// Event properties related api.
-type Event interface {
-	// connection ID
-	ConnectionID() string
-
-	// invitation ID
-	InvitationID() string
-}
-
 // didExchangeEvent implements didexchange.Event interface.
 type didExchangeEvent struct {
 	connectionID string

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -111,11 +111,19 @@ func TestService_Handle_Inviter(t *testing.T) {
 }
 
 func msgEventListener(t *testing.T, statusCh chan service.StateMsg, respondedFlag, completedFlag chan struct{}) {
+	type event interface {
+		// connection ID
+		ConnectionID() string
+
+		// invitation ID
+		InvitationID() string
+	}
+
 	connectionID := ""
 	invitationID := ""
 	for e := range statusCh {
 		require.Equal(t, DIDExchange, e.ProtocolName)
-		prop, ok := e.Properties.(Event)
+		prop, ok := e.Properties.(event)
 		if !ok {
 			require.Fail(t, "Failed to cast the event properties to service.Event")
 		}

--- a/pkg/restapi/operation/didexchange/models/invitation.go
+++ b/pkg/restapi/operation/didexchange/models/invitation.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
-	didexchangesvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 )
 
 // A GenericError is the default error message that is generated.
@@ -33,7 +32,7 @@ type GenericError struct {
 type CreateInvitationResponse struct {
 
 	// in: body
-	Payload *didexchangesvc.Invitation `json:""`
+	Payload *didexchange.Invitation `json:""`
 }
 
 // ReceiveInvitationRequest model

--- a/test/bdd/agent_steps.go
+++ b/test/bdd/agent_steps.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
-	didexsvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/didmethod/httpbinding"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/defaults"
@@ -170,10 +169,10 @@ func listenFor(host string, d time.Duration) error {
 }
 
 func (a *AgentSteps) eventListener(statusCh chan service.StateMsg, agentID string, states []string) {
-	var props didexsvc.Event
+	var props didexchange.Event
 	for e := range statusCh {
 		switch v := e.Properties.(type) {
-		case didexsvc.Event:
+		case didexchange.Event:
 			props = v
 		case error:
 			panic(fmt.Sprintf("Service processing failed: %s", v))

--- a/test/bdd/context.go
+++ b/test/bdd/context.go
@@ -8,7 +8,6 @@ package bdd
 
 import (
 	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
-	didexchange2 "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/context"
 )
 
@@ -16,7 +15,7 @@ import (
 type Context struct {
 	DIDExchangeClients map[string]*didexchange.Client
 	AgentCtx           map[string]*context.Provider
-	Invitations        map[string]*didexchange2.Invitation
+	Invitations        map[string]*didexchange.Invitation
 	PostStatesFlag     map[string]map[string]chan bool
 	ConnectionID       map[string]string
 }
@@ -24,7 +23,7 @@ type Context struct {
 // NewContext create new Context
 func NewContext() (*Context, error) {
 	instance := Context{DIDExchangeClients: make(map[string]*didexchange.Client),
-		Invitations: make(map[string]*didexchange2.Invitation), PostStatesFlag: make(map[string]map[string]chan bool),
+		Invitations: make(map[string]*didexchange.Invitation), PostStatesFlag: make(map[string]map[string]chan bool),
 		ConnectionID: make(map[string]string), AgentCtx: make(map[string]*context.Provider)}
 	return &instance, nil
 }


### PR DESCRIPTION
- The framework consumers use Client pkg instead of service pkg.
- This change fixes the dependency issues in bdd files as well as Rest API packages.

Closes #530 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
