### PR TITLE
feat: Introduce - forward an invitation & notify the introduce

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,8 @@ depend:
 .PHONY: mocks
 mocks: depend
 	$(call create_mock,pkg/client/introduce,Provider)
-	$(call create_mock,pkg/didcomm/protocol/introduce,Provider;InvitationEnvelope;Forwarder)
+	$(call create_mock,pkg/didcomm/protocol/introduce,Provider;InvitationEnvelope)
+	$(call create_mock,pkg/didcomm/common/service,Event)
 	$(call create_mock,pkg/didcomm/dispatcher,Outbound)
 	$(call create_mock,pkg/storage,Provider;Store)
 	$(call create_mock,pkg/didcomm/common/service,DIDComm)

--- a/pkg/client/introduce/client_test.go
+++ b/pkg/client/introduce/client_test.go
@@ -90,10 +90,13 @@ func TestClient_SendProposal(t *testing.T) {
 	storageProvider := storageMocks.NewMockProvider(ctrl)
 	storageProvider.EXPECT().OpenStore(introduce.Introduce).Return(store, nil).Times(2)
 
+	didService := serviceMocks.NewMockDIDComm(ctrl)
+	didService.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
+
 	introduceProvider := introduceMocks.NewMockProvider(ctrl)
 	introduceProvider.EXPECT().StorageProvider().Return(storageProvider)
 	introduceProvider.EXPECT().OutboundDispatcher().Return(nil)
-	introduceProvider.EXPECT().Service(didexchange.DIDExchange).Return(introduceMocks.NewMockForwarder(ctrl), nil)
+	introduceProvider.EXPECT().Service(didexchange.DIDExchange).Return(didService, nil)
 
 	svc, err := introduce.New(introduceProvider)
 	require.NoError(t, err)
@@ -132,10 +135,13 @@ func TestClient_SendProposalWithInvitation(t *testing.T) {
 	storageProvider := storageMocks.NewMockProvider(ctrl)
 	storageProvider.EXPECT().OpenStore(introduce.Introduce).Return(store, nil).Times(2)
 
+	didService := serviceMocks.NewMockDIDComm(ctrl)
+	didService.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
+
 	introduceProvider := introduceMocks.NewMockProvider(ctrl)
 	introduceProvider.EXPECT().StorageProvider().Return(storageProvider)
 	introduceProvider.EXPECT().OutboundDispatcher().Return(nil)
-	introduceProvider.EXPECT().Service(didexchange.DIDExchange).Return(introduceMocks.NewMockForwarder(ctrl), nil)
+	introduceProvider.EXPECT().Service(didexchange.DIDExchange).Return(didService, nil)
 
 	svc, err := introduce.New(introduceProvider)
 	require.NoError(t, err)
@@ -176,10 +182,13 @@ func TestClient_HandleRequest(t *testing.T) {
 	storageProvider := storageMocks.NewMockProvider(ctrl)
 	storageProvider.EXPECT().OpenStore(introduce.Introduce).Return(store, nil).Times(2)
 
+	didService := serviceMocks.NewMockDIDComm(ctrl)
+	didService.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
+
 	introduceProvider := introduceMocks.NewMockProvider(ctrl)
 	introduceProvider.EXPECT().StorageProvider().Return(storageProvider)
 	introduceProvider.EXPECT().OutboundDispatcher().Return(nil)
-	introduceProvider.EXPECT().Service(didexchange.DIDExchange).Return(introduceMocks.NewMockForwarder(ctrl), nil)
+	introduceProvider.EXPECT().Service(didexchange.DIDExchange).Return(didService, nil)
 
 	svc, err := introduce.New(introduceProvider)
 	require.NoError(t, err)
@@ -268,10 +277,13 @@ func TestClient_InvitationEnvelope(t *testing.T) {
 	storageProvider := storageMocks.NewMockProvider(ctrl)
 	storageProvider.EXPECT().OpenStore(introduce.Introduce).Return(store, nil).Times(2)
 
+	didService := serviceMocks.NewMockDIDComm(ctrl)
+	didService.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
+
 	introduceProvider := introduceMocks.NewMockProvider(ctrl)
 	introduceProvider.EXPECT().StorageProvider().Return(storageProvider)
 	introduceProvider.EXPECT().OutboundDispatcher().Return(nil)
-	introduceProvider.EXPECT().Service(didexchange.DIDExchange).Return(introduceMocks.NewMockForwarder(ctrl), nil)
+	introduceProvider.EXPECT().Service(didexchange.DIDExchange).Return(didService, nil)
 
 	svc, err := introduce.New(introduceProvider)
 	require.NoError(t, err)
@@ -330,10 +342,13 @@ func TestClient_SendRequest(t *testing.T) {
 	storageProvider := storageMocks.NewMockProvider(ctrl)
 	storageProvider.EXPECT().OpenStore(introduce.Introduce).Return(store, nil).Times(2)
 
+	didService := serviceMocks.NewMockDIDComm(ctrl)
+	didService.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
+
 	introduceProvider := introduceMocks.NewMockProvider(ctrl)
 	introduceProvider.EXPECT().StorageProvider().Return(storageProvider)
 	introduceProvider.EXPECT().OutboundDispatcher().Return(nil)
-	introduceProvider.EXPECT().Service(didexchange.DIDExchange).Return(introduceMocks.NewMockForwarder(ctrl), nil)
+	introduceProvider.EXPECT().Service(didexchange.DIDExchange).Return(didService, nil)
 
 	svc, err := introduce.New(introduceProvider)
 	require.NoError(t, err)

--- a/pkg/didcomm/protocol/didexchange/models.go
+++ b/pkg/didcomm/protocol/didexchange/models.go
@@ -39,7 +39,8 @@ type Invitation struct {
 	RoutingKeys []string `json:"routingKeys,omitempty"`
 
 	// the Type of the connection invitation
-	Type string `json:"@type,omitempty"`
+	Type   string            `json:"@type,omitempty"`
+	Thread *decorator.Thread `json:"~thread,omitempty"`
 }
 
 // Request defines a2a DID exchange request

--- a/pkg/didcomm/protocol/introduce/states_test.go
+++ b/pkg/didcomm/protocol/introduce/states_test.go
@@ -373,3 +373,9 @@ func Test_stateFromName(t *testing.T) {
 	st = stateFromName("unknown")
 	require.Equal(t, &noOp{}, st)
 }
+
+func Test_save(t *testing.T) {
+	const errMsg = "service save: json: unsupported type: chan struct {}"
+
+	require.EqualError(t, (&Service{}).save("ID", make(chan struct{})), errMsg)
+}


### PR DESCRIPTION
* listening `digexchange` events
* forward an invitation is done by using OutboundDispatcher().Send

Closes #954 
Signed-off-by: Andrii Soluk <isoluchok@gmail.com>