### PR TITLE
feat: Add support for public dids in did-exchange protocol

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -22,6 +22,14 @@ import (
 const (
 	// ConnectionID connection id is created to retriever connection record from db
 	ConnectionID = didexchange.ConnectionID
+	// InvitationMsgType defines the did-exchange invite message type.
+	InvitationMsgType = didexchange.InvitationMsgType
+	// RequestMsgType defines the did-exchange request message type.
+	RequestMsgType = didexchange.RequestMsgType
+	// ResponseMsgType defines the did-exchange response message type.
+	ResponseMsgType = didexchange.ResponseMsgType
+	// AckMsgType defines the did-exchange ack message type.
+	AckMsgType = didexchange.AckMsgType
 )
 
 // ErrConnectionNotFound is returned when connection not found

--- a/pkg/didcomm/common/service/event.go
+++ b/pkg/didcomm/common/service/event.go
@@ -55,7 +55,7 @@ type DIDCommAction struct {
 	Message *DIDCommMsg
 
 	// Continue function to be called by the consumer for further processing the message.
-	Continue func()
+	Continue func(args interface{})
 
 	// Stop invocation notifies the service that the consumer action event processing has failed or the consumer wants
 	// to stop the processing.
@@ -102,8 +102,12 @@ type Event interface {
 //	go service.AutoExecuteActionEvent(actionCh)
 func AutoExecuteActionEvent(ch chan DIDCommAction) error {
 	for msg := range ch {
-		msg.Continue()
+		msg.Continue(&Empty{})
 	}
 
 	return nil
+}
+
+// Empty is used if there are no arguments to Continue
+type Empty struct {
 }

--- a/pkg/didcomm/common/service/event_test.go
+++ b/pkg/didcomm/common/service/event_test.go
@@ -21,7 +21,7 @@ func TestAutoExecuteActionEvent(t *testing.T) {
 		close(done)
 	}()
 
-	ch <- DIDCommAction{Continue: func() {
+	ch <- DIDCommAction{Continue: func(args interface{}) {
 	}}
 
 	close(ch)

--- a/pkg/didcomm/protocol/introduce/service.go
+++ b/pkg/didcomm/protocol/introduce/service.go
@@ -282,7 +282,7 @@ func (s *Service) sendActionEvent(msg *metaData, aEvent chan<- service.DIDCommAc
 	aEvent <- service.DIDCommAction{
 		ProtocolName: Introduce,
 		Message:      msg.Msg.Clone(),
-		Continue: func() {
+		Continue: func(args interface{}) {
 			s.processCallback(msg)
 		},
 		Stop: func(err error) {

--- a/pkg/didcomm/protocol/introduce/service_test.go
+++ b/pkg/didcomm/protocol/introduce/service_test.go
@@ -413,7 +413,7 @@ func TestService_HandleInbound(t *testing.T) {
 		select {
 		case res := <-ch:
 			// TODO: need to check `Continue` function after implantation `processCallback`
-			res.Continue()
+			res.Continue(&service.Empty{})
 		case <-time.After(time.Second):
 			t.Error("timeout")
 		}
@@ -790,7 +790,7 @@ func continueAction(t *testing.T, ch chan service.DIDCommAction, action string) 
 	select {
 	case res := <-ch:
 		require.Equal(t, action, res.Message.Header.Type)
-		res.Continue()
+		res.Continue(&service.Empty{})
 
 		return
 	case <-time.After(time.Second):

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -392,6 +392,15 @@ func (c *Operation) handleActionEvents(e service.DIDCommAction) error {
 	case didexchange.Event:
 		props := v
 
+		// TODO: Updated #692 to match the functionality added in this PR to RestAPI. Currently there is a mismatch
+		//  between SDK client and RestAPI client. In case of SDK client, the consumer would need to approve invitation
+		//  and exchange request. But at the moment (due to this internally calling continue for invitation action item),
+		//  RestAPI would need approval only for exchange request.
+		if e.Message.Header.Type == didexchange.InvitationMsgType {
+			e.Continue(&service.Empty{})
+			return nil
+		}
+
 		err := c.sendConnectionNotification(props.ConnectionID(), "null")
 		if err != nil {
 			return fmt.Errorf("send connection notification failed : %w", err)

--- a/test/bdd/features/didexchange_e2e_sdk.feature
+++ b/test/bdd/features/didexchange_e2e_sdk.feature
@@ -18,6 +18,7 @@ Feature: Decentralized Identifier(DID) exchange between the agents using SDK
     And   "Bob" registers to receive notification for post state event "completed"
     And   "Alice" creates invitation
     And   "Bob" receives invitation from "Alice"
+    And   "Bob" approves invitation request
     And   "Alice" approves did exchange request
     And   "Alice" waits for post state event "completed"
     And   "Bob" waits for post state event "completed"

--- a/test/bdd/features/didexchange_public_did.feature
+++ b/test/bdd/features/didexchange_public_did.feature
@@ -8,7 +8,7 @@
 @all
 Feature: Decentralized Identifier(DID) exchange between the agents using public did in invitation
 
-  @didexchange_public_did
+  @didexchange_public_dids
   Scenario: did exchange e2e flow using public DID in invitation
     Given "Maria" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
     And   "Maria" creates public DID using sidetree "${SIDETREE_URL}"
@@ -17,12 +17,36 @@ Feature: Decentralized Identifier(DID) exchange between the agents using public 
     And   "Maria" creates did exchange client
     And   "Maria" registers to receive notification for post state event "completed"
     Given "Lisa" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+    And   "Lisa" creates public DID using sidetree "${SIDETREE_URL}"
+    # we wait until observer polls sidetree txn
+    Then  "Lisa" waits for public did to become available in sidetree for up to 10 seconds
     And   "Lisa" creates did exchange client
     And   "Lisa" registers to receive notification for post state event "completed"
     And   "Maria" creates invitation with public DID
     And   "Lisa" receives invitation from "Maria"
+    And   "Lisa" approves invitation request
     And   "Maria" approves did exchange request
     And   "Maria" waits for post state event "completed"
     And   "Lisa" waits for post state event "completed"
     And   "Maria" retrieves connection record and validates that connection state is "completed"
     And   "Lisa" retrieves connection record and validates that connection state is "completed"
+
+  @didexchange_mixed_public_and_peer_dids
+  Scenario: did exchange e2e flow using public DID in invitation
+    Given "Julia" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+    And   "Julia" creates public DID using sidetree "${SIDETREE_URL}"
+    # we wait until observer polls sidetree txn
+    Then  "Julia" waits for public did to become available in sidetree for up to 10 seconds
+    And   "Julia" creates did exchange client
+    And   "Julia" registers to receive notification for post state event "completed"
+    Given "Kate" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+    And   "Kate" creates did exchange client
+    And   "Kate" registers to receive notification for post state event "completed"
+    And   "Julia" creates invitation with public DID
+    And   "Kate" receives invitation from "Julia"
+    And   "Kate" approves invitation request
+    And   "Julia" approves did exchange request
+    And   "Julia" waits for post state event "completed"
+    And   "Kate" waits for post state event "completed"
+    And   "Julia" retrieves connection record and validates that connection state is "completed"
+    And   "Kate" retrieves connection record and validates that connection state is "completed"


### PR DESCRIPTION
Currently we support "peer" DIDs in exchange request and response. We should also support public dids.

Closes #561

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>
