### PR TITLE
feat: Add did-comm service conventions to did doc

### DIFF
--- a/pkg/doc/did/doc_test.go
+++ b/pkg/doc/did/doc_test.go
@@ -69,6 +69,14 @@ const validDoc = `{
         "amount": "0.50",
         "currency": "USD"
       }
+    },
+    {
+      "id": "did:example:123456789abcdefghi#did-communication",
+      "type": "did-communication",
+      "serviceEndpoint": "https://agent.example.com/",
+      "priority" : 0,
+      "recipientKeys" : ["did:example:123456789abcdefghi#key2"],
+      "routingKeys" : ["did:example:123456789abcdefghi#key2"]
     }
   ],
   "created": "2002-10-10T17:00:00Z"
@@ -119,13 +127,23 @@ func TestValid(t *testing.T) {
 			Value:      block.Bytes}}
 	require.Equal(t, ePubKey, doc.PublicKey)
 
-	// test service
-	eService := []Service{
+	// test services
+	eServices := []Service{
 		{ID: "did:example:123456789abcdefghi#inbox",
 			Type:            "SocialWebInboxService",
 			ServiceEndpoint: "https://social.example.com/83hfh37dj",
-			Properties:      map[string]interface{}{"spamCost": map[string]interface{}{"amount": "0.50", "currency": "USD"}}}}
-	require.Equal(t, eService, doc.Service)
+			Properties:      map[string]interface{}{"spamCost": map[string]interface{}{"amount": "0.50", "currency": "USD"}},
+		},
+		{ID: "did:example:123456789abcdefghi#did-communication",
+			Type:            "did-communication",
+			Priority:        0,
+			RecipientKeys:   []string{"did:example:123456789abcdefghi#key2"},
+			RoutingKeys:     []string{"did:example:123456789abcdefghi#key2"},
+			ServiceEndpoint: "https://agent.example.com/",
+			Properties:      map[string]interface{}{},
+		},
+	}
+	require.EqualValues(t, eServices, doc.Service)
 }
 
 func TestValidWithProof(t *testing.T) {

--- a/test/bdd/pkg/didresolver/didresolver_steps.go
+++ b/test/bdd/pkg/didresolver/didresolver_steps.go
@@ -227,7 +227,7 @@ func createSidetreeDoc(ctx *context.Provider) (*document.Document, error) {
 	}
 
 	pubKey := diddoc.PublicKey{
-		ID:         "#keys-1",
+		ID:         "#key-1",
 		Type:       "Ed25519VerificationKey2018",
 		Controller: "controller",
 		Value:      []byte(pubVerKey),
@@ -238,6 +238,8 @@ func createSidetreeDoc(ctx *context.Provider) (*document.Document, error) {
 			ID:              "#endpoint-1",
 			Type:            "did-communication",
 			ServiceEndpoint: ctx.InboundTransportEndpoint(),
+			RecipientKeys:   []string{pubKey.ID},
+			Priority:        0,
 		},
 	}
 


### PR DESCRIPTION
Did doc service definitions should support recipientKeys, routingKeys and priority within service definition.

Closes #818

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>
