### PR TITLE
fix: references to 'agent-rest' -> 'agent-rest-docker'

### DIFF
--- a/docs/rest/agent_docker.md
+++ b/docs/rest/agent_docker.md
@@ -3,7 +3,7 @@
 ## Build the Agent
 Build the docker image for `aries-agent-rest` by running following make target from project root directory. 
 
-`make agent-docker`
+`make agent-rest-docker`
 
 ## Run the Agent
 Above target will build docker image `aries-framework-go/agent-rest` which can be used to start agent by running command as simple as 

--- a/docs/test/bdd_tests.md
+++ b/docs/test/bdd_tests.md
@@ -13,7 +13,7 @@ Run all bdd tests using the following make target from project root directory.
 `make bdd-test`
 
 ## Run specific bdd test
-`make clean generate-test-keys agent-docker sample-webhook-docker`
+`make clean generate-test-keys agent-rest-docker sample-webhook-docker`
 
 Execute the following command inside test/bdd
 
@@ -21,7 +21,7 @@ Execute the following command inside test/bdd
 
 Example
 ```bash
-make clean generate-test-keys agent-docker sample-webhook-docker
+make clean generate-test-keys agent-rest-docker sample-webhook-docker
 cd test/bdd
 AGENT_LOG_LEVEL=info go test -v -run didexchange_e2e_sdk
 ```
@@ -33,7 +33,7 @@ via the make target mentioned above, then do the following:
 
 1. Navigate to test/bdd/fixtures
 
-2. To start Alice and Bob agents and webhooks, go to `agent` folder and run:
+2. To start Alice and Bob agents and webhooks, go to `agent-rest` folder and run:
 ```shell script
 (source .env && docker-compose down && NO_PROXY=* docker-compose up --force-recreate)
 ```


### PR DESCRIPTION
Fixed bunch of references to what used to be called `agent-rest` (the agent docker image), now called `agent-rest-docker`.

Tested against:

* `make all`
* `make run-openapi-demo`

Signed-off-by: George Aristy <george.aristy@securekey.com>

