### PR TITLE
Fix service endpoint in create invitation response

### DIFF
--- a/cmd/aries-agentd/startcmd/start_test.go
+++ b/cmd/aries-agentd/startcmd/start_test.go
@@ -103,7 +103,8 @@ func TestStartAriesDRequests(t *testing.T) {
 	testInboundHostURL := randomURL()
 
 	go func() {
-		parameters := &agentParameters{&HTTPServer{}, testHostURL, testInboundHostURL, path, []string{}}
+		parameters := &agentParameters{&HTTPServer{}, testHostURL, testInboundHostURL,
+			"", path, []string{}}
 		err := startAgent(parameters)
 		require.FailNow(t, agentUnexpectedExitErrMsg+": "+err.Error())
 	}()
@@ -218,7 +219,7 @@ func TestStartCmdWithMissingHostArg(t *testing.T) {
 }
 
 func TestStartAgentWithBlankHost(t *testing.T) {
-	parameters := &agentParameters{&mockServer{}, "", randomURL(), "", []string{}}
+	parameters := &agentParameters{&mockServer{}, "", randomURL(), "", "", []string{}}
 	err := startAgent(parameters)
 
 	require.NotNil(t, err)
@@ -239,7 +240,8 @@ func TestStartCmdWithoutInboundHostArg(t *testing.T) {
 }
 
 func TestStartAgentWithBlankInboundHost(t *testing.T) {
-	parameters := &agentParameters{&mockServer{}, randomURL(), "", "", []string{}}
+	parameters := &agentParameters{&mockServer{}, randomURL(), "",
+		"", "", []string{}}
 	err := startAgent(parameters)
 
 	require.NotNil(t, err)
@@ -292,7 +294,8 @@ func TestStartMultipleAgentsWithSameHost(t *testing.T) {
 	path1, cleanup1 := generateTempDir(t)
 	defer cleanup1()
 	go func() {
-		parameters := &agentParameters{&HTTPServer{}, host, inboundHost, path1, []string{}}
+		parameters := &agentParameters{&HTTPServer{}, host, inboundHost,
+			"", path1, []string{}}
 		err := startAgent(parameters)
 		require.FailNow(t, agentUnexpectedExitErrMsg+": "+err.Error())
 	}()
@@ -301,7 +304,7 @@ func TestStartMultipleAgentsWithSameHost(t *testing.T) {
 
 	path2, cleanup2 := generateTempDir(t)
 	defer cleanup2()
-	parameters := &agentParameters{&HTTPServer{}, host, inboundHost2, path2, []string{}}
+	parameters := &agentParameters{&HTTPServer{}, host, inboundHost2, "", path2, []string{}}
 	err := startAgent(parameters)
 
 	require.NotNil(t, err)
@@ -319,14 +322,14 @@ func TestStartMultipleAgentsWithSameDBPath(t *testing.T) {
 	defer cleanup()
 
 	go func() {
-		parameters := &agentParameters{&HTTPServer{}, host1, inboundHost1, path, []string{}}
+		parameters := &agentParameters{&HTTPServer{}, host1, inboundHost1, "", path, []string{}}
 		err := startAgent(parameters)
 		require.FailNow(t, agentUnexpectedExitErrMsg+": "+err.Error())
 	}()
 
 	waitForServerToStart(t, host1, inboundHost1)
 
-	parameters := &agentParameters{&HTTPServer{}, host2, inboundHost2, path, []string{}}
+	parameters := &agentParameters{&HTTPServer{}, host2, inboundHost2, "", path, []string{}}
 	err := startAgent(parameters)
 
 	require.NotNil(t, err)

--- a/pkg/didcomm/transport/http/inbound.go
+++ b/pkg/didcomm/transport/http/inbound.go
@@ -102,16 +102,20 @@ func validateHTTPMethod(w http.ResponseWriter, r *http.Request) bool {
 
 // Inbound http type.
 type Inbound struct {
-	server *http.Server
+	externalAddr string
+	server       *http.Server
 }
 
 // NewInbound creates a new HTTP inbound transport instance.
-func NewInbound(addr string) (*Inbound, error) {
-	if addr == "" {
+func NewInbound(internalAddr, externalAddr string) (*Inbound, error) {
+	if internalAddr == "" {
 		return nil, errors.New("http address is mandatory")
 	}
 
-	return &Inbound{server: &http.Server{Addr: addr}}, nil
+	if externalAddr == "" {
+		return &Inbound{externalAddr: internalAddr, server: &http.Server{Addr: internalAddr}}, nil
+	}
+	return &Inbound{externalAddr: externalAddr, server: &http.Server{Addr: internalAddr}}, nil
 }
 
 // Start the http server.
@@ -145,5 +149,5 @@ func (i *Inbound) Stop() error {
 // Endpoint provides the http connection details.
 func (i *Inbound) Endpoint() string {
 	// return http prefix as framework only supports http
-	return "http://" + i.server.Addr
+	return "http://" + i.externalAddr
 }

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -54,7 +54,7 @@ func storeProvider() (storage.Provider, error) {
 }
 
 func inboundTransport() (didcommtrans.InboundTransport, error) {
-	inbound, err := http.NewInbound(defaultInboundPort)
+	inbound, err := http.NewInbound(defaultInboundPort, "")
 	if err != nil {
 		return nil, fmt.Errorf("http inbound transport initialization failed: %w", err)
 	}

--- a/pkg/framework/aries/defaults/defaults.go
+++ b/pkg/framework/aries/defaults/defaults.go
@@ -26,9 +26,9 @@ func WithStorePath(storePath string) aries.Option {
 }
 
 // WithInboundHTTPAddr return new default inbound transport.
-func WithInboundHTTPAddr(addr string) aries.Option {
+func WithInboundHTTPAddr(internalAddr, externalAddr string) aries.Option {
 	return func(opts *aries.Aries) error {
-		inbound, err := http.NewInbound(addr)
+		inbound, err := http.NewInbound(internalAddr, externalAddr)
 		if err != nil {
 			return fmt.Errorf("http inbound transport initialization failed : %w", err)
 		}

--- a/pkg/framework/aries/defaults/defaults_test.go
+++ b/pkg/framework/aries/defaults/defaults_test.go
@@ -35,7 +35,7 @@ func TestWithDBPath(t *testing.T) {
 	t.Run("test with db path success", func(t *testing.T) {
 		path, cleanup := generateTempDir(t)
 		defer cleanup()
-		a, err := aries.New(WithStorePath(path), WithInboundHTTPAddr(":26502"))
+		a, err := aries.New(WithStorePath(path), WithInboundHTTPAddr(":26502", ""))
 		require.NoError(t, err)
 		require.NoError(t, a.Close())
 	})
@@ -46,13 +46,13 @@ func TestWithInboundHTTPPort(t *testing.T) {
 		path, cleanup := generateTempDir(t)
 		defer cleanup()
 
-		a, err := aries.New(WithStorePath(path), WithInboundHTTPAddr(":26503"))
+		a, err := aries.New(WithStorePath(path), WithInboundHTTPAddr(":26503", ""))
 		require.NoError(t, err)
 		require.NoError(t, a.Close())
 	})
 
 	t.Run("test inbound with http port - empty address", func(t *testing.T) {
-		_, err := aries.New(WithInboundHTTPAddr(""))
+		_, err := aries.New(WithInboundHTTPAddr("", ""))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "http inbound transport initialization failed")
 	})

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -34,7 +34,7 @@ var logger = log.New("aries-framework/did-exchange")
 const (
 	operationID             = "/connections"
 	createInvitationPath    = operationID + "/create-invitation"
-	receiveInvtiationPath   = operationID + "/receive-invitation"
+	receiveInvitationPath   = operationID + "/receive-invitation"
 	acceptInvitationPath    = operationID + "/{id}/accept-invitation"
 	connections             = operationID
 	connectionsByID         = operationID + "/{id}"
@@ -311,7 +311,7 @@ func (c *Operation) registerHandler() {
 		support.NewHTTPHandler(connections, http.MethodGet, c.QueryConnections),
 		support.NewHTTPHandler(connectionsByID, http.MethodGet, c.QueryConnectionByID),
 		support.NewHTTPHandler(createInvitationPath, http.MethodPost, c.CreateInvitation),
-		support.NewHTTPHandler(receiveInvtiationPath, http.MethodPost, c.ReceiveInvitation),
+		support.NewHTTPHandler(receiveInvitationPath, http.MethodPost, c.ReceiveInvitation),
 		support.NewHTTPHandler(acceptInvitationPath, http.MethodPost, c.AcceptInvitation),
 		support.NewHTTPHandler(acceptExchangeRequest, http.MethodPost, c.AcceptExchangeRequest),
 		support.NewHTTPHandler(removeConnection, http.MethodPost, c.RemoveConnection),

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -73,7 +73,7 @@ func TestOperation_ReceiveInvitation(t *testing.T) {
 		"label":"agent",
 		"@type":"did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/didexchange/1.0/invitation"}}`)
 
-	handler := getHandler(t, receiveInvtiationPath, nil)
+	handler := getHandler(t, receiveInvitationPath, nil)
 	buf, err := getResponseFromHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
 	require.NoError(t, err)
 
@@ -157,14 +157,14 @@ func TestOperation_ReceiveInvitationFailure(t *testing.T) {
       		"6LE8yhZB8Xffc5vFgFntE3YLrxq5JVUsoAvUQgUyktGt"
     		]
   	}`)
-	handler := getHandler(t, receiveInvtiationPath, errors.New("handler failed"))
+	handler := getHandler(t, receiveInvitationPath, errors.New("handler failed"))
 	buf, err := getResponseFromHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
 	require.NoError(t, err)
 	verifyError(buf.Bytes())
 
 	// Failure due to invalid request body
 	jsonStr = []byte("")
-	handler = getHandler(t, receiveInvtiationPath, nil)
+	handler = getHandler(t, receiveInvitationPath, nil)
 	buf, err = getResponseFromHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
 	require.NoError(t, err)
 	verifyError(buf.Bytes())

--- a/pkg/restapi/restapi_test.go
+++ b/pkg/restapi/restapi_test.go
@@ -29,7 +29,7 @@ func TestNew_Failure(t *testing.T) {
 func TestNew_Success(t *testing.T) {
 	path, cleanup := generateTempDir(t)
 	defer cleanup()
-	framework, err := aries.New(defaults.WithStorePath(path), defaults.WithInboundHTTPAddr(":26508"))
+	framework, err := aries.New(defaults.WithStorePath(path), defaults.WithInboundHTTPAddr(":26508", ""))
 	require.NoError(t, err)
 	require.NotNil(t, framework)
 

--- a/test/bdd/agent_sdk_steps.go
+++ b/test/bdd/agent_sdk_steps.go
@@ -63,7 +63,7 @@ func (a *AgentSDKSteps) create(agentID, inboundHost, inboundPort string, opts ..
 	if inboundPort == "random" {
 		inboundPort = strconv.Itoa(mustGetRandomPort(5))
 	}
-	opts = append(opts, defaults.WithInboundHTTPAddr(fmt.Sprintf("%s:%s", inboundHost, inboundPort)))
+	opts = append(opts, defaults.WithInboundHTTPAddr(fmt.Sprintf("%s:%s", inboundHost, inboundPort), ""))
 	opts = append(opts, defaults.WithStorePath(dbPath+"/"+agentID))
 	agent, err := aries.New(opts...)
 	if err != nil {


### PR DESCRIPTION
Closes #572 

Added a command line flag for specifying the external inbound host name. The external address is what's returned when you call Endpoint() on an Inbound object.

Fixed some small typos and formatting issues I found.

Signed-off-by: Derek Trider <derek.trider@securekey.com>