### PR TITLE
refactor: creation of VC which extends base data model

### DIFF
--- a/pkg/doc/verifiable/credential_jws_test.go
+++ b/pkg/doc/verifiable/credential_jws_test.go
@@ -20,7 +20,7 @@ func TestJWTCredClaimsMarshalJWS(t *testing.T) {
 	privateKey, err := readPrivateKey(filepath.Join(certPrefix, "issuer_private.pem"))
 	require.NoError(t, err)
 
-	vc, err := NewCredential([]byte(validCredential))
+	vc, _, err := NewCredential([]byte(validCredential))
 	require.NoError(t, err)
 
 	jwtClaims, err := vc.JWTClaims(true)
@@ -82,7 +82,7 @@ func TestCredJWSDecoderUnmarshal(t *testing.T) {
 		err = json.Unmarshal(vcBytes, &vcRaw)
 		require.NoError(t, err)
 
-		vc, err := NewCredential([]byte(jwtTestCredential))
+		vc, _, err := NewCredential([]byte(jwtTestCredential))
 		require.NoError(t, err)
 		require.Equal(t, vc.raw().stringJSON(t), vcRaw.stringJSON(t))
 	})

--- a/pkg/doc/verifiable/credential_jwt_unsecured_test.go
+++ b/pkg/doc/verifiable/credential_jwt_unsecured_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestCredentialJWTClaimsMarshallingToUnsecuredJWT(t *testing.T) {
-	vc, err := NewCredential([]byte(validCredential))
+	vc, _, err := NewCredential([]byte(validCredential))
 	require.NoError(t, err)
 
 	jwtClaims, err := vc.JWTClaims(true)
@@ -37,7 +37,7 @@ func TestCredentialJWTClaimsMarshallingToUnsecuredJWT(t *testing.T) {
 
 func TestCredUnsecuredJWTDecoderParseJWTClaims(t *testing.T) {
 	t.Run("Successful unsecured JWT decoding", func(t *testing.T) {
-		vc, err := NewCredential([]byte(validCredential))
+		vc, _, err := NewCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		jwtClaims, err := vc.JWTClaims(true)

--- a/pkg/doc/verifiable/presentation_test.go
+++ b/pkg/doc/verifiable/presentation_test.go
@@ -309,7 +309,7 @@ func TestPresentation_Credentials(t *testing.T) {
 		require.Len(t, credsData, 1)
 
 		// Decode the first verifiable credential
-		vc, err := NewCredential(credsData[0])
+		vc, _, err := NewCredential(credsData[0])
 		require.NoError(t, err)
 
 		// check some VC properties to double check that conversion is OK
@@ -346,7 +346,7 @@ func TestPresentation_Credentials(t *testing.T) {
 		require.Len(t, credsData, 1)
 
 		// Decode the first verifiable credential
-		vc, err := NewCredential(credsData[0])
+		vc, _, err := NewCredential(credsData[0])
 		require.NoError(t, err)
 		require.NotNil(t, vc)
 	})

--- a/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
+++ b/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
@@ -72,7 +72,7 @@ func main() {
 }
 
 func encodeVCToJWS(vcBytes []byte, privateKey interface{}) {
-	credential, err := verifiable.NewCredential(vcBytes)
+	credential, _, err := verifiable.NewCredential(vcBytes)
 	if err != nil {
 		abort("failed to decode credential: %v", err)
 	}
@@ -107,7 +107,7 @@ func encodeVPToJWS(vpBytes []byte, audience string, privateKey interface{}) {
 }
 
 func encodeVCToJWTUnsecured(vcBytes []byte) {
-	credential, err := verifiable.NewCredential(vcBytes)
+	credential, _, err := verifiable.NewCredential(vcBytes)
 	if err != nil {
 		abort("failed to decode credential: %v", err)
 	}
@@ -127,7 +127,7 @@ func encodeVCToJWTUnsecured(vcBytes []byte) {
 
 func decodeVCJWTToJSON(vcBytes []byte, publicKey interface{}) {
 	// Asked to decode JWT
-	credential, err := verifiable.NewCredential(vcBytes,
+	credential, _, err := verifiable.NewCredential(vcBytes,
 		verifiable.WithPublicKeyFetcher(func(issuerID, keyID string) (interface{}, error) {
 			return publicKey, nil
 		}))
@@ -187,7 +187,7 @@ func parseKeys(packedKeys string) (private, public interface{}) {
 }
 
 func encodeVCToJSON(vcBytes []byte) {
-	credential, err := verifiable.NewCredential(vcBytes, verifiable.WithNoCustomSchemaCheck())
+	credential, _, err := verifiable.NewCredential(vcBytes, verifiable.WithNoCustomSchemaCheck())
 	if err != nil {
 		abort("failed to decode credential: %v", err)
 	}


### PR DESCRIPTION
refactor: Selection of Verifiable Credential extensions based on the basic Credential

Simplified `NewCredential()` which decodes a base VC. Extensions can make extra decoding based on the VC and/or decoded JSON bytes returned.
Added `NewExtCredential()` which can be used when there are several VC with extended data model and we can build concrete extended VC depending on the e.g. `type` and `context` of the VC. 

closes #263

Signed-off-by: Dima <dkinoshenko@gmail.com>