### PR TITLE
refactor: Combine WithPacker and WithInboundPackers

### DIFF
--- a/pkg/didcomm/packager/package_test.go
+++ b/pkg/didcomm/packager/package_test.go
@@ -32,15 +32,15 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		mockedProviders := &mockProvider{
-			storage:        nil,
-			kms:            w,
-			outboundPacker: nil,
-			packers:        nil,
+			storage:       nil,
+			kms:           w,
+			primaryPacker: nil,
+			packers:       nil,
 		}
 		testPacker, err := jwe.New(mockedProviders, jwe.XC20P)
 		require.NoError(t, err)
 
-		mockedProviders.outboundPacker = testPacker
+		mockedProviders.primaryPacker = testPacker
 		packager, err := New(mockedProviders)
 		require.NoError(t, err)
 		_, err = packager.UnpackMessage(nil)
@@ -55,15 +55,15 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		mockedProviders := &mockProvider{
-			storage:        nil,
-			kms:            w,
-			outboundPacker: nil,
-			packers:        nil,
+			storage:       nil,
+			kms:           w,
+			primaryPacker: nil,
+			packers:       nil,
 		}
 		testPacker, err := jwe.New(mockedProviders, jwe.XC20P)
 		require.NoError(t, err)
 
-		mockedProviders.outboundPacker = testPacker
+		mockedProviders.primaryPacker = testPacker
 		packager, err := New(mockedProviders)
 		require.NoError(t, err)
 
@@ -94,16 +94,16 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		mockedProviders := &mockProvider{
-			storage:        nil,
-			kms:            w,
-			outboundPacker: nil,
-			packers:        nil,
+			storage:       nil,
+			kms:           w,
+			primaryPacker: nil,
+			packers:       nil,
 		}
 		testPacker, err := jwe.New(mockedProviders, jwe.XC20P)
 		require.NoError(t, err)
 
 		// use a real testPacker with a mocked KMS to validate pack/unpack
-		mockedProviders.outboundPacker = testPacker
+		mockedProviders.primaryPacker = testPacker
 		packager, err := New(mockedProviders)
 		require.NoError(t, err)
 
@@ -141,10 +141,10 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 		}
 
 		mockedProviders := &mockProvider{
-			storage:        nil,
-			kms:            w,
-			outboundPacker: nil,
-			packers:        nil,
+			storage:       nil,
+			kms:           w,
+			primaryPacker: nil,
+			packers:       nil,
 		}
 
 		// use a mocked packager with a mocked KMS to validate pack/unpack
@@ -156,7 +156,7 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 		mockPacker := &didcomm.MockAuthCrypt{DecryptValue: decryptValue,
 			EncryptValue: e, Type: "prs.hyperledger.aries-auth-message"}
 
-		mockedProviders.outboundPacker = mockPacker
+		mockedProviders.primaryPacker = mockPacker
 
 		packager, err := New(mockedProviders)
 		require.NoError(t, err)
@@ -190,7 +190,7 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 			return nil, fmt.Errorf("pack error")
 		}
 		mockPacker = &didcomm.MockAuthCrypt{EncryptValue: e}
-		mockedProviders.outboundPacker = mockPacker
+		mockedProviders.primaryPacker = mockPacker
 		packager, err = New(mockedProviders)
 		require.NoError(t, err)
 		packMsg, err = packager.PackMessage(&transport.Envelope{Message: []byte("msg1"),
@@ -207,16 +207,16 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 			Store: map[string][]byte{}}}))
 		require.NoError(t, err)
 		mockedProviders := &mockProvider{
-			storage:        nil,
-			kms:            w,
-			outboundPacker: nil,
-			packers:        nil,
+			storage:       nil,
+			kms:           w,
+			primaryPacker: nil,
+			packers:       nil,
 		}
 
 		// create a real testPacker (no mocking here)
 		testPacker, err := jwe.New(mockedProviders, jwe.XC20P)
 		require.NoError(t, err)
-		mockedProviders.outboundPacker = testPacker
+		mockedProviders.primaryPacker = testPacker
 
 		legacyPacker := legacy.New(mockedProviders)
 		mockedProviders.packers = []packer.Packer{testPacker, legacyPacker}
@@ -244,7 +244,7 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 
 		// pack with legacy, unpack using a packager that has JWE as default but supports legacy
 
-		mockedProviders.outboundPacker = legacyPacker
+		mockedProviders.primaryPacker = legacyPacker
 
 		packager2, err := New(mockedProviders)
 		require.NoError(t, err)
