### PR TITLE
feat: WebSocket - Support Duplex communication based on Transport Return Route Feature

### DIFF
--- a/pkg/didcomm/common/service/service.go
+++ b/pkg/didcomm/common/service/service.go
@@ -110,7 +110,8 @@ func (m *DIDCommMsg) ThreadID() (string, error) {
 
 // Destination provides the recipientKeys, routingKeys, and serviceEndpoint populated from Invitation
 type Destination struct {
-	RecipientKeys   []string
-	ServiceEndpoint string
-	RoutingKeys     []string
+	RecipientKeys        []string
+	ServiceEndpoint      string
+	RoutingKeys          []string
+	TransportReturnRoute string
 }

--- a/pkg/didcomm/dispatcher/outbound_test.go
+++ b/pkg/didcomm/dispatcher/outbound_test.go
@@ -160,6 +160,10 @@ type mockOutboundTransport struct {
 	expectedRequest string
 }
 
+func (o *mockOutboundTransport) Start(prov transport.Provider) error {
+	return nil
+}
+
 func (o *mockOutboundTransport) Send(data []byte, destination *service.Destination) (string, error) {
 	if string(data) != o.expectedRequest {
 		return "", errors.New("invalid request")

--- a/pkg/didcomm/transport/http/inbound_test.go
+++ b/pkg/didcomm/transport/http/inbound_test.go
@@ -40,6 +40,10 @@ func (p *mockProvider) Packager() commontransport.Packager {
 	return p.packagerValue
 }
 
+func (p *mockProvider) AriesFrameworkID() string {
+	return "aries-framework-instance-1"
+}
+
 func TestInboundHandler(t *testing.T) {
 	// test inboundHandler with empty args should fail
 	inHandler, err := NewInboundHandler(nil)

--- a/pkg/didcomm/transport/http/outbound.go
+++ b/pkg/didcomm/transport/http/outbound.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 )
 
 //go:generate testdata/scripts/openssl_env.sh testdata/scripts/generate_test_keys.sh
@@ -82,6 +83,11 @@ func NewOutbound(opts ...OutboundHTTPOpt) (*OutboundHTTPClient, error) {
 	}
 
 	return cs, nil
+}
+
+// Start starts outbound transport
+func (cs *OutboundHTTPClient) Start(prov transport.Provider) error {
+	return nil
 }
 
 // Send sends a2a exchange data via HTTP (client side)

--- a/pkg/didcomm/transport/transport_interface.go
+++ b/pkg/didcomm/transport/transport_interface.go
@@ -14,8 +14,12 @@ import (
 // OutboundTransport interface definition for transport layer
 // This is the client side of the agent
 type OutboundTransport interface {
+	// starts the outbound transport
+	Start(prov Provider) error
+
 	// Send send a2a exchange data
 	Send(data []byte, destination *service.Destination) (string, error)
+
 	// Accept url
 	Accept(string) bool
 }
@@ -24,17 +28,18 @@ type OutboundTransport interface {
 // message handle invocation.
 type InboundMessageHandler func(message []byte) error
 
-// InboundProvider contains dependencies for starting the inbound transport.
+// Provider contains dependencies for starting the inbound/outbound transports.
 // It is typically created by using aries.Context().
-type InboundProvider interface {
+type Provider interface {
 	InboundMessageHandler() InboundMessageHandler
 	Packager() transport.Packager
+	AriesFrameworkID() string
 }
 
 // InboundTransport interface definition for inbound transport layer
 type InboundTransport interface {
 	// starts the inbound transport
-	Start(prov InboundProvider) error
+	Start(prov Provider) error
 
 	// stops the inbound transport
 	Stop() error

--- a/pkg/didcomm/transport/ws/pool.go
+++ b/pkg/didcomm/transport/ws/pool.go
@@ -1,0 +1,99 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ws
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"nhooyr.io/websocket"
+
+	commtransport "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
+)
+
+type connPool struct {
+	connMap map[string]*websocket.Conn
+	sync.RWMutex
+	packager   commtransport.Packager
+	msgHandler transport.InboundMessageHandler
+}
+
+// nolint gochecknoglobals
+var pool = make(map[string]*connPool)
+
+func getConnPool(prov transport.Provider) *connPool {
+	id := prov.AriesFrameworkID()
+
+	if _, ok := pool[id]; !ok {
+		pool[id] = &connPool{
+			connMap:    make(map[string]*websocket.Conn),
+			packager:   prov.Packager(),
+			msgHandler: prov.InboundMessageHandler(),
+		}
+	}
+
+	return pool[id]
+}
+
+func (d *connPool) add(verKey string, wsConn *websocket.Conn) {
+	d.Lock()
+	defer d.Unlock()
+
+	d.connMap[verKey] = wsConn
+}
+
+func (d *connPool) fetch(verKey string) *websocket.Conn {
+	d.RLock()
+	defer d.RUnlock()
+
+	return d.connMap[verKey]
+}
+
+func (d *connPool) listener(conn *websocket.Conn) {
+	defer func() {
+		if err := conn.Close(websocket.StatusNormalClosure, "closing the connection"); err != nil {
+			logger.Errorf("connection close error")
+		}
+	}()
+
+	for {
+		_, message, err := conn.Read(context.Background())
+		if err != nil {
+			logger.Errorf("Error reading request message: %v", err)
+
+			break
+		}
+
+		unpackMsg, err := d.packager.UnpackMessage(message)
+
+		if err != nil {
+			logger.Errorf("failed to unpack msg: %v", err)
+
+			continue
+		}
+
+		trans := &decorator.Transport{}
+
+		err = json.Unmarshal(unpackMsg.Message, trans)
+		if err != nil {
+			logger.Errorf("unmarshal transport decorator : %v", err)
+		}
+
+		if trans != nil && trans.ReturnRoute != nil && trans.ReturnRoute.Value == "all" {
+			d.add(unpackMsg.FromVerKey, conn)
+		}
+
+		messageHandler := d.msgHandler
+
+		err = messageHandler(unpackMsg.Message)
+		if err != nil {
+			logger.Errorf("incoming msg processing failed: %v", err)
+		}
+	}
+}

--- a/pkg/didcomm/transport/ws/pool_test.go
+++ b/pkg/didcomm/transport/ws/pool_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ws
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"nhooyr.io/websocket"
+
+	commontransport "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	mockpackager "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/packager"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/test/transportutil"
+)
+
+func TestConnectionStore(t *testing.T) {
+	t.Run("test transport pool - agent with inbound (consumer)", func(t *testing.T) {
+		// request to be sent to the framework (with route option)
+		request := createTransportDecRequest(t, decorator.TransportReturnRouteAll)
+
+		// ------- setup the framework - with inbound transport ----- //
+		// instantiate inbound with port
+		port := ":" + strconv.Itoa(transportutil.GetRandomPort(5))
+		inbound, err := NewInbound(port, "")
+		require.NoError(t, err)
+		require.NotEmpty(t, inbound)
+
+		// instantiate outbound
+		outbound := NewOutbound()
+		require.NotNil(t, outbound)
+
+		// create a transport provider (framework context)
+		verKey := "ABCD"
+		mockPackager := &mockpackager.Packager{
+			UnpackValue: &commontransport.Envelope{Message: request, FromVerKey: verKey},
+		}
+
+		response := "Hello"
+		transportProvider := &mockTransportProvider{
+			packagerValue: mockPackager,
+			frameworkID:   uuid.New().String(),
+			executeInbound: func(message []byte) error {
+				resp, outboundErr := outbound.Send([]byte(response),
+					prepareDestinationWithTransport("ws://doesnt-matter", "", []string{verKey}))
+				require.NoError(t, outboundErr)
+				require.Equal(t, "", resp)
+				return nil
+			},
+		}
+
+		// start inbound
+		err = inbound.Start(transportProvider)
+		require.NoError(t, err)
+
+		// start outbound
+		err = outbound.Start(transportProvider)
+		require.NoError(t, err)
+		// ------- framework setup complete ----- //
+
+		// Consumer of the framework (fetches and receives message in same websocket client)
+		client, cleanup := websocketClient(t, port)
+		defer cleanup()
+
+		ctx := context.Background()
+
+		err = client.Write(ctx, websocket.MessageText, request)
+		require.NoError(t, err)
+
+		mt, message, err := client.Read(ctx)
+		require.NoError(t, err)
+		require.Equal(t, websocket.MessageText, mt)
+		require.Equal(t, response, string(message))
+	})
+
+	t.Run("test transport pool - agent without inbound (client)", func(t *testing.T) {
+		// request to be sent to the framework (with route option)
+		request := createTransportDecRequest(t, decorator.TransportReturnRouteAll)
+
+		// agent with inbound - just echoes messages back
+		addr := startWebSocketServer(t, echo)
+
+		// ------- setup the framework : without inbound transport ----- //
+		// instantiate outbound
+		outbound := NewOutbound()
+		require.NotNil(t, outbound)
+
+		// create a transport provider (framework context)
+		verKey := "ABCD"
+
+		done := make(chan struct{})
+
+		transportProvider := &mockTransportProvider{
+			packagerValue: &mockPackager{verKey: verKey},
+			frameworkID:   uuid.New().String(),
+			executeInbound: func(message []byte) error {
+				// validate the echo server response with the outbound sent message
+				require.Equal(t, request, message)
+				done <- struct{}{}
+				return nil
+			},
+		}
+
+		// start outbound
+		err := outbound.Start(transportProvider)
+		require.NoError(t, err)
+		// ------- framework setup complete ----- //
+
+		// send the outbound message
+		resp, err := outbound.Send(request,
+			prepareDestinationWithTransport("ws://"+addr, decorator.TransportReturnRouteAll, []string{verKey}))
+		require.NoError(t, err)
+		require.Equal(t, "", resp)
+
+		// make sure response is received by the agent
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "tests are not validated due to timeout")
+		}
+	})
+}

--- a/pkg/didcomm/transport/ws/support_test.go
+++ b/pkg/didcomm/transport/ws/support_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"nhooyr.io/websocket"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	commontransport "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/test/transportutil"
+)
+
+type mockProvider struct {
+	packagerValue commontransport.Packager
+}
+
+func (p *mockProvider) InboundMessageHandler() transport.InboundMessageHandler {
+	return func(message []byte) error {
+		logger.Infof("message received is %s", string(message))
+		if string(message) == "invalid-data" {
+			return errors.New("error")
+		}
+		return nil
+	}
+}
+
+func (p *mockProvider) Packager() commontransport.Packager {
+	return p.packagerValue
+}
+
+func (p *mockProvider) AriesFrameworkID() string {
+	return uuid.New().String()
+}
+
+func websocketClient(t *testing.T, port string) (*websocket.Conn, func()) {
+	require.NoError(t, transportutil.VerifyListener("localhost"+port, time.Second))
+
+	u := url.URL{Scheme: "ws", Host: "localhost" + port, Path: ""}
+	c, resp, err := websocket.Dial(context.Background(), u.String(), nil) // nolint - bodyclose (library closes the body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+
+	return c, func() {
+		require.NoError(t, c.Close(websocket.StatusNormalClosure, "closing the connection"))
+	}
+}
+
+func prepareDestination(endPoint string) *service.Destination {
+	return &service.Destination{
+		ServiceEndpoint: endPoint,
+	}
+}
+
+func prepareDestinationWithTransport(endPoint, returnRoute string, recipientKeys []string) *service.Destination {
+	return &service.Destination{
+		ServiceEndpoint:      endPoint,
+		RecipientKeys:        recipientKeys,
+		TransportReturnRoute: returnRoute,
+	}
+}
+
+func createTransportDecRequest(t *testing.T, transportReturnRoute string) []byte {
+	req := &decorator.Thread{
+		ID: uuid.New().String(),
+	}
+
+	outboundReq := struct {
+		*decorator.Transport
+		*decorator.Thread
+	}{
+		&decorator.Transport{ReturnRoute: &decorator.ReturnRoute{Value: transportReturnRoute}},
+		req,
+	}
+	request, err := json.Marshal(outboundReq)
+	require.NoError(t, err)
+	require.NotNil(t, request)
+
+	return request
+}
+
+func startWebSocketServer(t *testing.T, handlerFunc func(*testing.T, http.ResponseWriter, *http.Request)) string {
+	addr := "localhost:" + strconv.Itoa(transportutil.GetRandomPort(5))
+
+	server := &http.Server{Addr: addr}
+	server.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerFunc(t, w, r)
+	})
+
+	go func() {
+		require.NoError(t, server.ListenAndServe())
+	}()
+
+	require.NoError(t, transportutil.VerifyListener(addr, time.Second))
+
+	return addr
+}
+
+func echo(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	c, err := Accept(w, r)
+	require.NoError(t, err)
+
+	defer func() {
+		require.Contains(t, c.Close(websocket.StatusNormalClosure, "closing the connection").Error(),
+			"status = StatusNormalClosure")
+	}()
+
+	ctx := context.Background()
+
+	for {
+		mt, message, err := c.Read(ctx)
+		if err != nil {
+			break
+		}
+
+		logger.Infof("r: %s", message)
+
+		err = c.Write(ctx, mt, message)
+		require.NoError(t, err)
+	}
+}
+
+// mockPackager mock packager
+type mockPackager struct {
+	verKey string
+}
+
+func (m *mockPackager) PackMessage(e *commontransport.Envelope) ([]byte, error) {
+	return e.Message, nil
+}
+
+func (m *mockPackager) UnpackMessage(encMessage []byte) (*commontransport.Envelope, error) {
+	return &commontransport.Envelope{Message: encMessage, FromVerKey: m.verKey}, nil
+}
+
+type mockTransportProvider struct {
+	packagerValue  commontransport.Packager
+	executeInbound func(message []byte) error
+	frameworkID    string
+}
+
+func (p *mockTransportProvider) InboundMessageHandler() transport.InboundMessageHandler {
+	return p.executeInbound
+}
+
+func (p *mockTransportProvider) Packager() commontransport.Packager {
+	return p.packagerValue
+}
+
+func (p *mockTransportProvider) AriesFrameworkID() string {
+	if p.frameworkID != "" {
+		return p.frameworkID
+	}
+
+	return "framework-instance-1"
+}

