### PR TITLE
feat: Introduce - stops the protocol after receiving the second Response

### DIFF
--- a/pkg/didcomm/protocol/introduce/service.go
+++ b/pkg/didcomm/protocol/introduce/service.go
@@ -90,6 +90,7 @@ type record struct {
 	// IntroduceeIndex keeps an introducee index of from whom we got an invitation
 	IntroduceeIndex int                     `json:"introducee_index,omitempty"`
 	Invitation      *didexchange.Invitation `json:"invitation,omitempty"`
+	Destinations    []*service.Destination  `json:"destinations,omitempty"`
 }
 
 // Service for introduce protocol
@@ -546,6 +547,11 @@ func (s *Service) execute(next state, msg *metaData, dest *service.Destination) 
 
 	// sets the next state name
 	msg.StateName = next.Name()
+	if msg.Msg.Header.Type == ResponseMsgType && msg.dependency != nil {
+		if len(msg.dependency.Destinations()) > 0 {
+			msg.Destinations = msg.dependency.Destinations()
+		}
+	}
 
 	if err = s.save(msg.ThreadID, msg.record); err != nil {
 		return nil, fmt.Errorf("failed to persist state %s %w", next.Name(), err)


### PR DESCRIPTION
Added the possibility to stop the protocol (introducer side). It covers the following usage:

* stop the protocol after receiving the Response message (second response)

Closes #935 

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>