### PR TITLE
RestAPI - Get label value in CreateInvitation

### DIFF
--- a/cmd/aries-agentd/startcmd/start.go
+++ b/cmd/aries-agentd/startcmd/start.go
@@ -62,6 +62,12 @@ const (
 
 	agentWebhookFlagUsage = "URL to send notifications to." +
 		" This flag can be repeated, allowing for multiple listeners."
+
+	agentDefaultLabelFlagName = "agent-default-label"
+
+	agentDefaultLabelFlagShorthand = "l"
+
+	agentDefaultLabelFlagUsage = "Default Label for this agent. Defaults to blank if not set."
 )
 
 // ErrMissingHost is the error when the user provides a blank host argument.
@@ -73,9 +79,9 @@ var ErrMissingInboundHost = errors.New("unable to start aries agentd, HTTP Inbou
 var logger = log.New("aries-framework/agentd")
 
 type agentParameters struct {
-	server                                                 server
-	host, inboundHostInternal, inboundHostExternal, dbPath string
-	webhookURLs                                            []string
+	server                                                               server
+	host, inboundHostInternal, inboundHostExternal, dbPath, defaultLabel string
+	webhookURLs                                                          []string
 }
 
 type server interface {
@@ -119,8 +125,13 @@ func Cmd(server server) (*cobra.Command, error) {
 				return fmt.Errorf("agent DB path flag not found: %s", err)
 			}
 
+			invitationLabel, err := cmd.Flags().GetString(agentDefaultLabelFlagName)
+			if err != nil {
+				return fmt.Errorf("agent DB path flag not found: %s", err)
+			}
+
 			parameters := &agentParameters{server, host, inboundHost,
-				inboundHostExternal, dbPath, webhookURLs}
+				inboundHostExternal, dbPath, invitationLabel, webhookURLs}
 			err = startAgent(parameters)
 			if err != nil {
 				return fmt.Errorf("unable to start agent: %s", err)
@@ -167,6 +178,9 @@ func createFlags(startCmd *cobra.Command, webhookURLs *[]string) error {
 	startCmd.Flags().StringP(agentInboundHostExternalFlagName, agentInboundHostExternalFlagShorthand,
 		"", agentInboundHostExternalFlagUsage)
 
+	startCmd.Flags().StringP(agentDefaultLabelFlagName, agentDefaultLabelFlagShorthand, "",
+		agentDefaultLabelFlagUsage)
+
 	return nil
 }
 
@@ -199,7 +213,8 @@ func startAgent(parameters *agentParameters) error {
 	}
 
 	// get all HTTP REST API handlers available for controller API
-	restService, err := restapi.New(ctx, restapi.WithWebhookURLs(parameters.webhookURLs...))
+	restService, err := restapi.New(ctx, restapi.WithWebhookURLs(parameters.webhookURLs...),
+		restapi.WithDefaultLabel(parameters.defaultLabel))
 	if err != nil {
 		return fmt.Errorf("failed to start aries agentd on port [%s], failed to get rest service api :  %w",
 			parameters.host, err)

--- a/cmd/aries-agentd/startcmd/start_test.go
+++ b/cmd/aries-agentd/startcmd/start_test.go
@@ -104,7 +104,7 @@ func TestStartAriesDRequests(t *testing.T) {
 
 	go func() {
 		parameters := &agentParameters{&HTTPServer{}, testHostURL, testInboundHostURL,
-			"", path, []string{}}
+			"", path, "", []string{}}
 		err := startAgent(parameters)
 		require.FailNow(t, agentUnexpectedExitErrMsg+": "+err.Error())
 	}()
@@ -219,7 +219,7 @@ func TestStartCmdWithMissingHostArg(t *testing.T) {
 }
 
 func TestStartAgentWithBlankHost(t *testing.T) {
-	parameters := &agentParameters{&mockServer{}, "", randomURL(), "", "", []string{}}
+	parameters := &agentParameters{&mockServer{}, "", randomURL(), "", "", "", []string{}}
 	err := startAgent(parameters)
 
 	require.NotNil(t, err)
@@ -241,7 +241,7 @@ func TestStartCmdWithoutInboundHostArg(t *testing.T) {
 
 func TestStartAgentWithBlankInboundHost(t *testing.T) {
 	parameters := &agentParameters{&mockServer{}, randomURL(), "",
-		"", "", []string{}}
+		"", "", "", []string{}}
 	err := startAgent(parameters)
 
 	require.NotNil(t, err)
@@ -295,7 +295,7 @@ func TestStartMultipleAgentsWithSameHost(t *testing.T) {
 	defer cleanup1()
 	go func() {
 		parameters := &agentParameters{&HTTPServer{}, host, inboundHost,
-			"", path1, []string{}}
+			"", path1, "", []string{}}
 		err := startAgent(parameters)
 		require.FailNow(t, agentUnexpectedExitErrMsg+": "+err.Error())
 	}()
@@ -304,7 +304,7 @@ func TestStartMultipleAgentsWithSameHost(t *testing.T) {
 
 	path2, cleanup2 := generateTempDir(t)
 	defer cleanup2()
-	parameters := &agentParameters{&HTTPServer{}, host, inboundHost2, "", path2, []string{}}
+	parameters := &agentParameters{&HTTPServer{}, host, inboundHost2, "", path2, "", []string{}}
 	err := startAgent(parameters)
 
 	require.NotNil(t, err)
@@ -322,14 +322,14 @@ func TestStartMultipleAgentsWithSameDBPath(t *testing.T) {
 	defer cleanup()
 
 	go func() {
-		parameters := &agentParameters{&HTTPServer{}, host1, inboundHost1, "", path, []string{}}
+		parameters := &agentParameters{&HTTPServer{}, host1, inboundHost1, "", path, "", []string{}}
 		err := startAgent(parameters)
 		require.FailNow(t, agentUnexpectedExitErrMsg+": "+err.Error())
 	}()
 
 	waitForServerToStart(t, host1, inboundHost1)
 
-	parameters := &agentParameters{&HTTPServer{}, host2, inboundHost2, "", path, []string{}}
+	parameters := &agentParameters{&HTTPServer{}, host2, inboundHost2, "", path, "", []string{}}
 	err := startAgent(parameters)
 
 	require.NotNil(t, err)

--- a/images/agent/Dockerfile
+++ b/images/agent/Dockerfile
@@ -27,4 +27,4 @@ RUN GO_TAGS=${GO_TAGS} GOPROXY=${GOPROXY} make agent
 
 FROM alpine:${ALPINE_VER} as base
 COPY --from=aries-framework /go/src/github.com/hyperledger/aries-framework-go/build/bin/aries-agentd /usr/local/bin
-CMD aries-agentd start --api-host ${API_HOST} --inbound-host ${INBOUND_HOST} --inbound-host-external ${INBOUND_HOST_EXTERNAL} --webhook-url ${WEBHOOK_URL} -d ${DB_LOC}
+CMD aries-agentd start --api-host ${API_HOST} --inbound-host ${INBOUND_HOST} --inbound-host-external ${INBOUND_HOST_EXTERNAL} --webhook-url ${WEBHOOK_URL} -d ${DB_LOC} --agent-default-label ${AGENT_DEFAULT_LABEL}

--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -95,16 +95,15 @@ func New(ctx provider) (*Client, error) {
 }
 
 // CreateInvitation create invitation
-// TODO 'invitation.label' should come though 'provider' [Issue #552]
 // TODO 'alias' should be passed as arg and persisted with connection record [Issue #623]
-func (c *Client) CreateInvitation(alias string) (*Invitation, error) {
+func (c *Client) CreateInvitation(label string) (*Invitation, error) {
 	_, sigPubKey, err := c.kms.CreateKeySet()
 	if err != nil {
 		return nil, fmt.Errorf("failed CreateSigningKey: %w", err)
 	}
 	invitation := &didexchange.Invitation{
 		ID:              uuid.New().String(),
-		Label:           alias,
+		Label:           label,
 		RecipientKeys:   []string{sigPubKey},
 		ServiceEndpoint: c.inboundTransportEndpoint,
 		Type:            didexchange.InvitationMsgType,

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -359,14 +359,16 @@ func TestServiceEventError(t *testing.T) {
 	}
 
 	// register action event on service throws error
-	_, err := New(&mockprovider.Provider{StorageProviderValue: mockstore.NewMockStoreProvider(), ServiceValue: &didExSvc})
+	_, err := New(&mockprovider.Provider{StorageProviderValue: mockstore.NewMockStoreProvider(),
+		ServiceValue: &didExSvc})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "didexchange action event "+
 		"registration: action event registration failed")
 
 	// register msg event on service throws error
 	didExSvc.RegisterActionEventErr = nil
-	_, err = New(&mockprovider.Provider{StorageProviderValue: mockstore.NewMockStoreProvider(), ServiceValue: &didExSvc})
+	_, err = New(&mockprovider.Provider{StorageProviderValue: mockstore.NewMockStoreProvider(),
+		ServiceValue: &didExSvc})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "didexchange message event "+
 		"registration: msg event registration failed")

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -51,7 +51,7 @@ type provider interface {
 }
 
 // New returns new DID Exchange rest client protocol instance
-func New(ctx provider, notifier webhook.Notifier) (*Operation, error) {
+func New(ctx provider, notifier webhook.Notifier, defaultLabel string) (*Operation, error) {
 	didExchange, err := didexchange.New(ctx)
 	if err != nil {
 		return nil, err
@@ -61,9 +61,10 @@ func New(ctx provider, notifier webhook.Notifier) (*Operation, error) {
 		ctx:    ctx,
 		client: didExchange,
 		// TODO channel size - https://github.com/hyperledger/aries-framework-go/issues/246
-		actionCh: make(chan service.DIDCommAction, 10),
-		msgCh:    make(chan service.StateMsg, 10),
-		notifier: notifier,
+		actionCh:     make(chan service.DIDCommAction, 10),
+		msgCh:        make(chan service.StateMsg, 10),
+		notifier:     notifier,
+		defaultLabel: defaultLabel,
 	}
 	svc.registerHandler()
 
@@ -77,12 +78,13 @@ func New(ctx provider, notifier webhook.Notifier) (*Operation, error) {
 
 // Operation is controller REST service controller for DID Exchange
 type Operation struct {
-	ctx      provider
-	client   *didexchange.Client
-	handlers []operation.Handler
-	actionCh chan service.DIDCommAction
-	msgCh    chan service.StateMsg
-	notifier webhook.Notifier
+	ctx          provider
+	client       *didexchange.Client
+	handlers     []operation.Handler
+	actionCh     chan service.DIDCommAction
+	msgCh        chan service.StateMsg
+	notifier     webhook.Notifier
+	defaultLabel string
 }
 
 // CreateInvitation swagger:route POST /connections/create-invitation did-exchange createInvitation
@@ -102,14 +104,13 @@ func (c *Operation) CreateInvitation(rw http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	// derive label from alias for now
 	var alias string
 	if request.CreateInvitationParams != nil {
 		alias = request.CreateInvitationParams.Alias
 	}
 
 	// call didexchange client
-	invitation, err := c.client.CreateInvitation(alias)
+	invitation, err := c.client.CreateInvitation(c.defaultLabel)
 	if err != nil {
 		c.writeGenericError(rw, err)
 		return

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestOperation_GetAPIHandlers(t *testing.T) {
 	svc, err := New(&mockprovider.Provider{StorageProviderValue: mockstore.NewMockStoreProvider(),
-		ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil))
+		ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil), "")
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 
@@ -45,7 +45,7 @@ func TestOperation_GetAPIHandlers(t *testing.T) {
 }
 
 func TestNew_Fail(t *testing.T) {
-	svc, err := New(&mockprovider.Provider{ServiceErr: errors.New("test-error")}, webhook.NewHTTPNotifier(nil))
+	svc, err := New(&mockprovider.Provider{ServiceErr: errors.New("test-error")}, webhook.NewHTTPNotifier(nil), "")
 	require.Error(t, err)
 	require.Nil(t, svc)
 }
@@ -63,7 +63,7 @@ func TestOperation_CreateInvitation(t *testing.T) {
 		// verify response
 		require.NotEmpty(t, response.Invitation)
 		require.Equal(t, "endpoint", response.Invitation.ServiceEndpoint)
-		require.NotEmpty(t, response.Invitation.Label)
+		require.Empty(t, response.Invitation.Label)
 		require.NotEmpty(t, response.Alias)
 	})
 
@@ -248,7 +248,7 @@ func TestOperation_WriteGenericError(t *testing.T) {
 	const errMsg = "sample-error-msg"
 
 	svc, err := New(&mockprovider.Provider{StorageProviderValue: mockstore.NewMockStoreProvider(),
-		ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil))
+		ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil), "")
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 
@@ -269,7 +269,7 @@ func TestOperation_WriteGenericError(t *testing.T) {
 
 func TestOperation_WriteResponse(t *testing.T) {
 	svc, err := New(&mockprovider.Provider{StorageProviderValue: mockstore.NewMockStoreProvider(),
-		ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil))
+		ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil), "")
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 	svc.writeResponse(&httptest.ResponseRecorder{}, &models.QueryConnectionResponse{})
@@ -324,6 +324,7 @@ func getHandler(t *testing.T, lookup string, handleErr error) operation.Handler 
 		InboundEndpointValue: "endpoint",
 		StorageProviderValue: &mockstore.MockStoreProvider{Store: &s}},
 		webhook.NewHTTPNotifier(nil),
+		"",
 	)
 	require.NoError(t, err)
 	require.NotNil(t, svc)
@@ -366,6 +367,7 @@ func TestServiceEvents(t *testing.T) {
 				return nil
 			},
 		},
+		"",
 	)
 	require.NoError(t, err)
 	require.NotNil(t, op)
@@ -424,7 +426,7 @@ func TestOperationEventError(t *testing.T) {
 func TestHandleMessageEvent(t *testing.T) {
 	storeProv := &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: make(map[string][]byte)}}
 	op, err := New(&mockprovider.Provider{StorageProviderValue: storeProv,
-		ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil))
+		ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil), "")
 	require.NoError(t, err)
 	require.NotNil(t, op)
 
@@ -460,14 +462,14 @@ func TestSendConnectionNotification(t *testing.T) {
 	require.NoError(t, storeProv.Store.Put("conn_id1"+"completed", connBytes))
 	t.Run("send notification success", func(t *testing.T) {
 		op, err := New(&mockprovider.Provider{StorageProviderValue: storeProv,
-			ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil))
+			ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil), "")
 		require.NoError(t, err)
 		err = op.sendConnectionNotification(connID, "completed")
 		require.NoError(t, err)
 	})
 	t.Run("send notification connection not found error", func(t *testing.T) {
 		op, err := New(&mockprovider.Provider{StorageProviderValue: storeProv,
-			ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil))
+			ServiceValue: &protocol.MockDIDExchangeSvc{}}, webhook.NewHTTPNotifier(nil), "")
 		require.NoError(t, err)
 		err = op.sendConnectionNotification("id2", "")
 		require.Error(t, err)
@@ -479,7 +481,8 @@ func TestSendConnectionNotification(t *testing.T) {
 			notifyFunc: func(topic string, message []byte) error {
 				return errors.New("webhook error")
 			},
-		})
+		},
+			"")
 		require.NoError(t, err)
 		require.NotNil(t, op)
 		err = op.sendConnectionNotification(connID, "completed")

--- a/pkg/restapi/restapi.go
+++ b/pkg/restapi/restapi.go
@@ -14,7 +14,8 @@ import (
 )
 
 type allOpts struct {
-	webhookURLs []string
+	webhookURLs  []string
+	defaultLabel string
 }
 
 // Opt represents a REST Api option.
@@ -24,6 +25,13 @@ type Opt func(opts *allOpts)
 func WithWebhookURLs(webhookURLs ...string) Opt {
 	return func(opts *allOpts) {
 		opts.webhookURLs = webhookURLs
+	}
+}
+
+// WithDefaultLabel is an option allowing for the defaultLabel to be set.
+func WithDefaultLabel(defaultLabel string) Opt {
+	return func(opts *allOpts) {
+		opts.defaultLabel = defaultLabel
 	}
 }
 
@@ -39,7 +47,7 @@ func New(ctx *context.Provider, opts ...Opt) (*Controller, error) {
 	var allHandlers []operation.Handler
 
 	// Add DID Exchange Rest Handlers
-	exchange, err := didexchange.New(ctx, webhook.NewHTTPNotifier(restAPIOpts.webhookURLs))
+	exchange, err := didexchange.New(ctx, webhook.NewHTTPNotifier(restAPIOpts.webhookURLs), restAPIOpts.defaultLabel)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/restapi/restapi_test.go
+++ b/pkg/restapi/restapi_test.go
@@ -51,7 +51,7 @@ func TestNew_Success(t *testing.T) {
 	require.NotEmpty(t, controller.GetOperations())
 }
 
-func TestAddWebhookNotifierOption(t *testing.T) {
+func TestWithWebhookNotifierOption(t *testing.T) {
 	restAPIOpts := &allOpts{}
 
 	webhookURLs := []string{"localhost:8080"}
@@ -60,6 +60,17 @@ func TestAddWebhookNotifierOption(t *testing.T) {
 	webhookNotifierOpt(restAPIOpts)
 
 	require.Equal(t, webhookURLs, restAPIOpts.webhookURLs)
+}
+
+func TestWithDefaultLabelOption(t *testing.T) {
+	restAPIOpts := &allOpts{}
+
+	label := "testLabel"
+	webhookNotifierOpt := WithDefaultLabel(label)
+
+	webhookNotifierOpt(restAPIOpts)
+
+	require.Equal(t, label, restAPIOpts.defaultLabel)
 }
 
 func generateTempDir(t testing.TB) (string, func()) {

--- a/test/bdd/fixtures/agent/docker-compose.yml
+++ b/test/bdd/fixtures/agent/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - INBOUND_HOST=${ALICE_HOST}:${ALICE_INBOUND_PORT}
       - INBOUND_HOST_EXTERNAL=alice.aries.example.com:${ALICE_INBOUND_PORT}
       - WEBHOOK_URL=http://${ALICE_WEBHOOK_CONTAINER_NAME}:${ALICE_WEBHOOK_PORT}
+      - AGENT_DEFAULT_LABEL=alice-agent
       - DB_LOC=${ALICE_DB_LOC}
     ports:
       - ${ALICE_INBOUND_PORT}:${ALICE_INBOUND_PORT}
@@ -29,6 +30,7 @@ services:
       - INBOUND_HOST_EXTERNAL=bob.aries.example.com:${BOB_INBOUND_PORT}
       - WEBHOOK_URL=http://${BOB_WEBHOOK_CONTAINER_NAME}:${BOB_WEBHOOK_PORT}
       - DB_LOC=${BOB_DB_LOC}
+      - AGENT_DEFAULT_LABEL=bob-agent
     ports:
       - ${BOB_INBOUND_PORT}:${BOB_INBOUND_PORT}
       - ${BOB_API_PORT}:${BOB_API_PORT}


### PR DESCRIPTION
Closes #552 

Invitation label is now passed via a command line argument.

Signed-off-by: Derek Trider <derek.trider@securekey.com>