### PR TITLE
refactor: Serialization of Verifiable Credential with extended data model

### DIFF
--- a/pkg/doc/verifiable/common.go
+++ b/pkg/doc/verifiable/common.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package verifiable
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/square/go-jose/v3"
@@ -63,7 +64,7 @@ type typedID struct {
 type RefreshService typedID
 
 // TermsOfUse represents terms of use of Verifiable Credential by Issuer or Verifiable Presentation by Holder.
-type TermsOfUse typedID
+type TermsOfUse interface{}
 
 func describeSchemaValidationError(result *gojsonschema.Result, what string) string {
 	errMsg := what + " is not valid:\n"
@@ -71,4 +72,16 @@ func describeSchemaValidationError(result *gojsonschema.Result, what string) str
 		errMsg += fmt.Sprintf("- %s\n", desc)
 	}
 	return errMsg
+}
+
+func stringSlice(values []interface{}) ([]string, error) {
+	strings := make([]string, len(values))
+	for i := range values {
+		t, valid := values[i].(string)
+		if !valid {
+			return nil, errors.New("array element is not a string")
+		}
+		strings[i] = t
+	}
+	return strings, nil
 }

--- a/pkg/doc/verifiable/common_test.go
+++ b/pkg/doc/verifiable/common_test.go
@@ -26,3 +26,12 @@ func TestJwtAlgorithm_Jose(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported algorithm")
 }
+
+func TestStringSlice(t *testing.T) {
+	strings, err := stringSlice([]interface{}{"str1", "str2"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"str1", "str2"}, strings)
+
+	_, err = stringSlice([]interface{}{"str1", 15})
+	require.Error(t, err)
+}

--- a/pkg/doc/verifiable/credential_extension_switch_test.go
+++ b/pkg/doc/verifiable/credential_extension_switch_test.go
@@ -124,7 +124,7 @@ func Cred1Producer() CustomCredentialProducer {
 		},
 		Accept: func(vc *Credential) bool {
 			return hasContext(vc.Context, "https://www.w3.org/2018/credentials/examples/ext/type1") &&
-				hasType(vc.Types(), "CredType1")
+				hasType(vc.Types, "CredType1")
 		},
 	}
 }
@@ -150,7 +150,7 @@ func Cred2Producer() CustomCredentialProducer {
 		},
 		Accept: func(vc *Credential) bool {
 			return hasContext(vc.Context, "https://www.w3.org/2018/credentials/examples/ext/type2") &&
-				hasType(vc.Types(), "CredType2")
+				hasType(vc.Types, "CredType2")
 		},
 	}
 }
@@ -178,7 +178,7 @@ func DecodeCredentials(dataJSON []byte, producers ...CustomCredentialProducer) (
 	return baseCred, nil
 }
 
