### PR TITLE
fix: Get Connection details based on state 

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -174,6 +174,20 @@ func (c *Client) GetConnection(connectionID string) (*Connection, error) {
 	}, nil
 }
 
+// GetConnectionAtState fetches connection record for connection id at particular state.
+func (c *Client) GetConnectionAtState(connectionID, stateID string) (*Connection, error) {
+	conn, err := c.connectionStore.GetConnectionRecordAtState(connectionID, stateID)
+	if err != nil {
+		if errors.Is(err, storage.ErrDataNotFound) {
+			return nil, ErrConnectionNotFound
+		}
+		return nil, fmt.Errorf("cannot fetch state from store: connectionid=%s err=%s", connectionID, err)
+	}
+	return &Connection{
+		conn,
+	}, nil
+}
+
 // RemoveConnection removes connection record for given id
 func (c *Client) RemoveConnection(id string) error {
 	// TODO https://github.com/hyperledger/aries-framework-go/issues/553 RemoveConnection from did exchange service

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -375,7 +375,7 @@ func (c *Operation) handleMessageEvents(e service.StateMsg) error {
 		switch v := e.Properties.(type) {
 		case didexchange.Event:
 			props := v
-			err := c.sendConnectionNotification(props.ConnectionID())
+			err := c.sendConnectionNotification(props.ConnectionID(), e.StateID)
 			if err != nil {
 				return fmt.Errorf("send connection notification failed : %w", err)
 			}
@@ -393,8 +393,8 @@ func (c *Operation) handleActionEvents(e service.DIDCommAction) {
 	e.Continue()
 }
 
-func (c *Operation) sendConnectionNotification(connectionID string) error {
-	conn, err := c.client.GetConnection(connectionID)
+func (c *Operation) sendConnectionNotification(connectionID, stateID string) error {
+	conn, err := c.client.GetConnectionAtState(connectionID, stateID)
 	if err != nil {
 		logger.Errorf("Send notification failed, topic[%s], connectionID[%s]", connectionsWebhookTopic, connectionID)
 		return fmt.Errorf("connection notification webhook : %w", err)


### PR DESCRIPTION
Currently, RestAPI message handle the tests fail intermittently. The connectionID retrieved from events used to fetch connection data from database. There is a possibility that the data in db gets updated before consumer calls the
db. This would make previous state data getting lost and consumer would receive same state notification twice.

- Save connection data after state execution.
- Add new API to get connection based on connectionID and stateID.

Closes #607 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
