### PR TITLE
feat: Transport Return Route - Framework Configuration

### DIFF
--- a/pkg/didcomm/dispatcher/outbound.go
+++ b/pkg/didcomm/dispatcher/outbound.go
@@ -9,9 +9,11 @@ package dispatcher
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	commontransport "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 )
 
@@ -19,17 +21,23 @@ import (
 type provider interface {
 	Packager() commontransport.Packager
 	OutboundTransports() []transport.OutboundTransport
+	TransportReturnRoute() string
 }
 
 // OutboundDispatcher dispatch msgs to destination
 type OutboundDispatcher struct {
-	outboundTransports []transport.OutboundTransport
-	packager           commontransport.Packager
+	outboundTransports   []transport.OutboundTransport
+	packager             commontransport.Packager
+	transportReturnRoute string
 }
 
 // NewOutbound return new dispatcher outbound instance
 func NewOutbound(prov provider) *OutboundDispatcher {
-	return &OutboundDispatcher{outboundTransports: prov.OutboundTransports(), packager: prov.Packager()}
+	return &OutboundDispatcher{
+		outboundTransports:   prov.OutboundTransports(),
+		packager:             prov.Packager(),
+		transportReturnRoute: prov.TransportReturnRoute(),
+	}
 }
 
 // Send msg
@@ -39,18 +47,37 @@ func (o *OutboundDispatcher) Send(msg interface{}, senderVerKey string, des *ser
 			continue
 		}
 
-		bytes, err := json.Marshal(msg)
+		req, err := json.Marshal(msg)
 		if err != nil {
 			return fmt.Errorf("failed marshal to bytes: %w", err)
 		}
 
+		// update the outbound message with transport return route option [all or thread]
+		if o.transportReturnRoute == decorator.TransportReturnRouteAll ||
+			o.transportReturnRoute == decorator.TransportReturnRouteThread {
+			// create the decorator with the option set in the framework
+			transportDec := &decorator.Transport{ReturnRoute: &decorator.ReturnRoute{Value: o.transportReturnRoute}}
+
+			transportDecJSON, jsonErr := json.Marshal(transportDec)
+			if jsonErr != nil {
+				return fmt.Errorf("json marshal : %w", jsonErr)
+			}
+
+			request := string(req)
+			index := strings.Index(request, "{")
+
+			// add transport route option decorator to the original request
+			req = []byte(request[:index+1] + string(transportDecJSON)[1:len(string(transportDecJSON))-1] + "," +
+				request[index+1:])
+		}
+
 		packedMsg, err := o.packager.PackMessage(
-			&commontransport.Envelope{Message: bytes, FromVerKey: senderVerKey, ToVerKeys: des.RecipientKeys})
+			&commontransport.Envelope{Message: req, FromVerKey: senderVerKey, ToVerKeys: des.RecipientKeys})
 		if err != nil {
 			return fmt.Errorf("failed to pack msg: %w", err)
 		}
 
-		_, err = v.Send(packedMsg, des.ServiceEndpoint)
+		_, err = v.Send(packedMsg, des)
 		if err != nil {
 			return fmt.Errorf("failed to send msg using http outbound transport: %w", err)
 		}

--- a/pkg/didcomm/dispatcher/outbound_test.go
+++ b/pkg/didcomm/dispatcher/outbound_test.go
@@ -7,13 +7,17 @@ SPDX-License-Identifier: Apache-2.0
 package dispatcher
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	commontransport "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	mockdidcomm "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm"
 	mockpackager "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/packager"
@@ -21,8 +25,10 @@ import (
 
 func TestOutboundDispatcher_Send(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
-		o := NewOutbound(&mockProvider{packagerValue: &mockpackager.Packager{},
-			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: true}}})
+		o := NewOutbound(&mockProvider{
+			packagerValue:           &mockpackager.Packager{},
+			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: true}},
+		})
 		require.NoError(t, o.Send("data", "", &service.Destination{ServiceEndpoint: "url"}))
 	})
 
@@ -52,9 +58,89 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 	})
 }
 
