### PR TITLE
refactor: DIDExchange Service - Action Event refactor

### DIFF
--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -267,7 +267,6 @@ func TestService_Handle_Invitee(t *testing.T) {
 	// Alice automatically sends a Request to Bob and is now in REQUESTED state.
 	connRecord, err := s.connectionStore.GetConnectionRecord(connID)
 	require.NoError(t, err)
-
 	require.Equal(t, (&requested{}).Name(), connRecord.State)
 	require.Equal(t, invitation.ID, connRecord.InvitationID)
 	require.Equal(t, invitation.RecipientKeys, connRecord.RecipientKeys)
@@ -330,16 +329,6 @@ func handleMessagesInvitee(statusCh chan service.StateMsg, requestedCh chan stri
 }
 
 func TestService_Handle_EdgeCases(t *testing.T) {
-	t.Run("handleInbound - no action events registered", func(t *testing.T) {
-		svc, err := New(&mockdid.MockDIDCreator{Doc: getMockDID()}, &protocol.MockProvider{})
-		require.NoError(t, err)
-
-		_, err = svc.HandleInbound(&service.DIDCommMsg{
-			Header: &service.Header{Type: ResponseMsgType},
-		})
-		require.EqualError(t, err, "no clients are registered to handle the message")
-	})
-
 	t.Run("handleInbound - must not transition to same state", func(t *testing.T) {
 		s, err := New(&mockdid.MockDIDCreator{}, &protocol.MockProvider{})
 		require.NoError(t, err)

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -564,21 +564,6 @@ func TestAcceptInvitation(t *testing.T) {
 func TestOperationEventError(t *testing.T) {
 	const errMsg = "channel is already registered for the action event"
 
-	t.Run("action event registration failed", func(t *testing.T) {
-		client, err := didexchange.New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			ServiceValue: &protocol.MockDIDExchangeSvc{
-				RegisterActionEventErr: errors.New(errMsg),
-			}})
-
-		require.NoError(t, err)
-		ops := &Operation{client: client, actionCh: make(chan service.DIDCommAction)}
-		err = ops.startClientEventListener()
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "didexchange action event registration failed: "+errMsg)
-	})
-
 	t.Run("message event registration failed", func(t *testing.T) {
 		client, err := didexchange.New(&mockprovider.Provider{
 			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
@@ -588,7 +573,7 @@ func TestOperationEventError(t *testing.T) {
 			}})
 
 		require.NoError(t, err)
-		ops := &Operation{client: client, actionCh: make(chan service.DIDCommAction)}
+		ops := &Operation{client: client, msgCh: make(chan service.StateMsg)}
 		err = ops.startClientEventListener()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "didexchange message event registration failed: "+errMsg)


### PR DESCRIPTION
- Remove validation to check action event channel registration. The action events are no longer mandatory as clients can wait for message events.
- The consumer can handle events either through action or message event. In case of message event, consumer can call Accept APIs to continue the execution.

Closes #753 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>