### PR TITLE
refactor: Inbound transport optional

### DIFF
--- a/pkg/didcomm/dispatcher/outbound.go
+++ b/pkg/didcomm/dispatcher/outbound.go
@@ -43,8 +43,10 @@ func NewOutbound(prov provider) *OutboundDispatcher {
 // Send msg
 func (o *OutboundDispatcher) Send(msg interface{}, senderVerKey string, des *service.Destination) error {
 	for _, v := range o.outboundTransports {
-		if !v.Accept(des.ServiceEndpoint) {
-			continue
+		if !v.AcceptRecipient(des.RecipientKeys) {
+			if !v.Accept(des.ServiceEndpoint) {
+				continue
+			}
 		}
 
 		req, err := json.Marshal(msg)

--- a/pkg/didcomm/dispatcher/outbound_test.go
+++ b/pkg/didcomm/dispatcher/outbound_test.go
@@ -158,6 +158,7 @@ func (p *mockProvider) TransportReturnRoute() string {
 // mockOutboundTransport mock outbound transport
 type mockOutboundTransport struct {
 	expectedRequest string
+	acceptRecipient bool
 }
 
 func (o *mockOutboundTransport) Start(prov transport.Provider) error {
@@ -170,6 +171,10 @@ func (o *mockOutboundTransport) Send(data []byte, destination *service.Destinati
 	}
 
 	return "", nil
+}
+
+func (o *mockOutboundTransport) AcceptRecipient([]string) bool {
+	return o.acceptRecipient
 }
 
 func (o *mockOutboundTransport) Accept(url string) bool {

--- a/pkg/didcomm/packager/package_test.go
+++ b/pkg/didcomm/packager/package_test.go
@@ -285,10 +285,6 @@ func (m *mockProvider) StorageProvider() storage.Provider {
 	return m.storage
 }
 
-func (m *mockProvider) InboundTransportEndpoint() string {
-	return "sample-endpoint.com"
-}
-
 func (m *mockProvider) PrimaryPacker() packer.Packer {
 	return m.primaryPacker
 }

--- a/pkg/didcomm/packer/legacy/authcrypt/authcrypt_test.go
+++ b/pkg/didcomm/packer/legacy/authcrypt/authcrypt_test.go
@@ -63,10 +63,6 @@ func (p *provider) StorageProvider() storage.Provider {
 	return p.storeProvider
 }
 
-func (p *provider) InboundTransportEndpoint() string {
-	return ""
-}
-
 func newKMS(t *testing.T) (*kms.BaseKMS, storage.Store) {
 	msp := mockStorage.NewMockStoreProvider()
 	p := provider{storeProvider: msp}

--- a/pkg/didcomm/transport/http/outbound.go
+++ b/pkg/didcomm/transport/http/outbound.go
@@ -127,6 +127,11 @@ func (cs *OutboundHTTPClient) Send(data []byte, destination *service.Destination
 	return respData, nil
 }
 
+// AcceptRecipient checks if there is a connection for the list of recipient keys
+func (cs *OutboundHTTPClient) AcceptRecipient([]string) bool {
+	return false
+}
+
 // Accept url
 func (cs *OutboundHTTPClient) Accept(url string) bool {
 	return strings.HasPrefix(url, httpScheme)

--- a/pkg/didcomm/transport/transport_interface.go
+++ b/pkg/didcomm/transport/transport_interface.go
@@ -20,6 +20,10 @@ type OutboundTransport interface {
 	// Send send a2a exchange data
 	Send(data []byte, destination *service.Destination) (string, error)
 
+	// AcceptRecipient checks if there is a connection for the list of recipient keys. The framework executes this
+	// function before Accept() in outbound message dispatcher.
+	AcceptRecipient([]string) bool
+
 	// Accept url
 	Accept(string) bool
 }

--- a/pkg/didcomm/transport/ws/outbound_test.go
+++ b/pkg/didcomm/transport/ws/outbound_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"nhooyr.io/websocket"
 
 	commontransport "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
@@ -24,15 +25,6 @@ func TestClient(t *testing.T) {
 
 		require.True(t, outbound.Accept(webSocketScheme))
 		require.False(t, outbound.Accept("http"))
-	})
-
-	t.Run("test outbound transport - missing url", func(t *testing.T) {
-		outbound := NewOutbound()
-		require.NotNil(t, outbound)
-
-		_, err := outbound.Send([]byte(""), prepareDestination(""))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "url is mandatory")
 	})
 
 	t.Run("test outbound transport - invalid url", func(t *testing.T) {
@@ -81,6 +73,36 @@ func TestClient(t *testing.T) {
 		require.Equal(t, "", resp)
 	})
 
+	t.Run("test outbound transport pool - accept recipients", func(t *testing.T) {
+		verKey := "XYZ"
+		recKey := []string{verKey}
+
+		outbound := NewOutbound()
+		require.NotNil(t, outbound)
+
+		require.NoError(t, outbound.Start(&mockProvider{
+			&mockpackager.Packager{UnpackValue: &commontransport.Envelope{Message: []byte("data")}}},
+		))
+
+		addr := startWebSocketServer(t, echo)
+
+		resp, err := outbound.Send(createTransportDecRequest(t, decorator.TransportReturnRouteAll),
+			prepareDestinationWithTransport("ws://"+addr, decorator.TransportReturnRouteAll, recKey))
+		require.NoError(t, err)
+		require.Equal(t, "", resp)
+
+		// verify connection exists for the verKey
+		require.True(t, outbound.AcceptRecipient(recKey))
+
+		// close the connection and verify
+		conn := outbound.pool.fetch(verKey)
+		require.NoError(t, conn.Close(websocket.StatusNormalClosure, "close conn"))
+		require.False(t, outbound.AcceptRecipient(recKey))
+
+		// connection was remove in prev step
+		require.False(t, outbound.AcceptRecipient(recKey))
+	})
+
 	t.Run("test outbound transport pool success - transport decorator", func(t *testing.T) {
 		outbound := NewOutbound()
 		require.NotNil(t, outbound)
@@ -93,6 +115,22 @@ func TestClient(t *testing.T) {
 
 		resp, err := outbound.Send(createTransportDecRequest(t, decorator.TransportReturnRouteAll),
 			prepareDestinationWithTransport("ws://"+addr, decorator.TransportReturnRouteAll, nil))
+		require.NoError(t, err)
+		require.Equal(t, "", resp)
+	})
+
+	t.Run("test outbound transport pool - transport decorator value none", func(t *testing.T) {
+		outbound := NewOutbound()
+		require.NotNil(t, outbound)
+
+		require.NoError(t, outbound.Start(&mockProvider{
+			&mockpackager.Packager{UnpackValue: &commontransport.Envelope{Message: []byte("data")}}},
+		))
+
+		addr := startWebSocketServer(t, echo)
+
+		resp, err := outbound.Send(createTransportDecRequest(t, decorator.TransportReturnRouteNone),
+			prepareDestinationWithTransport("ws://"+addr, decorator.TransportReturnRouteNone, nil))
 		require.NoError(t, err)
 		require.Equal(t, "", resp)
 	})

--- a/pkg/didcomm/transport/ws/upgrade_js_wasm.go
+++ b/pkg/didcomm/transport/ws/upgrade_js_wasm.go
@@ -18,3 +18,15 @@ import (
 func Accept(_ http.ResponseWriter, _ *http.Request) (*websocket.Conn, error) {
 	return nil, errors.New("invalid operation with JS/WASM target")
 }
+
+func acceptRecipient(pool *connPool, keys []string) bool {
+	for _, v := range keys {
+		// check if the connection exists for the key
+		if c := pool.fetch(v); c != nil {
+			// TODO make sure connection is alive (conn.Ping() doesn't work with JS/WASM build)
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/didcomm/transport/ws/upgrade_srv.go
+++ b/pkg/didcomm/transport/ws/upgrade_srv.go
@@ -9,6 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 package ws
 
 import (
+	"context"
 	"net/http"
 
 	"nhooyr.io/websocket"
@@ -18,4 +19,25 @@ import (
 // the connection to a WebSocket.
 func Accept(w http.ResponseWriter, r *http.Request) (*websocket.Conn, error) {
 	return websocket.Accept(w, r, nil)
+}
+
+func acceptRecipient(pool *connPool, keys []string) bool {
+	for _, v := range keys {
+		// check if the connection exists for the key
+		if c := pool.fetch(v); c != nil {
+			// verify the connection is alive
+			if err := c.Ping(context.Background()); err != nil {
+				// remove from the pool
+				pool.remove(v)
+
+				logger.Infof("failed to ping to the connection for key=%s err=%v", err)
+
+				return false
+			}
+
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -17,25 +17,10 @@ import (
 	jwe "github.com/hyperledger/aries-framework-go/pkg/didcomm/packer/jwe/authcrypt"
 	legacy "github.com/hyperledger/aries-framework-go/pkg/didcomm/packer/legacy/authcrypt"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
-	didcommtrans "github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	arieshttp "github.com/hyperledger/aries-framework-go/pkg/didcomm/transport/http"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
-
-//nolint:gochecknoglobals
-var (
-	defaultInboundPort = ":8090"
-)
-
-func inboundTransport() (didcommtrans.InboundTransport, error) {
-	inbound, err := arieshttp.NewInbound(defaultInboundPort, "")
-	if err != nil {
-		return nil, fmt.Errorf("http inbound transport initialization failed: %w", err)
-	}
-
-	return inbound, nil
-}
 
 // defFrameworkOpts provides default framework options
 func defFrameworkOpts(frameworkOpts *Aries) error {
@@ -56,15 +41,6 @@ func defFrameworkOpts(frameworkOpts *Aries) error {
 		}
 
 		frameworkOpts.storeProvider = storeProv
-	}
-
-	if frameworkOpts.inboundTransport == nil {
-		inbound, err := inboundTransport()
-		if err != nil {
-			return fmt.Errorf("http inbound transport initialization failed: %w", err)
-		}
-
-		frameworkOpts.inboundTransport = inbound
 	}
 
 	frameworkOpts.protocolSvcCreators = append(frameworkOpts.protocolSvcCreators, newExchangeSvc())

--- a/pkg/framework/aries/default_test.go
+++ b/pkg/framework/aries/default_test.go
@@ -25,21 +25,4 @@ func TestDefaultFramework(t *testing.T) {
 		err := defFrameworkOpts(aries)
 		require.NoError(t, err)
 	})
-
-	t.Run("test default framework - inbound transport error", func(t *testing.T) {
-		currentInboundPort := defaultInboundPort
-		defer func() { defaultInboundPort = currentInboundPort }()
-
-		path, cleanup := generateTempDir(t)
-		defer cleanup()
-		dbPath = path
-
-		defaultInboundPort = ""
-
-		aries := &Aries{}
-
-		err := defFrameworkOpts(aries)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "http inbound transport initialization failed")
-	})
 }

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -262,25 +262,6 @@ func TestFramework(t *testing.T) {
 		require.NotEmpty(t, aries)
 	})
 
-	t.Run("test Inbound transport - default", func(t *testing.T) {
-		path, cleanup := generateTempDir(t)
-		defer cleanup()
-		dbPath = path
-
-		currentInboundPort := defaultInboundPort
-		defaultInboundPort = ":26501"
-		defer func() {
-			defaultInboundPort = currentInboundPort
-		}()
-
-		aries, err := New()
-		require.NoError(t, err)
-		require.NotEmpty(t, aries)
-
-		err = aries.Close()
-		require.NoError(t, err)
-	})
-
 	t.Run("test Inbound transport - start/stop error", func(t *testing.T) {
 		path, cleanup := generateTempDir(t)
 		defer cleanup()
@@ -380,10 +361,9 @@ func TestFramework(t *testing.T) {
 		require.NoError(t, aries.Close())
 
 		transportReturnRoute = decorator.TransportReturnRouteThread
-		aries, err = New(WithTransportReturnRoute(transportReturnRoute))
-		require.NoError(t, err)
-		require.Equal(t, transportReturnRoute, aries.transportReturnRoute)
-		require.NoError(t, aries.Close())
+		_, err = New(WithTransportReturnRoute(transportReturnRoute))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid transport return route option : "+transportReturnRoute)
 
 		transportReturnRoute = decorator.TransportReturnRouteNone
 		aries, err = New(WithTransportReturnRoute(transportReturnRoute))

--- a/pkg/internal/mock/didcomm/mock_transport.go
+++ b/pkg/internal/mock/didcomm/mock_transport.go
@@ -32,6 +32,11 @@ func (o *MockOutboundTransport) Send(data []byte, destination *service.Destinati
 	return o.ExpectedResponse, o.SendErr
 }
 
+// AcceptRecipient checks if there is a connection for the list of recipient keys
+func (o *MockOutboundTransport) AcceptRecipient([]string) bool {
+	return false
+}
+
 // Accept url
 func (o *MockOutboundTransport) Accept(url string) bool {
 	return o.AcceptValue

--- a/pkg/internal/mock/kms/mock_kms_provider.go
+++ b/pkg/internal/mock/kms/mock_kms_provider.go
@@ -60,8 +60,3 @@ type mockProvider struct {
 func (m *mockProvider) StorageProvider() storage.Provider {
 	return m.storage
 }
-
-// InboundTransportEndpoint returns a mock inbound endpoint
-func (m *mockProvider) InboundTransportEndpoint() string {
-	return "sample-endpoint.com"
-}

--- a/pkg/kms/crypto_box_test.go
+++ b/pkg/kms/crypto_box_test.go
@@ -28,10 +28,6 @@ func (p *testProvider) StorageProvider() storage.Provider {
 	return p.storeProvider
 }
 
-func (p *testProvider) InboundTransportEndpoint() string {
-	return ""
-}
-
 func newKMS(t *testing.T) (*BaseKMS, storage.Store) {
 	msp := mockStorage.NewMockStoreProvider()
 	p := testProvider{storeProvider: msp}

--- a/test/bdd/features/aries_e2e_route_option.feature
+++ b/test/bdd/features/aries_e2e_route_option.feature
@@ -12,8 +12,7 @@ Feature: DIDComm between Edge Agent(without Inbound) and Router/Mediator
     Given "Alice" agent is running on "localhost" port "random" with "websocket" as the transport provider
     And   "Alice" creates did exchange client
     And   "Alice" registers to receive notification for post state event "completed"
-    # TODO - https://github.com/hyperledger/aries-framework-go/issues/915 - remove inbound host/port from this step
-    Given "Bob" agent is running on "localhost" port "random" with "websocket" as the transport provider and "all" as the transport return route option
+    Given "Bob" edge agent is running with "websocket" as the outbound transport provider and "all" as the transport return route option
     And   "Bob" creates did exchange client
     And   "Bob" registers to receive notification for post state event "completed"
     And   "Alice" creates invitation


### PR DESCRIPTION
- Remove default inbound transport creation in the framework
- New AcceptRecipient function in OutboundTransport : The framework first checks if connection exists for the recKey and use that connection regardless of the url to support edge agents
- Removed unused InboundTransportEndpoint dependencies in kms services

closes #915 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>