### PR TITLE
feat: Create Public DID (VDRI & REST support)

### DIFF
--- a/pkg/framework/aries/api/vdri/vdri.go
+++ b/pkg/framework/aries/api/vdri/vdri.go
@@ -8,6 +8,7 @@ package vdri
 
 import (
 	"errors"
+	"io"
 	"time"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
@@ -15,6 +16,9 @@ import (
 
 // ErrNotFound is returned when a DID resolver does not find the DID.
 var ErrNotFound = errors.New("DID not found")
+
+// DIDCommServiceType default DID Communication service endpoint type
+const DIDCommServiceType = "did-communication"
 
 // Registry vdri registry
 type Registry interface {
@@ -87,6 +91,7 @@ type CreateDIDOpts struct {
 	ServiceType     string
 	KeyType         string
 	ServiceEndpoint string
+	RequestBuilder  func([]byte) (io.Reader, error)
 }
 
 // DocOpts is a create DID option
@@ -110,6 +115,14 @@ func WithKeyType(keyType string) DocOpts {
 func WithServiceEndpoint(serviceEndpoint string) DocOpts {
 	return func(opts *CreateDIDOpts) {
 		opts.ServiceEndpoint = serviceEndpoint
+	}
+}
+
+// WithRequestBuilder allows to supply request builder
+// which can be used to add headers to request stream to be sent to HTTP binding URL
+func WithRequestBuilder(builder func(payload []byte) (io.Reader, error)) DocOpts {
+	return func(opts *CreateDIDOpts) {
+		opts.RequestBuilder = builder
 	}
 }
 

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -274,13 +274,13 @@ func createVDRI(frameworkOpts *Aries) error {
 		opts = append(opts, vdri.WithVDRI(v))
 	}
 
-	p, err := peer.New(ctx.StorageProvider(), peer.WithCreatorServiceType("did-communication"),
-		peer.WithCreatorServiceEndpoint(ctx.InboundTransportEndpoint()))
+	p, err := peer.New(ctx.StorageProvider())
 	if err != nil {
 		return fmt.Errorf("create new vdri peer failed: %w", err)
 	}
 
-	opts = append(opts, vdri.WithVDRI(p))
+	opts = append(opts, vdri.WithVDRI(p), vdri.WithDefaultServiceType(vdriapi.DIDCommServiceType),
+		vdri.WithDefaultServiceEndpoint(ctx.InboundTransportEndpoint()))
 
 	frameworkOpts.vdriRegistry = vdri.New(ctx, opts...)
 

--- a/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
@@ -118,6 +118,7 @@ func (m *MockDIDExchangeSvc) AcceptInvitation(connectionID string) error {
 type MockProvider struct {
 	StoreProvider          *mockstore.MockStoreProvider
 	TransientStoreProvider *mockstore.MockStoreProvider
+	CustomVDRI             vdriapi.Registry
 }
 
 // OutboundDispatcher is mock outbound dispatcher for DID exchange service
@@ -150,5 +151,9 @@ func (p *MockProvider) Signer() kms.Signer {
 
 // VDRIRegistry is mock vdri registry
 func (p *MockProvider) VDRIRegistry() vdriapi.Registry {
+	if p.CustomVDRI != nil {
+		return p.CustomVDRI
+	}
+
 	return &mockvdri.MockVDRIRegistry{}
 }

--- a/pkg/restapi/errors/errors.go
+++ b/pkg/restapi/errors/errors.go
@@ -30,6 +30,9 @@ type genericError struct {
 type Group int32
 
 const (
+	// Common error group for general rest api errors
+	Common Group = 1000
+
 	// DIDExchange error group for DID exchange protocol rest api errors
 	DIDExchange Group = 2000
 

--- a/pkg/restapi/operation/common/models.go
+++ b/pkg/restapi/operation/common/models.go
@@ -1,0 +1,44 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+)
+
+// CreatePublicDIDRequest model
+//
+// This is used for operation to create public DID
+//
+// swagger:parameters createPublicDID
+type CreatePublicDIDRequest struct {
+	// Params for creating public DID
+	//
+	// in: path
+	*CreatePublicDIDParams
+}
+
+// CreatePublicDIDParams contains parameters for creating new public DID
+type CreatePublicDIDParams struct {
+	// Params for creating public DID
+	Method string `json:"method"`
+
+	// RequestHeader to be included while submitting request to http binding URL
+	RequestHeader string `json:"header"`
+}
+
+// CreatePublicDIDResponse model
+//
+// This is used for returning public DID created
+//
+// swagger:response createPublicDIDResponse
+type CreatePublicDIDResponse struct {
+
+	// in: body
+	// TODO return base64-encoded raw bytes of the DID doc [Issue: #855]
+	DID *did.Doc `json:"did"`
+}

--- a/pkg/restapi/operation/common/operation.go
+++ b/pkg/restapi/operation/common/operation.go
@@ -1,0 +1,159 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/common/support"
+	"github.com/hyperledger/aries-framework-go/pkg/restapi/errors"
+	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
+)
+
+var logger = log.New("aries-framework/controller/common")
+
+const (
+	vdriOperationID     = "/vdri"
+	createPublicDIDPath = vdriOperationID + "/create-public-did"
+)
+
+// Error codes
+const (
+	// InvalidRequestErrorCode is typically a code for invalid requests
+	InvalidRequestErrorCode = errors.Code(iota + errors.Common)
+
+	// CreatePublicDIDError is for failures while creating public DIDs
+	CreatePublicDIDError
+)
+
+// provider contains dependencies for the common controller operations
+// and is typically created by using aries.Context()
+type provider interface {
+	VDRIRegistry() vdriapi.Registry
+}
+
+// Operation contains basic common operations provided by controller REST API
+type Operation struct {
+	ctx      provider
+	handlers []operation.Handler
+}
+
+// New returns new common operations rest client instance
+func New(ctx provider) *Operation {
+	o := &Operation{ctx: ctx}
+	defer o.registerHandler()
+
+	return o
+}
+
+//
+
+// GetRESTHandlers get all controller API handler available for this service
+func (o *Operation) GetRESTHandlers() []operation.Handler {
+	return o.handlers
+}
+
+// registerHandler register handlers to be exposed from this protocol service as REST API endpoints
+func (o *Operation) registerHandler() {
+	// Add more protocol endpoints here to expose them as controller API endpoints
+	o.handlers = []operation.Handler{
+		support.NewHTTPHandler(createPublicDIDPath, http.MethodPost, o.CreatePublicDID),
+	}
+}
+
+// CreatePublicDID swagger:route POST /vdri/create-public-did vdri createPublicDID
+//
+// Creates a new Public DID....
+//
+// Responses:
+//    default: genericError
+//        200: createPublicDIDResponse
+func (o *Operation) CreatePublicDID(rw http.ResponseWriter, req *http.Request) {
+	var request CreatePublicDIDRequest
+
+	err := getQueryParams(&request, req.URL.Query())
+	if err != nil {
+		errors.SendHTTPBadRequest(rw, InvalidRequestErrorCode, err)
+		return
+	}
+
+	if request.CreatePublicDIDParams == nil || request.Method == "" {
+		errors.SendHTTPBadRequest(rw, InvalidRequestErrorCode, fmt.Errorf("invalid method name"))
+		return
+	}
+
+	logger.Debugf("creating public DID for method[%s]", request.Method)
+
+	doc, err := o.ctx.VDRIRegistry().Create(strings.ToLower(request.Method),
+		vdriapi.WithRequestBuilder(getBasicRequestBuilder(request.RequestHeader)))
+	if err != nil {
+		errors.SendHTTPInternalServerError(rw, CreatePublicDIDError, err)
+		return
+	}
+
+	o.writeResponse(rw, CreatePublicDIDResponse{DID: doc})
+}
+
+// writeResponse writes interface value to response
+func (o *Operation) writeResponse(rw io.Writer, v interface{}) {
+	err := json.NewEncoder(rw).Encode(v)
+	// as of now, just log errors for writing response
+	if err != nil {
+		logger.Errorf("Unable to send error response, %s", err)
+	}
+}
+
+// getQueryParams converts query strings to `map[string]string`
+// and unmarshals to the value pointed by v by following
+// `json.Unmarshal` rules.
+func getQueryParams(v interface{}, vals url.Values) error {
+	// normalize all query string key/values
+	args := make(map[string]string)
+
+	for k, v := range vals {
+		if len(v) > 0 {
+			args[k] = v[0]
+		}
+	}
+
+	b, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(b, v)
+}
+
+// prepareBasicRequestBuilder is basic request builder for public DID creation
+// request body format is : {"header": {raw header}, "payload": "payload"}
+func getBasicRequestBuilder(header string) func(payload []byte) (io.Reader, error) {
+	return func(payload []byte) (io.Reader, error) {
+		request := struct {
+			Header  json.RawMessage `json:"header"`
+			Payload string          `json:"payload"`
+		}{
+			Header:  json.RawMessage(header),
+			Payload: base64.URLEncoding.EncodeToString(payload),
+		}
+
+		b, err := json.Marshal(request)
+		if err != nil {
+			return nil, err
+		}
+
+		return bytes.NewReader(b), nil
+	}
+}

--- a/pkg/restapi/operation/common/operation_test.go
+++ b/pkg/restapi/operation/common/operation_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/vdri"
+	resterrs "github.com/hyperledger/aries-framework-go/pkg/restapi/errors"
+	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
+)
+
+func TestOperation_GetAPIHandlers(t *testing.T) {
+	svc := New(&protocol.MockProvider{})
+	require.NotNil(t, svc)
+
+	handlers := svc.GetRESTHandlers()
+	require.NotEmpty(t, handlers)
+}
+
+func TestOperation_CreatePublicDID(t *testing.T) {
+	t.Run("Successful Create public DID", func(t *testing.T) {
+		svc := New(&protocol.MockProvider{})
+		require.NotNil(t, svc)
+
+		handler := lookupCreatePublicDIDHandler(t, svc)
+		buf, err := getSuccessResponseFromHandler(handler, nil, handler.Path()+"?method=sidetree")
+		require.NoError(t, err)
+
+		response := CreatePublicDIDResponse{}
+		err = json.Unmarshal(buf.Bytes(), &response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.DID)
+		require.NotEmpty(t, response.DID.ID)
+		require.NotEmpty(t, response.DID.PublicKey)
+		require.NotEmpty(t, response.DID.Service)
+	})
+
+	t.Run("Failed Create public DID", func(t *testing.T) {
+		svc := New(&protocol.MockProvider{})
+		require.NotNil(t, svc)
+
+		handler := lookupCreatePublicDIDHandler(t, svc)
+		buf, code, err := sendRequestToHandler(handler, nil, handler.Path())
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, code)
+		verifyError(t, InvalidRequestErrorCode, buf.Bytes())
+
+		handler = lookupCreatePublicDIDHandler(t, svc)
+		buf, code, err = sendRequestToHandler(handler, nil, handler.Path()+"?-----")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, code)
+		verifyError(t, InvalidRequestErrorCode, buf.Bytes())
+	})
+
+	t.Run("Failed Create public DID, VDRI error", func(t *testing.T) {
+		svc := New(&protocol.MockProvider{CustomVDRI: &vdri.MockVDRIRegistry{CreateErr: fmt.Errorf("just-fail-it")}})
+		require.NotNil(t, svc)
+
+		handler := lookupCreatePublicDIDHandler(t, svc)
+		buf, code, err := sendRequestToHandler(handler, nil, handler.Path()+"?method=valid")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusInternalServerError, code)
+		verifyError(t, CreatePublicDIDError, buf.Bytes())
+	})
+}
+
+func TestBuildSideTreeRequest(t *testing.T) {
+	registry := vdri.MockVDRIRegistry{}
+	didDoc, err := registry.Create("sidetree")
+	require.NoError(t, err)
+	require.NotNil(t, didDoc)
+
+	b, err := didDoc.JSONBytes()
+	require.NoError(t, err)
+
+	r, err := getBasicRequestBuilder(`{"operation":"create"}`)(b)
+	require.NoError(t, err)
+	require.NotNil(t, r)
+}
+
+func TestOperation_WriteResponse(t *testing.T) {
+	svc := New(&protocol.MockProvider{})
+	require.NotNil(t, svc)
+	svc.writeResponse(&mockWriter{}, CreatePublicDIDResponse{})
+}
+
+func lookupCreatePublicDIDHandler(t *testing.T, op *Operation) operation.Handler {
+	handlers := op.GetRESTHandlers()
+	require.NotEmpty(t, handlers)
+
+	for _, h := range handlers {
+		if h.Path() == createPublicDIDPath {
+			return h
+		}
+	}
+
+	require.Fail(t, "unable to find handler")
+
+	return nil
+}
+
+// getSuccessResponseFromHandler reads response from given http handle func.
+// expects http status OK.
+func getSuccessResponseFromHandler(handler operation.Handler, requestBody io.Reader,
+	path string) (*bytes.Buffer, error) {
+	response, status, err := sendRequestToHandler(handler, requestBody, path)
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: got %v, want %v",
+			status, http.StatusOK)
+	}
+
+	return response, err
+}
+
+// sendRequestToHandler reads response from given http handle func.
+func sendRequestToHandler(handler operation.Handler, requestBody io.Reader, path string) (*bytes.Buffer, int, error) {
+	// prepare request
+	req, err := http.NewRequest(handler.Method(), path, requestBody)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// prepare router
+	router := mux.NewRouter()
+
+	router.HandleFunc(handler.Path(), handler.Handle()).Methods(handler.Method())
+
+	// create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+
+	// serve http on given response and request
+	router.ServeHTTP(rr, req)
+
+	return rr.Body, rr.Code, nil
+}
+
+func verifyError(t *testing.T, code resterrs.Code, data []byte) {
+	// Parser generic error response
+	errResponse := struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}{}
+	err := json.Unmarshal(data, &errResponse)
+	require.NoError(t, err)
+
+	// verify response
+	require.NotEmpty(t, code, errResponse.Code)
+	require.NotEmpty(t, errResponse.Message)
+}
+
+type mockWriter struct {
+}
+
+func (m *mockWriter) Write(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("sample-error")
+}

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -28,7 +28,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
-var logger = log.New("aries-framework/did-exchange")
+var logger = log.New("aries-framework/controller/did-exchange")
 
 const (
 	operationID             = "/connections"

--- a/pkg/restapi/restapi.go
+++ b/pkg/restapi/restapi.go
@@ -9,6 +9,7 @@ package restapi
 import (
 	"github.com/hyperledger/aries-framework-go/pkg/framework/context"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
+	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation/common"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/webhook"
 )
@@ -51,7 +52,11 @@ func New(ctx *context.Provider, opts ...Opt) (*Controller, error) {
 		return nil, err
 	}
 
+	// Add common Rest Handlers
+	general := common.New(ctx)
+
 	allHandlers = append(allHandlers, exchange.GetRESTHandlers()...)
+	allHandlers = append(allHandlers, general.GetRESTHandlers()...)
 
 	return &Controller{handlers: allHandlers}, nil
 }

