### PR TITLE
refactor: Introduce - replace custom mock with gomock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 #
 
 # Exclude any mocks
-mocks/
+gomocks/
 
 # Binaries for programs and plugins
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ license:
 	@scripts/check_license.sh
 
 .PHONY: unit-test
-unit-test: mocks
+unit-test:
+	@make -s mocks
 	@scripts/check_unit.sh
 
 .PHONY: bdd-test
@@ -120,8 +121,8 @@ comma:= ,
 semicolon:= ;
 
 define create_mock
-  mkdir -p $(1)/mocks && rm -rf $(1)/mocks/*
-  $(MOCKGEN) -destination $(1)/mocks/mocks.go -self_package mocks -package mocks $(PROJECT_ROOT)/$(1) $(subst $(semicolon),$(comma),$(2))
+  mkdir -p $(1)/gomocks && rm -rf $(1)/gomocks/*
+  $(MOCKGEN) -destination $(1)/gomocks/mocks.go -self_package mocks -package mocks $(PROJECT_ROOT)/$(1) $(subst $(semicolon),$(comma),$(2))
 endef
 
 build-mockgen:
@@ -130,12 +131,17 @@ build-mockgen:
 .PHONY: mocks
 mocks: build-mockgen
 	$(call create_mock,pkg/client/introduce,Provider)
-	$(call create_mock,pkg/didcomm/protocol/introduce,InvitationEnvelope)
+	$(call create_mock,pkg/didcomm/protocol/introduce,Provider;InvitationEnvelope)
+	$(call create_mock,pkg/didcomm/dispatcher,Outbound)
 	$(call create_mock,pkg/storage,Provider;Store)
 	$(call create_mock,pkg/didcomm/common/service,DIDComm)
 
+.PHONY: clean-mocks
+clean-mocks:
+	@find . -name gomocks -type d -exec rm -r {} +
+
 .PHONY: clean
-clean: clean-fixtures clean-build clean-images
+clean: clean-fixtures clean-build clean-images clean-mocks
 
 .PHONY: clean-images
 clean-images: clean-fixtures

--- a/pkg/client/introduce/client_test.go
+++ b/pkg/client/introduce/client_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/hyperledger/aries-framework-go/pkg/client/introduce/mocks"
+	mocks "github.com/hyperledger/aries-framework-go/pkg/client/introduce/gomocks"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	serviceMocks "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service/mocks"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/introduce"
-	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
-	storageMocks "github.com/hyperledger/aries-framework-go/pkg/storage/mocks"
+	introduceMocks "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/introduce/gomocks"
+	storageMocks "github.com/hyperledger/aries-framework-go/pkg/storage/gomocks"
 )
 
 func TestNew(t *testing.T) {
@@ -81,12 +81,21 @@ func TestClient_handleOutbound(t *testing.T) {
 func TestClient_SendProposal(t *testing.T) {
 	const UUID = "382a7cf8-2c57-4f2f-9359-8ac45b7b4b1f"
 
-	svc, err := introduce.New(&protocol.MockProvider{})
-	require.NoError(t, err)
-	require.NotNil(t, svc)
-
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	store := storageMocks.NewMockStore(ctrl)
+
+	storageProvider := storageMocks.NewMockProvider(ctrl)
+	storageProvider.EXPECT().OpenStore(introduce.Introduce).Return(store, nil).Times(2)
+
+	introduceProvider := introduceMocks.NewMockProvider(ctrl)
+	introduceProvider.EXPECT().StorageProvider().Return(storageProvider)
+	introduceProvider.EXPECT().OutboundDispatcher().Return(nil)
+
+	svc, err := introduce.New(introduceProvider)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
 
 	DIDComm := serviceMocks.NewMockDIDComm(ctrl)
 	DIDComm.EXPECT().HandleOutbound(gomock.Any(), gomock.Any()).Return(nil)
@@ -97,12 +106,7 @@ func TestClient_SendProposal(t *testing.T) {
 			{ServiceEndpoint: "service/endpoint2"},
 		},
 	}
-
-	store := storageMocks.NewMockStore(ctrl)
 	store.EXPECT().Put(invitationEnvelopePrefix+UUID, toBytes(t, opts)).Return(nil)
-
-	storageProvider := storageMocks.NewMockProvider(ctrl)
-	storageProvider.EXPECT().OpenStore(introduce.Introduce).Return(store, nil)
 
 	provider := mocks.NewMockProvider(ctrl)
 	provider.EXPECT().Service(introduce.Introduce).Return(DIDComm, nil)
@@ -118,12 +122,21 @@ func TestClient_SendProposal(t *testing.T) {
 func TestClient_SendProposalWithInvitation(t *testing.T) {
 	const UUID = "382a7cf8-2c57-4f2f-9359-8ac45b7b4b1f"
 
-	svc, err := introduce.New(&protocol.MockProvider{})
-	require.NoError(t, err)
-	require.NotNil(t, svc)
-
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	store := storageMocks.NewMockStore(ctrl)
+
+	storageProvider := storageMocks.NewMockProvider(ctrl)
+	storageProvider.EXPECT().OpenStore(introduce.Introduce).Return(store, nil).Times(2)
+
+	introduceProvider := introduceMocks.NewMockProvider(ctrl)
+	introduceProvider.EXPECT().StorageProvider().Return(storageProvider)
+	introduceProvider.EXPECT().OutboundDispatcher().Return(nil)
+
+	svc, err := introduce.New(introduceProvider)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
 
 	DIDComm := serviceMocks.NewMockDIDComm(ctrl)
 	DIDComm.EXPECT().HandleOutbound(gomock.Any(), gomock.Any()).Return(nil)
@@ -136,12 +149,7 @@ func TestClient_SendProposalWithInvitation(t *testing.T) {
 			ServiceEndpoint: "service/endpoint",
 		}},
 	}
-
-	store := storageMocks.NewMockStore(ctrl)
 	store.EXPECT().Put(invitationEnvelopePrefix+UUID, toBytes(t, opts)).Return(nil)
-
-	storageProvider := storageMocks.NewMockProvider(ctrl)
-	storageProvider.EXPECT().OpenStore(introduce.Introduce).Return(store, nil)
 
 	provider := mocks.NewMockProvider(ctrl)
 	provider.EXPECT().Service(introduce.Introduce).Return(DIDComm, nil)
@@ -157,12 +165,21 @@ func TestClient_SendProposalWithInvitation(t *testing.T) {
 func TestClient_HandleRequest(t *testing.T) {
 	const UUID = "382a7cf8-2c57-4f2f-9359-8ac45b7b4b1f"
 
-	svc, err := introduce.New(&protocol.MockProvider{})
-	require.NoError(t, err)
-	require.NotNil(t, svc)
-
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	store := storageMocks.NewMockStore(ctrl)
+
+	storageProvider := storageMocks.NewMockProvider(ctrl)
+	storageProvider.EXPECT().OpenStore(introduce.Introduce).Return(store, nil).Times(2)
+
+	introduceProvider := introduceMocks.NewMockProvider(ctrl)
+	introduceProvider.EXPECT().StorageProvider().Return(storageProvider)
+	introduceProvider.EXPECT().OutboundDispatcher().Return(nil)
+
+	svc, err := introduce.New(introduceProvider)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
 
 	opts := InvitationEnvelope{
 		Dests: []*service.Destination{
@@ -170,12 +187,7 @@ func TestClient_HandleRequest(t *testing.T) {
 			{ServiceEndpoint: "service/endpoint2"},
 		},
 	}
-
-	store := storageMocks.NewMockStore(ctrl)
 	store.EXPECT().Put(invitationEnvelopePrefix+UUID, toBytes(t, opts)).Return(nil)
-
-	storageProvider := storageMocks.NewMockProvider(ctrl)
-	storageProvider.EXPECT().OpenStore(introduce.Introduce).Return(store, nil)
 
 	provider := mocks.NewMockProvider(ctrl)
 	provider.EXPECT().Service(introduce.Introduce).Return(serviceMocks.NewMockDIDComm(ctrl), nil)
@@ -200,10 +212,6 @@ func TestClient_HandleRequest(t *testing.T) {
 
 func TestClient_HandleRequestWithInvitation(t *testing.T) {
 	const UUID = "382a7cf8-2c57-4f2f-9359-8ac45b7b4b1f"
-
-	svc, err := introduce.New(&protocol.MockProvider{})
-	require.NoError(t, err)
-	require.NotNil(t, svc)
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -248,12 +256,21 @@ func TestClient_HandleRequestWithInvitation(t *testing.T) {
 func TestClient_InvitationEnvelope(t *testing.T) {
 	const UUID = "382a7cf8-2c57-4f2f-9359-8ac45b7b4b1f"
 
-	svc, err := introduce.New(&protocol.MockProvider{})
-	require.NoError(t, err)
-	require.NotNil(t, svc)
-
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	store := storageMocks.NewMockStore(ctrl)
+
+	storageProvider := storageMocks.NewMockProvider(ctrl)
+	storageProvider.EXPECT().OpenStore(introduce.Introduce).Return(store, nil).Times(2)
+
+	introduceProvider := introduceMocks.NewMockProvider(ctrl)
+	introduceProvider.EXPECT().StorageProvider().Return(storageProvider)
+	introduceProvider.EXPECT().OutboundDispatcher().Return(nil)
+
+	svc, err := introduce.New(introduceProvider)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
 
 	opts := InvitationEnvelope{
 		Inv: &didexchange.Invitation{
@@ -263,14 +280,9 @@ func TestClient_InvitationEnvelope(t *testing.T) {
 			ServiceEndpoint: "service/endpoint",
 		}},
 	}
-
-	store := storageMocks.NewMockStore(ctrl)
 	store.EXPECT().Get(invitationEnvelopePrefix+UUID).Return(toBytes(t, opts), nil).Times(1)
 	store.EXPECT().Get(invitationEnvelopePrefix+UUID).Return(nil, errors.New("error")).Times(1)
 	store.EXPECT().Get(invitationEnvelopePrefix+UUID).Return([]byte(`[]`), nil).Times(1)
-
-	storageProvider := storageMocks.NewMockProvider(ctrl)
-	storageProvider.EXPECT().OpenStore(introduce.Introduce).Return(store, nil)
 
 	provider := mocks.NewMockProvider(ctrl)
 	provider.EXPECT().Service(introduce.Introduce).Return(serviceMocks.NewMockDIDComm(ctrl), nil)
@@ -298,12 +310,21 @@ func TestClient_InvitationEnvelope(t *testing.T) {
 func TestClient_SendRequest(t *testing.T) {
 	const UUID = "382a7cf8-2c57-4f2f-9359-8ac45b7b4b1f"
 
-	svc, err := introduce.New(&protocol.MockProvider{})
-	require.NoError(t, err)
-	require.NotNil(t, svc)
-
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	store := storageMocks.NewMockStore(ctrl)
+
+	storageProvider := storageMocks.NewMockProvider(ctrl)
+	storageProvider.EXPECT().OpenStore(introduce.Introduce).Return(store, nil).Times(2)
+
+	introduceProvider := introduceMocks.NewMockProvider(ctrl)
+	introduceProvider.EXPECT().StorageProvider().Return(storageProvider)
+	introduceProvider.EXPECT().OutboundDispatcher().Return(nil)
+
+	svc, err := introduce.New(introduceProvider)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
 
 	DIDComm := serviceMocks.NewMockDIDComm(ctrl)
 	DIDComm.EXPECT().HandleOutbound(gomock.Any(), gomock.Any()).Return(nil)
@@ -313,13 +334,8 @@ func TestClient_SendRequest(t *testing.T) {
 			ServiceEndpoint: "service/endpoint",
 		}},
 	}
-
-	store := storageMocks.NewMockStore(ctrl)
 	store.EXPECT().Put(invitationEnvelopePrefix+UUID, toBytes(t, opts)).Return(nil).Times(1)
 	store.EXPECT().Put(invitationEnvelopePrefix+UUID, toBytes(t, opts)).Return(errors.New("test error")).Times(1)
-
-	storageProvider := storageMocks.NewMockProvider(ctrl)
-	storageProvider.EXPECT().OpenStore(introduce.Introduce).Return(store, nil)
 
 	provider := mocks.NewMockProvider(ctrl)
 	provider.EXPECT().Service(introduce.Introduce).Return(DIDComm, nil)

--- a/pkg/didcomm/protocol/introduce/states_test.go
+++ b/pkg/didcomm/protocol/introduce/states_test.go
@@ -9,10 +9,11 @@ package introduce
 import (
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
-	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
+	dispatcherMocks "github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher/gomocks"
 )
 
 func notTransition(t *testing.T, st state) {
@@ -35,14 +36,20 @@ func TestNoopState(t *testing.T) {
 }
 
 func TestNoOpState_ExecuteInbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
 	followup, err := (&noOp{}).ExecuteInbound(ctx, &metaData{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
 
 func TestNoOpState_ExecuteOutbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
 	followup, err := (&noOp{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
@@ -66,14 +73,20 @@ func TestStartState(t *testing.T) {
 }
 
 func TestStartState_ExecuteInbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
 	followup, err := (&start{}).ExecuteInbound(ctx, &metaData{})
 	require.NoError(t, err)
 	require.Equal(t, &arranging{}, followup)
 }
 
 func TestStartState_ExecuteOutbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
 	followup, err := (&start{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
 	require.NoError(t, err)
 	require.Equal(t, &noOp{}, followup)
@@ -87,14 +100,20 @@ func TestDoneState(t *testing.T) {
 }
 
 func TestDoneState_ExecuteInbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
 	followup, err := (&done{}).ExecuteInbound(ctx, &metaData{})
 	require.NoError(t, err)
 	require.Equal(t, &noOp{}, followup)
 }
 
 func TestDoneState_ExecuteOutbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
 	followup, err := (&done{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
@@ -118,14 +137,26 @@ func TestArrangingState(t *testing.T) {
 }
 
 func TestArrangingState_ExecuteInbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dispatcher := dispatcherMocks.NewMockOutbound(ctrl)
+	dispatcher.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	ctx := internalContext{Outbound: dispatcher}
 	followup, err := (&arranging{}).ExecuteInbound(ctx, &metaData{})
 	require.NoError(t, err)
 	require.Equal(t, &noOp{}, followup)
 }
 
 func TestArrangingState_ExecuteOutbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dispatcher := dispatcherMocks.NewMockOutbound(ctrl)
+	dispatcher.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	ctx := internalContext{Outbound: dispatcher}
 	followup, err := (&arranging{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
 	require.NoError(t, err)
 	require.Equal(t, &noOp{}, followup)
@@ -149,14 +180,20 @@ func TestDeliveringState(t *testing.T) {
 }
 
 func TestDeliveringState_ExecuteInbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
 	followup, err := (&delivering{}).ExecuteInbound(ctx, &metaData{})
 	require.NoError(t, err)
 	require.Equal(t, &done{}, followup)
 }
 
 func TestDeliveringState_ExecuteOutbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
 	followup, err := (&delivering{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
@@ -180,14 +217,20 @@ func TestConfirmingState(t *testing.T) {
 }
 
 func TestConfirmingState_ExecuteInbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
 	followup, err := (&confirming{}).ExecuteInbound(ctx, &metaData{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
 
 func TestConfirmingState_ExecuteOutbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
 	followup, err := (&confirming{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
@@ -211,14 +254,20 @@ func TestAbandoningState(t *testing.T) {
 }
 
 func TestAbandoningState_ExecuteInbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
 	followup, err := (&abandoning{}).ExecuteInbound(ctx, &metaData{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
 
 func TestAbandoningState_ExecuteOutbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
 	followup, err := (&abandoning{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
@@ -242,14 +291,23 @@ func TestDecidingState(t *testing.T) {
 }
 
 func TestDecidingState_ExecuteInbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dispatcher := dispatcherMocks.NewMockOutbound(ctrl)
+	dispatcher.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	ctx := internalContext{Outbound: dispatcher}
 	followup, err := (&deciding{}).ExecuteInbound(ctx, &metaData{})
 	require.NoError(t, err)
 	require.Equal(t, &waiting{}, followup)
 }
 
 func TestDecidingState_ExecuteOutbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
 	followup, err := (&deciding{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
@@ -273,14 +331,20 @@ func TestWaitingState(t *testing.T) {
 }
 
 func TestWaitingState_ExecuteInbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
 	followup, err := (&waiting{}).ExecuteInbound(ctx, &metaData{})
 	require.NoError(t, err)
 	require.Equal(t, &noOp{}, followup)
 }
 
 func TestWaitingState_ExecuteOutbound(t *testing.T) {
-	ctx := internalContext{Outbound: &mockdispatcher.MockOutbound{}}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
 	followup, err := (&waiting{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)


### PR DESCRIPTION
* gomock instead of  custom mock (introduce protocol)

Part of https://github.com/hyperledger/aries-framework-go/issues/269

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>