### PR TITLE
refactor: Introduce - send message logic

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -157,7 +157,7 @@ func (c *Client) HandleInvitation(invitation *Invitation) (string, error) {
 		return "", fmt.Errorf("failed to create DIDCommMsg: %w", err)
 	}
 
-	connectionID, err := c.didexchangeSvc.HandleInbound(msg)
+	connectionID, err := c.didexchangeSvc.HandleInbound(msg, "", "")
 	if err != nil {
 		return "", fmt.Errorf("failed from didexchange service handle: %w", err)
 	}

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -589,7 +589,7 @@ func TestServiceEvents(t *testing.T) {
 
 	msg, err := service.NewDIDCommMsg(request)
 	require.NoError(t, err)
-	_, err = didExSvc.HandleInbound(msg)
+	_, err = didExSvc.HandleInbound(msg, "", "")
 	require.NoError(t, err)
 
 	select {
@@ -679,7 +679,7 @@ func TestAcceptExchangeRequest(t *testing.T) {
 
 	msg, err := service.NewDIDCommMsg(request)
 	require.NoError(t, err)
-	_, err = didExSvc.HandleInbound(msg)
+	_, err = didExSvc.HandleInbound(msg, "", "")
 	require.NoError(t, err)
 
 	select {
@@ -760,7 +760,7 @@ func TestAcceptInvitation(t *testing.T) {
 
 		msg, svcErr := service.NewDIDCommMsg(invitation)
 		require.NoError(t, svcErr)
-		_, err = didExSvc.HandleInbound(msg)
+		_, err = didExSvc.HandleInbound(msg, "", "")
 		require.NoError(t, err)
 
 		select {

--- a/pkg/client/introduce/client.go
+++ b/pkg/client/introduce/client.go
@@ -107,12 +107,12 @@ func (c *Client) SendProposalWithInvitation(inv *didexchange.Invitation, recipie
 
 // SendRequest sends a request
 // sending a request means that introducee is willing to share its invitation
-func (c *Client) SendRequest(dest *service.Destination) error {
+func (c *Client) SendRequest(myDID, theirDID string) error {
 	return c.handleOutbound(&introduce.Request{
 		Type: introduce.RequestMsgType,
 		ID:   c.newUUID(),
 	}, InvitationEnvelope{
-		Recps: []*introduce.Recipient{{Destination: dest}},
+		Recps: []*introduce.Recipient{{MyDID: myDID, TheirDID: theirDID}},
 	})
 }
 
@@ -164,7 +164,7 @@ func (c *Client) handleOutbound(msg interface{}, o InvitationEnvelope) error {
 		return err
 	}
 
-	return c.service.HandleOutbound(didMsg, o.Recps[0].Destination)
+	return c.service.HandleOutbound(didMsg, o.Recps[0].MyDID, o.Recps[0].MyDID)
 }
 
 // InvitationEnvelope keeps the information needed for sending a proposal

--- a/pkg/client/introduce/client_test.go
+++ b/pkg/client/introduce/client_test.go
@@ -103,12 +103,12 @@ func TestClient_SendProposal(t *testing.T) {
 	require.NotNil(t, svc)
 
 	DIDComm := serviceMocks.NewMockDIDComm(ctrl)
-	DIDComm.EXPECT().HandleOutbound(gomock.Any(), gomock.Any()).Return(nil)
+	DIDComm.EXPECT().HandleOutbound(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	opts := InvitationEnvelope{
 		Recps: []*introduce.Recipient{
-			{Destination: &service.Destination{ServiceEndpoint: "service/endpoint1"}},
-			{Destination: &service.Destination{ServiceEndpoint: "service/endpoint2"}},
+			{MyDID: "My_DID1", TheirDID: "THEIR_DID1"},
+			{MyDID: "My_DID2", TheirDID: "THEIR_DID2"},
 		},
 	}
 	store.EXPECT().Put(invitationEnvelopePrefix+UUID, toBytes(t, opts)).Return(nil)
@@ -148,14 +148,14 @@ func TestClient_SendProposalWithInvitation(t *testing.T) {
 	require.NotNil(t, svc)
 
 	DIDComm := serviceMocks.NewMockDIDComm(ctrl)
-	DIDComm.EXPECT().HandleOutbound(gomock.Any(), gomock.Any()).Return(nil)
+	DIDComm.EXPECT().HandleOutbound(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	opts := InvitationEnvelope{
 		Inv: &didexchange.Invitation{
 			ID: UUID,
 		},
 		Recps: []*introduce.Recipient{
-			{Destination: &service.Destination{ServiceEndpoint: "service/endpoint"}},
+			{MyDID: "My_DID", TheirDID: "THEIR_DID"},
 		},
 	}
 	store.EXPECT().Put(invitationEnvelopePrefix+UUID, toBytes(t, opts)).Return(nil)
@@ -197,7 +197,7 @@ func TestClient_HandleRequest(t *testing.T) {
 	opts := InvitationEnvelope{
 		Recps: []*introduce.Recipient{
 			{To: &introduce.To{Name: "Carol"}},
-			{Destination: &service.Destination{ServiceEndpoint: "service/endpoint"}},
+			{MyDID: "My_DID2", TheirDID: "THEIR_DID2"},
 		},
 	}
 	store.EXPECT().Put(invitationEnvelopePrefix+UUID, toBytes(t, opts)).Return(nil)
@@ -294,8 +294,8 @@ func TestClient_InvitationEnvelope(t *testing.T) {
 			ID: UUID,
 		},
 		Recps: []*introduce.Recipient{
-			{To: &introduce.To{Name: "Carol"}, Destination: &service.Destination{ServiceEndpoint: "service/endpoint1"}},
-			{Destination: &service.Destination{ServiceEndpoint: "service/endpoint1"}},
+			{To: &introduce.To{Name: "Carol"}, MyDID: "My_DID1", TheirDID: "THEIR_DID1"},
+			{MyDID: "My_DID2", TheirDID: "THEIR_DID2"},
 		},
 	}
 	store.EXPECT().Get(invitationEnvelopePrefix+UUID).Return(toBytes(t, opts), nil)
@@ -355,11 +355,11 @@ func TestClient_SendRequest(t *testing.T) {
 	require.NotNil(t, svc)
 
 	DIDComm := serviceMocks.NewMockDIDComm(ctrl)
-	DIDComm.EXPECT().HandleOutbound(gomock.Any(), gomock.Any()).Return(nil)
+	DIDComm.EXPECT().HandleOutbound(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	opts := InvitationEnvelope{
 		Recps: []*introduce.Recipient{
-			{Destination: &service.Destination{ServiceEndpoint: "service/endpoint"}},
+			{MyDID: "My_DID", TheirDID: "THEIR_DID"},
 		},
 	}
 	store.EXPECT().Put(invitationEnvelopePrefix+UUID, toBytes(t, opts)).Return(nil)
@@ -373,10 +373,10 @@ func TestClient_SendRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	client.newUUID = func() string { return UUID }
-	require.NoError(t, client.SendRequest(opts.Recps[0].Destination))
+	require.NoError(t, client.SendRequest(opts.Recps[0].MyDID, opts.Recps[0].TheirDID))
 
 	// with error
-	require.EqualError(t, client.SendRequest(opts.Recps[0].Destination), "test error")
+	require.EqualError(t, client.SendRequest(opts.Recps[0].MyDID, opts.Recps[0].TheirDID), "test error")
 }
 
 func toBytes(t *testing.T, v interface{}) []byte {

--- a/pkg/didcomm/common/service/service.go
+++ b/pkg/didcomm/common/service/service.go
@@ -16,9 +16,9 @@ import (
 // Handler provides protocol service handle api.
 type Handler interface {
 	// HandleInbound handles inbound messages.
-	HandleInbound(msg *DIDCommMsg) (string, error)
+	HandleInbound(msg *DIDCommMsg, myDID string, theirDID string) (string, error)
 	// HandleOutbound handles outbound messages.
-	HandleOutbound(msg *DIDCommMsg, dest *Destination) error
+	HandleOutbound(msg *DIDCommMsg, myDID, theirDID string) error
 }
 
 // DIDComm defines service APIs.

--- a/pkg/didcomm/dispatcher/api.go
+++ b/pkg/didcomm/dispatcher/api.go
@@ -20,4 +20,5 @@ type Service interface {
 // Outbound interface
 type Outbound interface {
 	Send(interface{}, string, *service.Destination) error
+	SendToDID(msg interface{}, myDID, theirDID string) error
 }

--- a/pkg/didcomm/dispatcher/outbound.go
+++ b/pkg/didcomm/dispatcher/outbound.go
@@ -40,6 +40,11 @@ func NewOutbound(prov provider) *OutboundDispatcher {
 	}
 }
 
+// SendToDID msg
+func (o *OutboundDispatcher) SendToDID(msg interface{}, myDID, theirDID string) error {
+	return nil
+}
+
 // Send msg
 func (o *OutboundDispatcher) Send(msg interface{}, senderVerKey string, des *service.Destination) error {
 	for _, v := range o.outboundTransports {

--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -126,7 +126,7 @@ func New(prov provider) (*Service, error) {
 }
 
 // HandleInbound handles inbound didexchange messages.
-func (s *Service) HandleInbound(msg *service.DIDCommMsg) (string, error) {
+func (s *Service) HandleInbound(msg *service.DIDCommMsg, myDID, theirDID string) (string, error) {
 	logger.Debugf("receive inbound message : %s", msg.Payload)
 
 	// fetch the thread id
@@ -181,7 +181,7 @@ func (s *Service) Accept(msgType string) bool {
 }
 
 // HandleOutbound handles outbound didexchange messages.
-func (s *Service) HandleOutbound(msg *service.DIDCommMsg, destination *service.Destination) error {
+func (s *Service) HandleOutbound(msg *service.DIDCommMsg, myDID, theirDID string) error {
 	return errors.New("not implemented")
 }
 

--- a/pkg/didcomm/protocol/introduce/states_test.go
+++ b/pkg/didcomm/protocol/introduce/states_test.go
@@ -45,7 +45,7 @@ func TestNoOp_ExecuteInbound(t *testing.T) {
 }
 
 func TestNoOp_ExecuteOutbound(t *testing.T) {
-	followup, err := (&noOp{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
+	followup, err := (&noOp{}).ExecuteOutbound(internalContext{}, &metaData{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -74,7 +74,7 @@ func TestStart_ExecuteInbound(t *testing.T) {
 }
 
 func TestStart_ExecuteOutbound(t *testing.T) {
-	followup, err := (&start{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
+	followup, err := (&start{}).ExecuteOutbound(internalContext{}, &metaData{})
 	require.EqualError(t, err, "start ExecuteOutbound: not implemented yet")
 	require.Nil(t, followup)
 }
@@ -92,7 +92,7 @@ func TestDone_ExecuteInbound(t *testing.T) {
 }
 
 func TestDone_ExecuteOutbound(t *testing.T) {
-	followup, err := (&done{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
+	followup, err := (&done{}).ExecuteOutbound(internalContext{}, &metaData{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -119,12 +119,12 @@ func TestArranging_ExecuteOutbound(t *testing.T) {
 	defer ctrl.Finish()
 
 	dispatcher := dispatcherMocks.NewMockOutbound(ctrl)
-	dispatcher.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	dispatcher.EXPECT().SendToDID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	ctx := internalContext{Outbound: dispatcher}
 	followup, err := (&arranging{}).ExecuteOutbound(ctx, &metaData{
 		Msg: &service.DIDCommMsg{Payload: []byte(`{}`)},
-	}, &service.Destination{})
+	})
 	require.NoError(t, err)
 	require.Equal(t, &noOp{}, followup)
 
@@ -132,7 +132,7 @@ func TestArranging_ExecuteOutbound(t *testing.T) {
 	errMsg := "json: cannot unmarshal array into Go value of type introduce.Proposal"
 	followup, err = (&arranging{}).ExecuteOutbound(ctx, &metaData{
 		Msg: &service.DIDCommMsg{Payload: []byte(`[]`)},
-	}, &service.Destination{})
+	})
 	require.EqualError(t, errors.Unwrap(err), errMsg)
 	require.Nil(t, followup)
 }
@@ -155,7 +155,7 @@ func TestDelivering_CanTransitionTo(t *testing.T) {
 }
 
 func TestDelivering_ExecuteOutbound(t *testing.T) {
-	followup, err := (&delivering{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
+	followup, err := (&delivering{}).ExecuteOutbound(internalContext{}, &metaData{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -178,7 +178,7 @@ func TestConfirming_CanTransitionTo(t *testing.T) {
 }
 
 func TestConfirming_ExecuteOutbound(t *testing.T) {
-	followup, err := (&confirming{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
+	followup, err := (&confirming{}).ExecuteOutbound(internalContext{}, &metaData{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -206,7 +206,7 @@ func TestAbandoning_ExecuteInbound(t *testing.T) {
 		defer ctrl.Finish()
 
 		dispatcher := dispatcherMocks.NewMockOutbound(ctrl)
-		dispatcher.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("test error"))
+		dispatcher.EXPECT().SendToDID(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("test error"))
 
 		followup, err := (&abandoning{}).ExecuteInbound(internalContext{Outbound: dispatcher}, &metaData{
 			Msg: &service.DIDCommMsg{
@@ -220,7 +220,7 @@ func TestAbandoning_ExecuteInbound(t *testing.T) {
 }
 
 func TestAbandoning_ExecuteOutbound(t *testing.T) {
-	followup, err := (&abandoning{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
+	followup, err := (&abandoning{}).ExecuteOutbound(internalContext{}, &metaData{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -247,7 +247,7 @@ func TestDeciding_ExecuteInbound(t *testing.T) {
 	defer ctrl.Finish()
 
 	dispatcher := dispatcherMocks.NewMockOutbound(ctrl)
-	dispatcher.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	dispatcher.EXPECT().SendToDID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	ctx := internalContext{Outbound: dispatcher}
 
@@ -257,7 +257,7 @@ func TestDeciding_ExecuteInbound(t *testing.T) {
 }
 
 func TestDeciding_ExecuteOutbound(t *testing.T) {
-	followup, err := (&deciding{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
+	followup, err := (&deciding{}).ExecuteOutbound(internalContext{}, &metaData{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -286,7 +286,7 @@ func TestWaiting_ExecuteInbound(t *testing.T) {
 }
 
 func TestWaiting_ExecuteOutbound(t *testing.T) {
-	followup, err := (&waiting{}).ExecuteOutbound(internalContext{}, &metaData{}, &service.Destination{})
+	followup, err := (&waiting{}).ExecuteOutbound(internalContext{}, &metaData{})
 	require.Error(t, err)
 	require.Nil(t, followup)
 }
@@ -320,7 +320,7 @@ func TestRequesting_ExecuteOutbound(t *testing.T) {
 
 	followup, err := (&requesting{}).ExecuteOutbound(internalContext{}, &metaData{
 		Msg: &service.DIDCommMsg{Payload: []byte(`[]`)},
-	}, nil)
+	})
 
 	const errMsg = "requesting outbound unmarshal: json: cannot unmarshal array into Go value of type introduce.Request"
 

--- a/pkg/didcomm/protocol/route/support_test.go
+++ b/pkg/didcomm/protocol/route/support_test.go
@@ -66,6 +66,10 @@ func (m *mockOutbound) Send(msg interface{}, senderVerKey string, des *service.D
 	return m.validateSend(msg)
 }
 
+func (m *mockOutbound) SendToDID(msg interface{}, myDID, theirDID string) error {
+	return nil
+}
+
 func generateRequestMsgPayload(t *testing.T, id string) *service.DIDCommMsg {
 	requestBytes, err := json.Marshal(&Request{
 		Type: RequestMsgType,

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -113,7 +113,7 @@ func (p *Provider) InboundMessageHandler() transport.InboundMessageHandler {
 		// find the service which accepts the message type
 		for _, svc := range p.services {
 			if svc.Accept(msg.Header.Type) {
-				_, err = svc.HandleInbound(msg)
+				_, err = svc.HandleInbound(msg, "", "")
 				return err
 			}
 		}

--- a/pkg/internal/mock/didcomm/dispatcher/mock_outbound.go
+++ b/pkg/internal/mock/didcomm/dispatcher/mock_outbound.go
@@ -18,3 +18,8 @@ type MockOutbound struct {
 func (m *MockOutbound) Send(msg interface{}, senderVerKey string, des *service.Destination) error {
 	return m.SendErr
 }
+
+// SendToDID msg
+func (m *MockOutbound) SendToDID(msg interface{}, myDID, theirDID string) error {
+	return nil
+}

--- a/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/mock_didexchange.go
@@ -24,7 +24,7 @@ import (
 type MockDIDExchangeSvc struct {
 	ProtocolName             string
 	HandleFunc               func(*service.DIDCommMsg) (string, error)
-	HandleOutboundFunc       func(msg *service.DIDCommMsg, dest *service.Destination) error
+	HandleOutboundFunc       func(msg *service.DIDCommMsg, myDID, theirDID string) error
 	AcceptFunc               func(string) bool
 	RegisterActionEventErr   error
 	UnregisterActionEventErr error
@@ -35,7 +35,7 @@ type MockDIDExchangeSvc struct {
 }
 
 // HandleInbound msg
-func (m *MockDIDExchangeSvc) HandleInbound(msg *service.DIDCommMsg) (string, error) {
+func (m *MockDIDExchangeSvc) HandleInbound(msg *service.DIDCommMsg, myDID, theirDID string) (string, error) {
 	if m.HandleFunc != nil {
 		return m.HandleFunc(msg)
 	}
@@ -44,9 +44,9 @@ func (m *MockDIDExchangeSvc) HandleInbound(msg *service.DIDCommMsg) (string, err
 }
 
 // HandleOutbound msg
-func (m *MockDIDExchangeSvc) HandleOutbound(msg *service.DIDCommMsg, dest *service.Destination) error {
+func (m *MockDIDExchangeSvc) HandleOutbound(msg *service.DIDCommMsg, myDID, theirDID string) error {
 	if m.HandleOutboundFunc != nil {
-		return m.HandleOutboundFunc(msg, dest)
+		return m.HandleOutboundFunc(msg, myDID, theirDID)
 	}
 
 	return nil

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -514,7 +514,7 @@ func TestAcceptExchangeRequest(t *testing.T) {
 	msg, err := service.NewDIDCommMsg(request)
 	require.NoError(t, err)
 
-	_, err = didExSvc.HandleInbound(msg)
+	_, err = didExSvc.HandleInbound(msg, "", "")
 	require.NoError(t, err)
 
 	cid := <-connID
@@ -586,7 +586,7 @@ func TestAcceptInvitation(t *testing.T) {
 	msg, err := service.NewDIDCommMsg(invitation)
 	require.NoError(t, err)
 
-	_, err = didExSvc.HandleInbound(msg)
+	_, err = didExSvc.HandleInbound(msg, "", "")
 	require.NoError(t, err)
 
 	var cid string


### PR DESCRIPTION
* messages are sent by using `SendToDID(msg interface{}, myDID, theirDID string) error` function
* Handler interface was changed to: 
```
type Handler interface {
	HandleInbound(msg *DIDCommMsg, myDID string, theirDID string) (string, error)
	HandleOutbound(msg *DIDCommMsg, myDID, theirDID string) error
}
```

Closes #963  
Signed-off-by: Andrii Soluk <isoluchok@gmail.com>