### PR TITLE
feat: OpenAPI user interface for demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ build
 vc-test-suite
 test/bdd/db
 test/bdd/fixtures/keys/tls
+test/bdd/fixtures/demo/openapi/specs
 *.log

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Go framework for Aries
 ##### Prerequisites (General)
 - Go 1.13
 
-##### Prerequisites (for running tests)
+##### Prerequisites (for running tests and demos)
 - Go 1.13
 - Docker
 - Docker-Compose
@@ -32,6 +32,15 @@ make checks
 # run unit tests
 make unit-test
 ```
+##### Running demo locally
+The demo is to play around with APIs using the OpenAPI (Swagger) user interface and JSON.
+
+The demo can be launched by `make run-openapi-demo`
+This target will start Alice and Bob demo agent containers. Once started, OpenAPI user interface for agents can be accessed using below URLs.
+
+[Alice agent OpenAPI user interface](http://localhost:8089/openapi/)
+
+[Bob agent OpenAPI user interface](http://localhost:9089/openapi/),
 
 ##### Crypto material generation for tests
 For unit-tests, crypto material is generated under:

--- a/cmd/aries-agentd/main.go
+++ b/cmd/aries-agentd/main.go
@@ -11,7 +11,6 @@ SPDX-License-Identifier: Apache-2.0
 //
 //
 //     Schemes: http, https
-//     Host: 127.0.0.1:8080
 //     Version: 0.1.0
 //     License: SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -291,7 +290,7 @@ func (c *Operation) RemoveConnection(rw http.ResponseWriter, req *http.Request) 
 }
 
 // writeGenericError writes given error to writer as generic error response
-func (c *Operation) writeGenericError(rw io.Writer, err error) {
+func (c *Operation) writeGenericError(rw http.ResponseWriter, err error) {
 	errResponse := models.GenericError{
 		Body: struct {
 			Code    int32  `json:"code"`
@@ -306,7 +305,11 @@ func (c *Operation) writeGenericError(rw io.Writer, err error) {
 }
 
 // writeResponse writes interface value to response
-func (c *Operation) writeResponse(rw io.Writer, v interface{}) {
+func (c *Operation) writeResponse(rw http.ResponseWriter, v interface{}) {
+	// TODO CORS response header should be added through customizable response filters to REST API [Issue #624]
+	// add CORS response header
+	rw.Header().Set("Access-Control-Allow-Origin", "*")
+
 	err := json.NewEncoder(rw).Encode(v)
 	// as of now, just log errors for writing response
 	if err != nil {

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -272,7 +272,7 @@ func TestOperation_WriteResponse(t *testing.T) {
 		ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil))
 	require.NoError(t, err)
 	require.NotNil(t, svc)
-	svc.writeResponse(&mockWriter{errors.New("failed to write")}, &models.QueryConnectionResponse{})
+	svc.writeResponse(&httptest.ResponseRecorder{}, &models.QueryConnectionResponse{})
 }
 
 // getResponseFromHandler reads response from given http handle func
@@ -338,14 +338,6 @@ func getHandler(t *testing.T, lookup string, handleErr error) operation.Handler 
 	}
 	require.Fail(t, "unable to find handler")
 	return nil
-}
-
-type mockWriter struct {
-	failure error
-}
-
-func (m mockWriter) Write([]byte) (int, error) {
-	return 0, m.failure
 }
 
 func TestServiceEvents(t *testing.T) {

--- a/scripts/generate-openapi-demo-specs.sh
+++ b/scripts/generate-openapi-demo-specs.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -e
+
+BASE_SPEC_LOC="${SPEC_PATH}/openAPI.yml"
+DEMO_PATH="${OPENAPI_DEMO_PATH}"
+IMAGE="${DOCKER_IMAGE:-quay.io/goswagger/swagger}"
+IMAGE_VERSION="${DOCKER_IMAGE_VERSION:-latest}"
+OUTPUT_PATH="$DEMO_PATH/specs"
+
+if [ ! -f "$BASE_SPEC_LOC" ]; then
+    echo "'$BASE_SPEC_LOC' doesn't exists"
+    exit 1
+fi
+
+set -o allexport
+[[ -f $DEMO_PATH/.env ]] && source $DEMO_PATH/.env
+set +o allexport
+
+mkdir -p $OUTPUT_PATH
+
+# generate sub specs using .env entries and mix them using 'swagger mixin'
+while IFS='=' read -r name value ; do
+  if [[ $name == *'_API_HOST' ]]; then
+    result="${!name}"
+    echo "host: $result" > $OUTPUT_PATH/$result.yml
+    command="mixin $BASE_SPEC_LOC $OUTPUT_PATH/${result}.yml -o $OUTPUT_PATH/openapi-${result}.yml --format yaml"
+    docker run --rm -e GOPATH=$HOME/go:/go -v $HOME:$HOME -w $(pwd) ${IMAGE}:${IMAGE_VERSION} $command
+    rm -rf $OUTPUT_PATH/$result.yml
+  fi
+done < <(env)
+
+

--- a/scripts/generate-openapi-spec.sh
+++ b/scripts/generate-openapi-spec.sh
@@ -6,7 +6,6 @@
 #
 set -e
 
-CODEBASE="$(dirname "$PWD")"
 SPEC_LOC="${SPEC_LOC}"
 SPEC_META="${SPEC_META:-cmd/aries-agentd/main.go}"
 OUTPUT="$SPEC_LOC/openAPI.yml"

--- a/scripts/run_openapi_demo.sh
+++ b/scripts/run_openapi_demo.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -e
+
+COMPOSE_FILES="${DEMO_COMPOSE_FILES}"
+DEMO_PATH="${DEMO_COMPOSE_PATH}"
+AGENT_PATH="${AGENT_COMPOSE_PATH}"
+AGENT_COMPOSE_FILE="$PWD/$AGENT_PATH/docker-compose.yml"
+
+echo "Starting agent demo containers"
+
+set -o allexport
+[[ -f $DEMO_PATH/.env ]] && source $DEMO_PATH/.env
+set +o allexport
+
+set -o allexport
+[[ -f $AGENT_PATH/.env ]] && source $AGENT_PATH/.env
+set +o allexport
+
+cd $DEMO_PATH
+docker-compose  -f docker-compose-demo.yml -f $AGENT_COMPOSE_FILE up --force-recreate
+

--- a/test/bdd/fixtures/demo/openapi/.env
+++ b/test/bdd/fixtures/demo/openapi/.env
@@ -1,0 +1,14 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# This file contains the default images and tags used in the docker-based
+# Fabric fixtures. The images and tags can be overridden using environment
+# variables. See docker compose documentation.
+
+
+# Demo Agent API hosts
+ALICE_API_HOST=localhost:8082
+BOB_API_HOST=localhost:9082

--- a/test/bdd/fixtures/demo/openapi/docker-compose-demo.yml
+++ b/test/bdd/fixtures/demo/openapi/docker-compose-demo.yml
@@ -1,0 +1,30 @@
+#
+# Copyright IBM Corp, SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+version: '2'
+
+services:
+
+  alice.openapi.demo.com:
+    container_name: alice.openpi.demo.com
+    image: swaggerapi/swagger-ui
+    environment:
+      - SWAGGER_JSON=/specs/openapi-${ALICE_API_HOST}.yml
+      - BASE_URL=/openapi
+    ports:
+      - 8089:8080
+    volumes:
+      - ./specs:/specs
+
+  bob.openapi.demo.com:
+    container_name: bob.openpi.demo.com
+    image: swaggerapi/swagger-ui
+    environment:
+      - SWAGGER_JSON=/specs/openapi-${BOB_API_HOST}.yml
+      - BASE_URL=/openapi
+    ports:
+      - 9089:8080
+    volumes:
+      - ./specs:/specs


### PR DESCRIPTION
Added below targets
- _`make generate-demo-specs`_ : generates demo specs for each demo agents
- _`make run-openapi-demo`_ : starts swagger ui docker containers using generated
spec as base.
- Part of #94

Once started, below links can be used to play with agents
**Alice Demo Agent :** http://localhost:8089/openapi/
**Bob Demo Agent :** http://localhost:9089/openapi/

Existing images/containers built for bdd tests are reused for demo.

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