--- a/pkg/vdri/httpbinding/resolver.go
+++ b/pkg/vdri/httpbinding/resolver.go
@@ -23,12 +23,7 @@ func (v *VDRI) resolveDID(uri string) ([]byte, error) {
 		return nil, fmt.Errorf("HTTP Get request failed: %w", err)
 	}
 
-	defer func() {
-		e := resp.Body.Close()
-		if e != nil {
-			logger.Errorf("Failed to close response body: %v", e)
-		}
-	}()
+	defer closeResponseBody(resp.Body)
 
 	if containsDIDDocument(resp) {
 		var gotBody []byte

--- a/pkg/vdri/httpbinding/resolver_test.go
+++ b/pkg/vdri/httpbinding/resolver_test.go
@@ -54,35 +54,40 @@ func TestWithOutboundOpts(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
-	var err error
+	t.Run("test new with no options", func(t *testing.T) {
+		var err error
+		// OK with no options
+		_, err = New("https://uniresolver.io/")
+		require.NoError(t, err)
+	})
 
-	// OK with no options
-	_, err = New("https://uniresolver.io/")
-	require.NoError(t, err)
+	t.Run("test new with all options are applied", func(t *testing.T) {
+		// All options are applied
+		i := 0
+		_, err := New("https://uniresolver.io/",
+			func(opts *VDRI) {
+				i += 1 // nolint
+			},
+			func(opts *VDRI) {
+				i += 2
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, 1+2, i)
+	})
 
-	// All options are applied
-	i := 0
-	_, err = New("https://uniresolver.io/",
-		func(opts *VDRI) {
-			i += 1 // nolint
-		},
-		func(opts *VDRI) {
-			i += 2
-		},
-	)
-	require.NoError(t, err)
-	require.Equal(t, 1+2, i)
+	t.Run("test new with invalid url", func(t *testing.T) {
+		// Invalid URL
+		_, err := New("invalid url")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "base URL invalid")
 
-	// Invalid URL
-	_, err = New("invalid url")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "base URL invalid")
-
-	r, err := New("https://uniresolver.io/", WithAccept(func(method string) bool {
-		return false
-	}))
-	require.NoError(t, err)
-	require.False(t, r.Accept("w"))
+		r, err := New("https://uniresolver.io/", WithAccept(func(method string) bool {
+			return false
+		}))
+		require.NoError(t, err)
+		require.False(t, r.Accept("w"))
+	})
 }
 
 func TestRead_DIDDoc(t *testing.T) {

--- a/pkg/vdri/httpbinding/vdri.go
+++ b/pkg/vdri/httpbinding/vdri.go
@@ -7,9 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package httpbinding
 
 import (
+	"bytes"
 	"crypto/tls"
-	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -20,6 +22,12 @@ import (
 )
 
 var logger = log.New("aries-framework/vdri/httpbinding")
+
+const (
+	pubKeyIndex1      = "#key-1"
+	pubKeyController  = "controller"
+	svcEndpointIndex1 = "#endpoint-1"
+)
 
 // VDRI via HTTP(s) endpoint
 type VDRI struct {
@@ -57,12 +65,106 @@ func (v *VDRI) Accept(method string) bool {
 
 // Store did doc
 func (v *VDRI) Store(doc *did.Doc, by *[]vdriapi.ModifiedBy) error {
-	return errors.New("not supported")
+	logger.Warnf(" store not supported in http binding vdri")
+	return nil
 }
 
 // Build did doc
+// TODO separate this public DID create from httpbinding
+//  and remove with request builder option [Issue #860]
 func (v *VDRI) Build(pubKey *vdriapi.PubKey, opts ...vdriapi.DocOpts) (*did.Doc, error) {
-	return nil, errors.New("not supported")
+	// Apply options
+	docOpts := &vdriapi.CreateDIDOpts{}
+
+	for _, opt := range opts {
+		opt(docOpts)
+	}
+
+	publicKey := did.PublicKey{
+		ID:         pubKeyIndex1,
+		Type:       pubKey.Type,
+		Controller: pubKeyController,
+		Value:      []byte(pubKey.Value),
+	}
+
+	t := time.Now()
+
+	didDoc := &did.Doc{
+		Context:   []string{did.Context},
+		PublicKey: []did.PublicKey{publicKey},
+		Created:   &t,
+		Updated:   &t,
+	}
+
+	if docOpts.ServiceType != "" {
+		s := did.Service{
+			ID:              svcEndpointIndex1,
+			Type:            docOpts.ServiceType,
+			ServiceEndpoint: docOpts.ServiceEndpoint,
+		}
+
+		if docOpts.ServiceType == vdriapi.DIDCommServiceType {
+			s.RecipientKeys = []string{publicKey.ID}
+			s.Priority = 0
+		}
+
+		didDoc.Service = []did.Service{s}
+	}
+
+	docBytes, err := didDoc.JSONBytes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get document bytes : %s", err)
+	}
+
+	var reqBody io.Reader
+	if docOpts.RequestBuilder != nil {
+		reqBody, err = docOpts.RequestBuilder(docBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build request : %s", err)
+		}
+	} else {
+		reqBody = bytes.NewReader(docBytes)
+	}
+
+	resDoc, err := v.sendCreateRequest(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send create DID request: %s", err)
+	}
+
+	return resDoc, nil
+}
+
+// TODO add timeouts on external calls [Issue: #855]
+func (v *VDRI) sendCreateRequest(req io.Reader) (*did.Doc, error) {
+	httpReq, err := http.NewRequest(http.MethodPost, v.endpointURL, req)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := v.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+
+	defer closeResponseBody(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("got unexpected response status '%d'", resp.StatusCode)
+	}
+
+	responseBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response : %s", err)
+	}
+
+	didDoc, err := did.ParseDocument(responseBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse public DID document: %s", err)
+	}
+
+	return didDoc, nil
 }
 
 // Close frees resources being maintained by vdri.
@@ -93,5 +195,12 @@ func WithTLSConfig(tlsConfig *tls.Config) Option {
 func WithAccept(accept Accept) Option {
 	return func(opts *VDRI) {
 		opts.accept = accept
+	}
+}
+
+func closeResponseBody(respBody io.Closer) {
+	e := respBody.Close()
+	if e != nil {
+		logger.Errorf("Failed to close response body: %v", e)
 	}
 }

--- a/pkg/vdri/httpbinding/vdri_test.go
+++ b/pkg/vdri/httpbinding/vdri_test.go
@@ -7,9 +7,17 @@ SPDX-License-Identifier: Apache-2.0
 package httpbinding
 
 import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/vdri"
 )
 
 func TestVDRI_Close(t *testing.T) {
@@ -20,22 +28,120 @@ func TestVDRI_Close(t *testing.T) {
 	})
 }
 
-func TestVDRI_Store(t *testing.T) {
-	t.Run("test success", func(t *testing.T) {
-		v, err := New("/did:example:334455")
-		require.NoError(t, err)
-		err = v.Store(nil, nil)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "not supported")
-	})
-}
-
 func TestVDRI_Build(t *testing.T) {
-	t.Run("test success", func(t *testing.T) {
-		v, err := New("/did:example:334455")
+	pubKey := &vdriapi.PubKey{Type: "sample-type", Value: "sample-value"}
+
+	const svcEndPoint = "http://sample-svc:8080"
+
+	newDidDoc, err := (&vdri.MockVDRIRegistry{}).Create("test")
+
+	require.NoError(t, err)
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.Header().Add("Content-type", "application/json")
+		res.WriteHeader(http.StatusOK)
+		b, e := newDidDoc.JSONBytes()
+		require.NoError(t, e)
+		_, e = res.Write(b)
+		require.NoError(t, e)
+	}))
+
+	defer testServer.Close()
+
+	t.Run("test HTTP Binding VDRI build with default opts", func(t *testing.T) {
+		resolver, err := New(testServer.URL)
 		require.NoError(t, err)
-		_, err = v.Build(nil)
+		require.NotNil(t, resolver)
+
+		result, err := resolver.Build(pubKey)
+		require.NoError(t, err)
+		require.NotEmpty(t, result)
+		require.NoError(t, err)
+		require.Equal(t, newDidDoc.ID, result.ID)
+		require.Equal(t, newDidDoc.PublicKey, result.PublicKey)
+	})
+
+	t.Run("test HTTP Binding VDRI build with request builder opts", func(t *testing.T) {
+		resolver, err := New(testServer.URL)
+		require.NoError(t, err)
+		require.NotNil(t, resolver)
+
+		didBuilt, err := resolver.Build(pubKey, vdriapi.WithServiceType(vdriapi.DIDCommServiceType),
+			vdriapi.WithServiceEndpoint(svcEndPoint),
+			vdriapi.WithRequestBuilder(
+				func(b []byte) (io.Reader, error) {
+					return bytes.NewReader(b), nil
+				}))
+		require.NoError(t, err)
+		require.Equal(t, newDidDoc.ID, didBuilt.ID)
+		require.Equal(t, newDidDoc.PublicKey, didBuilt.PublicKey)
+	})
+
+	t.Run("test HTTP Binding VDRI build with request builder errors", func(t *testing.T) {
+		const sampleErr = "sample-error"
+		resolver, err := New("localhost:8080")
+		require.NoError(t, err)
+		require.NotNil(t, resolver)
+
+		didBuilt, err := resolver.Build(pubKey, vdriapi.WithServiceType(vdriapi.DIDCommServiceType),
+			vdriapi.WithServiceEndpoint(svcEndPoint),
+			vdriapi.WithRequestBuilder(
+				func(b []byte) (io.Reader, error) {
+					return nil, fmt.Errorf(sampleErr)
+				}))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "not supported")
+		require.Contains(t, err.Error(), sampleErr)
+		require.Nil(t, didBuilt)
+
+		didBuilt, err = resolver.Build(pubKey, vdriapi.WithServiceType(vdriapi.DIDCommServiceType),
+			vdriapi.WithServiceEndpoint(svcEndPoint),
+			vdriapi.WithRequestBuilder(
+				func(b []byte) (io.Reader, error) {
+					return bytes.NewReader([]byte("-----")), nil
+				}))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to send request")
+		require.Nil(t, didBuilt)
+	})
+
+	t.Run("test HTTP Binding VDRI build with send create-request errors", func(t *testing.T) {
+		testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			res.Header().Add("Content-type", "application/json")
+
+			reqURI := req.URL.String()
+			fmt.Println("reqURI", reqURI)
+
+			if reqURI == "/status400" {
+				res.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			res.WriteHeader(http.StatusOK)
+		}))
+
+		defer func() { testServer.Close() }()
+
+		allTests := []struct {
+			reqURI string
+			errMsg string
+		}{
+			{"/status400", "got unexpected response status"},
+			{"/ss", " validation of DID doc failed"},
+		}
+
+		for _, test := range allTests {
+			resolver, err := New(testServer.URL + test.reqURI)
+			require.NoError(t, err)
+			require.NotNil(t, resolver)
+
+			didBuilt, err := resolver.Build(pubKey, vdriapi.WithServiceType(vdriapi.DIDCommServiceType),
+				vdriapi.WithServiceEndpoint(svcEndPoint),
+				vdriapi.WithRequestBuilder(
+					func(b []byte) (io.Reader, error) {
+						return bytes.NewReader(b), nil
+					}))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.errMsg)
+			require.Nil(t, didBuilt)
+		}
 	})
 }