-func hasContext(allContexts []interface{}, targetContext string) bool {
+func hasContext(allContexts []string, targetContext string) bool {
 	for _, thatType := range allContexts {
 		if thatType == targetContext {
 			return true
@@ -205,7 +205,7 @@ func TestCredentialExtensibilitySwitch(t *testing.T) {
 	cred1, correct := i1.(*Cred1)
 	require.True(t, correct)
 	require.NotNil(t, cred1.Base)
-	require.Equal(t, []string{"VerifiableCredential", "CredType1"}, cred1.Base.Type)
+	require.Equal(t, []string{"VerifiableCredential", "CredType1"}, cred1.Base.Types)
 	require.Equal(t, "custom field 1", cred1.CustomField)
 	require.Equal(t, "custom subject 1", cred1.Subject.CustomSubjectField)
 
@@ -215,7 +215,7 @@ func TestCredentialExtensibilitySwitch(t *testing.T) {
 	cred2, correct := i2.(*Cred2)
 	require.True(t, correct)
 	require.NotNil(t, cred2.Base)
-	require.Equal(t, []string{"VerifiableCredential", "CredType2"}, cred2.Base.Type)
+	require.Equal(t, []string{"VerifiableCredential", "CredType2"}, cred2.Base.Types)
 	require.Equal(t, "custom field 2", cred2.CustomField)
 	require.Equal(t, "custom subject 2", cred2.Subject.CustomSubjectField)
 

--- a/pkg/doc/verifiable/credential_jws_test.go
+++ b/pkg/doc/verifiable/credential_jws_test.go
@@ -29,16 +29,20 @@ func TestJWTCredClaimsMarshalJWS(t *testing.T) {
 		jws, err := jwtClaims.MarshalJWS(RS256, privateKey, "any")
 		require.NoError(t, err)
 
-		_, rawVC, err := decodeCredJWS([]byte(jws), func(issuerID, keyID string) (i interface{}, e error) {
+		vcBytes, err := decodeCredJWS([]byte(jws), func(issuerID, keyID string) (i interface{}, e error) {
 			publicKey, pcErr := readPublicKey(filepath.Join(certPrefix, "issuer_public.pem"))
 			require.NoError(t, pcErr)
 			require.NotNil(t, publicKey)
 
 			return publicKey, nil
 		})
+		require.NoError(t, err)
+
+		vcRaw, err := newRawCredential(vcBytes)
+		require.NoError(t, err)
 
 		require.NoError(t, err)
-		require.Equal(t, vc.raw().stringJSON(t), rawVC.stringJSON(t))
+		require.Equal(t, vc.raw().stringJSON(t), vcRaw.stringJSON(t))
 	})
 
 	t.Run("Marshal signed JWT failed with invalid private key", func(t *testing.T) {
@@ -58,35 +62,30 @@ func TestCredJWSDecoderUnmarshal(t *testing.T) {
 	privateKey, err := readPrivateKey(filepath.Join(certPrefix, "issuer_private.pem"))
 	require.NoError(t, err)
 
+	pkFetcher := func(_, _ string) (interface{}, error) {
+		publicKey, err := readPublicKey(filepath.Join(certPrefix, "issuer_public.pem"))
+		require.NoError(t, err)
+		require.NotNil(t, publicKey)
+
+		return publicKey, err
+	}
+
+	validJWS := createJWS(t, []byte(jwtTestCredential), false)
+
 	t.Run("Successful JWS decoding", func(t *testing.T) {
-		jws := createJWS(t, []byte(jwtTestCredential), false)
+		vcBytes, err := decodeCredJWS(validJWS, pkFetcher)
+		require.NoError(t, err)
 
-		decoder := &credJWSDecoder{
-			PKFetcher: func(issuerID, keyID string) (i interface{}, e error) {
-				publicKey, err := readPublicKey(filepath.Join(certPrefix, "issuer_public.pem"))
-				require.NoError(t, err)
-				require.NotNil(t, publicKey)
-
-				return publicKey, nil
-			},
-		}
-
-		decodedCred, err := decoder.UnmarshalClaims(jws)
+		vcRaw, err := newRawCredential(vcBytes)
 		require.NoError(t, err)
 
 		vc, err := NewCredential([]byte(jwtTestCredential))
 		require.NoError(t, err)
-		require.Equal(t, vc.raw().stringJSON(t), decodedCred.Credential.stringJSON(t))
+		require.Equal(t, vc.raw().stringJSON(t), vcRaw.stringJSON(t))
 	})
 
 	t.Run("Invalid serialized JWS", func(t *testing.T) {
-		decoder := new(credJWSDecoder)
-
-		_, err := decoder.UnmarshalClaims([]byte("invalid JWS"))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "VC is not valid serialized JWS")
-
-		_, err = decoder.UnmarshalVCClaim([]byte("invalid JWS"))
+		_, err := decodeCredJWS([]byte("invalid JWS"), pkFetcher)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "VC is not valid serialized JWS")
 	})
@@ -105,32 +104,22 @@ func TestCredJWSDecoderUnmarshal(t *testing.T) {
 		rawJWT, err := jwt.Signed(signer).Claims(claims).CompactSerialize()
 		require.NoError(t, err)
 
-		decoder := new(credJWSDecoder)
-
-		_, err = decoder.UnmarshalClaims([]byte(rawJWT))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to parse JWT claims")
-
-		_, err = decoder.UnmarshalVCClaim([]byte(rawJWT))
+		_, err = decodeCredJWS([]byte(rawJWT), pkFetcher)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to parse JWT claims")
 	})
 
 	t.Run("Invalid signature of JWS", func(t *testing.T) {
-		jws := createJWS(t, []byte(jwtTestCredential), false)
+		pkFetcherOther := func(issuerID, keyID string) (interface{}, error) {
+			// use public key of VC Holder (while expecting to use the ones of Issuer)
+			publicKey, err := readPublicKey(filepath.Join(certPrefix, "holder_public.pem"))
+			require.NoError(t, err)
+			require.NotNil(t, publicKey)
 
-		decoder := &credJWSDecoder{
-			PKFetcher: func(issuerID, keyID string) (i interface{}, e error) {
-				// use public key of VC Holder (while expecting to use the ones of Issuer)
-				publicKey, err := readPublicKey(filepath.Join(certPrefix, "holder_public.pem"))
-				require.NoError(t, err)
-				require.NotNil(t, publicKey)
-
-				return publicKey, nil
-			},
+			return publicKey, nil
 		}
 
-		_, err := decoder.UnmarshalClaims(jws)
+		_, err := decodeCredJWS(validJWS, pkFetcherOther)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "JWT signature verification failed")
 	})

--- a/pkg/doc/verifiable/credential_jwt_unsecured.go
+++ b/pkg/doc/verifiable/credential_jwt_unsecured.go
@@ -18,10 +18,7 @@ func (jcc *JWTCredClaims) MarshalUnsecuredJWT() (string, error) {
 	return marshalUnsecuredJWT(headers, jcc)
 }
 
-// credUnsecuredJWTDecoder parses serialized unsecured JWT.
-type credUnsecuredJWTDecoder struct{}
-
-func (ud *credUnsecuredJWTDecoder) UnmarshalClaims(rawJwt []byte) (*JWTCredClaims, error) {
+func unmarshalUnsecuredJWTClaims(rawJwt []byte) (*JWTCredClaims, error) {
 	_, bytesClaim, err := unmarshalUnsecuredJWT(rawJwt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode unsecured JWT: %w", err)
@@ -36,22 +33,6 @@ func (ud *credUnsecuredJWTDecoder) UnmarshalClaims(rawJwt []byte) (*JWTCredClaim
 	return credClaims, nil
 }
 
-func (ud *credUnsecuredJWTDecoder) UnmarshalVCClaim(rawJwt []byte) (map[string]interface{}, error) {
-	_, bytesClaim, err := unmarshalUnsecuredJWT(rawJwt)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode unsecured JWT: %w", err)
-	}
-
-	rawClaims := new(jwtVCClaim)
-	err = json.Unmarshal(bytesClaim, rawClaims)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse JWT claims: %w", err)
-	}
-
-	return rawClaims.VC, nil
-}
-
-func decodeCredJWTUnsecured(rawJwt []byte) ([]byte, *rawCredential, error) {
-	decoder := new(credUnsecuredJWTDecoder)
-	return decodeCredJWT(rawJwt, decoder)
+func decodeCredJWTUnsecured(rawJwt []byte) ([]byte, error) {
+	return decodeCredJWT(rawJwt, unmarshalUnsecuredJWTClaims)
 }

--- a/pkg/doc/verifiable/presentation_test.go
+++ b/pkg/doc/verifiable/presentation_test.go
@@ -314,7 +314,7 @@ func TestPresentation_Credentials(t *testing.T) {
 
 		// check some VC properties to double check that conversion is OK
 		require.Equal(t, "http://example.edu/credentials/1872", vc.ID)
-		require.Equal(t, []string{"VerifiableCredential", "AlumniCredential"}, vc.Type)
+		require.Equal(t, []string{"VerifiableCredential", "AlumniCredential"}, vc.Types)
 	})
 
 	t.Run("failure handling on extraction of verifiable credentials from list", func(t *testing.T) {

--- a/pkg/doc/verifiable/support_test.go
+++ b/pkg/doc/verifiable/support_test.go
@@ -149,8 +149,8 @@ func readPrivateKey(keyFilePath string) (*rsa.PrivateKey, error) {
 	return privKey, nil
 }
 
-func (raw *rawCredential) stringJSON(t *testing.T) string {
-	bytes, err := json.Marshal(raw)
+func (rc *rawCredential) stringJSON(t *testing.T) string {
+	bytes, err := rc.marshalJSON()
 	require.NoError(t, err)
 	return string(bytes)
 }


### PR DESCRIPTION
closes #327

Signed-off-by: Dima <dkinoshenko@gmail.com>

This PR brings the following improvements to the Verifiable Credential (VC):
- Keep extra fields of raw VC in a map (motivated by  [issue 22533](https://github.com/golang/go/issues/22533)); this leverages the extensibility of the data model and allows more strict serialization of the VC.
- Use stricter types in `Credential`: issuer, context, type (used generic `interface{}` or `[]interface{}` before).
- Simplify JWT decoding. Previously, JWT decoding resulted in returning `*rawCredential` and serialized JSON (`[]byte`) of VC. Now it returns only serialized JSON which is then unmarshalled to `rawCredential`.
