### PR TITLE
feat: error handling in controller REST API

### DIFF
--- a/cmd/aries-agent-rest/startcmd/start_test.go
+++ b/cmd/aries-agent-rest/startcmd/start_test.go
@@ -156,7 +156,7 @@ func validateRequests(t *testing.T, testHostURL, testInboundHostURL string) {
 		// controller API test
 		{
 			name:               "1: testing get",
-			r:                  newreq("GET", fmt.Sprintf("http://%s/connections/create-invitation", testHostURL), nil, ""),
+			r:                  newreq("GET", fmt.Sprintf("http://%s/connections", testHostURL), nil, ""),
 			expectedStatus:     http.StatusOK,
 			expectResponseData: true,
 		},

--- a/pkg/restapi/errors/errors.go
+++ b/pkg/restapi/errors/errors.go
@@ -1,0 +1,75 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package errors
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+)
+
+var logger = log.New("aries-framework/rest")
+
+// genericError is aries rest api error response
+// swagger:response genericError
+type genericError struct {
+	// in: body
+	Code Code `json:"code"`
+	// in: body
+	Message string `json:"message"`
+}
+
+// Group is the error groups.
+// Note: recommended to use [0-9]*000 pattern for any new entries
+// Example: 2000, 3000, 4000 ...... 25000
+type Group int32
+
+const (
+	// DIDExchange error group for DID exchange protocol rest api errors
+	DIDExchange Group = 2000
+
+	// Introduce error group for Introduce protocol rest api errors
+	Introduce Group = 3000
+)
+
+// Code is the error code of aries rest api errors
+type Code int32
+
+const (
+	// UnknownStatus default error code for unknown errors
+	UnknownStatus Code = iota
+)
+
+// SendHTTPBadRequest sends http status code BAD REQUEST to response with given error body
+func SendHTTPBadRequest(rw http.ResponseWriter, code Code, err error) {
+	SendHTTPStatusError(rw, code, err, http.StatusBadRequest)
+}
+
+// SendHTTPInternalServerError sends http status code INTERNAL SERVER ERROR to response with given error body
+func SendHTTPInternalServerError(rw http.ResponseWriter, code Code, err error) {
+	SendHTTPStatusError(rw, code, err, http.StatusInternalServerError)
+}
+
+// SendUnknownError sends unnknown/default error through response with given error body
+func SendUnknownError(rw http.ResponseWriter, err error) {
+	SendHTTPStatusError(rw, UnknownStatus, err, http.StatusInternalServerError)
+}
+
+// SendHTTPStatusError sends given http status code to response with error body
+func SendHTTPStatusError(rw http.ResponseWriter, code Code, err error, statusCode int) {
+	rw.WriteHeader(statusCode)
+	rw.Header().Set("Content-Type", "application/json")
+
+	e := json.NewEncoder(rw).Encode(genericError{
+		Code:    code,
+		Message: err.Error(),
+	})
+	if e != nil {
+		logger.Errorf("Unable to send error response, %s", e)
+	}
+}

