### PR TITLE
feat: Forward Message - Base structure implementation

### DIFF
--- a/pkg/didcomm/dispatcher/api.go
+++ b/pkg/didcomm/dispatcher/api.go
@@ -19,6 +19,12 @@ type Service interface {
 
 // Outbound interface
 type Outbound interface {
+	// Sends the message after packing with the sender key and recipient keys.
 	Send(interface{}, string, *service.Destination) error
+
+	// Sends the message after packing with the keys derived from DIDs.
 	SendToDID(msg interface{}, myDID, theirDID string) error
+
+	// Forward forwards the message without packing to the destination.
+	Forward(interface{}, *service.Destination) error
 }

--- a/pkg/didcomm/protocol/route/models.go
+++ b/pkg/didcomm/protocol/route/models.go
@@ -50,3 +50,13 @@ type UpdateResponse struct {
 	Action       string `json:"action,omitempty"`
 	Result       string `json:"result,omitempty"`
 }
+
+// Forward route forward message.
+// nolint lll - url in the next line is long
+// https://github.com/hyperledger/aries-rfcs/blob/master/concepts/0094-cross-domain-messaging/README.md#corerouting10forward
+type Forward struct {
+	Type string      `json:"@type,omitempty"`
+	ID   string      `json:"@id,omitempty"`
+	To   string      `json:"@to,omitempty"`
+	Msg  interface{} `json:"@msg,omitempty"`
+}

--- a/pkg/didcomm/protocol/route/support_test.go
+++ b/pkg/didcomm/protocol/route/support_test.go
@@ -59,7 +59,8 @@ func (p *mockProvider) KMS() kms.KeyManager {
 
 // mock outbound
 type mockOutbound struct {
-	validateSend func(msg interface{}) error
+	validateSend    func(msg interface{}) error
+	validateForward func(msg interface{}) error
 }
 
 func (m *mockOutbound) Send(msg interface{}, senderVerKey string, des *service.Destination) error {
@@ -68,6 +69,10 @@ func (m *mockOutbound) Send(msg interface{}, senderVerKey string, des *service.D
 
 func (m *mockOutbound) SendToDID(msg interface{}, myDID, theirDID string) error {
 	return nil
+}
+
+func (m *mockOutbound) Forward(msg interface{}, des *service.Destination) error {
+	return m.validateForward(msg)
 }
 
 func generateRequestMsgPayload(t *testing.T, id string) *service.DIDCommMsg {
@@ -119,6 +124,21 @@ func generateKeylistUpdateResponseMsgPayload(t *testing.T, id string, updates []
 	require.NoError(t, err)
 
 	didMsg, err := service.NewDIDCommMsg(respBytes)
+	require.NoError(t, err)
+
+	return didMsg
+}
+
+func generateForwardMsgPayload(t *testing.T, id, to string, msg interface{}) *service.DIDCommMsg {
+	requestBytes, err := json.Marshal(&Forward{
+		Type: ForwardMsgType,
+		ID:   id,
+		To:   to,
+		Msg:  msg,
+	})
+	require.NoError(t, err)
+
+	didMsg, err := service.NewDIDCommMsg(requestBytes)
 	require.NoError(t, err)
 
 	return didMsg

--- a/pkg/internal/mock/didcomm/dispatcher/mock_outbound.go
+++ b/pkg/internal/mock/didcomm/dispatcher/mock_outbound.go
@@ -23,3 +23,8 @@ func (m *MockOutbound) Send(msg interface{}, senderVerKey string, des *service.D
 func (m *MockOutbound) SendToDID(msg interface{}, myDID, theirDID string) error {
 	return nil
 }
+
+// Forward msg
+func (m *MockOutbound) Forward(msg interface{}, des *service.Destination) error {
+	return nil
+}


### PR DESCRIPTION
- Base structure for [Forward Message type](https://github.com/hyperledger/aries-rfcs/blob/master/concepts/0094-cross-domain-messaging/README.md#corerouting10forward)

closes #957 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
