### PR TITLE
feat: Introduce - implement behavior when introducer stops the protocol

### DIFF
--- a/pkg/didcomm/protocol/introduce/service.go
+++ b/pkg/didcomm/protocol/introduce/service.go
@@ -572,7 +572,7 @@ func (s *Service) Name() string {
 // Accept msg checks the msg type
 func (s *Service) Accept(msgType string) bool {
 	switch msgType {
-	case ProposalMsgType, RequestMsgType, ResponseMsgType, AckMsgType:
+	case ProposalMsgType, RequestMsgType, ResponseMsgType, AckMsgType, ProblemReportMsgType:
 		return true
 	}
 


### PR DESCRIPTION
Added the possibility to stop the protocol (introducer side). It covers the following usage:
* stop the protocol after receiving the Response message (first response)
* stop the protocol after receiving the Request message

Closes #922 

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>
