### PR TITLE
feat: Controller API bddtests to verify completed state

### DIFF
--- a/images/agent/Dockerfile
+++ b/images/agent/Dockerfile
@@ -27,4 +27,4 @@ RUN GO_TAGS=${GO_TAGS} GOPROXY=${GOPROXY} make agent
 
 FROM alpine:${ALPINE_VER} as base
 COPY --from=aries-framework /go/src/github.com/hyperledger/aries-framework-go/build/bin/aries-agentd /usr/local/bin
-CMD aries-agentd start --api-host ${API_HOST} --inbound-host ${INBOUND_HOST} --webhook-url ${WEBHOOK_URL} -d ${DB_LOC}
+CMD aries-agentd start --api-host ${API_HOST} --inbound-host ${INBOUND_HOST} --inbound-host-external ${INBOUND_HOST_EXTERNAL} --webhook-url ${WEBHOOK_URL} -d ${DB_LOC}

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -121,10 +121,6 @@ func FeatureContext(s *godog.Suite) {
 	context.Args[SideTreeURL] = "http://localhost:48326/.sidetree/document"
 	context.Args[DIDDocPath] = "fixtures/sidetree-node/config/didDocument.json"
 
-	// TODO below 2 env variables to be removed as part of issue #572
-	context.Args[AliceAgentHost] = "alice.agent.example.com"
-	context.Args[BobAgentHost] = "bob.agent.example.com"
-
 	// Context is shared between tests
 	NewAgentSDKSteps(context).RegisterSteps(s)
 	NewAgentControllerSteps(context).RegisterSteps(s)

--- a/test/bdd/fixtures/agent/docker-compose.yml
+++ b/test/bdd/fixtures/agent/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - API_HOST=${ALICE_HOST}:${ALICE_API_PORT}
       - INBOUND_HOST=${ALICE_HOST}:${ALICE_INBOUND_PORT}
+      - INBOUND_HOST_EXTERNAL=alice.aries.example.com:${ALICE_INBOUND_PORT}
       - WEBHOOK_URL=http://${ALICE_WEBHOOK_CONTAINER_NAME}:${ALICE_WEBHOOK_PORT}
       - DB_LOC=${ALICE_DB_LOC}
     ports:
@@ -25,6 +26,7 @@ services:
     environment:
       - API_HOST=${BOB_HOST}:${BOB_API_PORT}
       - INBOUND_HOST=${BOB_HOST}:${BOB_INBOUND_PORT}
+      - INBOUND_HOST_EXTERNAL=bob.aries.example.com:${BOB_INBOUND_PORT}
       - WEBHOOK_URL=http://${BOB_WEBHOOK_CONTAINER_NAME}:${BOB_WEBHOOK_PORT}
       - DB_LOC=${BOB_DB_LOC}
     ports:


### PR DESCRIPTION
- after fixing #572, agents will use external host while creating
invitations. This fixes issue with controller REST API test where
communication between agents were failing.
- closes #629

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>