--- a/pkg/restapi/errors/errors_test.go
+++ b/pkg/restapi/errors/errors_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package errors
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	invalidRequest = Code(iota + DIDExchange)
+	createInvitationError
+	receiveInvitationError
+	removeConnectionError
+)
+
+func TestSendError(t *testing.T) {
+	const errMsg = "here is the sample which I want to write to response"
+
+	t.Run("Test sending HTTP Status Forbidden", func(t *testing.T) {
+		var errors = []struct {
+			err        error
+			errCode    Code
+			statusCode int
+			response   genericError
+		}{
+			{fmt.Errorf(errMsg), UnknownStatus, http.StatusBadRequest,
+				genericError{Code: UnknownStatus, Message: errMsg}},
+			{fmt.Errorf(errMsg), createInvitationError, http.StatusBadRequest,
+				genericError{Code: createInvitationError, Message: errMsg}},
+			{fmt.Errorf(errMsg), receiveInvitationError, http.StatusBadRequest,
+				genericError{Code: receiveInvitationError, Message: errMsg}},
+			{fmt.Errorf(errMsg), removeConnectionError, http.StatusBadRequest,
+				genericError{Code: removeConnectionError, Message: errMsg}},
+		}
+
+		for _, data := range errors {
+			rr := httptest.NewRecorder()
+
+			SendHTTPBadRequest(rr, data.errCode, data.err)
+			require.NotEmpty(t, rr.Body.Bytes())
+
+			response := genericError{}
+			err := json.Unmarshal(rr.Body.Bytes(), &response)
+			require.NoError(t, err)
+
+			require.Equal(t, data.statusCode, rr.Code)
+			require.Equal(t, data.response, response)
+		}
+	})
+
+	t.Run("Test sending HTTP Status Internal Server error", func(t *testing.T) {
+		const errMsg = "here is the sample which I want to write to response"
+		var errors = []struct {
+			err        error
+			errCode    Code
+			statusCode int
+			response   genericError
+		}{
+			{fmt.Errorf(errMsg), UnknownStatus, http.StatusInternalServerError,
+				genericError{Code: UnknownStatus, Message: errMsg}},
+			{fmt.Errorf(errMsg), createInvitationError, http.StatusInternalServerError,
+				genericError{Code: createInvitationError, Message: errMsg}},
+			{fmt.Errorf(errMsg), receiveInvitationError, http.StatusInternalServerError,
+				genericError{Code: receiveInvitationError, Message: errMsg}},
+			{fmt.Errorf(errMsg), removeConnectionError, http.StatusInternalServerError,
+				genericError{Code: removeConnectionError, Message: errMsg}},
+		}
+
+		for _, data := range errors {
+			rr := httptest.NewRecorder()
+
+			SendHTTPInternalServerError(rr, data.errCode, data.err)
+			require.NotEmpty(t, rr.Body.Bytes())
+
+			response := genericError{}
+			err := json.Unmarshal(rr.Body.Bytes(), &response)
+			require.NoError(t, err)
+
+			require.Equal(t, data.statusCode, rr.Code)
+			require.Equal(t, data.response, response)
+		}
+	})
+
+	t.Run("Test sending Unknown error", func(t *testing.T) {
+		const errMsg = "here is the sample which I want to write to response"
+		var errors = []struct {
+			err        error
+			statusCode int
+			response   genericError
+		}{
+			{fmt.Errorf(errMsg), http.StatusInternalServerError,
+				genericError{Code: UnknownStatus, Message: errMsg}},
+			{fmt.Errorf(errMsg), http.StatusInternalServerError,
+				genericError{Code: UnknownStatus, Message: errMsg}},
+			{fmt.Errorf(errMsg), http.StatusInternalServerError,
+				genericError{Code: UnknownStatus, Message: errMsg}},
+			{fmt.Errorf(errMsg), http.StatusInternalServerError,
+				genericError{Code: UnknownStatus, Message: errMsg}},
+		}
+
+		for _, data := range errors {
+			rr := httptest.NewRecorder()
+
+			SendUnknownError(rr, data.err)
+			require.NotEmpty(t, rr.Body.Bytes())
+
+			response := genericError{}
+			err := json.Unmarshal(rr.Body.Bytes(), &response)
+			require.NoError(t, err)
+
+			require.Equal(t, data.statusCode, rr.Code)
+			require.Equal(t, data.response, response)
+		}
+	})
+
+	t.Run("Test sending HTTP status codes", func(t *testing.T) {
+		const errMsg = "here is the sample which I want to write to response"
+		var errors = []struct {
+			err        error
+			errCode    Code
+			statusCode int
+			response   genericError
+		}{
+			{fmt.Errorf(errMsg), UnknownStatus, http.StatusOK,
+				genericError{Code: UnknownStatus, Message: errMsg}},
+			{fmt.Errorf(errMsg), invalidRequest, http.StatusForbidden,
+				genericError{Code: invalidRequest, Message: errMsg}},
+			{fmt.Errorf(errMsg), receiveInvitationError, http.StatusNotAcceptable,
+				genericError{Code: receiveInvitationError, Message: errMsg}},
+			{fmt.Errorf(errMsg), removeConnectionError, http.StatusNoContent,
+				genericError{Code: removeConnectionError, Message: errMsg}},
+		}
+
+		for _, data := range errors {
+			rr := httptest.NewRecorder()
+
+			SendHTTPStatusError(rr, data.errCode, data.err, data.statusCode)
+			require.NotEmpty(t, rr.Body.Bytes())
+
+			response := genericError{}
+			err := json.Unmarshal(rr.Body.Bytes(), &response)
+			require.NoError(t, err)
+
+			require.Equal(t, data.statusCode, rr.Code)
+			require.Equal(t, data.response, response)
+		}
+	})
+}
+
+func TestSendErrorFailures(t *testing.T) {
+	rw := &mockRWriter{}
+	SendHTTPStatusError(rw, UnknownStatus, fmt.Errorf("sample error"), http.StatusBadRequest)
+}
+
+// mockRWriter to recreate response writer error scenario
+type mockRWriter struct {
+}
+
+func (m *mockRWriter) Header() http.Header {
+	return make(map[string][]string)
+}
+
+func (m *mockRWriter) Write([]byte) (int, error) {
+	return 0, fmt.Errorf("failed to write body")
+}
+
+func (m *mockRWriter) WriteHeader(statusCode int) {}

--- a/pkg/restapi/operation/didexchange/models/invitation.go
+++ b/pkg/restapi/operation/didexchange/models/invitation.go
@@ -12,18 +12,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
 )
 
-// A GenericError is the default error message that is generated.
-// For certain status codes there are more appropriate error structures.
-//
-// swagger:response genericError
-type GenericError struct {
-	// in: body
-	Body struct {
-		Code    int32  `json:"code"`
-		Message string `json:"message"`
-	} `json:"body"`
-}
-
 // CreateInvitationRequest model
 //
 // This is used for operation to create invitation

--- a/test/bdd/pkg/didexchange/didexchange_controller_steps.go
+++ b/test/bdd/pkg/didexchange/didexchange_controller_steps.go
@@ -326,16 +326,17 @@ func sendHTTP(method, destination string, message []byte, result interface{}) er
 
 	defer closeResponse(resp.Body)
 
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to get response from '%s', unexpected status code [%d]", destination, resp.StatusCode)
-	}
-
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("unable to read response from '%s', cause :%s", destination, err)
 	}
 
 	logger.Debugf(" Got response from '%s' [method: %s], response payload: %s", destination, method, string(data))
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to get successful response from '%s', unexpected status code [%d], "+
+			"and message [%s]", destination, resp.StatusCode, string(data))
+	}
 
 	return json.Unmarshal(data, result)
 }


### PR DESCRIPTION
- different HTTP Status code for error scenarios
- generic error message body
- closes #756

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>