### PR TITLE
fix: Query connection not returning transient data

### DIFF
--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -533,7 +533,7 @@ func TestSendConnectionNotification(t *testing.T) {
 	connBytes, err := json.Marshal(connRec)
 	require.NoError(t, err)
 	require.NoError(t, storeProv.Store.Put("conn_id1", connBytes))
-	require.NoError(t, storeProv.Store.Put("conn_id1"+"completed", connBytes))
+	require.NoError(t, storeProv.Store.Put("connstate_id1"+"completed", connBytes))
 
 	t.Run("send notification success", func(t *testing.T) {
 		op, err := New(&mockprovider.Provider{


### PR DESCRIPTION
- Add transient db search in query connection function
- Implement iterator in mem storage

Closes #722 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
