### PR TITLE
fix: Execute state handling in a goroutine

### DIFF
--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -164,8 +164,15 @@ func (s *Service) HandleInbound(msg *service.DIDCommMsg) error {
 		}
 		return nil
 	}
+
 	// if no action event is triggered, continue the execution
-	return s.handle(&message{Msg: msg, ThreadID: thid, NextStateName: next.Name()})
+	go func() {
+		if err = s.handle(&message{Msg: msg, ThreadID: thid, NextStateName: next.Name()}); err != nil {
+			logger.Errorf("didexchange processing error : %s", err)
+		}
+	}()
+
+	return nil
 }
 
 // Name return service name


### PR DESCRIPTION
- Added goroutine as State execution was executing in calling agents inbound thread. This would resulted in agent invoking next call before calling agent executing previous thread.

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
