### PR TITLE
refactor: Integrate did-communication service conventions

### DIFF
--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -549,15 +549,26 @@ func getMockDID() *did.Doc {
 		Service: []did.Service{
 			{
 				ServiceEndpoint: "https://localhost:8090",
+				Type:            "did-communication",
+				Priority:        0,
+				RecipientKeys:   []string{"did:example:123456789abcdefghi#keys-2"},
+			},
+			{
+				ServiceEndpoint: "https://localhost:8090",
+				Type:            "did-communication",
+				Priority:        1,
+				RecipientKeys:   []string{"did:example:123456789abcdefghi#keys-1"},
 			},
 		},
-		PublicKey: []did.PublicKey{{
-			ID:         "did:example:123456789abcdefghi#keys-1",
-			Controller: "did:example:123456789abcdefghi",
-			Type:       "Secp256k1VerificationKey2018",
-			Value:      base58.Decode("H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV")},
+		PublicKey: []did.PublicKey{
 			{
 				ID:         "did:example:123456789abcdefghi#keys-1",
+				Controller: "did:example:123456789abcdefghi",
+				Type:       "Secp256k1VerificationKey2018",
+				Value:      base58.Decode("H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"),
+			},
+			{
+				ID:         "did:example:123456789abcdefghi#keys-2",
 				Controller: "did:example:123456789abcdefghi",
 				Type:       "Ed25519VerificationKey2018",
 				Value:      base58.Decode("H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"),
@@ -566,26 +577,6 @@ func getMockDID() *did.Doc {
 				ID:         "did:example:123456789abcdefghw#key2",
 				Controller: "did:example:123456789abcdefghw",
 				Type:       "RsaVerificationKey2018",
-				Value:      base58.Decode("H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"),
-			},
-		},
-	}
-}
-
-func getMockDIDPublicKey() *did.Doc {
-	return &did.Doc{
-		Context: []string{"https://w3id.org/did/v1"},
-		ID:      "did:peer:123456789abcdefghi#inbox",
-		Service: []did.Service{
-			{
-				ServiceEndpoint: "https://localhost:8090",
-			},
-		},
-		PublicKey: []did.PublicKey{
-			{
-				ID:         "did:example:123456789abcdefghi#keys-1",
-				Controller: "did:example:123456789abcdefghi",
-				Type:       "Secp256k1VerificationKey2018",
 				Value:      base58.Decode("H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"),
 			},
 		},

--- a/pkg/internal/mock/vdri/mock_registry.go
+++ b/pkg/internal/mock/vdri/mock_registry.go
@@ -89,6 +89,8 @@ func createDefaultDID() *did.Doc {
 		ID:              "did:example:123456789abcdefghi#did-communication",
 		Type:            "did-communication",
 		ServiceEndpoint: "https://agent.example.com/",
+		RecipientKeys:   []string{creator},
+		Priority:        0,
 	}
 
 	signingKey := did.PublicKey{


### PR DESCRIPTION
We are currently picking first key of type Ed25519VerificationKey2018 from did document public keys for:
-- sender verification key
-- recipient keys in destination
Refactor current logic to read above mentioned keys from recipient keys in did-communication service for both peer and public did documents.

Closes #822

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>
