### PR TITLE
refactor: Accept Invitation API - Return error message

### DIFF
--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/gorilla/mux"
 
@@ -163,23 +162,7 @@ func (c *Operation) AcceptInvitation(rw http.ResponseWriter, req *http.Request) 
 	params := mux.Vars(req)
 	logger.Debugf("Accepting connection invitation for id[%s]", params["id"])
 
-	// TODO https://github.com/hyperledger/aries-framework-go/issues/550 Support for AcceptInvitation API
-	response := models.AcceptInvitationResponse{
-		ConnectionID:  params["id"],
-		DID:           "TAaW9Dmxa93B8e5x6iLwFJ",
-		State:         "requested",
-		CreateTime:    time.Now(),
-		UpdateTime:    time.Now(),
-		Accept:        "auto",
-		Initiator:     "external",
-		InvitationKey: "none",
-		InviterLabel:  "other party",
-		Mode:          "none",
-		RequestID:     "678ad4b6-4e2b-40a1-804e-8ba504945e26",
-		RoutingState:  "none",
-	}
-
-	c.writeResponse(rw, response)
+	c.writeGenericError(rw, errors.New("please use receive invitation API to save and approve invitation"))
 }
 
 // AcceptExchangeRequest swagger:route POST /connections/{id}/accept-request did-exchange acceptRequest

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -243,17 +243,12 @@ func TestOperation_AcceptInvitation(t *testing.T) {
 	buf, err := getResponseFromHandler(handler, bytes.NewBuffer([]byte("test-id")), operationID+"/1111/accept-invitation")
 	require.NoError(t, err)
 
-	response := models.AcceptInvitationResponse{}
+	response := models.GenericError{}
 	err = json.Unmarshal(buf.Bytes(), &response)
 	require.NoError(t, err)
 
-	// verify response
 	require.NotEmpty(t, response)
-	require.NotEmpty(t, response.ConnectionID)
-	require.NotEmpty(t, response.CreateTime)
-	require.NotEmpty(t, response.UpdateTime)
-	require.NotEmpty(t, response.RequestID)
-	require.NotEmpty(t, response.DID)
+	require.Equal(t, "please use receive invitation API to save and approve invitation", response.Body.Message)
 }
 
 func TestOperation_AcceptExchangeRequest(t *testing.T) {


### PR DESCRIPTION
- The Recieve Invitation API saves and approves the invitation recieved. Updated Accept Invitation API to return error message.

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
