### PR TITLE
feat: bdd tests for get all connections

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -153,10 +153,21 @@ func (c *Client) HandleInvitation(invitation *Invitation) error {
 }
 
 // QueryConnections queries connections matching given parameters
-func (c *Client) QueryConnections(request *QueryConnectionsParams) ([]*didexchange.ConnectionRecord, error) {
-	// TODO query all connections from criteria [Issue #655]
+func (c *Client) QueryConnections(request *QueryConnectionsParams) ([]*Connection, error) {
+	// TODO query all connections from all criteria [Issue #655]
 	// TODO also results needs to be paged  [Issue #655]
-	return c.connectionStore.QueryConnectionRecords()
+	records, err := c.connectionStore.QueryConnectionRecords()
+	if err != nil {
+		return nil, fmt.Errorf("failed query connections: %w", err)
+	}
+	var result []*Connection
+	for _, record := range records {
+		if request.State != "" && request.State != record.State {
+			continue
+		}
+		result = append(result, &Connection{ConnectionRecord: record})
+	}
+	return result, nil
 }
 
 // GetConnection fetches single connection record for given id

--- a/pkg/client/didexchange/models.go
+++ b/pkg/client/didexchange/models.go
@@ -42,7 +42,6 @@ type QueryConnectionsParams struct {
 // This is used to represent query connection result
 // TODO: this model is not final, to be updated as part of #226
 //
-// swagger:model Connection
 type Connection struct {
 	*didexchange.ConnectionRecord
 }

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,7 +21,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
-	didexchangeSvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/common/support"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
@@ -234,27 +232,14 @@ func (c *Operation) QueryConnections(rw http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	records, err := c.client.QueryConnections(&request)
+	results, err := c.client.QueryConnections(&request)
 	if err != nil {
 		c.writeGenericError(rw, err)
 		return
 	}
 
-	// TODO more filters to be applied as part of [Issue #655]
-	var result []*didexchangeSvc.ConnectionRecord
-	if request.State != "" {
-		// filter by state
-		for _, record := range records {
-			if strings.EqualFold(record.State, request.State) {
-				result = append(result, record)
-			}
-		}
-	} else {
-		result = records
-	}
-
 	response := models.QueryConnectionsResponse{
-		Results: result,
+		Results: results,
 	}
 
 	c.writeResponse(rw, response)

--- a/pkg/restapi/operation/didexchange/models/invitation.go
+++ b/pkg/restapi/operation/didexchange/models/invitation.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
-	didexchangeSvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 )
 
 // A GenericError is the default error message that is generated.
@@ -240,7 +239,7 @@ type QueryConnectionResponse struct {
 type QueryConnectionsResponse struct {
 
 	// in: body
-	Results []*didexchangeSvc.ConnectionRecord `json:"results"`
+	Results []*didexchange.Connection `json:"results"`
 }
 
 // AcceptExchangeRequestParams model

--- a/test/bdd/agent_controller_steps.go
+++ b/test/bdd/agent_controller_steps.go
@@ -202,7 +202,6 @@ func (a *AgentWithControllerSteps) validateConnection(agentID, stateValue string
 	logger.Debugf(" Getting connection by ID %s from %s", connectionID, destination)
 	// call controller
 	var response models.QueryConnectionResponse
-	// strings.Replace(connectionsByID, "{id}", connectionID)
 	err := sendHTTP(http.MethodGet, destination+strings.Replace(connectionsByID, "{id}", connectionID, 1), nil, &response)
 	if err != nil {
 		logger.Errorf("Failed to perform receive invitation, cause : %s", err)
@@ -213,6 +212,43 @@ func (a *AgentWithControllerSteps) validateConnection(agentID, stateValue string
 	// Verify state
 	if response.Result.State != stateValue {
 		return fmt.Errorf("Expected state[%s] for agent[%s], but got[%s]", stateValue, agentID, response.Result.State)
+	}
+
+	// Also make sure new connection is available in list of connections for given agent
+	return a.verifyConnectionList(agentID, stateValue, connectionID)
+}
+
+func (a *AgentWithControllerSteps) verifyConnectionList(agentID, queryState, verifyID string) error {
+	destination, ok := a.controllerURLs[agentID]
+	if !ok {
+		return fmt.Errorf(" unable to find controller URL registered for agent [%s]", agentID)
+	}
+
+	logger.Debugf(" Getting connections by state %s from %s", queryState, destination)
+
+	// call controller
+	var response models.QueryConnectionsResponse
+	err := sendHTTP(http.MethodGet, destination+operationID+"?state="+queryState, nil, &response)
+	if err != nil {
+		logger.Errorf("Failed to perform receive invitation, cause : %s", err)
+		return err
+	}
+	logger.Debugf("Got %d connections for state `%s`", len(response.Results), queryState)
+
+	if len(response.Results) == 0 {
+		return fmt.Errorf("no connections found with state '%s' in connections list", queryState)
+	}
+
+	var found bool
+	for _, connection := range response.Results {
+		if connection.State == queryState && connection.ConnectionID == verifyID {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("no connections found with state '%s' and connection ID '%s' in connections list", queryState, verifyID)
 	}
 
 	return nil


### PR DESCRIPTION
- added one more verification step in controller tests to verify
completed connection against connections list.
- moved state based filter logic from REST API to client
- removed openapi annotations from client model
- reverted exported service model `ConnectionRecord` from client 
- closes #429

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
