### PR TITLE
refactor: Return ID in service.HandleInbound API

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -141,22 +141,23 @@ func (c *Client) CreateInvitationWithDID(label, did string) (*Invitation, error)
 	return &Invitation{invitation}, nil
 }
 
-// HandleInvitation handle incoming invitation
-func (c *Client) HandleInvitation(invitation *Invitation) error {
+// HandleInvitation handle incoming invitation and returns the connectionID.
+func (c *Client) HandleInvitation(invitation *Invitation) (string, error) {
 	payload, err := json.Marshal(invitation)
 	if err != nil {
-		return fmt.Errorf("failed marshal invitation: %w", err)
+		return "", fmt.Errorf("failed marshal invitation: %w", err)
 	}
 
 	msg, err := service.NewDIDCommMsg(payload)
 	if err != nil {
-		return fmt.Errorf("failed to create DIDCommMsg: %w", err)
+		return "", fmt.Errorf("failed to create DIDCommMsg: %w", err)
 	}
 
-	if err = c.didexchangeSvc.HandleInbound(msg); err != nil {
-		return fmt.Errorf("failed from didexchange service handle: %w", err)
+	connectionID, err := c.didexchangeSvc.HandleInbound(msg)
+	if err != nil {
+		return "", fmt.Errorf("failed from didexchange service handle: %w", err)
 	}
-	return nil
+	return connectionID, nil
 }
 
 // AcceptExchangeRequest accepts/approves exchange request.

--- a/pkg/didcomm/common/service/service.go
+++ b/pkg/didcomm/common/service/service.go
@@ -16,7 +16,7 @@ import (
 // Handler provides protocol service handle api.
 type Handler interface {
 	// HandleInbound handles inbound didexchange messages.
-	HandleInbound(msg *DIDCommMsg) error
+	HandleInbound(msg *DIDCommMsg) (string, error)
 }
 
 // DIDComm defines service APIs.

--- a/pkg/didcomm/protocol/introduce/service_test.go
+++ b/pkg/didcomm/protocol/introduce/service_test.go
@@ -256,7 +256,10 @@ func TestService_HandleInboundStop(t *testing.T) {
 	require.NoError(t, svc.RegisterActionEvent(aCh))
 	sCh := make(chan service.StateMsg)
 	require.NoError(t, svc.RegisterMsgEvent(sCh))
-	go func() { require.NoError(t, svc.HandleInbound(msg)) }()
+	go func() {
+		_, err := svc.HandleInbound(msg)
+		require.NoError(t, err)
+	}()
 
 	for {
 		select {
@@ -279,7 +282,9 @@ func TestService_HandleInbound(t *testing.T) {
 	t.Run("No clients", func(t *testing.T) {
 		svc, err := New(&protocol.MockProvider{})
 		require.NoError(t, err)
-		require.EqualError(t, svc.HandleInbound(&service.DIDCommMsg{}), "no clients are registered to handle the message")
+
+		_, err = svc.HandleInbound(&service.DIDCommMsg{})
+		require.EqualError(t, err, "no clients are registered to handle the message")
 	})
 
 	t.Run("ThreadID Error", func(t *testing.T) {
@@ -289,7 +294,9 @@ func TestService_HandleInbound(t *testing.T) {
 		require.NoError(t, err)
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
-		require.EqualError(t, svc.HandleInbound(msg), service.ErrThreadIDNotFound.Error())
+
+		_, err = svc.HandleInbound(msg)
+		require.EqualError(t, err, service.ErrThreadIDNotFound.Error())
 	})
 
 	t.Run("Storage error", func(t *testing.T) {
@@ -303,7 +310,9 @@ func TestService_HandleInbound(t *testing.T) {
 		require.NoError(t, err)
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
-		require.EqualError(t, svc.HandleInbound(msg), "cannot fetch state from store: thid=ID err=test err")
+
+		_, err = svc.HandleInbound(msg)
+		require.EqualError(t, err, "cannot fetch state from store: thid=ID err=test err")
 	})
 
 	t.Run("Bad transition", func(t *testing.T) {
@@ -317,7 +326,9 @@ func TestService_HandleInbound(t *testing.T) {
 		require.NoError(t, err)
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
-		require.EqualError(t, svc.HandleInbound(msg), "invalid state transition: noop -> deciding")
+
+		_, err = svc.HandleInbound(msg)
+		require.EqualError(t, err, "invalid state transition: noop -> deciding")
 	})
 
 	t.Run("Invalid state", func(t *testing.T) {
@@ -330,7 +341,9 @@ func TestService_HandleInbound(t *testing.T) {
 		require.NoError(t, err)
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
-		require.EqualError(t, svc.HandleInbound(msg), "invalid state name unknown")
+
+		_, err = svc.HandleInbound(msg)
+		require.EqualError(t, err, "invalid state name unknown")
 	})
 
 	t.Run("Unknown msg type error", func(t *testing.T) {
@@ -340,7 +353,9 @@ func TestService_HandleInbound(t *testing.T) {
 		require.NoError(t, err)
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
-		require.EqualError(t, svc.HandleInbound(msg), "unrecognized msgType: unknown")
+
+		_, err = svc.HandleInbound(msg)
+		require.EqualError(t, err, "unrecognized msgType: unknown")
 	})
 
 	t.Run("Happy path (send an action event)", func(t *testing.T) {
@@ -350,7 +365,10 @@ func TestService_HandleInbound(t *testing.T) {
 		require.NoError(t, err)
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
-		go func() { require.NoError(t, svc.HandleInbound(msg)) }()
+		go func() {
+			_, err = svc.HandleInbound(msg)
+			require.NoError(t, err)
+		}()
 
 		select {
 		case res := <-ch:
@@ -368,7 +386,9 @@ func TestService_HandleInbound(t *testing.T) {
 		require.NoError(t, err)
 		aCh := make(chan service.DIDCommAction, 1)
 		require.NoError(t, svc.RegisterActionEvent(aCh))
-		require.NoError(t, svc.HandleInbound(msg))
+
+		_, err = svc.HandleInbound(msg)
+		require.NoError(t, err)
 
 		if len(aCh) != 1 {
 			t.Error("action was not received")
@@ -386,7 +406,10 @@ func TestService_HandleInbound(t *testing.T) {
 		require.NoError(t, svc.RegisterActionEvent(aCh))
 		sCh := make(chan service.StateMsg)
 		require.NoError(t, svc.RegisterMsgEvent(sCh))
-		go func() { require.NoError(t, svc.HandleInbound(msg)) }()
+		go func() {
+			_, err = svc.HandleInbound(msg)
+			require.NoError(t, err)
+		}()
 
 		select {
 		case res := <-sCh:
@@ -403,7 +426,9 @@ func TestService_HandleInbound(t *testing.T) {
 		require.NoError(t, err)
 		ch := make(chan service.DIDCommAction, 1)
 		require.NoError(t, svc.RegisterActionEvent(ch))
-		require.Nil(t, errors.Unwrap(svc.HandleInbound(msg)))
+
+		_, err = svc.HandleInbound(msg)
+		require.Nil(t, errors.Unwrap(err))
 	})
 }
 
@@ -532,7 +557,10 @@ func TestService_SkipProposal(t *testing.T) {
 		require.NoError(t, err)
 
 		// handle Response msg
-		go func() { require.NoError(t, svc.HandleInbound(respMsg)) }()
+		go func() {
+			_, err = svc.HandleInbound(respMsg)
+			require.NoError(t, err)
+		}()
 		continueAction(t, aCh, ResponseMsgType)
 		checkStateMsg(t, sCh, service.PreState, ResponseMsgType, stateNameDelivering)
 		checkStateMsg(t, sCh, service.PostState, ResponseMsgType, stateNameDelivering)
@@ -563,7 +591,10 @@ func TestService_SkipProposal(t *testing.T) {
 		require.NoError(t, err)
 
 		// handle Proposal msg (sends Request)
-		go func() { require.NoError(t, svc.HandleInbound(reqMsg)) }()
+		go func() {
+			_, err := svc.HandleInbound(reqMsg)
+			require.NoError(t, err)
+		}()
 		continueAction(t, aCh, ProposalMsgType)
 		checkStateMsg(t, sCh, service.PreState, ProposalMsgType, stateNameDeciding)
 		checkStateMsg(t, sCh, service.PostState, ProposalMsgType, stateNameDeciding)
@@ -596,7 +627,10 @@ func TestService_ProposalWithRequest(t *testing.T) {
 		}))
 		require.NoError(t, err)
 		// handle inbound Request msg
-		go func() { require.NoError(t, svc.HandleInbound(reqMsg)) }()
+		go func() {
+			_, err = svc.HandleInbound(reqMsg)
+			require.NoError(t, err)
+		}()
 		// sends the first Proposal
 		continueAction(t, aCh, RequestMsgType)
 		checkStateMsg(t, sCh, service.PreState, RequestMsgType, stateNameStart)
@@ -612,7 +646,10 @@ func TestService_ProposalWithRequest(t *testing.T) {
 		}))
 		require.NoError(t, err)
 		// handle inbound Response msg
-		go func() { require.NoError(t, svc.HandleInbound(firstRespMsg)) }()
+		go func() {
+			_, err = svc.HandleInbound(firstRespMsg)
+			require.NoError(t, err)
+		}()
 		// sends the second Proposal
 		continueAction(t, aCh, ResponseMsgType)
 		checkStateMsg(t, sCh, service.PreState, ResponseMsgType, stateNameArranging)
@@ -626,7 +663,10 @@ func TestService_ProposalWithRequest(t *testing.T) {
 		}))
 		require.NoError(t, err)
 		// handle inbound second Response msg
-		go func() { require.NoError(t, svc.HandleInbound(secondRespMsg)) }()
+		go func() {
+			_, err := svc.HandleInbound(secondRespMsg)
+			require.NoError(t, err)
+		}()
 		continueAction(t, aCh, ResponseMsgType)
 		checkStateMsg(t, sCh, service.PreState, ResponseMsgType, stateNameDelivering)
 		checkStateMsg(t, sCh, service.PostState, ResponseMsgType, stateNameDelivering)
@@ -667,7 +707,10 @@ func TestService_ProposalWithRequest(t *testing.T) {
 		require.NoError(t, err)
 
 		// handle Proposal msg (sends Request)
-		go func() { require.NoError(t, svc.HandleInbound(propMsg)) }()
+		go func() {
+			_, err := svc.HandleInbound(propMsg)
+			require.NoError(t, err)
+		}()
 		continueAction(t, aCh, ProposalMsgType)
 		checkStateMsg(t, sCh, service.PreState, ProposalMsgType, stateNameDeciding)
 		checkStateMsg(t, sCh, service.PostState, ProposalMsgType, stateNameDeciding)

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -107,7 +107,8 @@ func (p *Provider) InboundMessageHandler() transport.InboundMessageHandler {
 		// find the service which accepts the message type
 		for _, svc := range p.services {
 			if svc.Accept(msg.Header.Type) {
-				return svc.HandleInbound(msg)
+				_, err = svc.HandleInbound(msg)
+				return err
 			}
 		}
 		return fmt.Errorf("no message handlers found for the message type: %s", msg.Header.Type)

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
@@ -69,23 +70,23 @@ func TestNewProvider(t *testing.T) {
 			AcceptFunc: func(msgType string) bool {
 				return msgType == "valid-message-type"
 			},
-			HandleFunc: func(msg *service.DIDCommMsg) error {
+			HandleFunc: func(msg *service.DIDCommMsg) (string, error) {
 				payload := &struct {
 					Label string `json:"label,omitempty"`
 				}{}
 
 				err := json.Unmarshal(msg.Payload, payload)
 				if err != nil {
-					return fmt.Errorf("invalid payload data format: %w", err)
+					return "", fmt.Errorf("invalid payload data format: %w", err)
 				}
 
 				for _, label := range []string{"Carol"} {
 					if label == payload.Label {
-						return errors.New("error handling the message")
+						return "", errors.New("error handling the message")
 					}
 				}
 
-				return nil
+				return uuid.New().String(), nil
 			},
 		}))
 		require.NoError(t, err)

--- a/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package protocol
 
 import (
+	"github.com/google/uuid"
+
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/didstore"
@@ -23,7 +25,7 @@ import (
 // MockDIDExchangeSvc mock did exchange service
 type MockDIDExchangeSvc struct {
 	ProtocolName             string
-	HandleFunc               func(*service.DIDCommMsg) error
+	HandleFunc               func(*service.DIDCommMsg) (string, error)
 	AcceptFunc               func(string) bool
 	RegisterActionEventErr   error
 	UnregisterActionEventErr error
@@ -32,11 +34,11 @@ type MockDIDExchangeSvc struct {
 }
 
 // HandleInbound msg
-func (m *MockDIDExchangeSvc) HandleInbound(msg *service.DIDCommMsg) error {
+func (m *MockDIDExchangeSvc) HandleInbound(msg *service.DIDCommMsg) (string, error) {
 	if m.HandleFunc != nil {
 		return m.HandleFunc(msg)
 	}
-	return nil
+	return uuid.New().String(), nil
 }
 
 // Accept msg checks the msg type

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -138,29 +138,17 @@ func (c *Operation) ReceiveInvitation(rw http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	err = c.client.HandleInvitation(request.Invitation)
+	connectionID, err := c.client.HandleInvitation(request.Invitation)
 	if err != nil {
 		c.writeGenericError(rw, err)
 		return
 	}
 
-	// TODO https://github.com/hyperledger/aries-framework-go/issues/537 Return Connection data
-	sampleResponse := models.ReceiveInvitationResponse{
-		ConnectionID:  "f52024c4-04e7-4aeb-8486-1040155c6764",
-		DID:           "TAaW9Dmxa93B8e5x6iLwFJ",
-		State:         "requested",
-		CreateTime:    time.Now(),
-		UpdateTime:    time.Now(),
-		Accept:        "auto",
-		Initiator:     "external",
-		InvitationKey: "none",
-		InviterLabel:  "other party",
-		Mode:          "none",
-		RequestID:     "678ad4b6-4e2b-40a1-804e-8ba504945e26",
-		RoutingState:  "none",
+	resp := models.ReceiveInvitationResponse{
+		ConnectionID: connectionID,
 	}
 
-	c.writeResponse(rw, sampleResponse)
+	c.writeResponse(rw, resp)
 }
 
 // AcceptInvitation swagger:route POST /connections/{id}/accept-invitation did-exchange acceptInvitation

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 
@@ -118,10 +119,6 @@ func TestOperation_ReceiveInvitation(t *testing.T) {
 	// verify response
 	require.NotEmpty(t, response)
 	require.NotEmpty(t, response.ConnectionID)
-	require.NotEmpty(t, response.CreateTime)
-	require.NotEmpty(t, response.UpdateTime)
-	require.NotEmpty(t, response.RequestID)
-	require.NotEmpty(t, response.DID)
 }
 
 func TestOperation_QueryConnectionByID(t *testing.T) {
@@ -349,8 +346,8 @@ func getHandler(t *testing.T, lookup string, handleErr error) operation.Handler 
 	svc, err := New(&mockprovider.Provider{
 		ServiceValue: &protocol.MockDIDExchangeSvc{
 			ProtocolName: "mockProtocolSvc",
-			HandleFunc: func(msg *service.DIDCommMsg) error {
-				return handleErr
+			HandleFunc: func(msg *service.DIDCommMsg) (string, error) {
+				return uuid.New().String(), handleErr
 			},
 		},
 		KMSValue:             &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
@@ -435,7 +432,7 @@ func TestServiceEvents(t *testing.T) {
 	msg, err := service.NewDIDCommMsg(request)
 	require.NoError(t, err)
 
-	err = didExSvc.HandleInbound(msg)
+	_, err = didExSvc.HandleInbound(msg)
 	require.NoError(t, err)
 
 	cid := <-connID

--- a/test/bdd/agent_controller_steps.go
+++ b/test/bdd/agent_controller_steps.go
@@ -199,6 +199,9 @@ func (a *AgentWithControllerSteps) receiveInvitation(inviteeAgentID, inviterAgen
 		return fmt.Errorf("failed to get valid payload from receive invitation call for agent [%s]", inviteeAgentID)
 	}
 
+	// invitee connectionID
+	a.connectionIDs[inviteeAgentID] = result.ConnectionID
+
 	return nil
 }
 
@@ -211,6 +214,9 @@ func (a *AgentWithControllerSteps) approveRequest(agentID string) error {
 
 	// wait to receive action event
 	connectionID := <-ch
+
+	// inviter connectionID
+	a.connectionIDs[agentID] = connectionID
 
 	controllerURL, ok := a.controllerURLs[agentID]
 	if !ok {
@@ -229,7 +235,7 @@ func (a *AgentWithControllerSteps) waitForPostEvent(agentID, statesValue string)
 	if err != nil {
 		return fmt.Errorf("wait for post event : %w", err)
 	}
-	a.connectionIDs[agentID] = <-ch
+	<-ch
 
 	return nil
 }

--- a/test/bdd/context.go
+++ b/test/bdd/context.go
@@ -23,6 +23,8 @@ type Context struct {
 	PostStatesFlag     map[string]map[string]chan bool
 	ConnectionID       map[string]string
 	Args               map[string]string
+	Role               map[string]string
+	RoleMu             sync.RWMutex
 	sync.RWMutex
 }
 
@@ -36,6 +38,7 @@ func NewContext() (*Context, error) {
 		ConnectionID:       make(map[string]string),
 		AgentCtx:           make(map[string]*context.Provider),
 		Args:               make(map[string]string),
+		Role:               make(map[string]string),
 	}
 	return &instance, nil
 }


### PR DESCRIPTION
- Support to return ID in HandleInbound API for correlating messages

Closes #537 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
