### PR TITLE
refactor: DIDExchange - Remove Action Events for exResponse and exAck type

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -109,7 +109,7 @@ func (c *Client) CreateInvitation(label string) (*Invitation, error) {
 		Label:           label,
 		RecipientKeys:   []string{verKey},
 		ServiceEndpoint: c.inboundTransportEndpoint,
-		Type:            didexchange.ConnectionInvite,
+		Type:            didexchange.InvitationMsgType,
 	}
 
 	err = c.connectionStore.SaveInvitation(invitation)
@@ -126,7 +126,7 @@ func (c *Client) CreateInvitationWithDID(label, did string) (*Invitation, error)
 		ID:    uuid.New().String(),
 		Label: label,
 		DID:   did,
-		Type:  didexchange.ConnectionInvite,
+		Type:  didexchange.InvitationMsgType,
 	}
 
 	err := c.connectionStore.SaveInvitation(invitation)

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -282,7 +282,7 @@ func TestServiceEvents(t *testing.T) {
 
 	request, err := json.Marshal(
 		&didexchange.Request{
-			Type:  didexchange.ConnectionRequest,
+			Type:  didexchange.RequestMsgType,
 			ID:    id,
 			Label: "test",
 			Connection: &didexchange.Connection{

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -332,7 +332,7 @@ func TestServiceEvents(t *testing.T) {
 
 	request, err := json.Marshal(
 		&didexsvc.Request{
-			Type:  didexsvc.ConnectionRequest,
+			Type:  didexsvc.RequestMsgType,
 			ID:    id,
 			Label: "test",
 			Connection: &didexsvc.Connection{


### PR DESCRIPTION
- Remove action events for exResponse and exAck message types
- Refactor Events test cases
- Add missing test cases
- Renamed prefixes for message type from Connection to DIDExchange

Closes #571 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
