### PR TITLE
feat: DIDExchange RestAPI - Update state name for action callback and Support for Accept Invitation

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -60,6 +60,9 @@ type protocolService interface {
 
 	// Accepts/Approves exchange request
 	AcceptExchangeRequest(connectionID string) error
+
+	// Accepts/Approves exchange invitation
+	AcceptInvitation(connectionID string) error
 }
 
 // New return new instance of didexchange client
@@ -152,6 +155,17 @@ func (c *Client) HandleInvitation(invitation *Invitation) (string, error) {
 	}
 
 	return connectionID, nil
+}
+
+// TODO https://github.com/hyperledger/aries-framework-go/issues/754 - e.Continue v Explicit API call for action events
+
+// AcceptInvitation accepts/approves exchange invitation.
+func (c *Client) AcceptInvitation(connectionID string) error {
+	if err := c.didexchangeSvc.AcceptInvitation(connectionID); err != nil {
+		return fmt.Errorf("did exchange client - accept exchange invitation: %w", err)
+	}
+
+	return nil
 }
 
 // AcceptExchangeRequest accepts/approves exchange request.

--- a/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
@@ -111,6 +111,11 @@ func (m *MockDIDExchangeSvc) AcceptExchangeRequest(connectionID string) error {
 	return nil
 }
 
+// AcceptInvitation accepts/approves exchange invitation.
+func (m *MockDIDExchangeSvc) AcceptInvitation(connectionID string) error {
+	return nil
+}
+
 // MockProvider is provider for DIDExchange Service
 type MockProvider struct {
 	StoreProvider          *mockstore.MockStoreProvider

--- a/pkg/restapi/operation/didexchange/models/invitation.go
+++ b/pkg/restapi/operation/didexchange/models/invitation.go
@@ -143,10 +143,10 @@ type AcceptInvitationRequest struct {
 type AcceptInvitationResponse struct {
 
 	// State of the connection invitation
-	State string `json:"state"`
+	State string `json:"state,omitempty"`
 
 	// Other party's DID
-	InviterDID string `json:"their_did"`
+	InviterDID string `json:"their_did,omitempty"`
 
 	// Created time
 	CreateTime time.Time `json:"created_at,omitempty"`
@@ -155,19 +155,19 @@ type AcceptInvitationResponse struct {
 	Accept string `json:"accept,omitempty"`
 
 	// My DID
-	DID string `json:"my_did"`
+	DID string `json:"my_did,omitempty"`
 
 	// Request ID of invitation response
-	RequestID string `json:"request_id"`
+	RequestID string `json:"request_id,omitempty"`
 
 	// Other party's label
 	InviterLabel string `json:"their_label,omitempty"`
 
 	// Alias
-	Alias string `json:"alias"`
+	Alias string `json:"alias,omitempty"`
 
 	// Other party's role
-	InviterRole string `json:"their_role"`
+	InviterRole string `json:"their_role,omitempty"`
 
 	// Connection invitation initiator
 	Initiator string `json:"initiator,omitempty"`
@@ -185,7 +185,7 @@ type AcceptInvitationResponse struct {
 	InboundConnectionID string `json:"inbound_connection_id,omitempty"`
 
 	// the connection ID of the connection invitation
-	ConnectionID string `json:"connection_id"`
+	ConnectionID string `json:"connection_id,omitempty"`
 
 	// Error message
 	Error string `json:"error_msg,omitempty"`

--- a/test/bdd/features/didexchange_e2e_controller.feature
+++ b/test/bdd/features/didexchange_e2e_controller.feature
@@ -14,6 +14,7 @@ Feature: Decentralized Identifier(DID) exchange between the agents using control
     And "Bob" agent is running on "localhost" port "9081" with controller "http://localhost:9082" and webhook "http://localhost:9083"
     And   "Alice" creates invitation through controller with label "alice-agent"
     And   "Bob" receives invitation from "Alice" through controller
+    And   "Bob" approves exchange invitation
     And   "Alice" approves exchange request
     And   "Alice" waits for post state event "completed" to webhook
     And   "Bob" waits for post state event "completed" to webhook

--- a/test/bdd/webhook/main.go
+++ b/test/bdd/webhook/main.go
@@ -40,12 +40,7 @@ func connections(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 	}
-	if connMsg.State == "null" {
-		// check for action event and log the connectionID
-		logger.Infof("received action event :: connID=%s", connMsg.ConnectionID)
-	} else {
-		logger.Infof("received state transition event :: connID=%s state=%s", connMsg.ConnectionID, connMsg.State)
-	}
+	logger.Infof("received state transition event :: connID=%s state=%s", connMsg.ConnectionID, connMsg.State)
 
 	connectionTopics <- msg
 }


### PR DESCRIPTION
- Currently action events are triggered before updating the state for the incoming message(invited/requested). Moved action event triggering point after state is updated, ie, invited and requested based on agent role (invitee/inviter).
- Added support to Accept Invitation through RestAPI client. Now, RestAPI triggers accept-invitation when it receives "invited" and accept-request on "requested" state from webhook notification.

Closes #690 
Closes #692 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>