### PR TITLE
feat: Query connections feature

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -153,12 +153,10 @@ func (c *Client) HandleInvitation(invitation *Invitation) error {
 }
 
 // QueryConnections queries connections matching given parameters
-func (c *Client) QueryConnections(request *QueryConnectionsParams) ([]*Connection, error) {
-	// TODO https://github.com/hyperledger/aries-framework-go/issues/429 query all connections from did exchange service
-	return []*Connection{
-		{&didexchange.ConnectionRecord{ConnectionID: uuid.New().String()}},
-		{&didexchange.ConnectionRecord{ConnectionID: uuid.New().String()}},
-	}, nil
+func (c *Client) QueryConnections(request *QueryConnectionsParams) ([]*didexchange.ConnectionRecord, error) {
+	// TODO query all connections from criteria [Issue #655]
+	// TODO also results needs to be paged  [Issue #655]
+	return c.connectionStore.QueryConnectionRecords()
 }
 
 // GetConnection fetches single connection record for given id

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -548,6 +548,11 @@ func (m *mockStore) Get(k string) ([]byte, error) {
 	return m.get(k)
 }
 
+// Search returns storage iterator
+func (m *mockStore) Iterator(start, limit string) storage.StoreIterator {
+	return nil
+}
+
 func getMockDID() *did.Doc {
 	return &did.Doc{
 		Context: []string{"https://w3id.org/did/v1"},

--- a/pkg/restapi/operation/didexchange/models/invitation.go
+++ b/pkg/restapi/operation/didexchange/models/invitation.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
+	didexchangeSvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 )
 
 // A GenericError is the default error message that is generated.
@@ -239,9 +240,7 @@ type QueryConnectionResponse struct {
 type QueryConnectionsResponse struct {
 
 	// in: body
-	Body struct {
-		Results []*didexchange.Connection `json:"results"`
-	}
+	Results []*didexchangeSvc.ConnectionRecord `json:"results"`
 }
 
 // AcceptExchangeRequestParams model

--- a/pkg/storage/leveldb/leveldb_store.go
+++ b/pkg/storage/leveldb/leveldb_store.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 
 	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/util"
 
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
@@ -125,4 +127,12 @@ func (s *leveldbStore) Get(k string) ([]byte, error) {
 		return nil, err
 	}
 	return data, nil
+}
+
+// Iterator returns iterator for the latest snapshot of the underlying db.
+func (s *leveldbStore) Iterator(start, limit string) storage.StoreIterator {
+	if start == "" || limit == "" {
+		iterator.NewEmptyIterator(errors.New("start or limit key is mandatory"))
+	}
+	return s.db.NewIterator(&util.Range{Start: []byte(start), Limit: []byte(limit)}, nil)
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -30,4 +30,42 @@ type Store interface {
 
 	// Get fetches the record based on key
 	Get(k string) ([]byte, error)
+
+	// Iterator returns an iterator for the latest snapshot of the
+	// underlying store
+	//
+	// Args:
+	//
+	// start: Start of the key range, include in the range.
+	// limit: Limit of the key range, not include in the range.
+	//
+	// Returns:
+	//
+	// StoreIterator: iterator for result range
+	Iterator(start, limit string) StoreIterator
+}
+
+// StoreIterator is the iterator for the latest snapshot of the underlying store.
+type StoreIterator interface {
+	// Next moves the iterator to the next key/value pair.
+	// It returns false if the iterator is exhausted.
+	Next() bool
+
+	// Release releases associated resources. Release should always success
+	// and can be called multiple times without causing error.
+	Release()
+
+	// Error returns any accumulated error. Exhausting all the key/value pairs
+	// is not considered to be an error.
+	Error() error
+
+	// Key returns the key of the current key/value pair, or nil if done.
+	// The caller should not modify the contents of the returned slice, and
+	// its contents may change on the next call to any 'seeks method'.
+	Key() []byte
+
+	// Value returns the value of the current key/value pair, or nil if done.
+	// The caller should not modify the contents of the returned slice, and
+	// its contents may change on the next call to any 'seeks method'.
+	Value() []byte
 }


### PR DESCRIPTION
- added Iterator() to store api interface to get iterator for given range.
- added query connections feature in connection recorder and client
- controller REST API to query all connections through client
- REST API to filter connections by state
- remaining query criteria will be applied as part of #655
- closes #429 

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
