### PR TITLE
test: Construct Verifiable Credential object (encoding side)

### DIFF
--- a/pkg/doc/verifiable/common.go
+++ b/pkg/doc/verifiable/common.go
@@ -53,17 +53,17 @@ func SingleKey(pubKey interface{}) PublicKeyFetcher {
 // Proof defines embedded proof of Verifiable Credential
 type Proof interface{}
 
-// ExtraFields is a map of extra fields of struct build when unmarshalling JSON which are not
+// CustomFields is a map of extra fields of struct build when unmarshalling JSON which are not
 // mapped to the struct fields.
-type ExtraFields map[string]interface{}
+type CustomFields map[string]interface{}
 
 // TypedID defines a flexible structure with id and name fields and arbitrary extra fields
-// kept in ExtraFields.
+// kept in CustomFields.
 type TypedID struct {
 	ID   string `json:"id,omitempty"`
 	Type string `json:"type,omitempty"`
 
-	ExtraFields `json:"-"`
+	CustomFields `json:"-"`
 }
 
 // MarshalJSON defines custom marshalling of TypedID to JSON.
@@ -73,7 +73,7 @@ func (tid *TypedID) MarshalJSON() ([]byte, error) {
 
 	alias := (*Alias)(tid)
 
-	data, err := marshalWithExtraFields(alias, tid.ExtraFields)
+	data, err := marshalWithCustomFields(alias, tid.CustomFields)
 	if err != nil {
 		return nil, fmt.Errorf("marshal TypedID: %w", err)
 	}
@@ -88,9 +88,9 @@ func (tid *TypedID) UnmarshalJSON(data []byte) error {
 
 	alias := (*Alias)(tid)
 
-	tid.ExtraFields = make(ExtraFields)
+	tid.CustomFields = make(CustomFields)
 
-	err := unmarshalWithExtraFields(data, alias, tid.ExtraFields)
+	err := unmarshalWithCustomFields(data, alias, tid.CustomFields)
 	if err != nil {
 		return fmt.Errorf("unmarshal TypedID: %w", err)
 	}

--- a/pkg/doc/verifiable/common_test.go
+++ b/pkg/doc/verifiable/common_test.go
@@ -42,7 +42,7 @@ func TestTypedID_MarshalJSON(t *testing.T) {
 		tid := TypedID{
 			ID:   "http://example.com/policies/credential/4",
 			Type: "IssuerPolicy",
-			ExtraFields: map[string]interface{}{
+			CustomFields: map[string]interface{}{
 				"profile": "http://example.com/profiles/credential",
 			},
 		}
@@ -59,7 +59,7 @@ func TestTypedID_MarshalJSON(t *testing.T) {
 
 	t.Run("Invalid marshalling", func(t *testing.T) {
 		tid := TypedID{
-			ExtraFields: map[string]interface{}{
+			CustomFields: map[string]interface{}{
 				"invalid": make(chan int),
 			},
 		}
@@ -89,7 +89,7 @@ func TestTypedID_UnmarshalJSON(t *testing.T) {
 
 		require.Equal(t, "http://example.com/policies/credential/4", tid.ID)
 		require.Equal(t, "IssuerPolicy", tid.Type)
-		require.Equal(t, ExtraFields{
+		require.Equal(t, CustomFields{
 			"profile": "http://example.com/profiles/credential",
 			"prohibition": []interface{}{
 				map[string]interface{}{
@@ -98,7 +98,7 @@ func TestTypedID_UnmarshalJSON(t *testing.T) {
 					"target":   "http://example.edu/credentials/3732",
 				},
 			},
-		}, tid.ExtraFields)
+		}, tid.CustomFields)
 	})
 
 	t.Run("Invalid unmarshalling", func(t *testing.T) {

--- a/pkg/doc/verifiable/credential_extension_switch_test.go
+++ b/pkg/doc/verifiable/credential_extension_switch_test.go
@@ -157,8 +157,8 @@ func (fp *FailingCredentialProducer) Apply(vc *Credential, dataJSON []byte) (int
 }
 
 func hasContext(allContexts []string, targetContext string) bool {
-	for _, thatType := range allContexts {
-		if thatType == targetContext {
+	for _, thatContext := range allContexts {
+		if thatContext == targetContext {
 			return true
 		}
 	}

--- a/pkg/doc/verifiable/credential_jwt.go
+++ b/pkg/doc/verifiable/credential_jwt.go
@@ -32,7 +32,7 @@ type JWTCredClaims struct {
 // newJWTCredClaims creates JWT Claims of VC with an option to minimize certain fields of VC
 // which is put into "vc" claim.
 func newJWTCredClaims(vc *Credential, minimizeVC bool) (*JWTCredClaims, error) {
-	subjectID, err := vc.SubjectID()
+	subjectID, err := subjectID(vc.Subject)
 	if err != nil {
 		return nil, fmt.Errorf("get VC subject id: %w", err)
 	}
@@ -62,7 +62,7 @@ func newJWTCredClaims(vc *Credential, minimizeVC bool) (*JWTCredClaims, error) {
 		raw = vc.raw()
 	}
 
-	vcMap, err := mergeExtraFields(raw, raw.ExtraFields)
+	vcMap, err := mergeCustomFields(raw, raw.CustomFields)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/doc/verifiable/example_credential_test.go
+++ b/pkg/doc/verifiable/example_credential_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifiable_test
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+)
+
+type UniversityDegree struct {
+	Type       string `json:"type,omitempty"`
+	University string `json:"university,omitempty"`
+}
+
+type UniversityDegreeSubject struct {
+	ID     string           `json:"id,omitempty"`
+	Name   string           `json:"name,omitempty"`
+	Spouse string           `json:"spouse,omitempty"`
+	Degree UniversityDegree `json:"degree,omitempty"`
+}
+
+type UniversityDegreeCredential struct {
+	*verifiable.Credential
+
+	ReferenceNumber int `json:"referenceNumber,omitempty"`
+}
+
+func (udc *UniversityDegreeCredential) MarshalJSON() ([]byte, error) {
+	// todo too complex! (https://github.com/hyperledger/aries-framework-go/issues/847)
+	c := udc.Credential
+	cp := *c
+
+	cp.CustomFields = map[string]interface{}{
+		"referenceNumber": udc.ReferenceNumber,
+	}
+
+	return json.Marshal(&cp)
+}
+
+//nolint:gochecknoglobals
+var privKey = ed25519.PrivateKey{56, 237, 176, 143, 247, 162, 167, 111, 85, 161, 158, 14, 243, 173, 144, 51, 157, 109, 155, 228, 77, 170, 238, 85, 220, 144, 158, 51, 14, 40, 153, 141, 193, 179, 12, 234, 125, 193, 60, 56, 198, 150, 80, 93, 30, 58, 14, 152, 205, 6, 50, 98, 125, 212, 65, 17, 15, 11, 230, 3, 226, 187, 7, 89} //nolint:lll
+
+//nolint:lll
+func ExampleCredential_embedding() {
+	issued := time.Date(2010, time.January, 1, 19, 23, 24, 0, time.UTC)
+	expired := time.Date(2020, time.January, 1, 19, 23, 24, 0, time.UTC)
+
+	vc := &UniversityDegreeCredential{
+		Credential: &verifiable.Credential{
+			Context: []string{"https://www.w3.org/2018/credentials/v1", "https://www.w3.org/2018/credentials/examples/v1"},
+			ID:      "http://example.edu/credentials/1872",
+			Types:   []string{"VerifiableCredential", "UniversityDegreeCredential"},
+			Subject: UniversityDegreeSubject{
+				ID:     "did:example:ebfeb1f712ebc6f1c276e12ec21",
+				Name:   "Jayden Doe",
+				Spouse: "did:example:c276e12ec21ebfeb1f712ebc6f1",
+				Degree: UniversityDegree{
+					Type:       "BachelorDegree",
+					University: "MIT",
+				},
+			},
+			Issuer: verifiable.Issuer{
+				ID:   "did:example:76e12ec712ebc6f1c221ebfeb1f",
+				Name: "Example University",
+			},
+			Issued:  &issued,
+			Expired: &expired,
+			Schemas: []verifiable.TypedID{},
+		},
+		ReferenceNumber: 83294847,
+	}
+
+	// Marshal to JSON.
+	vcBytes, err := json.Marshal(vc)
+	if err != nil {
+		fmt.Println("failed to marshal VC to JSON")
+	}
+
+	fmt.Println(string(vcBytes))
+
+	// Marshal to JWS.
+	jwtClaims, err := vc.JWTClaims(true)
+	if err != nil {
+		fmt.Println(fmt.Errorf("failed to marshal JWT claims of VC: %w", err))
+	}
+
+	jws, err := jwtClaims.MarshalJWS(verifiable.EdDSA, privKey, "")
+	if err != nil {
+		fmt.Println(fmt.Errorf("failed to sign VC inside JWT: %w", err))
+	}
+
+	fmt.Println(jws)
+
+	// Decode JWS and make sure it's coincide with JSON.
+	_, vcBytesFromJWS, err := verifiable.NewCredential(
+		[]byte(jws),
+		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(privKey.Public())))
+	if err != nil {
+		fmt.Println(fmt.Errorf("failed to encode VC from JWS: %w", err))
+	}
+
+	fmt.Println(string(vcBytesFromJWS))
+	// todo missing referenceNumber here (https://github.com/hyperledger/aries-framework-go/issues/847)
+
+	// Output:
+	// {"@context":["https://www.w3.org/2018/credentials/v1","https://www.w3.org/2018/credentials/examples/v1"],"credentialSchema":[],"credentialSubject":{"degree":{"type":"BachelorDegree","university":"MIT"},"id":"did:example:ebfeb1f712ebc6f1c276e12ec21","name":"Jayden Doe","spouse":"did:example:c276e12ec21ebfeb1f712ebc6f1"},"expirationDate":"2020-01-01T19:23:24Z","id":"http://example.edu/credentials/1872","issuanceDate":"2010-01-01T19:23:24Z","issuer":{"id":"did:example:76e12ec712ebc6f1c221ebfeb1f","name":"Example University"},"referenceNumber":83294847,"type":["VerifiableCredential","UniversityDegreeCredential"]}
+	// eyJhbGciOiJFZERTQSIsImtpZCI6IiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1Nzc5MDY2MDQsImlhdCI6MTI2MjM3MzgwNCwiaXNzIjoiZGlkOmV4YW1wbGU6NzZlMTJlYzcxMmViYzZmMWMyMjFlYmZlYjFmIiwianRpIjoiaHR0cDovL2V4YW1wbGUuZWR1L2NyZWRlbnRpYWxzLzE4NzIiLCJuYmYiOjEyNjIzNzM4MDQsInN1YiI6ImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSIsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjEiXSwiY3JlZGVudGlhbFNjaGVtYSI6W10sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImRlZ3JlZSI6eyJ0eXBlIjoiQmFjaGVsb3JEZWdyZWUiLCJ1bml2ZXJzaXR5IjoiTUlUIn0sImlkIjoiZGlkOmV4YW1wbGU6ZWJmZWIxZjcxMmViYzZmMWMyNzZlMTJlYzIxIiwibmFtZSI6IkpheWRlbiBEb2UiLCJzcG91c2UiOiJkaWQ6ZXhhbXBsZTpjMjc2ZTEyZWMyMWViZmViMWY3MTJlYmM2ZjEifSwiaXNzdWVyIjp7Im5hbWUiOiJFeGFtcGxlIFVuaXZlcnNpdHkifSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIlVuaXZlcnNpdHlEZWdyZWVDcmVkZW50aWFsIl19fQ.AHn2A2q5DL1heX3_izq_2yrsBDhoZ6BGGKhoRvhfMnMUuuOnBOdekdTg-dfUMJgipXRql_6WzBUIj4wTFehXCw
+	// {"@context":["https://www.w3.org/2018/credentials/v1","https://www.w3.org/2018/credentials/examples/v1"],"credentialSchema":[],"credentialSubject":{"degree":{"type":"BachelorDegree","university":"MIT"},"id":"did:example:ebfeb1f712ebc6f1c276e12ec21","name":"Jayden Doe","spouse":"did:example:c276e12ec21ebfeb1f712ebc6f1"},"expirationDate":"2020-01-01T19:23:24Z","id":"http://example.edu/credentials/1872","issuanceDate":"2010-01-01T19:23:24Z","issuer":{"id":"did:example:76e12ec712ebc6f1c221ebfeb1f","name":"Example University"},"type":["VerifiableCredential","UniversityDegreeCredential"]}
+}
+
+//nolint:lll
+func ExampleCredential_extraFields() {
+	issued := time.Date(2010, time.January, 1, 19, 23, 24, 0, time.UTC)
+	expired := time.Date(2020, time.January, 1, 19, 23, 24, 0, time.UTC)
+
+	vc := &verifiable.Credential{
+		Context: []string{"https://www.w3.org/2018/credentials/v1", "https://www.w3.org/2018/credentials/examples/v1"},
+		ID:      "http://example.edu/credentials/1872",
+		Types:   []string{"VerifiableCredential", "UniversityDegreeCredential"},
+		Subject: UniversityDegreeSubject{
+			ID:     "did:example:ebfeb1f712ebc6f1c276e12ec21",
+			Name:   "Jayden Doe",
+			Spouse: "did:example:c276e12ec21ebfeb1f712ebc6f1",
+			Degree: UniversityDegree{
+				Type:       "BachelorDegree",
+				University: "MIT",
+			},
+		},
+		Issuer: verifiable.Issuer{
+			ID:   "did:example:76e12ec712ebc6f1c221ebfeb1f",
+			Name: "Example University",
+		},
+		Issued:  &issued,
+		Expired: &expired,
+		Schemas: []verifiable.TypedID{},
+		CustomFields: map[string]interface{}{
+			"referenceNumber": 83294847,
+		},
+	}
+
+	// Marshal to JSON.
+	vcBytes, err := json.Marshal(vc)
+	if err != nil {
+		fmt.Println("failed to marshal VC to JSON")
+	}
+
+	fmt.Println(string(vcBytes))
+
+	// Marshal to JWS.
+	jwtClaims, err := vc.JWTClaims(true)
+	if err != nil {
+		fmt.Println(fmt.Errorf("failed to marshal JWT claims of VC: %w", err))
+	}
+
+	jws, err := jwtClaims.MarshalJWS(verifiable.EdDSA, privKey, "")
+	if err != nil {
+		fmt.Println(fmt.Errorf("failed to sign VC inside JWT: %w", err))
+	}
+
+	fmt.Println(jws)
+
+	// Decode JWS and make sure it's coincide with JSON.
+	_, vcBytesFromJWS, err := verifiable.NewCredential(
+		[]byte(jws),
+		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(privKey.Public())))
+	if err != nil {
+		fmt.Println(fmt.Errorf("failed to encode VC from JWS: %w", err))
+	}
+
+	fmt.Println(string(vcBytesFromJWS))
+
+	// Output:
+	// {"@context":["https://www.w3.org/2018/credentials/v1","https://www.w3.org/2018/credentials/examples/v1"],"credentialSchema":[],"credentialSubject":{"degree":{"type":"BachelorDegree","university":"MIT"},"id":"did:example:ebfeb1f712ebc6f1c276e12ec21","name":"Jayden Doe","spouse":"did:example:c276e12ec21ebfeb1f712ebc6f1"},"expirationDate":"2020-01-01T19:23:24Z","id":"http://example.edu/credentials/1872","issuanceDate":"2010-01-01T19:23:24Z","issuer":{"id":"did:example:76e12ec712ebc6f1c221ebfeb1f","name":"Example University"},"referenceNumber":83294847,"type":["VerifiableCredential","UniversityDegreeCredential"]}
+	// eyJhbGciOiJFZERTQSIsImtpZCI6IiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1Nzc5MDY2MDQsImlhdCI6MTI2MjM3MzgwNCwiaXNzIjoiZGlkOmV4YW1wbGU6NzZlMTJlYzcxMmViYzZmMWMyMjFlYmZlYjFmIiwianRpIjoiaHR0cDovL2V4YW1wbGUuZWR1L2NyZWRlbnRpYWxzLzE4NzIiLCJuYmYiOjEyNjIzNzM4MDQsInN1YiI6ImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSIsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjEiXSwiY3JlZGVudGlhbFNjaGVtYSI6W10sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImRlZ3JlZSI6eyJ0eXBlIjoiQmFjaGVsb3JEZWdyZWUiLCJ1bml2ZXJzaXR5IjoiTUlUIn0sImlkIjoiZGlkOmV4YW1wbGU6ZWJmZWIxZjcxMmViYzZmMWMyNzZlMTJlYzIxIiwibmFtZSI6IkpheWRlbiBEb2UiLCJzcG91c2UiOiJkaWQ6ZXhhbXBsZTpjMjc2ZTEyZWMyMWViZmViMWY3MTJlYmM2ZjEifSwiaXNzdWVyIjp7Im5hbWUiOiJFeGFtcGxlIFVuaXZlcnNpdHkifSwicmVmZXJlbmNlTnVtYmVyIjo4LjMyOTQ4NDdlKzA3LCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiVW5pdmVyc2l0eURlZ3JlZUNyZWRlbnRpYWwiXX19.auzCDgrk2TOK9BQFZHVI4p5bX1EI3CEfFNjXneC0r5fV5JE9jHY7WAIuRgKoFhNnadLKHdIekED_NrnlOEa0BA
+	// {"@context":["https://www.w3.org/2018/credentials/v1","https://www.w3.org/2018/credentials/examples/v1"],"credentialSchema":[],"credentialSubject":{"degree":{"type":"BachelorDegree","university":"MIT"},"id":"did:example:ebfeb1f712ebc6f1c276e12ec21","name":"Jayden Doe","spouse":"did:example:c276e12ec21ebfeb1f712ebc6f1"},"expirationDate":"2020-01-01T19:23:24Z","id":"http://example.edu/credentials/1872","issuanceDate":"2010-01-01T19:23:24Z","issuer":{"id":"did:example:76e12ec712ebc6f1c221ebfeb1f","name":"Example University"},"referenceNumber":83294847,"type":["VerifiableCredential","UniversityDegreeCredential"]}
+}

--- a/pkg/doc/verifiable/json.go
+++ b/pkg/doc/verifiable/json.go
@@ -9,21 +9,21 @@ import (
 	"encoding/json"
 )
 
-// marshalWithExtraFields marshals value merged with extra fields defined in the map into JSON.
-func marshalWithExtraFields(v interface{}, ef map[string]interface{}) ([]byte, error) {
-	// Convert value into a JSON map of known fields.
-	kf, err := mergeExtraFields(v, ef)
+// marshalWithCustomFields marshals value merged with custom fields defined in the map into JSON bytes.
+func marshalWithCustomFields(v interface{}, cf map[string]interface{}) ([]byte, error) {
+	// Merge value and custom fields into the joint map.
+	vm, err := mergeCustomFields(v, cf)
 	if err != nil {
 		return nil, err
 	}
 
-	// Marshal extended known fields map.
-	return json.Marshal(kf)
+	// Marshal the joint map.
+	return json.Marshal(vm)
 }
 
-// unmarshalWithExtraFields unmarshals JSON into value v and puts all JSON fields which do not belong to value
-// into extra fields map ef.
-func unmarshalWithExtraFields(data []byte, v interface{}, ef map[string]interface{}) error {
+// unmarshalWithCustomFields unmarshals JSON into value v and puts all JSON fields which do not belong to value
+// into custom fields map cf.
+func unmarshalWithCustomFields(data []byte, v interface{}, cf map[string]interface{}) error {
 	err := json.Unmarshal(data, v)
 	if err != nil {
 		return err
@@ -50,37 +50,45 @@ func unmarshalWithExtraFields(data []byte, v interface{}, ef map[string]interfac
 		return err
 	}
 
-	// Copy only those entries which do not belong to the value (i.e. extra fields).
+	// Copy only those entries which do not belong to the value (i.e. custom fields).
 	for k, v := range af {
 		if _, ok := vf[k]; !ok {
-			ef[k] = v
+			cf[k] = v
 		}
 	}
 
 	return nil
 }
 
-// mergeExtraFields converts value to the JSON-like map and merges it with extra fields map.
-func mergeExtraFields(v interface{}, ef map[string]interface{}) (map[string]interface{}, error) {
-	// Convert raw credential into a JSON map of known fields.
-	rcBytes, err := json.Marshal(v)
+// mergeCustomFields converts value to the JSON-like map and merges it with custom fields map cf.
+func mergeCustomFields(v interface{}, cf map[string]interface{}) (map[string]interface{}, error) {
+	kf, err := toMap(v)
 	if err != nil {
 		return nil, err
 	}
 
-	var kf map[string]interface{}
-
-	err = json.Unmarshal(rcBytes, &kf)
-	if err != nil {
-		return nil, err
-	}
-
-	// Supplement value map with extra fields.
-	for k, v := range ef {
+	// Supplement value map with custom fields.
+	for k, v := range cf {
 		if _, exists := kf[k]; !exists {
 			kf[k] = v
 		}
 	}
 
 	return kf, nil
+}
+
+func toMap(v interface{}) (map[string]interface{}, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	var m map[string]interface{}
+
+	err = json.Unmarshal(b, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
 }

--- a/pkg/doc/verifiable/json_test.go
+++ b/pkg/doc/verifiable/json_test.go
@@ -29,11 +29,11 @@ func Test_marshalJSON(t *testing.T) {
 			I: 7,
 		}
 
-		ef := map[string]interface{}{
+		cf := map[string]interface{}{
 			"boolValue": false,
 			"intValue":  8,
 		}
-		actual, err := marshalWithExtraFields(&v, ef)
+		actual, err := marshalWithCustomFields(&v, cf)
 		require.NoError(t, err)
 
 		expectedMap := map[string]interface{}{
@@ -49,7 +49,7 @@ func Test_marshalJSON(t *testing.T) {
 
 	t.Run("Failed JSON marshall", func(t *testing.T) {
 		// artificial example - pass smth which cannot be marshalled
-		_, err := marshalWithExtraFields(make(chan int), map[string]interface{}{})
+		_, err := marshalWithCustomFields(make(chan int), map[string]interface{}{})
 		require.Error(t, err)
 	})
 }
@@ -66,8 +66,8 @@ func Test_unmarshalJSON(t *testing.T) {
 
 	t.Run("Successful JSON unmarshalling", func(t *testing.T) {
 		v := new(testJSON)
-		ef := make(map[string]interface{})
-		err := unmarshalWithExtraFields(data, v, ef)
+		cf := make(map[string]interface{})
+		err := unmarshalWithCustomFields(data, v, cf)
 		require.NoError(t, err)
 
 		expectedV := testJSON{
@@ -78,22 +78,22 @@ func Test_unmarshalJSON(t *testing.T) {
 			"boolValue": false,
 		}
 		require.Equal(t, expectedV, *v)
-		require.Equal(t, expectedEf, ef)
+		require.Equal(t, expectedEf, cf)
 	})
 
 	t.Run("Failed JSON unmarshalling", func(t *testing.T) {
-		ef := make(map[string]interface{})
+		cf := make(map[string]interface{})
 
 		// invalid JSON
-		err := unmarshalWithExtraFields([]byte("not JSON"), "", ef)
+		err := unmarshalWithCustomFields([]byte("not JSON"), "", cf)
 		require.Error(t, err)
 
 		// unmarshallable value
-		err = unmarshalWithExtraFields(data, make(chan int), ef)
+		err = unmarshalWithCustomFields(data, make(chan int), cf)
 		require.Error(t, err)
 
 		// incompatible structure of value
-		err = unmarshalWithExtraFields(data, new(testJSONInvalid), ef)
+		err = unmarshalWithCustomFields(data, new(testJSONInvalid), cf)
 		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
Here we add examples of VC encoding. VC base model extension is shown by 2 ways:
- struct embedding
- using `ExtraFields` map

Struct embedding does not work properly for now (#847 is created), so it's recommended to use `ExtraFields` map for extensions.

closes #831

Signed-off-by: Dima <dkinoshenko@gmail.com>