--- a/pkg/framework/aries/example_test.go
+++ b/pkg/framework/aries/example_test.go
@@ -46,7 +46,7 @@ func newMockInTransport() *mockInTransport {
 	return &mockInTransport{}
 }
 
-func (c *mockInTransport) Start(prov transport.InboundProvider) error {
+func (c *mockInTransport) Start(prov transport.Provider) error {
 	return nil
 }
 

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -482,7 +482,7 @@ type mockInboundTransport struct {
 	stopError  error
 }
 
-func (m *mockInboundTransport) Start(prov transport.InboundProvider) error {
+func (m *mockInboundTransport) Start(prov transport.Provider) error {
 	if m.startError != nil {
 		return m.startError
 	}

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -34,6 +34,7 @@ type Provider struct {
 	outboundTransports       []transport.OutboundTransport
 	vdriRegistry             vdriapi.Registry
 	transportReturnRoute     string
+	frameworkID              string
 }
 
 // New instantiates a new context provider.
@@ -140,6 +141,11 @@ func (p *Provider) TransportReturnRoute() string {
 	return p.transportReturnRoute
 }
 
+// AriesFrameworkID returns an inbound transport endpoint.
+func (p *Provider) AriesFrameworkID() string {
+	return p.frameworkID
+}
+
 // ProviderOption configures the framework.
 type ProviderOption func(opts *Provider) error
 
@@ -230,6 +236,16 @@ func WithPacker(primary packer.Packer, additionalPackers ...packer.Packer) Provi
 	return func(opts *Provider) error {
 		opts.primaryPacker = primary
 		opts.packers = append(opts.packers, additionalPackers...)
+		return nil
+	}
+}
+
+// WithAriesFrameworkID injects the framework ID into the context. This is used to tie different framework components.
+// The client can have multiple framework and with same instance of transport shared across it and this id is used
+// by the framework to tie the inbound transport and outbound transports (in case of duplex communication).
+func WithAriesFrameworkID(id string) ProviderOption {
+	return func(opts *Provider) error {
+		opts.frameworkID = id
 		return nil
 	}
 }

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -95,7 +95,7 @@ func TestNewProvider(t *testing.T) {
 		// valid json and message type
 		err = inboundHandler([]byte(`
 		{
-			"@id": "5678876542345",
+			"@frameworkID": "5678876542345",
 			"@type": "valid-message-type"
 		}`))
 		require.NoError(t, err)
@@ -213,5 +213,12 @@ func TestNewProvider(t *testing.T) {
 		prov, err := New(WithTransportReturnRoute(transportReturnRoute))
 		require.NoError(t, err)
 		require.Equal(t, transportReturnRoute, prov.TransportReturnRoute())
+	})
+
+	t.Run("test new with framework id", func(t *testing.T) {
+		frameworkID := "aries-framework-1"
+		prov, err := New(WithAriesFrameworkID(frameworkID))
+		require.NoError(t, err)
+		require.Equal(t, frameworkID, prov.AriesFrameworkID())
 	})
 }

--- a/pkg/internal/mock/didcomm/mock_transport.go
+++ b/pkg/internal/mock/didcomm/mock_transport.go
@@ -5,7 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package didcomm
 
-import "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
+)
 
 // MockOutboundTransport mock outbound transport structure
 type MockOutboundTransport struct {
@@ -19,12 +22,17 @@ func NewMockOutboundTransport(expectedResponse string) *MockOutboundTransport {
 	return &MockOutboundTransport{ExpectedResponse: expectedResponse}
 }
 
+// Start starts the transport.
+func (o *MockOutboundTransport) Start(prov transport.Provider) error {
+	return nil
+}
+
 // Send implementation of MockOutboundTransport.Send api
-func (transport *MockOutboundTransport) Send(data []byte, destination *service.Destination) (string, error) {
-	return transport.ExpectedResponse, transport.SendErr
+func (o *MockOutboundTransport) Send(data []byte, destination *service.Destination) (string, error) {
+	return o.ExpectedResponse, o.SendErr
 }
 
 // Accept url
-func (transport *MockOutboundTransport) Accept(url string) bool {
-	return transport.AcceptValue
+func (o *MockOutboundTransport) Accept(url string) bool {
+	return o.AcceptValue
 }


### PR DESCRIPTION
- Add new function Start() to Outbound Transport : Called by framework by passin the context (similar to Inbound Transport)
- Add new function AriesFrameworkID() to Context : Framework uses this ID to map between inbound and outbound transport for duplex communication
- Update WebSocket transport implementation to support Duplex communication based on Transport Return Route config

closes #877  

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