+func TestOutboundDispatcherTransportReturnRoute(t *testing.T) {
+	t.Run("transport route option - value set all", func(t *testing.T) {
+		transportReturnRoute := "all"
+		req := &decorator.Thread{
+			ID: uuid.New().String(),
+		}
+
+		outboundReq := struct {
+			*decorator.Transport
+			*decorator.Thread
+		}{
+			&decorator.Transport{ReturnRoute: &decorator.ReturnRoute{Value: transportReturnRoute}},
+			req,
+		}
+		expectedRequest, err := json.Marshal(outboundReq)
+		require.NoError(t, err)
+		require.NotNil(t, expectedRequest)
+
+		o := NewOutbound(&mockProvider{
+			packagerValue: &mockPackager{},
+			outboundTransportsValue: []transport.OutboundTransport{&mockOutboundTransport{
+				expectedRequest: string(expectedRequest)},
+			},
+			transportReturnRoute: transportReturnRoute,
+		})
+
+		require.NoError(t, o.Send(req, "", &service.Destination{ServiceEndpoint: "url"}))
+	})
+
+	t.Run("transport route option - value set thread", func(t *testing.T) {
+		transportReturnRoute := "thread"
+		req := &decorator.Thread{
+			ID: uuid.New().String(),
+		}
+
+		outboundReq := struct {
+			*decorator.Transport
+			*decorator.Thread
+		}{
+			&decorator.Transport{ReturnRoute: &decorator.ReturnRoute{Value: transportReturnRoute}},
+			req,
+		}
+		expectedRequest, err := json.Marshal(outboundReq)
+		require.NoError(t, err)
+		require.NotNil(t, expectedRequest)
+
+		o := NewOutbound(&mockProvider{
+			packagerValue: &mockPackager{},
+			outboundTransportsValue: []transport.OutboundTransport{&mockOutboundTransport{
+				expectedRequest: string(expectedRequest)},
+			},
+			transportReturnRoute: transportReturnRoute,
+		})
+
+		require.NoError(t, o.Send(req, "", &service.Destination{ServiceEndpoint: "url"}))
+	})
+
+	t.Run("transport route option - no value set", func(t *testing.T) {
+		req := &decorator.Thread{
+			ID: uuid.New().String(),
+		}
+
+		expectedRequest, err := json.Marshal(req)
+		require.NoError(t, err)
+		require.NotNil(t, expectedRequest)
+
+		o := NewOutbound(&mockProvider{
+			packagerValue: &mockPackager{},
+			outboundTransportsValue: []transport.OutboundTransport{&mockOutboundTransport{
+				expectedRequest: string(expectedRequest)},
+			},
+			transportReturnRoute: "",
+		})
+
+		require.NoError(t, o.Send(req, "", &service.Destination{ServiceEndpoint: "url"}))
+	})
+}
+
+// mockProvider mock provider
 type mockProvider struct {
 	packagerValue           commontransport.Packager
 	outboundTransportsValue []transport.OutboundTransport
+	transportReturnRoute    string
 }
 
 func (p *mockProvider) Packager() commontransport.Packager {
@@ -63,4 +149,37 @@ func (p *mockProvider) Packager() commontransport.Packager {
 
 func (p *mockProvider) OutboundTransports() []transport.OutboundTransport {
 	return p.outboundTransportsValue
+}
+
+func (p *mockProvider) TransportReturnRoute() string {
+	return p.transportReturnRoute
+}
+
+// mockOutboundTransport mock outbound transport
+type mockOutboundTransport struct {
+	expectedRequest string
+}
+
+func (o *mockOutboundTransport) Send(data []byte, destination *service.Destination) (string, error) {
+	if string(data) != o.expectedRequest {
+		return "", errors.New("invalid request")
+	}
+
+	return "", nil
+}
+
+func (o *mockOutboundTransport) Accept(url string) bool {
+	return true
+}
+
+// mockPackager mock packager
+type mockPackager struct {
+}
+
+func (m *mockPackager) PackMessage(e *commontransport.Envelope) ([]byte, error) {
+	return e.Message, nil
+}
+
+func (m *mockPackager) UnpackMessage(encMessage []byte) (*commontransport.Envelope, error) {
+	return nil, nil
 }

--- a/pkg/didcomm/protocol/decorator/decorator.go
+++ b/pkg/didcomm/protocol/decorator/decorator.go
@@ -8,6 +8,17 @@ package decorator
 
 import "time"
 
+const (
+	// TransportReturnRouteNone return route option none
+	TransportReturnRouteNone = "none"
+
+	// TransportReturnRouteAll return route option all
+	TransportReturnRouteAll = "all"
+
+	// TransportReturnRouteThread return route option thread
+	TransportReturnRouteThread = "thread"
+)
+
 // Thread thread data
 type Thread struct {
 	ID  string `json:"thid,omitempty"`
@@ -17,4 +28,15 @@ type Thread struct {
 // Timing keeps expiration time
 type Timing struct {
 	ExpiresTime time.Time `json:"expires_time,omitempty"`
+}
+
+// Transport transport decorator
+// https://github.com/hyperledger/aries-rfcs/tree/master/features/0092-transport-return-route
+type Transport struct {
+	ReturnRoute *ReturnRoute `json:"~transport,omitempty"`
+}
+
+// ReturnRoute works with Transport decorator. Acceptable values - "none", "all" or "thread".
+type ReturnRoute struct {
+	Value string `json:"~return_route,omitempty"`
 }

--- a/pkg/didcomm/transport/http/outbound_test.go
+++ b/pkg/didcomm/transport/http/outbound_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 )
 
 func TestWithOutboundOpts(t *testing.T) {
@@ -72,25 +74,31 @@ func TestOutboundHTTPTransport(t *testing.T) {
 
 	// test Outbound transport's api
 	// first with an empty url
-	r, e := ot.Send([]byte("Hello World"), "")
+	r, e := ot.Send([]byte("Hello World"), prepareDestination("serverURL"))
 	require.Error(t, e)
 	require.Empty(t, r)
 
 	// now try a bad url
-	r, e = ot.Send([]byte("Hello World"), "https://badurl")
+	r, e = ot.Send([]byte("Hello World"), prepareDestination("https://badurl"))
 	require.Error(t, e)
 	require.Empty(t, r)
 
 	// and try with a 'bad' payload with a valid url..
-	r, e = ot.Send([]byte("bad"), serverURL)
+	r, e = ot.Send([]byte("bad"), prepareDestination(serverURL))
 	require.Error(t, e)
 	require.Empty(t, r)
 
 	// finally using a valid url
-	r, e = ot.Send([]byte("Hello World"), serverURL)
+	r, e = ot.Send([]byte("Hello World"), prepareDestination(serverURL))
 	require.NoError(t, e)
 	require.NotEmpty(t, r)
 
 	require.True(t, ot.Accept("http://example.com"))
 	require.False(t, ot.Accept("123:22"))
+}
+
+func prepareDestination(endPoint string) *service.Destination {
+	return &service.Destination{
+		ServiceEndpoint: endPoint,
+	}
 }

--- a/pkg/didcomm/transport/transport_interface.go
+++ b/pkg/didcomm/transport/transport_interface.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package transport
 
 import (
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
 )
 
@@ -14,7 +15,7 @@ import (
 // This is the client side of the agent
 type OutboundTransport interface {
 	// Send send a2a exchange data
-	Send(data []byte, destination string) (string, error)
+	Send(data []byte, destination *service.Destination) (string, error)
 	// Accept url
 	Accept(string) bool
 }

--- a/pkg/didcomm/transport/ws/outbound.go
+++ b/pkg/didcomm/transport/ws/outbound.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 
 	"nhooyr.io/websocket"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 )
 
 const webSocketScheme = "ws"
@@ -27,12 +29,12 @@ func NewOutbound() *OutboundClient {
 }
 
 // Send sends a2a data via WS.
-func (cs *OutboundClient) Send(data []byte, url string) (string, error) {
-	if url == "" {
+func (cs *OutboundClient) Send(data []byte, destination *service.Destination) (string, error) {
+	if destination.ServiceEndpoint == "" {
 		return "", errors.New("url is mandatory")
 	}
 
-	client, _, err := websocket.Dial(context.Background(), url, nil)
+	client, _, err := websocket.Dial(context.Background(), destination.ServiceEndpoint, nil)
 	if err != nil {
 		return "", fmt.Errorf("websocket client : %w", err)
 	}

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -33,6 +33,7 @@ type Provider struct {
 	outboundDispatcher       dispatcher.Outbound
 	outboundTransports       []transport.OutboundTransport
 	vdriRegistry             vdriapi.Registry
+	transportReturnRoute     string
 }
 
 // New instantiates a new context provider.
@@ -134,6 +135,11 @@ func (p *Provider) VDRIRegistry() vdriapi.Registry {
 	return p.vdriRegistry
 }
 
+// TransportReturnRoute returns transport return route
+func (p *Provider) TransportReturnRoute() string {
+	return p.transportReturnRoute
+}
+
 // ProviderOption configures the framework.
 type ProviderOption func(opts *Provider) error
 
@@ -149,6 +155,14 @@ func WithOutboundTransports(transports ...transport.OutboundTransport) ProviderO
 func WithOutboundDispatcher(outboundDispatcher dispatcher.Outbound) ProviderOption {
 	return func(opts *Provider) error {
 		opts.outboundDispatcher = outboundDispatcher
+		return nil
+	}
+}
+
+// WithTransportReturnRoute injects transport return route option to the Aries framework.
+func WithTransportReturnRoute(transportReturnRoute string) ProviderOption {
+	return func(opts *Provider) error {
+		opts.transportReturnRoute = transportReturnRoute
 		return nil
 	}
 }

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -200,11 +200,18 @@ func TestNewProvider(t *testing.T) {
 			&mockdidcomm.MockOutboundTransport{ExpectedResponse: "data1"}))
 		require.NoError(t, err)
 		require.Equal(t, 2, len(prov.outboundTransports))
-		r, err := prov.outboundTransports[0].Send([]byte("data"), "url")
+		r, err := prov.outboundTransports[0].Send([]byte("data"), &service.Destination{ServiceEndpoint: "url"})
 		require.NoError(t, err)
 		require.Equal(t, "data", r)
-		r, err = prov.outboundTransports[1].Send([]byte("data1"), "url")
+		r, err = prov.outboundTransports[1].Send([]byte("data1"), &service.Destination{ServiceEndpoint: "url"})
 		require.NoError(t, err)
 		require.Equal(t, "data1", r)
+	})
+
+	t.Run("test new with transport return route", func(t *testing.T) {
+		transportReturnRoute := "none"
+		prov, err := New(WithTransportReturnRoute(transportReturnRoute))
+		require.NoError(t, err)
+		require.Equal(t, transportReturnRoute, prov.TransportReturnRoute())
 	})
 }

--- a/pkg/internal/mock/didcomm/mock_transport.go
+++ b/pkg/internal/mock/didcomm/mock_transport.go
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package didcomm
 
+import "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+
 // MockOutboundTransport mock outbound transport structure
 type MockOutboundTransport struct {
 	ExpectedResponse string
@@ -18,7 +20,7 @@ func NewMockOutboundTransport(expectedResponse string) *MockOutboundTransport {
 }
 
 // Send implementation of MockOutboundTransport.Send api
-func (transport *MockOutboundTransport) Send(data []byte, destination string) (string, error) {
+func (transport *MockOutboundTransport) Send(data []byte, destination *service.Destination) (string, error) {
 	return transport.ExpectedResponse, transport.SendErr
 }
 


### PR DESCRIPTION
- Aries framework level option to set the transport return route value [none, all, thread]; Added the option at framework level(edge agent doesn't have inbound capability) rather than each DIDComm message type.
- Pass the framework option to Outbound Dispatcher
- Outbound dispatcher injects the transport decorator to the outbound message before packing

Part of #858 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
