### PR TITLE
feat: Add thread decorator in the exchange request and sign the exchange response with Invitation RecipientKeys

### DIFF
--- a/pkg/didcomm/protocol/decorator/decorator.go
+++ b/pkg/didcomm/protocol/decorator/decorator.go
@@ -10,7 +10,8 @@ import "time"
 
 // Thread thread data
 type Thread struct {
-	ID string `json:"thid,omitempty"`
+	ID  string `json:"thid,omitempty"`
+	PID string `json:"pthid"`
 }
 
 // Timing keeps expiration time

--- a/pkg/didcomm/protocol/didexchange/models.go
+++ b/pkg/didcomm/protocol/didexchange/models.go
@@ -45,10 +45,11 @@ type Invitation struct {
 // Request defines a2a DID exchange request
 // https://github.com/hyperledger/aries-rfcs/tree/master/features/0023-did-exchange#1-exchange-request
 type Request struct {
-	Type       string      `json:"@type,omitempty"`
-	ID         string      `json:"@id,omitempty"`
-	Label      string      `json:"label,omitempty"`
-	Connection *Connection `json:"connection,omitempty"`
+	Type       string            `json:"@type,omitempty"`
+	ID         string            `json:"@id,omitempty"`
+	Label      string            `json:"label,omitempty"`
+	Connection *Connection       `json:"connection,omitempty"`
+	Thread     *decorator.Thread `json:"~thread,omitempty"`
 }
 
 // Response defines a2a DID exchange response

--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -236,7 +236,7 @@ func (s *Service) handle(msg *message, aEvent chan<- service.DIDCommAction) erro
 			Type:         service.PreState,
 			Msg:          msg.Msg.Clone(),
 			StateID:      next.Name(),
-			Properties:   createEventProperties(msg.ConnRecord.ConnectionID, ""),
+			Properties:   createEventProperties(msg.ConnRecord.ConnectionID, msg.ConnRecord.InvitationID),
 		})
 		logger.Debugf("sent pre event for state %s", next.Name())
 
@@ -353,7 +353,7 @@ func (s *Service) sendActionEvent(internalMsg *message, aEvent chan<- service.DI
 			internalMsg.err = err
 			s.processCallback(internalMsg)
 		},
-		Properties: createEventProperties(internalMsg.ConnRecord.ConnectionID, ""),
+		Properties: createEventProperties(internalMsg.ConnRecord.ConnectionID, internalMsg.ConnRecord.InvitationID),
 	}
 
 	return nil
@@ -546,13 +546,18 @@ func (s *Service) invitationMsgRecord(msg *service.DIDCommMsg) (*ConnectionRecor
 		return nil, err
 	}
 
+	recKey, err := s.ctx.getInvitationRecipientKey(invitation)
+	if err != nil {
+		return nil, err
+	}
+
 	connRecord := &ConnectionRecord{
 		ConnectionID:    generateRandomID(),
 		ThreadID:        thID,
 		State:           stateNameNull,
 		InvitationID:    invitation.ID,
 		ServiceEndPoint: invitation.ServiceEndpoint,
-		RecipientKeys:   invitation.RecipientKeys,
+		RecipientKeys:   []string{recKey},
 		TheirLabel:      invitation.Label,
 		Namespace:       findNameSpace(msg.Header.Type),
 	}

--- a/pkg/internal/mock/vdr/didcreator/mock_creator.go
+++ b/pkg/internal/mock/vdr/didcreator/mock_creator.go
@@ -48,6 +48,12 @@ func createDefaultDID() *did.Doc {
 		panic(err)
 	}
 
+	service := did.Service{
+		ID:              "did:example:123456789abcdefghi#did-communication",
+		Type:            "did-communication",
+		ServiceEndpoint: "https://agent.example.com/",
+	}
+
 	signingKey := did.PublicKey{
 		ID:         creator,
 		Type:       keyType,
@@ -61,6 +67,7 @@ func createDefaultDID() *did.Doc {
 		Context:   []string{didContext},
 		ID:        didID,
 		PublicKey: []did.PublicKey{signingKey},
+		Service:   []did.Service{service},
 		Created:   &createdTime,
 	}
 }


### PR DESCRIPTION
closes #676 
closes #728 
 
Signed-off-by: talwinder.kaur <talwinder.kaur@securekey.com>