@@ -267,13 +267,13 @@ func newMockKMSProvider(storagePvdr *mockstorage.MockStoreProvider) *mockProvide
 
 // mockProvider mocks provider for KMS
 type mockProvider struct {
-	storage        *mockstorage.MockStoreProvider
-	kms            kms.KeyManager
-	packers        []packer.Packer
-	outboundPacker packer.Packer
+	storage       *mockstorage.MockStoreProvider
+	kms           kms.KeyManager
+	packers       []packer.Packer
+	primaryPacker packer.Packer
 }
 
-func (m *mockProvider) InboundPackers() []packer.Packer {
+func (m *mockProvider) Packers() []packer.Packer {
 	return m.packers
 }
 
@@ -289,6 +289,6 @@ func (m *mockProvider) InboundTransportEndpoint() string {
 	return "sample-endpoint.com"
 }
 
-func (m *mockProvider) Packer() packer.Packer {
-	return m.outboundPacker
+func (m *mockProvider) PrimaryPacker() packer.Packer {
+	return m.primaryPacker
 }

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -130,10 +130,8 @@ func setAdditionalDefaultOpts(frameworkOpts *Aries) {
 		frameworkOpts.packerCreator = func(provider packer.Provider) (packer.Packer, error) {
 			return legacy.New(provider), nil
 		}
-	}
 
-	if frameworkOpts.inboundPackerCreators == nil {
-		frameworkOpts.inboundPackerCreators = []packer.Creator{
+		frameworkOpts.packerCreators = []packer.Creator{
 			func(provider packer.Provider) (packer.Packer, error) {
 				return legacy.New(provider), nil
 			},

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -30,8 +30,8 @@ type Provider struct {
 	transientStoreProvider   storage.Provider
 	kms                      kms.KMS
 	packager                 commontransport.Packager
-	packer                   packer.Packer
-	inboundPackers           []packer.Packer
+	primaryPacker            packer.Packer
+	packers                  []packer.Packer
 	inboundTransportEndpoint string
 	outboundTransport        transport.OutboundTransport
 	didResolver              didresolver.Resolver
@@ -84,14 +84,14 @@ func (p *Provider) Packager() commontransport.Packager {
 	return p.packager
 }
 
-// InboundPackers returns a list of enabled packers
-func (p *Provider) InboundPackers() []packer.Packer {
-	return p.inboundPackers
+// Packers returns a list of enabled packers
+func (p *Provider) Packers() []packer.Packer {
+	return p.packers
 }
 
-// Packer returns the outbound Packer service
-func (p *Provider) Packer() packer.Packer {
-	return p.packer
+// PrimaryPacker returns the main inbound/outbound Packer service
+func (p *Provider) PrimaryPacker() packer.Packer {
+	return p.primaryPacker
 }
 
 // Signer returns the kms signing service
@@ -231,18 +231,13 @@ func WithPackager(p commontransport.Packager) ProviderOption {
 	}
 }
 
-// WithPacker injects a Packer into the context as the outbound Packer
-func WithPacker(p packer.Packer) ProviderOption {
+// WithPacker injects at least one Packer into the context,
+// with the primary Packer being used for inbound/outbound communication
+// and the additional packers being available for unpacking inbound messages.
+func WithPacker(primary packer.Packer, additionalPackers ...packer.Packer) ProviderOption {
 	return func(opts *Provider) error {
-		opts.packer = p
-		return nil
-	}
-}
-
-// WithInboundPackers injects a variable number of Packer services into the Aries framework
-func WithInboundPackers(packers ...packer.Packer) ProviderOption {
-	return func(opts *Provider) error {
-		opts.inboundPackers = append(opts.inboundPackers, packers...)
+		opts.primaryPacker = primary
+		opts.packers = append(opts.packers, additionalPackers...)
 		return nil
 	}
 }

--- a/pkg/internal/mock/provider/mock_provider.go
+++ b/pkg/internal/mock/provider/mock_provider.go
@@ -49,12 +49,12 @@ func (p *Provider) TransientStorageProvider() storage.Provider {
 	return p.TransientStorageProviderValue
 }
 
-// InboundPackers returns the available Packer services
-func (p *Provider) InboundPackers() []packer.Packer {
+// Packers returns the available Packer services
+func (p *Provider) Packers() []packer.Packer {
 	return p.PackerList
 }
 
-// Packer returns the outbound Packer service
-func (p *Provider) Packer() packer.Packer {
+// PrimaryPacker returns the main Packer service
+func (p *Provider) PrimaryPacker() packer.Packer {
 	return p.PackerValue
 }


### PR DESCRIPTION
WithPacker now takes at least 1 Packer(Creator for framework).
The first Packer is used for outbound, all Packers are used for
inbound.

Fixes #764

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>