### PR TITLE
Get label value from command line and fix service endpoint

### DIFF
--- a/cmd/aries-agentd/startcmd/start_test.go
+++ b/cmd/aries-agentd/startcmd/start_test.go
@@ -103,7 +103,7 @@ func TestStartAriesDRequests(t *testing.T) {
 	testInboundHostURL := randomURL()
 
 	go func() {
-		parameters := &agentParameters{&HTTPServer{}, testHostURL, testInboundHostURL, path, []string{}}
+		parameters := &agentParameters{&HTTPServer{}, testHostURL, testInboundHostURL, path, []string{}, "agent"}
 		err := startAgent(parameters)
 		require.FailNow(t, agentUnexpectedExitErrMsg+": "+err.Error())
 	}()
@@ -218,7 +218,7 @@ func TestStartCmdWithMissingHostArg(t *testing.T) {
 }
 
 func TestStartAgentWithBlankHost(t *testing.T) {
-	parameters := &agentParameters{&mockServer{}, "", randomURL(), "", []string{}}
+	parameters := &agentParameters{&mockServer{}, "", randomURL(), "", []string{}, "agent"}
 	err := startAgent(parameters)
 
 	require.NotNil(t, err)
@@ -239,7 +239,7 @@ func TestStartCmdWithoutInboundHostArg(t *testing.T) {
 }
 
 func TestStartAgentWithBlankInboundHost(t *testing.T) {
-	parameters := &agentParameters{&mockServer{}, randomURL(), "", "", []string{}}
+	parameters := &agentParameters{&mockServer{}, randomURL(), "", "", []string{}, "agent"}
 	err := startAgent(parameters)
 
 	require.NotNil(t, err)
@@ -292,7 +292,7 @@ func TestStartMultipleAgentsWithSameHost(t *testing.T) {
 	path1, cleanup1 := generateTempDir(t)
 	defer cleanup1()
 	go func() {
-		parameters := &agentParameters{&HTTPServer{}, host, inboundHost, path1, []string{}}
+		parameters := &agentParameters{&HTTPServer{}, host, inboundHost, path1, []string{}, "agent"}
 		err := startAgent(parameters)
 		require.FailNow(t, agentUnexpectedExitErrMsg+": "+err.Error())
 	}()
@@ -301,7 +301,7 @@ func TestStartMultipleAgentsWithSameHost(t *testing.T) {
 
 	path2, cleanup2 := generateTempDir(t)
 	defer cleanup2()
-	parameters := &agentParameters{&HTTPServer{}, host, inboundHost2, path2, []string{}}
+	parameters := &agentParameters{&HTTPServer{}, host, inboundHost2, path2, []string{}, "agent"}
 	err := startAgent(parameters)
 
 	require.NotNil(t, err)
@@ -319,14 +319,14 @@ func TestStartMultipleAgentsWithSameDBPath(t *testing.T) {
 	defer cleanup()
 
 	go func() {
-		parameters := &agentParameters{&HTTPServer{}, host1, inboundHost1, path, []string{}}
+		parameters := &agentParameters{&HTTPServer{}, host1, inboundHost1, path, []string{}, "agent"}
 		err := startAgent(parameters)
 		require.FailNow(t, agentUnexpectedExitErrMsg+": "+err.Error())
 	}()
 
 	waitForServerToStart(t, host1, inboundHost1)
 
-	parameters := &agentParameters{&HTTPServer{}, host2, inboundHost2, path, []string{}}
+	parameters := &agentParameters{&HTTPServer{}, host2, inboundHost2, path, []string{}, "agent"}
 	err := startAgent(parameters)
 
 	require.NotNil(t, err)

--- a/pkg/restapi/restapi.go
+++ b/pkg/restapi/restapi.go
@@ -14,7 +14,8 @@ import (
 )
 
 type allOpts struct {
-	webhookURLs []string
+	webhookURLs     []string
+	invitationLabel string
 }
 
 // Opt represents a REST Api option.
@@ -24,6 +25,13 @@ type Opt func(opts *allOpts)
 func WithWebhookURLs(webhookURLs ...string) Opt {
 	return func(opts *allOpts) {
 		opts.webhookURLs = webhookURLs
+	}
+}
+
+// WithInvitationLabel is an option allowing for the invitation label to be set.
+func WithInvitationLabel(invitationLabel string) Opt {
+	return func(opts *allOpts) {
+		opts.invitationLabel = invitationLabel
 	}
 }
 
@@ -39,7 +47,7 @@ func New(ctx *context.Provider, opts ...Opt) (*Controller, error) {
 	var allHandlers []operation.Handler
 
 	// Add DID Exchange Rest Handlers
-	exchange, err := didexchange.New(ctx, webhook.NewHTTPNotifier(restAPIOpts.webhookURLs))
+	exchange, err := didexchange.New(ctx, webhook.NewHTTPNotifier(restAPIOpts.webhookURLs), restAPIOpts.invitationLabel)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/restapi/restapi_test.go
+++ b/pkg/restapi/restapi_test.go
@@ -51,7 +51,7 @@ func TestNew_Success(t *testing.T) {
 	require.NotEmpty(t, controller.GetOperations())
 }
 
-func TestAddWebhookNotifierOption(t *testing.T) {
+func TestWithWebhookNotifierOption(t *testing.T) {
 	restAPIOpts := &allOpts{}
 
 	webhookURLs := []string{"localhost:8080"}
@@ -60,6 +60,17 @@ func TestAddWebhookNotifierOption(t *testing.T) {
 	webhookNotifierOpt(restAPIOpts)
 
 	require.Equal(t, webhookURLs, restAPIOpts.webhookURLs)
+}
+
+func TestWithInvitationLabelOption(t *testing.T) {
+	restAPIOpts := &allOpts{}
+
+	invitationLabel := "testLabel"
+	webhookNotifierOpt := WithInvitationLabel(invitationLabel)
+
+	webhookNotifierOpt(restAPIOpts)
+
+	require.Equal(t, invitationLabel, restAPIOpts.invitationLabel)
 }
 
 func generateTempDir(t testing.TB) (string, func()) {


### PR DESCRIPTION
Closes #552 and #572.

The invitation can now be passed in via command line.

Also, now when the inbound server starts up it only uses the port from the inbound url command line option. This is so the server can start locally while the inbound url can be provided in the create invitation response.

Fixed some small types and formatting issues I found.

Signed-off-by: Derek Trider <derek.trider@securekey.com>