--- a/pkg/vdri/peer/creator.go
+++ b/pkg/vdri/peer/creator.go
@@ -14,8 +14,6 @@ import (
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 )
 
-const didCommServiceType = "did-communication"
-
 // Build builds new DID Document
 func (v *VDRI) Build(pubKey *vdriapi.PubKey, opts ...vdriapi.DocOpts) (*did.Doc, error) {
 	docOpts := &vdriapi.CreateDIDOpts{}
@@ -24,29 +22,12 @@ func (v *VDRI) Build(pubKey *vdriapi.PubKey, opts ...vdriapi.DocOpts) (*did.Doc,
 		opt(docOpts)
 	}
 
-	didDoc, err := build(pubKey, v.applyCreatorOpts(docOpts))
+	didDoc, err := build(pubKey, docOpts)
 	if err != nil {
 		return nil, fmt.Errorf("create peer DID : %w", err)
 	}
 
 	return didDoc, nil
-}
-
-// applyCreatorOpts applies creator options to doc options
-func (v *VDRI) applyCreatorOpts(docOpts *vdriapi.CreateDIDOpts) *vdriapi.CreateDIDOpts {
-	if docOpts == nil {
-		docOpts = &vdriapi.CreateDIDOpts{ServiceType: v.serviceType, ServiceEndpoint: v.serviceEndpoint}
-	}
-
-	if docOpts.ServiceType == "" {
-		docOpts.ServiceType = v.serviceType
-	}
-
-	if docOpts.ServiceEndpoint == "" {
-		docOpts.ServiceEndpoint = v.serviceEndpoint
-	}
-
-	return docOpts
 }
 
 func build(pubKey *vdriapi.PubKey, docOpts *vdriapi.CreateDIDOpts) (*did.Doc, error) {
@@ -67,7 +48,7 @@ func build(pubKey *vdriapi.PubKey, docOpts *vdriapi.CreateDIDOpts) (*did.Doc, er
 			ServiceEndpoint: docOpts.ServiceEndpoint,
 		}
 
-		if docOpts.ServiceType == didCommServiceType {
+		if docOpts.ServiceType == vdriapi.DIDCommServiceType {
 			s.RecipientKeys = []string{publicKey.ID}
 			s.Priority = 0
 		}

--- a/pkg/vdri/peer/creator_test.go
+++ b/pkg/vdri/peer/creator_test.go
@@ -19,31 +19,10 @@ import (
 )
 
 const (
-	serviceEndpoint    = "sample-endpoint.com"
-	serviceTypeDIDComm = "did-communication"
-	keyType            = "key-type"
+	keyType = "key-type"
 )
 
 func TestDIDCreator(t *testing.T) {
-	t.Run("test default creator options", func(t *testing.T) {
-		c, err := New(&storage.MockStoreProvider{}, WithCreatorServiceEndpoint(serviceEndpoint),
-			WithCreatorServiceType(serviceTypeDIDComm))
-		require.NoError(t, err)
-		require.NotNil(t, c)
-		didDoc, err := c.Build(getSigningKey())
-		require.NoError(t, err)
-		require.NotNil(t, didDoc)
-
-		// verify not empty services
-		require.NotEmpty(t, didDoc.Service)
-		require.Equal(t, serviceTypeDIDComm, didDoc.Service[0].Type)
-		require.Equal(t, serviceEndpoint, didDoc.Service[0].ServiceEndpoint)
-
-		// verify public key
-		require.NotEmpty(t, didDoc.PublicKey)
-		require.Equal(t, keyType, didDoc.PublicKey[0].Type)
-	})
-
 	t.Run("test create without service type", func(t *testing.T) {
 		c, err := New(&storage.MockStoreProvider{})
 		require.NoError(t, err)
@@ -58,8 +37,7 @@ func TestDIDCreator(t *testing.T) {
 	})
 
 	t.Run("test request overrides", func(t *testing.T) {
-		c, err := New(&storage.MockStoreProvider{}, WithCreatorServiceEndpoint(serviceEndpoint),
-			WithCreatorServiceType(serviceEndpoint))
+		c, err := New(&storage.MockStoreProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, c)
 

--- a/pkg/vdri/peer/vdri.go
+++ b/pkg/vdri/peer/vdri.go
@@ -17,47 +17,22 @@ const (
 	StoreNamespace = "peer"
 )
 
-// Option configures the peer vdri
-type Option func(opts *VDRI)
-
 // VDRI implements building new peer dids
 type VDRI struct {
-	serviceEndpoint string
-	serviceType     string
-	store           storage.Store
+	store storage.Store
 }
 
 // New return new instance of peer vdri
-func New(s storage.Provider, opts ...Option) (*VDRI, error) {
+func New(s storage.Provider) (*VDRI, error) {
 	didDBStore, err := s.OpenStore(StoreNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("open store : %w", err)
 	}
 
-	vdri := &VDRI{store: didDBStore}
-
-	for _, option := range opts {
-		option(vdri)
-	}
-
-	return vdri, nil
+	return &VDRI{store: didDBStore}, nil
 }
 
 // Accept did method
 func (v *VDRI) Accept(method string) bool {
 	return method == didMethod
-}
-
-// WithCreatorServiceType is service type for this creator
-func WithCreatorServiceType(serviceType string) Option {
-	return func(opts *VDRI) {
-		opts.serviceType = serviceType
-	}
-}
-
-// WithCreatorServiceEndpoint allows for setting service endpoint
-func WithCreatorServiceEndpoint(serviceEndpoint string) Option {
-	return func(opts *VDRI) {
-		opts.serviceEndpoint = serviceEndpoint
-	}
 }

--- a/pkg/vdri/registry_test.go
+++ b/pkg/vdri/registry_test.go
@@ -19,6 +19,22 @@ import (
 	mockvdri "github.com/hyperledger/aries-framework-go/pkg/internal/mock/vdri"
 )
 
+func TestRegistry_New(t *testing.T) {
+	t.Run("test new success", func(t *testing.T) {
+		registry := New(&mockprovider.Provider{})
+		require.NotNil(t, registry)
+	})
+	t.Run("test new with opts success", func(t *testing.T) {
+		const sampleSvcType = "sample-svc-type"
+		const sampleSvcEndpoint = "sample-svc-endpoint"
+		registry := New(&mockprovider.Provider{},
+			WithDefaultServiceEndpoint(sampleSvcEndpoint), WithDefaultServiceType(sampleSvcType))
+		require.NotNil(t, registry)
+		require.Equal(t, sampleSvcEndpoint, registry.defServiceEndpoint)
+		require.Equal(t, sampleSvcType, registry.defServiceType)
+	})
+}
+
 func TestRegistry_Close(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
 		registry := New(&mockprovider.Provider{})

--- a/test/bdd/features/didexchange_public_did.feature
+++ b/test/bdd/features/didexchange_public_did.feature
@@ -12,13 +12,13 @@ Feature: Decentralized Identifier(DID) exchange between the agents using public 
   @didexchange_public_dids_invitation
   Scenario: did exchange e2e flow using public DID in invitation
     Given "Maria" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
-    And   "Maria" creates public DID using sidetree "${SIDETREE_URL}"
+    And   "Maria" creates public DID for did method "sidetree" using "${SIDETREE_URL}"
     # we wait until observer polls sidetree txn
     Then  "Maria" waits for public did to become available in sidetree for up to 10 seconds
     And   "Maria" creates did exchange client
     And   "Maria" registers to receive notification for post state event "completed"
     Given "Lisa" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
-    And   "Lisa" creates public DID using sidetree "${SIDETREE_URL}"
+    And   "Lisa" creates public DID for did method "sidetree" using "${SIDETREE_URL}"
     # we wait until observer polls sidetree txn
     Then  "Lisa" waits for public did to become available in sidetree for up to 10 seconds
     And   "Lisa" creates did exchange client
@@ -35,7 +35,7 @@ Feature: Decentralized Identifier(DID) exchange between the agents using public 
   @didexchange_mixed_public_and_peer_dids
   Scenario: did exchange e2e flow using public DID in invitation
     Given "Julia" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
-    And   "Julia" creates public DID using sidetree "${SIDETREE_URL}"
+    And   "Julia" creates public DID for did method "sidetree" using "${SIDETREE_URL}"
     # we wait until observer polls sidetree txn
     Then  "Julia" waits for public did to become available in sidetree for up to 10 seconds
     And   "Julia" creates did exchange client


### PR DESCRIPTION
- add rest endpoint `/vdri/create-public-did` to created public DIDs
using VDRI of agent
- VDRI Build() for httpbinding to create public DIDs using custom request
builders
- `/vdri/create-public-did` to accept optional `request header` parameter to add custom headers to 
request being sent to http binding endpoint.
- closes #845

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
