### PR TITLE
feat: Implement service behavior according to Client dependency

### DIFF
--- a/pkg/didcomm/protocol/introduce/models.go
+++ b/pkg/didcomm/protocol/introduce/models.go
@@ -17,6 +17,7 @@ type Proposal struct {
 	ID     string            `json:"@id,omitempty"`
 	To     To                `json:"to,omitempty"`
 	NWise  bool              `json:"nwise,omitempty"`
+	Thread *decorator.Thread `json:"~thread,omitempty"`
 	Timing *decorator.Timing `json:"~timing,omitempty"`
 }
 


### PR DESCRIPTION
* added tests for state machine behavior (`SkipProposal`, `Proposal`, `ProposalUnusual`)
* service logic according to dependency (`ExecuteInbound`,`ExecuteOutbound`)


Closes #802 
Part of #269

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>