### PR TITLE
feat: Introduce - add requesting state to the service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ depend:
 .PHONY: mocks
 mocks: depend
 	$(call create_mock,pkg/client/introduce,Provider)
-	$(call create_mock,pkg/didcomm/protocol/introduce,Provider;InvitationEnvelope)
+	$(call create_mock,pkg/didcomm/protocol/introduce,Provider;InvitationEnvelope;Forwarder)
 	$(call create_mock,pkg/didcomm/dispatcher,Outbound)
 	$(call create_mock,pkg/storage,Provider;Store)
 	$(call create_mock,pkg/didcomm/common/service,DIDComm)

--- a/pkg/client/introduce/client.go
+++ b/pkg/client/introduce/client.go
@@ -118,29 +118,27 @@ func (c *Client) SendRequest(dest *service.Destination) error {
 
 // HandleRequest is a helper function to prepare the right protocol dependency interface
 // It can be executed after receiving a Request action message (the client does not have a public Invitation)
-func (c *Client) HandleRequest(msg service.DIDCommMsg, dest1, dest2 *service.Destination) error {
+func (c *Client) HandleRequest(msg service.DIDCommMsg, dest *service.Destination) error {
 	thID, err := msg.ThreadID()
 	if err != nil {
 		return fmt.Errorf("handle request threadID: %w", err)
 	}
 
 	return c.saveInvitationEnvelope(thID, InvitationEnvelope{
-		Dests: []*service.Destination{dest1, dest2},
+		Dests: []*service.Destination{dest},
 	})
 }
 
 // HandleRequestWithInvitation is a helper function to prepare the right protocol dependency interface
 // It can be executed after receiving a Request action message (the client has a public Invitation)
-// nolint: lll
-func (c *Client) HandleRequestWithInvitation(msg service.DIDCommMsg, inv *didexchange.Invitation, dest *service.Destination) error {
+func (c *Client) HandleRequestWithInvitation(msg service.DIDCommMsg, inv *didexchange.Invitation) error {
 	thID, err := msg.ThreadID()
 	if err != nil {
 		return fmt.Errorf("handle request with invitation threadID: %w", err)
 	}
 
 	return c.saveInvitationEnvelope(thID, InvitationEnvelope{
-		Inv:   inv,
-		Dests: []*service.Destination{dest},
+		Inv: inv,
 	})
 }
 

--- a/pkg/client/introduce/client_test.go
+++ b/pkg/client/introduce/client_test.go
@@ -92,6 +92,7 @@ func TestClient_SendProposal(t *testing.T) {
 	introduceProvider := introduceMocks.NewMockProvider(ctrl)
 	introduceProvider.EXPECT().StorageProvider().Return(storageProvider)
 	introduceProvider.EXPECT().OutboundDispatcher().Return(nil)
+	introduceProvider.EXPECT().Service(didexchange.DIDExchange).Return(introduceMocks.NewMockForwarder(ctrl), nil)
 
 	svc, err := introduce.New(introduceProvider)
 	require.NoError(t, err)
@@ -133,6 +134,7 @@ func TestClient_SendProposalWithInvitation(t *testing.T) {
 	introduceProvider := introduceMocks.NewMockProvider(ctrl)
 	introduceProvider.EXPECT().StorageProvider().Return(storageProvider)
 	introduceProvider.EXPECT().OutboundDispatcher().Return(nil)
+	introduceProvider.EXPECT().Service(didexchange.DIDExchange).Return(introduceMocks.NewMockForwarder(ctrl), nil)
 
 	svc, err := introduce.New(introduceProvider)
 	require.NoError(t, err)
@@ -176,6 +178,7 @@ func TestClient_HandleRequest(t *testing.T) {
 	introduceProvider := introduceMocks.NewMockProvider(ctrl)
 	introduceProvider.EXPECT().StorageProvider().Return(storageProvider)
 	introduceProvider.EXPECT().OutboundDispatcher().Return(nil)
+	introduceProvider.EXPECT().Service(didexchange.DIDExchange).Return(introduceMocks.NewMockForwarder(ctrl), nil)
 
 	svc, err := introduce.New(introduceProvider)
 	require.NoError(t, err)
@@ -184,7 +187,6 @@ func TestClient_HandleRequest(t *testing.T) {
 	opts := InvitationEnvelope{
 		Dests: []*service.Destination{
 			{ServiceEndpoint: "service/endpoint1"},
-			{ServiceEndpoint: "service/endpoint2"},
 		},
 	}
 	store.EXPECT().Put(invitationEnvelopePrefix+UUID, toBytes(t, opts)).Return(nil)
@@ -203,10 +205,10 @@ func TestClient_HandleRequest(t *testing.T) {
 		ID:   UUID,
 	}))
 	require.NoError(t, err)
-	require.NoError(t, client.HandleRequest(*msg, opts.Dests[0], opts.Dests[1]))
+	require.NoError(t, client.HandleRequest(*msg, opts.Dests[0]))
 
 	// cover error case
-	err = client.HandleRequest(service.DIDCommMsg{}, opts.Dests[0], opts.Dests[1])
+	err = client.HandleRequest(service.DIDCommMsg{}, opts.Dests[0])
 	require.EqualError(t, errors.Unwrap(err), service.ErrNoHeader.Error())
 }
 
@@ -220,9 +222,6 @@ func TestClient_HandleRequestWithInvitation(t *testing.T) {
 		Inv: &didexchange.Invitation{
 			ID: UUID,
 		},
-		Dests: []*service.Destination{{
-			ServiceEndpoint: "service/endpoint",
-		}},
 	}
 
 	store := storageMocks.NewMockStore(ctrl)
@@ -246,10 +245,10 @@ func TestClient_HandleRequestWithInvitation(t *testing.T) {
 		ID:   UUID,
 	}))
 	require.NoError(t, err)
-	require.NoError(t, client.HandleRequestWithInvitation(*msg, opts.Inv, opts.Dests[0]))
+	require.NoError(t, client.HandleRequestWithInvitation(*msg, opts.Inv))
 
 	// cover error case
-	err = client.HandleRequestWithInvitation(service.DIDCommMsg{}, opts.Inv, opts.Dests[0])
+	err = client.HandleRequestWithInvitation(service.DIDCommMsg{}, opts.Inv)
 	require.EqualError(t, errors.Unwrap(err), service.ErrNoHeader.Error())
 }
 
@@ -267,6 +266,7 @@ func TestClient_InvitationEnvelope(t *testing.T) {
 	introduceProvider := introduceMocks.NewMockProvider(ctrl)
 	introduceProvider.EXPECT().StorageProvider().Return(storageProvider)
 	introduceProvider.EXPECT().OutboundDispatcher().Return(nil)
+	introduceProvider.EXPECT().Service(didexchange.DIDExchange).Return(introduceMocks.NewMockForwarder(ctrl), nil)
 
 	svc, err := introduce.New(introduceProvider)
 	require.NoError(t, err)
@@ -321,6 +321,7 @@ func TestClient_SendRequest(t *testing.T) {
 	introduceProvider := introduceMocks.NewMockProvider(ctrl)
 	introduceProvider.EXPECT().StorageProvider().Return(storageProvider)
 	introduceProvider.EXPECT().OutboundDispatcher().Return(nil)
+	introduceProvider.EXPECT().Service(didexchange.DIDExchange).Return(introduceMocks.NewMockForwarder(ctrl), nil)
 
 	svc, err := introduce.New(introduceProvider)
 	require.NoError(t, err)

--- a/pkg/didcomm/protocol/introduce/models.go
+++ b/pkg/didcomm/protocol/introduce/models.go
@@ -17,6 +17,7 @@ type Proposal struct {
 	ID     string            `json:"@id,omitempty"`
 	To     To                `json:"to,omitempty"`
 	NWise  bool              `json:"nwise,omitempty"`
+	Thread *decorator.Thread `json:"~thread,omitempty"`
 	Timing *decorator.Timing `json:"~timing,omitempty"`
 }
 

--- a/pkg/didcomm/protocol/introduce/service.go
+++ b/pkg/didcomm/protocol/introduce/service.go
@@ -34,7 +34,10 @@ const (
 	AckMsgType = IntroduceSpec + "ack"
 )
 
-const initialWaitCount = 2
+const (
+	initialWaitCount    = 2
+	introduceeIndexNone = -1
+)
 
 var logger = log.New("aries-framework/introduce/service")
 
@@ -49,8 +52,9 @@ var logger = log.New("aries-framework/introduce/service")
 //
 // Correct usage is described below:
 // - Destinations length is 0 and Invitation is <nil> (introducee)
-// - Destinations length is 0 and Invitation is not <nil> (introducee with invitation)
-// - Destinations length is 1 and Invitation is not <nil> (introducer skip proposal)
+// - Destinations length is 0 and Invitation is not <nil> (introducee or introducer skip proposal)
+// - Destinations length is 1 and Invitation is <nil> (introducer)
+// - Destinations length is 1 and Invitation is not <nil> (introducer)
 // - Destinations length is 2 and Invitation is <nil> (introducer)
 // NOTE: The state machine logic depends on the combinations above.
 type InvitationEnvelope interface {
@@ -72,10 +76,13 @@ type metaData struct {
 }
 
 type record struct {
-	StateName string
+	StateName string `json:"state_name,omitempty"`
 	// WaitCount - how many introducees still need to approve the introduction proposal
 	// (initial value = introducee count, e.g. 2)
-	WaitCount int
+	WaitCount int `json:"wait_count,omitempty"`
+	// IntroduceeIndex keeps an introducee index of from whom we got an invitation
+	IntroduceeIndex int                     `json:"introducee_index,omitempty"`
+	Invitation      *didexchange.Invitation `json:"invitation,omitempty"`
 }
 
 // Service for introduce protocol
@@ -95,6 +102,13 @@ type Service struct {
 type Provider interface {
 	OutboundDispatcher() dispatcher.Outbound
 	StorageProvider() storage.Provider
+	Service(id string) (interface{}, error)
+}
+
+// Forwarder provides the possibility to forward an invitation
+type Forwarder interface {
+	// method should be implemented in didexchange service
+	SendInvitation(inv *didexchange.Invitation, dest *service.Destination) error
 }
 
 // New returns introduce service
@@ -104,9 +118,20 @@ func New(p Provider) (*Service, error) {
 		return nil, err
 	}
 
+	didSvc, err := p.Service(didexchange.DIDExchange)
+	if err != nil {
+		return nil, err
+	}
+
+	forwarderSvc, ok := didSvc.(Forwarder)
+	if !ok {
+		return nil, errors.New("cast service to forwarder service failed")
+	}
+
 	svc := &Service{
 		ctx: internalContext{
-			Outbound: p.OutboundDispatcher(),
+			Outbound:       p.OutboundDispatcher(),
+			SendInvitation: forwarderSvc.SendInvitation,
 		},
 		store:     store,
 		callbacks: make(chan *metaData),
@@ -218,8 +243,10 @@ func (s *Service) doHandle(msg *service.DIDCommMsg, outbound bool) (*metaData, e
 
 	return &metaData{
 		record: record{
-			StateName: next.Name(),
-			WaitCount: rec.WaitCount,
+			StateName:       next.Name(),
+			WaitCount:       rec.WaitCount,
+			IntroduceeIndex: rec.IntroduceeIndex,
+			Invitation:      rec.Invitation,
 		},
 		Msg:      msg,
 		ThreadID: thID,
@@ -251,18 +278,9 @@ func (s *Service) HandleInbound(msg *service.DIDCommMsg) (string, error) {
 	return "", s.handle(mData, nil)
 }
 
-func (s *Service) sendRequest(msg *service.DIDCommMsg, dest *service.Destination) error {
-	return nil
-}
-
 // HandleOutbound handles outbound message (introduce protocol)
 func (s *Service) HandleOutbound(msg *service.DIDCommMsg, dest *service.Destination) error {
 	logger.Infof("entered into HandleOutbound: %v", msg.Header)
-
-	// request is not a part of any state machine, so we just need to send a request
-	if msg.Header.Type == RequestMsgType {
-		return s.sendRequest(msg, dest)
-	}
 
 	mData, err := s.doHandle(msg, true)
 	if err != nil {
@@ -316,6 +334,12 @@ func (s *Service) processCallback(msg *metaData) {
 
 func nextState(msg *service.DIDCommMsg, rec *record, outbound bool) (state, error) {
 	switch msg.Header.Type {
+	case RequestMsgType:
+		if outbound {
+			return &requesting{}, nil
+		}
+
+		return &arranging{}, nil
 	case ProposalMsgType:
 		if outbound {
 			return &arranging{}, nil
@@ -323,10 +347,6 @@ func nextState(msg *service.DIDCommMsg, rec *record, outbound bool) (state, erro
 
 		return &deciding{}, nil
 	case ResponseMsgType:
-		if outbound {
-			return &waiting{}, nil
-		}
-
 		rec.WaitCount--
 
 		if rec.WaitCount == 0 {
@@ -345,8 +365,9 @@ func (s *Service) currentStateRecord(thID string) (*record, error) {
 	src, err := s.store.Get(thID)
 	if errors.Is(err, storage.ErrDataNotFound) {
 		return &record{
-			StateName: stateNameStart,
-			WaitCount: initialWaitCount,
+			StateName:       stateNameStart,
+			WaitCount:       initialWaitCount,
+			IntroduceeIndex: introduceeIndexNone,
 		}, nil
 	}
 
@@ -389,6 +410,8 @@ func stateFromName(name string) (state, error) {
 		return &confirming{}, nil
 	case stateNameAbandoning:
 		return &abandoning{}, nil
+	case stateNameRequesting:
+		return &requesting{}, nil
 	case stateNameDeciding:
 		return &deciding{}, nil
 	case stateNameWaiting:
@@ -400,8 +423,7 @@ func stateFromName(name string) (state, error) {
 
 // canTriggerActionEvents checks if the incoming message can trigger an action event
 func canTriggerActionEvents(msg *service.DIDCommMsg) bool {
-	// TODO: need to check more msg.Header.Type
-	return msg.Header.Type == ProposalMsgType || msg.Header.Type == ResponseMsgType
+	return msg.Header.Type == ProposalMsgType || msg.Header.Type == ResponseMsgType || msg.Header.Type == RequestMsgType
 }
 
 func isNoOp(s state) bool {
@@ -409,11 +431,43 @@ func isNoOp(s state) bool {
 	return ok
 }
 
+func isSkipProposal(msg *metaData) bool {
+	if msg.dependency == nil {
+		return false
+	}
+
+	switch msg.StateName {
+	case stateNameRequesting, stateNameDeciding, stateNameWaiting:
+		return false
+	}
+
+	return msg.dependency.Invitation() != nil
+}
+
+func injectInvitation(msg *metaData) error {
+	if msg.Msg.Header.Type != ResponseMsgType || msg.Invitation != nil || isSkipProposal(msg) {
+		return nil
+	}
+
+	msg.IntroduceeIndex++
+
+	var resp *Response
+	if err := json.Unmarshal(msg.Msg.Payload, &resp); err != nil {
+		return err
+	}
+
+	msg.Invitation = resp.Invitation
+
+	return nil
+}
+
 func (s *Service) handle(msg *metaData, dest *service.Destination) error {
 	logger.Infof("entered into private handle message: %v ", msg.Msg.Header)
-	// if we got one destination value, this is definitely skip proposal
-	if msg.dependency != nil && len(msg.dependency.Destinations()) == 1 {
-		msg.StateName = stateNameDelivering
+
+	if isSkipProposal(msg) {
+		if msg.Msg.Header.Type == ResponseMsgType {
+			msg.StateName = stateNameDelivering
+		}
 	}
 
 	next, err := stateFromName(msg.StateName)
@@ -424,52 +478,67 @@ func (s *Service) handle(msg *metaData, dest *service.Destination) error {
 	logger.Infof("next valid state to transition -> %s ", next.Name())
 
 	for !isNoOp(next) {
-		s.sendMsgEvents(&service.StateMsg{
-			ProtocolName: Introduce,
-			Type:         service.PreState,
-			Msg:          msg.Msg.Clone(),
-			StateID:      next.Name(),
-		})
-		logger.Infof("sent pre event for state %s", next.Name())
-
-		var (
-			followup state
-			err      error
-		)
-
-		if dest != nil {
-			followup, err = next.ExecuteOutbound(s.ctx, msg, dest)
-		} else {
-			followup, err = next.ExecuteInbound(s.ctx, msg)
-		}
-
+		next, err = s.execute(next, msg, dest)
 		if err != nil {
-			return fmt.Errorf("execute state %s %w", next.Name(), err)
+			return fmt.Errorf("execute: %w", err)
 		}
-
-		logger.Infof("finish execute next state: %s", next.Name())
-
-		if err = s.save(msg.ThreadID, record{
-			StateName: next.Name(),
-			WaitCount: msg.WaitCount,
-		}); err != nil {
-			return fmt.Errorf("failed to persist state %s %w", next.Name(), err)
-		}
-
-		logger.Infof("persisted the connection using %s and updated the state to %s", msg.ThreadID, next.Name())
-
-		s.sendMsgEvents(&service.StateMsg{
-			ProtocolName: Introduce,
-			Type:         service.PostState,
-			Msg:          msg.Msg.Clone(),
-			StateID:      next.Name(),
-		})
-		logger.Infof("sent post event for state %s", next.Name())
-
-		next = followup
 	}
 
 	return nil
+}
+
+func (s *Service) execute(next state, msg *metaData, dest *service.Destination) (state, error) {
+	s.sendMsgEvents(&service.StateMsg{
+		ProtocolName: Introduce,
+		Type:         service.PreState,
+		Msg:          msg.Msg.Clone(),
+		StateID:      next.Name(),
+	})
+	logger.Infof("sent pre event for state %s", next.Name())
+
+	var (
+		followup state
+		err      error
+	)
+
+	if err = injectInvitation(msg); err != nil {
+		return nil, fmt.Errorf("inject invitation: %w", err)
+	}
+
+	if dest != nil {
+		followup, err = next.ExecuteOutbound(s.ctx, msg, dest)
+	} else {
+		followup, err = next.ExecuteInbound(s.ctx, msg)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("execute state %s %w", next.Name(), err)
+	}
+
+	logger.Infof("finish execute next state: %s", next.Name())
+
+	r := record{
+		StateName:       next.Name(),
+		WaitCount:       msg.WaitCount,
+		IntroduceeIndex: msg.IntroduceeIndex,
+		Invitation:      msg.Invitation,
+	}
+
+	if err = s.save(msg.ThreadID, r); err != nil {
+		return nil, fmt.Errorf("failed to persist state %s %w", next.Name(), err)
+	}
+
+	logger.Infof("persisted the connection using %s and updated the state to %s", msg.ThreadID, next.Name())
+
+	s.sendMsgEvents(&service.StateMsg{
+		ProtocolName: Introduce,
+		Type:         service.PostState,
+		Msg:          msg.Msg.Clone(),
+		StateID:      next.Name(),
+	})
+	logger.Infof("sent post event for state %s", next.Name())
+
+	return followup, nil
 }
 
 // Name returns service name

--- a/pkg/didcomm/protocol/introduce/states_test.go
+++ b/pkg/didcomm/protocol/introduce/states_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package introduce
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -14,14 +15,18 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	dispatcherMocks "github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher/gomocks"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
+	mocks "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/introduce/gomocks"
 )
 
 func notTransition(t *testing.T, st state) {
+	t.Helper()
+
 	var allState = [...]state{
 		&noOp{}, &start{}, &done{},
 		&arranging{}, &delivering{},
 		&confirming{}, &abandoning{},
-		&deciding{}, &waiting{},
+		&deciding{}, &waiting{}, &requesting{},
 	}
 
 	for _, s := range allState {
@@ -29,39 +34,31 @@ func notTransition(t *testing.T, st state) {
 	}
 }
 
-func TestNoopState(t *testing.T) {
+func TestNoOp_CanTransitionTo(t *testing.T) {
 	noop := &noOp{}
 	require.Equal(t, stateNameNoop, noop.Name())
 	notTransition(t, noop)
 }
 
-func TestNoOpState_ExecuteInbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
-	followup, err := (&noOp{}).ExecuteInbound(ctx, &metaData{})
+func TestNoOp_ExecuteInbound(t *testing.T) {
+	followup, err := (&noOp{}).ExecuteInbound(internalContext{}, &metaData{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
 
-func TestNoOpState_ExecuteOutbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
-	followup, err := (&noOp{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
+func TestNoOp_ExecuteOutbound(t *testing.T) {
+	followup, err := (&noOp{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
 
-// start state can transition to ...
-func TestStartState(t *testing.T) {
+func TestStart_CanTransitionTo(t *testing.T) {
 	st := &start{}
 	require.Equal(t, stateNameStart, st.Name())
 
 	require.True(t, st.CanTransitionTo(&arranging{}))
 	require.True(t, st.CanTransitionTo(&deciding{}))
+	require.True(t, st.CanTransitionTo(&requesting{}))
 
 	require.False(t, st.CanTransitionTo(&delivering{}))
 	require.False(t, st.CanTransitionTo(&noOp{}))
@@ -72,55 +69,37 @@ func TestStartState(t *testing.T) {
 	require.False(t, st.CanTransitionTo(&waiting{}))
 }
 
-func TestStartState_ExecuteInbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
-	followup, err := (&start{}).ExecuteInbound(ctx, &metaData{})
+func TestStart_ExecuteInbound(t *testing.T) {
+	followup, err := (&start{}).ExecuteInbound(internalContext{}, &metaData{})
 	require.NoError(t, err)
 	require.Equal(t, &arranging{}, followup)
 }
 
-func TestStartState_ExecuteOutbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
-	followup, err := (&start{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
+func TestStart_ExecuteOutbound(t *testing.T) {
+	followup, err := (&start{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
 	require.NoError(t, err)
 	require.Equal(t, &noOp{}, followup)
 }
 
-// done state can transition to ...
-func TestDoneState(t *testing.T) {
-	done := &done{}
-	require.Equal(t, stateNameDone, done.Name())
-	notTransition(t, done)
+func TestDone_CanTransitionTo(t *testing.T) {
+	st := &done{}
+	require.Equal(t, stateNameDone, st.Name())
+	notTransition(t, st)
 }
 
-func TestDoneState_ExecuteInbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
-	followup, err := (&done{}).ExecuteInbound(ctx, &metaData{})
+func TestDone_ExecuteInbound(t *testing.T) {
+	followup, err := (&done{}).ExecuteInbound(internalContext{}, &metaData{})
 	require.NoError(t, err)
 	require.Equal(t, &noOp{}, followup)
 }
 
-func TestDoneState_ExecuteOutbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
-	followup, err := (&done{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
+func TestDone_ExecuteOutbound(t *testing.T) {
+	followup, err := (&done{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
 
-// arranging state can transition to ...
-func TestArrangingState(t *testing.T) {
+func TestArranging_CanTransitionTo(t *testing.T) {
 	st := &arranging{}
 	require.Equal(t, stateNameArranging, st.Name())
 
@@ -134,9 +113,25 @@ func TestArrangingState(t *testing.T) {
 	require.False(t, st.CanTransitionTo(&confirming{}))
 	require.False(t, st.CanTransitionTo(&deciding{}))
 	require.False(t, st.CanTransitionTo(&waiting{}))
+	require.False(t, st.CanTransitionTo(&requesting{}))
 }
 
-func TestArrangingState_ExecuteInbound(t *testing.T) {
+func TestArranging_ExecuteInbound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dispatcher := dispatcherMocks.NewMockOutbound(ctrl)
+	dispatcher.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	dep := mocks.NewMockInvitationEnvelope(ctrl)
+	dep.EXPECT().Destinations().Return([]*service.Destination{{}})
+
+	followup, err := (&arranging{}).ExecuteInbound(internalContext{Outbound: dispatcher}, &metaData{dependency: dep})
+	require.NoError(t, err)
+	require.Equal(t, &noOp{}, followup)
+}
+
+func TestArranging_ExecuteOutbound(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -144,26 +139,22 @@ func TestArrangingState_ExecuteInbound(t *testing.T) {
 	dispatcher.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	ctx := internalContext{Outbound: dispatcher}
-	followup, err := (&arranging{}).ExecuteInbound(ctx, &metaData{})
+	followup, err := (&arranging{}).ExecuteOutbound(ctx, &metaData{
+		Msg: &service.DIDCommMsg{Payload: []byte(`{}`)},
+	}, &service.Destination{})
 	require.NoError(t, err)
 	require.Equal(t, &noOp{}, followup)
+
+	// JSON error
+	errMsg := "json: cannot unmarshal array into Go value of type introduce.Proposal"
+	followup, err = (&arranging{}).ExecuteOutbound(ctx, &metaData{
+		Msg: &service.DIDCommMsg{Payload: []byte(`[]`)},
+	}, &service.Destination{})
+	require.EqualError(t, errors.Unwrap(err), errMsg)
+	require.Nil(t, followup)
 }
 
-func TestArrangingState_ExecuteOutbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	dispatcher := dispatcherMocks.NewMockOutbound(ctrl)
-	dispatcher.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-
-	ctx := internalContext{Outbound: dispatcher}
-	followup, err := (&arranging{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
-	require.NoError(t, err)
-	require.Equal(t, &noOp{}, followup)
-}
-
-// delivering state can transition to ...
-func TestDeliveringState(t *testing.T) {
+func TestDelivering_CanTransitionTo(t *testing.T) {
 	st := &delivering{}
 	require.Equal(t, stateNameDelivering, st.Name())
 
@@ -177,30 +168,79 @@ func TestDeliveringState(t *testing.T) {
 	require.False(t, st.CanTransitionTo(&arranging{}))
 	require.False(t, st.CanTransitionTo(&deciding{}))
 	require.False(t, st.CanTransitionTo(&waiting{}))
+	require.False(t, st.CanTransitionTo(&requesting{}))
 }
 
-func TestDeliveringState_ExecuteInbound(t *testing.T) {
+func TestDelivering_ExecuteInbound(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
-	followup, err := (&delivering{}).ExecuteInbound(ctx, &metaData{})
-	require.NoError(t, err)
-	require.Equal(t, &done{}, followup)
+	t.Run("Happy path", func(t *testing.T) {
+		ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
+		ctx.SendInvitation = func(inv *didexchange.Invitation, dest *service.Destination) error {
+			return nil
+		}
+
+		dep := mocks.NewMockInvitationEnvelope(ctrl)
+		dep.EXPECT().Destinations().Return([]*service.Destination{{}}).Times(1)
+		dep.EXPECT().Invitation().Return(&didexchange.Invitation{}).Times(2)
+
+		followup, err := (&delivering{}).ExecuteInbound(ctx, &metaData{dependency: dep})
+		require.NoError(t, err)
+		require.Equal(t, &done{}, followup)
+	})
+
+	t.Run("SendInvitation Error", func(t *testing.T) {
+		const errMsg = "test err"
+
+		ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
+		ctx.SendInvitation = func(inv *didexchange.Invitation, dest *service.Destination) error {
+			return errors.New(errMsg)
+		}
+
+		dep := mocks.NewMockInvitationEnvelope(ctrl)
+		dep.EXPECT().Destinations().Return([]*service.Destination{{}}).Times(2)
+		dep.EXPECT().Invitation().Return(nil).Times(1)
+
+		followup, err := (&delivering{}).ExecuteInbound(ctx, &metaData{dependency: dep})
+		require.Nil(t, followup)
+		require.EqualError(t, err, "send inbound invitation: "+errMsg)
+
+		// SkipProposal
+		dep.EXPECT().Invitation().Return(&didexchange.Invitation{}).Times(2)
+		followup, err = (&delivering{}).ExecuteInbound(ctx, &metaData{dependency: dep})
+		require.Nil(t, followup)
+		require.EqualError(t, err, "send inbound invitation (skip): "+errMsg)
+	})
+
+	t.Run("Error Send", func(t *testing.T) {
+		const errMsg = "test err"
+
+		outbound := dispatcherMocks.NewMockOutbound(ctrl)
+		outbound.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New(errMsg))
+
+		ctx := internalContext{Outbound: outbound}
+		ctx.SendInvitation = func(inv *didexchange.Invitation, dest *service.Destination) error {
+			return nil
+		}
+
+		dep := mocks.NewMockInvitationEnvelope(ctrl)
+		dep.EXPECT().Destinations().Return([]*service.Destination{{}, {}}).Times(1)
+		dep.EXPECT().Invitation().Return(nil).Times(1)
+
+		followup, err := (&delivering{}).ExecuteInbound(ctx, &metaData{dependency: dep})
+		require.Nil(t, followup)
+		require.EqualError(t, errors.Unwrap(err), errMsg)
+	})
 }
 
-func TestDeliveringState_ExecuteOutbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
-	followup, err := (&delivering{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
+func TestDelivering_ExecuteOutbound(t *testing.T) {
+	followup, err := (&delivering{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
 
-// confirming state can transition to ...
-func TestConfirmingState(t *testing.T) {
+func TestConfirming_CanTransitionTo(t *testing.T) {
 	st := &confirming{}
 	require.Equal(t, stateNameConfirming, st.Name())
 
@@ -214,30 +254,22 @@ func TestConfirmingState(t *testing.T) {
 	require.False(t, st.CanTransitionTo(&confirming{}))
 	require.False(t, st.CanTransitionTo(&deciding{}))
 	require.False(t, st.CanTransitionTo(&waiting{}))
+	require.False(t, st.CanTransitionTo(&requesting{}))
 }
 
-func TestConfirmingState_ExecuteInbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
-	followup, err := (&confirming{}).ExecuteInbound(ctx, &metaData{})
+func TestConfirming_ExecuteInbound(t *testing.T) {
+	followup, err := (&confirming{}).ExecuteInbound(internalContext{}, &metaData{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
 
-func TestConfirmingState_ExecuteOutbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
-	followup, err := (&confirming{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
+func TestConfirming_ExecuteOutbound(t *testing.T) {
+	followup, err := (&confirming{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
 
-// abandoning state can transition to ...
-func TestAbandoningState(t *testing.T) {
+func TestAbandoning_CanTransitionTo(t *testing.T) {
 	st := &abandoning{}
 	require.Equal(t, stateNameAbandoning, st.Name())
 
@@ -251,30 +283,22 @@ func TestAbandoningState(t *testing.T) {
 	require.False(t, st.CanTransitionTo(&deciding{}))
 	require.False(t, st.CanTransitionTo(&abandoning{}))
 	require.False(t, st.CanTransitionTo(&waiting{}))
+	require.False(t, st.CanTransitionTo(&requesting{}))
 }
 
-func TestAbandoningState_ExecuteInbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
-	followup, err := (&abandoning{}).ExecuteInbound(ctx, &metaData{})
+func TestAbandoning_ExecuteInbound(t *testing.T) {
+	followup, err := (&abandoning{}).ExecuteInbound(internalContext{}, &metaData{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
 
-func TestAbandoningState_ExecuteOutbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
-	followup, err := (&abandoning{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
+func TestAbandoning_ExecuteOutbound(t *testing.T) {
+	followup, err := (&abandoning{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
 
-// deciding state can transition to ...
-func TestDecidingState(t *testing.T) {
+func TestDeciding_CanTransitionTo(t *testing.T) {
 	st := &deciding{}
 	require.Equal(t, stateNameDeciding, st.Name())
 
@@ -288,9 +312,10 @@ func TestDecidingState(t *testing.T) {
 	require.False(t, st.CanTransitionTo(&confirming{}))
 	require.False(t, st.CanTransitionTo(&deciding{}))
 	require.False(t, st.CanTransitionTo(&abandoning{}))
+	require.False(t, st.CanTransitionTo(&requesting{}))
 }
 
-func TestDecidingState_ExecuteInbound(t *testing.T) {
+func TestDeciding_ExecuteInbound(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -298,23 +323,22 @@ func TestDecidingState_ExecuteInbound(t *testing.T) {
 	dispatcher.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	ctx := internalContext{Outbound: dispatcher}
-	followup, err := (&deciding{}).ExecuteInbound(ctx, &metaData{})
+
+	dep := mocks.NewMockInvitationEnvelope(ctrl)
+	dep.EXPECT().Invitation().Return(nil)
+
+	followup, err := (&deciding{}).ExecuteInbound(ctx, &metaData{dependency: dep})
 	require.NoError(t, err)
 	require.Equal(t, &waiting{}, followup)
 }
 
-func TestDecidingState_ExecuteOutbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
-	followup, err := (&deciding{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
+func TestDeciding_ExecuteOutbound(t *testing.T) {
+	followup, err := (&deciding{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
 
-// waiting state can transition to ...
-func TestWaitingState(t *testing.T) {
+func TestWaiting_CanTransitionTo(t *testing.T) {
 	st := &waiting{}
 	require.Equal(t, stateNameWaiting, st.Name())
 
@@ -328,24 +352,54 @@ func TestWaitingState(t *testing.T) {
 	require.False(t, st.CanTransitionTo(&deciding{}))
 	require.False(t, st.CanTransitionTo(&abandoning{}))
 	require.False(t, st.CanTransitionTo(&waiting{}))
+	require.False(t, st.CanTransitionTo(&requesting{}))
 }
 
-func TestWaitingState_ExecuteInbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
-	followup, err := (&waiting{}).ExecuteInbound(ctx, &metaData{})
+func TestWaiting_ExecuteInbound(t *testing.T) {
+	followup, err := (&waiting{}).ExecuteInbound(internalContext{}, &metaData{})
 	require.NoError(t, err)
 	require.Equal(t, &noOp{}, followup)
 }
 
-func TestWaitingState_ExecuteOutbound(t *testing.T) {
+func TestWaiting_ExecuteOutbound(t *testing.T) {
+	followup, err := (&waiting{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
+	require.Error(t, err)
+	require.Nil(t, followup)
+}
+
+func TestRequesting_CanTransitionTo(t *testing.T) {
+	st := &requesting{}
+	require.Equal(t, stateNameRequesting, st.Name())
+
+	require.True(t, st.CanTransitionTo(&deciding{}))
+	require.True(t, st.CanTransitionTo(&done{}))
+
+	require.False(t, st.CanTransitionTo(&noOp{}))
+	require.False(t, st.CanTransitionTo(&start{}))
+	require.False(t, st.CanTransitionTo(&delivering{}))
+	require.False(t, st.CanTransitionTo(&arranging{}))
+	require.False(t, st.CanTransitionTo(&confirming{}))
+	require.False(t, st.CanTransitionTo(&abandoning{}))
+	require.False(t, st.CanTransitionTo(&waiting{}))
+	require.False(t, st.CanTransitionTo(&requesting{}))
+}
+
+func TestRequesting_ExecuteInbound(t *testing.T) {
+	followup, err := (&requesting{}).ExecuteInbound(internalContext{}, &metaData{})
+	require.Error(t, err)
+	require.Nil(t, followup)
+}
+
+func TestRequesting_ExecuteOutbound(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	ctx := internalContext{Outbound: dispatcherMocks.NewMockOutbound(ctrl)}
-	followup, err := (&waiting{}).ExecuteOutbound(ctx, &metaData{}, &service.Destination{})
-	require.Error(t, err)
+	followup, err := (&requesting{}).ExecuteOutbound(internalContext{}, &metaData{
+		Msg: &service.DIDCommMsg{Payload: []byte(`[]`)},
+	}, nil)
+
+	const errMsg = "requesting outbound unmarshal: json: cannot unmarshal array into Go value of type introduce.Request"
+
+	require.EqualError(t, err, errMsg)
 	require.Nil(t, followup)
 }


### PR DESCRIPTION
* added tests for state machine behavior (`SkipProposal`, `Proposal`, `ProposalUnusual`,`SkipProposalWithRequest`,`ProposalWithRequest`,`ProposalUnusualWithRequest`)
* service logic was changed according to the dependency 
* state`s methods were implemented `ExecuteInbound`,`ExecuteOutbound`


Closes #802 https://github.com/hyperledger/aries-framework-go/issues/853
Part of #269

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>

