### PR TITLE
refactor: Automatic detection for decoding of VC and VP

### DIFF
--- a/pkg/doc/verifiable/common.go
+++ b/pkg/doc/verifiable/common.go
@@ -13,20 +13,6 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-// jwtDecoding defines if to decode VC from JWT
-type jwtDecoding int
-
-const (
-	// noJwtDecoding not a JWT
-	noJwtDecoding jwtDecoding = iota
-
-	// jwsDecoding indicated to unmarshal from Signed Token
-	jwsDecoding
-
-	// unsecuredJWTDecoding indicates to unmarshal from Unsecured Token
-	unsecuredJWTDecoding
-)
-
 // JWSAlgorithm defines JWT signature algorithms of Verifiable Credential
 type JWSAlgorithm int
 

--- a/pkg/doc/verifiable/jws.go
+++ b/pkg/doc/verifiable/jws.go
@@ -6,7 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 package verifiable
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/square/go-jose/v3"
 	"github.com/square/go-jose/v3/jwt"
@@ -58,4 +61,23 @@ func verifyJWTSignature(token *jwt.JSONWebToken, fetcher PublicKeyFetcher, issue
 		return fmt.Errorf("verify JWT signature: %w", err)
 	}
 	return nil
+}
+
+func isJWS(data []byte) bool {
+	parts := strings.Split(string(data), ".")
+
+	isValidJSON := func(s string) bool {
+		b, err := base64.RawURLEncoding.DecodeString(s)
+		if err != nil {
+			return false
+		}
+		var j map[string]interface{}
+		err = json.Unmarshal(b, &j)
+		return err == nil
+	}
+
+	return len(parts) == 3 &&
+		isValidJSON(parts[0]) &&
+		isValidJSON(parts[1]) &&
+		parts[2] != ""
 }

--- a/pkg/doc/verifiable/jws_test.go
+++ b/pkg/doc/verifiable/jws_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifiable
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_isJWS(t *testing.T) {
+	b64 := base64.RawURLEncoding.EncodeToString([]byte("not json"))
+	j, err := json.Marshal(map[string]string{"alg": "none"})
+	require.NoError(t, err)
+	jb64 := base64.RawURLEncoding.EncodeToString(j)
+
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "two parts only",
+			args: args{[]byte("two parts.only")},
+			want: false,
+		},
+		{
+			name: "empty third part",
+			args: args{[]byte("empty third.part.")},
+			want: false,
+		},
+		{
+			name: "part 1 is not base64 decoded",
+			args: args{[]byte("not base64.part2.part3")},
+			want: false,
+		},
+		{
+			name: "part 1 is not JSON",
+			args: args{[]byte(fmt.Sprintf("%s.part2.part3", b64))},
+			want: false,
+		},
+		{
+			name: "part 2 is not base64 decoded",
+			args: args{[]byte(fmt.Sprintf("%s.not base64.part3", jb64))},
+			want: false,
+		},
+		{
+			name: "part 2 is not JSON",
+			args: args{[]byte(fmt.Sprintf("%s.%s.part3", jb64, b64))},
+			want: false,
+		},
+		{
+			name: "is JWS",
+			args: args{[]byte(fmt.Sprintf("%s.%s.signature", jb64, jb64))},
+			want: true,
+		},
+	}
+	for i := range tests {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isJWS(tt.args.data); got != tt.want {
+				t.Errorf("isJWS() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/doc/verifiable/jwt_unsecured.go
+++ b/pkg/doc/verifiable/jwt_unsecured.go
@@ -67,3 +67,22 @@ func unmarshalUnsecuredJWT(rawJWT []byte) (joseHeaders map[string]string, bytesC
 
 	return headers, bytesPayload, nil
 }
+
+func isJWTUnsecured(data []byte) bool {
+	parts := strings.Split(string(data), ".")
+
+	isValidJSON := func(s string) bool {
+		b, err := base64.RawURLEncoding.DecodeString(s)
+		if err != nil {
+			return false
+		}
+		var j map[string]interface{}
+		err = json.Unmarshal(b, &j)
+		return err == nil
+	}
+
+	return len(parts) == 3 &&
+		isValidJSON(parts[0]) &&
+		isValidJSON(parts[1]) &&
+		parts[2] == ""
+}

--- a/pkg/doc/verifiable/jwt_unsecured_test.go
+++ b/pkg/doc/verifiable/jwt_unsecured_test.go
@@ -86,3 +86,63 @@ func TestUnmarshalUnsecuredJWT(t *testing.T) {
 		require.Contains(t, err.Error(), "unmarshal JSON-based JWT claims")
 	})
 }
+
+func Test_isJWTUnsecured(t *testing.T) {
+	b64 := base64.RawURLEncoding.EncodeToString([]byte("not json"))
+	j, err := json.Marshal(map[string]string{"alg": "none"})
+	require.NoError(t, err)
+	jb64 := base64.RawURLEncoding.EncodeToString(j)
+
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "two parts only",
+			args: args{[]byte("two parts.only")},
+			want: false,
+		},
+		{
+			name: "not empty third part",
+			args: args{[]byte("third.part.not-empty")},
+			want: false,
+		},
+		{
+			name: "part 1 is not base64 decoded",
+			args: args{[]byte("not base64.part2.part3")},
+			want: false,
+		},
+		{
+			name: "part 1 is not JSON",
+			args: args{[]byte(fmt.Sprintf("%s.part2.part3", b64))},
+			want: false,
+		},
+		{
+			name: "part 2 is not base64 decoded",
+			args: args{[]byte(fmt.Sprintf("%s.not base64.part3", jb64))},
+			want: false,
+		},
+		{
+			name: "part 2 is not JSON",
+			args: args{[]byte(fmt.Sprintf("%s.%s.part3", jb64, b64))},
+			want: false,
+		},
+		{
+			name: "is JWT unsecured",
+			args: args{[]byte(fmt.Sprintf("%s.%s.", jb64, jb64))},
+			want: true,
+		},
+	}
+	for i := range tests {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isJWTUnsecured(tt.args.data); got != tt.want {
+				t.Errorf("isJWTUnsecured() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
+++ b/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
@@ -126,7 +126,7 @@ func encodeVCToJWTUnsecured(vcBytes []byte) {
 func decodeVCJWTToJSON(vcBytes []byte, publicKey interface{}) {
 	// Asked to decode JWT
 	credential, err := verifiable.NewCredential(vcBytes,
-		verifiable.WithJWSDecoding(func(issuerID, keyID string) (interface{}, error) {
+		verifiable.WithPublicKeyFetcher(func(issuerID, keyID string) (interface{}, error) {
 			return publicKey, nil
 		}))
 	if err != nil {


### PR DESCRIPTION
Automatic detection of decoding of Verifiable Credential and Verifiable Presentation.

A user is not obligated to explicitly define the nature of input bytes when creating new VC or VP.

closes #514

Signed-off-by: Dima <dkinoshenko@gmail.com>