### PR TITLE
fix: Linter warning on websocket.Accept for JS/WASM build

### DIFF
--- a/pkg/didcomm/transport/ws/inbound.go
+++ b/pkg/didcomm/transport/ws/inbound.go
@@ -134,7 +134,7 @@ func processRequest(w http.ResponseWriter, r *http.Request, prov transport.Inbou
 }
 
 func upgradeConnection(w http.ResponseWriter, r *http.Request) (*websocket.Conn, func(), error) {
-	c, err := websocket.Accept(w, r, nil)
+	c, err := Accept(w, r)
 	if err != nil {
 		logger.Errorf("failed to upgrade the connection : %v", err)
 		return nil, nil, err

--- a/pkg/didcomm/transport/ws/outbound_test.go
+++ b/pkg/didcomm/transport/ws/outbound_test.go
@@ -74,7 +74,7 @@ func TestClient(t *testing.T) {
 		outbound := NewOutbound()
 		require.NotNil(t, outbound)
 		addr := startWebSocketServer(t, func(_ *testing.T, w http.ResponseWriter, r *http.Request) {
-			c, err := websocket.Accept(w, r, nil)
+			c, err := Accept(w, r)
 			require.NoError(t, err)
 
 			defer func() {
@@ -106,7 +106,7 @@ func TestClient(t *testing.T) {
 		outbound := NewOutbound()
 		require.NotNil(t, outbound)
 		addr := startWebSocketServer(t, func(_ *testing.T, w http.ResponseWriter, r *http.Request) {
-			c, err := websocket.Accept(w, r, nil)
+			c, err := Accept(w, r)
 			require.NoError(t, err)
 
 			require.NoError(t, c.Close(websocket.StatusAbnormalClosure, "error"))
@@ -121,7 +121,7 @@ func TestClient(t *testing.T) {
 		outbound := NewOutbound()
 		require.NotNil(t, outbound)
 		addr := startWebSocketServer(t, func(_ *testing.T, w http.ResponseWriter, r *http.Request) {
-			c, err := websocket.Accept(w, r, nil)
+			c, err := Accept(w, r)
 			require.NoError(t, err)
 
 			_, _, err = c.Read(context.Background())
@@ -154,7 +154,7 @@ func startWebSocketServer(t *testing.T, handlerFunc func(*testing.T, http.Respon
 }
 
 func echo(t *testing.T, w http.ResponseWriter, r *http.Request) {
-	c, err := websocket.Accept(w, r, nil)
+	c, err := Accept(w, r)
 	require.NoError(t, err)
 
 	defer func() {

--- a/pkg/didcomm/transport/ws/upgrade_js_wasm.go
+++ b/pkg/didcomm/transport/ws/upgrade_js_wasm.go
@@ -1,0 +1,20 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ws
+
+import (
+	"errors"
+	"net/http"
+
+	"nhooyr.io/websocket"
+)
+
+// Accept accepts a WebSocket handshake from a client and upgrades the
+// the connection to a WebSocket.
+func Accept(_ http.ResponseWriter, _ *http.Request) (*websocket.Conn, error) {
+	return nil, errors.New("invalid operation with JS/WASM target")
+}

--- a/pkg/didcomm/transport/ws/upgrade_srv.go
+++ b/pkg/didcomm/transport/ws/upgrade_srv.go
@@ -1,0 +1,21 @@
+// +build !js,!wasm
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ws
+
+import (
+	"net/http"
+
+	"nhooyr.io/websocket"
+)
+
+// Accept accepts a WebSocket handshake from a client and upgrades the
+// the connection to a WebSocket.
+func Accept(w http.ResponseWriter, r *http.Request) (*websocket.Conn, error) {
+	return websocket.Accept(w, r, nil)
+}


### PR DESCRIPTION
The dependent package for WebSocket doesn't support Accept function for JS/WASM build. Split the function call in transport package based on the build target.

Closes #879 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>

