### PR TITLE
test: Introduce - add BDD tests

### DIFF
--- a/test/bdd/agent/agent_controller_steps.go
+++ b/test/bdd/agent/agent_controller_steps.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package bdd
+package agent
 
 import (
 	"fmt"
@@ -15,20 +15,20 @@ import (
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/context"
 )
 
-// AgentWithControllerSteps contains steps for controller based agent
-type AgentWithControllerSteps struct {
+// ControllerSteps contains steps for controller based agent
+type ControllerSteps struct {
 	bddContext *context.BDDContext
 }
 
-// NewAgentControllerSteps creates steps for agent with controller
-func NewAgentControllerSteps(ctx *context.BDDContext) *AgentWithControllerSteps {
-	return &AgentWithControllerSteps{
+// NewControllerSteps creates steps for agent with controller
+func NewControllerSteps(ctx *context.BDDContext) *ControllerSteps {
+	return &ControllerSteps{
 		bddContext: ctx,
 	}
 }
 
 // RegisterSteps registers agent steps
-func (a *AgentWithControllerSteps) RegisterSteps(s *godog.Suite) {
+func (a *ControllerSteps) RegisterSteps(s *godog.Suite) {
 	s.Step(`^"([^"]*)" agent is running on "([^"]*)" port "([^"]*)" with controller "([^"]*)" and webhook "([^"]*)"$`,
 		a.checkAgentIsRunning)
 	s.Step(`^"([^"]*)" agent is running on "([^"]*)" port "([^"]*)" with controller "([^"]*)" and webhook "([^"]*)" `+
@@ -36,7 +36,7 @@ func (a *AgentWithControllerSteps) RegisterSteps(s *godog.Suite) {
 		a.checkAgentWithHTTPResolverIsRunning)
 }
 
-func (a *AgentWithControllerSteps) checkAgentWithHTTPResolverIsRunning(
+func (a *ControllerSteps) checkAgentWithHTTPResolverIsRunning(
 	agentID, inboundHost, inboundPort, controllerURL, webhookURL, resolverURL, didMethod string) error {
 	httpBindingURL := a.bddContext.Args[resolverURL]
 
@@ -51,7 +51,7 @@ func (a *AgentWithControllerSteps) checkAgentWithHTTPResolverIsRunning(
 	return a.checkAgentIsRunning(agentID, inboundHost, inboundPort, controllerURL, webhookURL)
 }
 
-func (a *AgentWithControllerSteps) checkAgentIsRunning(
+func (a *ControllerSteps) checkAgentIsRunning(
 	agentID, inboundHost, inboundPort, controllerURL, webhookURL string) error {
 	// verify controller
 	err := a.healthCheck(controllerURL)
@@ -87,7 +87,7 @@ func (a *AgentWithControllerSteps) checkAgentIsRunning(
 	return nil
 }
 
-func (a *AgentWithControllerSteps) healthCheck(url string) error {
+func (a *ControllerSteps) healthCheck(url string) error {
 	resp, err := http.Get(url) //nolint: gosec
 	if err != nil {
 		return err

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -18,10 +18,12 @@ import (
 	"github.com/DATA-DOG/godog"
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/test/bdd/agent"
 	"github.com/hyperledger/aries-framework-go/test/bdd/dockerutil"
 	bddctx "github.com/hyperledger/aries-framework-go/test/bdd/pkg/context"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/didexchange"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/didresolver"
+	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/introduce"
 )
 
 const (
@@ -143,12 +145,15 @@ func FeatureContext(s *godog.Suite) {
 	bddContext.Args[DIDDocPath] = "fixtures/sidetree-mock/config/didDocument.json"
 
 	// Context is shared between tests
-	NewAgentSDKSteps(bddContext).RegisterSteps(s)
-	NewAgentControllerSteps(bddContext).RegisterSteps(s)
+	agent.NewSDKSteps(bddContext).RegisterSteps(s)
+	agent.NewControllerSteps(bddContext).RegisterSteps(s)
 
 	// Register did exchange tests
 	didexchange.NewDIDExchangeSDKSteps(bddContext).RegisterSteps(s)
 	didexchange.NewDIDExchangeControllerSteps(bddContext).RegisterSteps(s)
+
+	// Register introduce tests
+	introduce.NewIntroduceSDKSteps(bddContext).RegisterSteps(s)
 
 	// Register did resolver tests
 	didresolver.NewDIDResolverSteps(bddContext).RegisterSteps(s)

--- a/test/bdd/features/introduce.feature
+++ b/test/bdd/features/introduce.feature
@@ -1,0 +1,240 @@
+
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+@all
+@introduce
+Feature: Introduce protocol
+  @skip_proposal
+  Scenario: Alice has a Carol's public invitation
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Alice" sends introduce proposal to the "Bob" with "Carol" invitation
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" forwards Carol's invitation to Bob
+    And   "Bob" and "Carol" exchange DIDs
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,delivering,delivering,done,done"
+    And   "Bob" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,done,done"
+
+  @skip_proposal_with_request
+  Scenario: Alice has a Carol's public invitation. The protocol starts with request.
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Bob" sends introduce request to the "Alice" asking about "Carol"
+    And   "Alice" sends introduce proposal back to the requester with pub invitation
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" forwards Carol's invitation to Bob
+    And   "Bob" and "Carol" exchange DIDs
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,delivering,delivering,done,done"
+    And   "Bob" checks the history of introduce protocol events "requesting,requesting,deciding,deciding,waiting,waiting,done,done"
+
+  @skip_proposal_stop
+  Scenario: Alice has a Carol's public invitation but Bob does not want the introduction
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Alice" sends introduce proposal to the "Bob" with "Carol" invitation
+    And   "Bob" doesn't want to know "Carol" and sends introduce response
+    And   "Alice" continue with the introduce protocol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,delivering,delivering,abandoning,abandoning,done,done"
+    And   "Bob" checks the history of introduce protocol events "deciding,deciding,abandoning,abandoning,done,done"
+
+  @skip_proposal_stop_with_request
+  Scenario: Alice has a Carol's public invitation but Bob does not want the introduction. The protocol starts with request.
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Bob" sends introduce request to the "Alice" asking about "Carol"
+    And   "Alice" sends introduce proposal back to the requester with pub invitation
+    And   "Bob" doesn't want to know "Carol" and sends introduce response
+    And   "Alice" continue with the introduce protocol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,delivering,delivering,abandoning,abandoning,done,done"
+    And   "Bob" checks the history of introduce protocol events "requesting,requesting,deciding,deciding,abandoning,abandoning,done,done"
+
+  @skip_proposal_introducer_stop
+  Scenario: Alice stops the protocol after receiving approve
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Alice" sends introduce proposal to the "Bob" with "Carol" invitation
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" stops the introduce protocol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,abandoning,abandoning,done,done"
+    And   "Bob" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
+
+  @skip_proposal_introducer_stop_with_request
+  Scenario: Alice stops the protocol after receiving approve. The protocol starts with request
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Bob" sends introduce request to the "Alice" asking about "Carol"
+    And   "Alice" sends introduce proposal back to the requester with pub invitation
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" stops the introduce protocol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,abandoning,abandoning,done,done"
+    And   "Bob" checks the history of introduce protocol events "requesting,requesting,deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
+
+  @proposal
+  Scenario: Bob sends a response with approve and an invitation.
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Bob" creates introduce client with an invitation
+    And   "Alice" sends introduce proposal to the "Bob" and "Carol"
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" continue with the introduce protocol
+    And   "Carol" wants to know "Bob" and sends introduce response with approve
+    And   "Alice" forwards Bob's invitation to Carol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,delivering,delivering,confirming,confirming,done,done"
+    And   "Bob" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,done,done"
+    And   "Carol" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,done,done"
+
+  @proposal_with_request
+  Scenario: Bob sends a response with approve and an invitation the protocol starts with request
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Bob" creates introduce client with an invitation
+    And   "Bob" sends introduce request to the "Alice" asking about "Carol"
+    And   "Alice" sends introduce proposal back to the "Bob" and requested introduce
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" continue with the introduce protocol
+    And   "Carol" wants to know "Bob" and sends introduce response with approve
+    And   "Alice" forwards Bob's invitation to Carol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,delivering,delivering,confirming,confirming,done,done"
+    And   "Bob" checks the history of introduce protocol events "requesting,requesting,deciding,deciding,waiting,waiting,done,done"
+    And   "Carol" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,done,done"
+
+  @proposal_unusual
+  Scenario: Carol sends a response with approve and an invitation
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Carol" creates introduce client with an invitation
+    And   "Alice" sends introduce proposal to the "Bob" and "Carol"
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" continue with the introduce protocol
+    And   "Carol" wants to know "Bob" and sends introduce response with approve
+    And   "Alice" forwards Carol's invitation to Bob
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,delivering,delivering,confirming,confirming,done,done"
+    And   "Bob" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,done,done"
+    And   "Carol" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,done,done"
+
+  @proposal_unusual_with_request
+  Scenario: Carol sends a response with approve and an invitation the protocol starts with request
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Carol" creates introduce client with an invitation
+    And   "Bob" sends introduce request to the "Alice" asking about "Carol"
+    And   "Alice" sends introduce proposal back to the "Bob" and requested introduce
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" continue with the introduce protocol
+    And   "Carol" wants to know "Bob" and sends introduce response with approve
+    And   "Alice" forwards Carol's invitation to Bob
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,delivering,delivering,confirming,confirming,done,done"
+    And   "Bob" checks the history of introduce protocol events "requesting,requesting,deciding,deciding,waiting,waiting,done,done"
+    And   "Carol" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,done,done"
+
+  @proposal_no_invitation
+  Scenario: No one provided an invitation
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Alice" sends introduce proposal to the "Bob" and "Carol"
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" continue with the introduce protocol
+    And   "Carol" wants to know "Bob" and sends introduce response with approve
+    And   "Alice" continue with the introduce protocol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,delivering,delivering,abandoning,abandoning,done,done"
+    And   "Bob" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
+    And   "Carol" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
+
+  @proposal_no_invitation_with_request
+  Scenario: No one provided an invitation the protocol starts with request
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Bob" sends introduce request to the "Alice" asking about "Carol"
+    And   "Alice" sends introduce proposal back to the "Bob" and requested introduce
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" continue with the introduce protocol
+    And   "Carol" wants to know "Bob" and sends introduce response with approve
+    And   "Alice" continue with the introduce protocol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,delivering,delivering,abandoning,abandoning,done,done"
+    And   "Bob" checks the history of introduce protocol events "requesting,requesting,deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
+    And   "Carol" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
+
+  @proposal_stop
+  Scenario: Bob does not want the introduction
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Alice" sends introduce proposal to the "Bob" and "Carol"
+    And   "Bob" doesn't want to know "Carol" and sends introduce response
+    And   "Alice" continue with the introduce protocol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,abandoning,abandoning,done,done"
+    And   "Bob" checks the history of introduce protocol events "deciding,deciding,abandoning,abandoning,done,done"
+
+  @proposal_stop_with_request
+  Scenario: Bob does not want the introduction the protocol starts with request
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Bob" sends introduce request to the "Alice" asking about "Carol"
+    And   "Alice" sends introduce proposal back to the "Bob" and requested introduce
+    And   "Bob" doesn't want to know "Carol" and sends introduce response
+    And   "Alice" continue with the introduce protocol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,abandoning,abandoning,done,done"
+    And   "Bob" checks the history of introduce protocol events "requesting,requesting,deciding,deciding,abandoning,abandoning,done,done"
+
+  @proposal_stop_unusual
+  Scenario: Carol does not want the introduction
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Alice" sends introduce proposal to the "Bob" and "Carol"
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" continue with the introduce protocol
+    And   "Carol" doesn't want to know "Bob" and sends introduce response
+    And   "Alice" continue with the introduce protocol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,delivering,delivering,abandoning,abandoning,done,done"
+    And   "Bob" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
+    And   "Carol" checks the history of introduce protocol events "deciding,deciding,abandoning,abandoning,done,done"
+
+  @proposal_stop_unusual_with_request
+  Scenario: Carol does not want the introduction the protocol starts with request
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Bob" sends introduce request to the "Alice" asking about "Carol"
+    And   "Alice" sends introduce proposal back to the "Bob" and requested introduce
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" continue with the introduce protocol
+    And   "Carol" doesn't want to know "Bob" and sends introduce response
+    And   "Alice" continue with the introduce protocol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,delivering,delivering,abandoning,abandoning,done,done"
+    And   "Bob" checks the history of introduce protocol events "requesting,requesting,deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
+    And   "Carol" checks the history of introduce protocol events "deciding,deciding,abandoning,abandoning,done,done"
+
+  @proposal_introducer_stop
+  Scenario: Introducer stops the protocol after receiving approve
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Bob" creates introduce client with an invitation
+    And   "Alice" sends introduce proposal to the "Bob" and "Carol"
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" stops the introduce protocol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,abandoning,abandoning,done,done"
+    And   "Bob" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
+
+  @proposal_introducer_stop_with_request
+  Scenario: Introducer stops the protocol after receiving approve the protocol starts with request
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Bob" creates introduce client with an invitation
+    And   "Bob" sends introduce request to the "Alice" asking about "Carol"
+    And   "Alice" sends introduce proposal back to the "Bob" and requested introduce
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" stops the introduce protocol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,abandoning,abandoning,done,done"
+    And   "Bob" checks the history of introduce protocol events "requesting,requesting,deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
+
+  @proposal_introducer_second_stop
+  Scenario: Introducer stops the protocol after receiving second approve
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Bob" creates introduce client with an invitation
+    And   "Alice" sends introduce proposal to the "Bob" and "Carol"
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" continue with the introduce protocol
+    And   "Carol" wants to know "Bob" and sends introduce response with approve
+    And   "Alice" stops the introduce protocol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,abandoning,abandoning,done,done"
+    And   "Bob" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
+    And   "Carol" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
+
+
+  @proposal_introducer_second_stop_with_request
+  Scenario: Introducer stops the protocol after receiving second approve the protocol starts with request
+    And   "Bob,Carol" exchange DIDs with "Alice"
+    And   "Bob" creates introduce client with an invitation
+    And   "Bob" sends introduce request to the "Alice" asking about "Carol"
+    And   "Alice" sends introduce proposal back to the "Bob" and requested introduce
+    And   "Bob" wants to know "Carol" and sends introduce response with approve
+    And   "Alice" continue with the introduce protocol
+    And   "Carol" wants to know "Bob" and sends introduce response with approve
+    And   "Alice" stops the introduce protocol
+    And   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,abandoning,abandoning,done,done"
+    And   "Bob" checks the history of introduce protocol events "requesting,requesting,deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
+    And   "Carol" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"

--- a/test/bdd/pkg/didresolver/didresolver_steps.go
+++ b/test/bdd/pkg/didresolver/didresolver_steps.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/godog"
-
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
@@ -51,16 +50,23 @@ func NewDIDResolverSteps(ctx *bddctx.BDDContext) *Steps {
 	return &Steps{bddContext: ctx}
 }
 
-func (d *Steps) createDIDDocument(agentID, method string) error {
-	doc, err := d.bddContext.AgentCtx[agentID].VDRIRegistry().Create(method,
-		vdriapi.WithRequestBuilder(buildSideTreeRequest))
-	if err != nil {
-		return err
+func (d *Steps) createDIDDocument(agents, method string) error {
+	for _, agentID := range strings.Split(agents, ",") {
+		doc, err := d.bddContext.AgentCtx[agentID].VDRIRegistry().Create(method,
+			vdriapi.WithRequestBuilder(buildSideTreeRequest))
+		if err != nil {
+			return fmt.Errorf("[%s] %v", agents, err)
+		}
+
+		d.bddContext.PublicDIDs[agentID] = doc
 	}
 
-	d.bddContext.PublicDIDs[agentID] = doc
-
 	return nil
+}
+
+// CreateDIDDocument creates DIDDocument
+func CreateDIDDocument(ctx *bddctx.BDDContext, agents, method string) error {
+	return (&Steps{bddContext: ctx}).createDIDDocument(agents, method)
 }
 
 func (d *Steps) createDIDDocumentFromFile(sideTreeURL, didDocumentPath string) error {

--- a/test/bdd/pkg/introduce/introduce_sdk_steps.go
+++ b/test/bdd/pkg/introduce/introduce_sdk_steps.go
@@ -1,0 +1,418 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package introduce
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/DATA-DOG/godog"
+
+	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
+	"github.com/hyperledger/aries-framework-go/pkg/client/introduce"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	introduceService "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/introduce"
+	"github.com/hyperledger/aries-framework-go/test/bdd/agent"
+	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/context"
+	bddDIDExchange "github.com/hyperledger/aries-framework-go/test/bdd/pkg/didexchange"
+	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/didresolver"
+)
+
+// SDKSteps is steps for introduce using client SDK
+type SDKSteps struct {
+	bddContext      *context.BDDContext
+	didExchangeSDKS *bddDIDExchange.SDKSteps
+	clients         map[string]*introduce.Client
+	actions         map[string]chan service.DIDCommAction
+	events          map[string]chan service.StateMsg
+}
+
+// NewIntroduceSDKSteps creates steps for introduce with SDK
+func NewIntroduceSDKSteps(ctx *context.BDDContext) *SDKSteps {
+	return &SDKSteps{
+		bddContext: ctx,
+		clients:    make(map[string]*introduce.Client),
+		actions:    make(map[string]chan service.DIDCommAction),
+		events:     make(map[string]chan service.StateMsg),
+	}
+}
+
+// RegisterSteps registers agent steps
+func (a *SDKSteps) RegisterSteps(s *godog.Suite) {
+	s.Step(`^"([^"]*)" creates introduce client with an invitation$`, a.createIntroduceClientWithInvitation)
+	s.Step(`^"([^"]*)" sends introduce proposal to the "([^"]*)" and "([^"]*)"$`, a.sendProposal)
+	s.Step(`^"([^"]*)" sends introduce proposal to the "([^"]*)" with "([^"]*)" invitation$`, a.sendProposalWithInvitation)
+	s.Step(`^"([^"]*)" sends introduce request to the "([^"]*)" asking about "([^"]*)"$`, a.sendRequest)
+	s.Step(`^"([^"]*)" sends introduce proposal back to the "([^"]*)" and requested introduce$`, a.handleRequest)
+	s.Step(`^"([^"]*)" sends introduce proposal back to the requester with pub invitation$`, a.handleRequestWithInvitation)
+	s.Step(`^"([^"]*)" wants to know "([^"]*)" and sends introduce response with approve$`, a.checkAndContinue)
+	s.Step(`^"([^"]*)" doesn't want to know "([^"]*)" and sends introduce response$`, a.checkAndStop)
+	s.Step(`^"([^"]*)" continue with the introduce protocol$`, a.continueWithProtocol)
+	s.Step(`^"([^"]*)" forwards`, a.continueWithProtocol)
+	s.Step(`^"([^"]*)" stops the introduce protocol$`, a.stopProtocol)
+	s.Step(`^"([^"]*)" checks the history of introduce protocol events "([^"]*)"`, a.checkHistoryEvents)
+	s.Step(`^"([^"]*)" exchange DIDs with "([^"]*)"$`, a.createConnections)
+	s.Step(`^"([^"]*)" and "([^"]*)" exchange DIDs$`, a.connectionEstablished)
+}
+
+func (a *SDKSteps) connectionEstablished(agent1, agent2 string) error {
+	if err := a.didExchangeSDKS.ApproveRequest(agent1); err != nil {
+		return err
+	}
+
+	if err := a.didExchangeSDKS.ApproveRequest(agent2); err != nil {
+		return err
+	}
+
+	return a.didExchangeSDKS.WaitForPostEvent(agent2+","+agent1, "completed")
+}
+
+func (a *SDKSteps) createConnections(introducees, introducer string) error {
+	const (
+		inboundHost     = "localhost"
+		inboundPort     = "random"
+		endpointURL     = "${SIDETREE_URL}"
+		acceptDidMethod = "sidetree"
+	)
+
+	participants := introducees + "," + introducer
+	agentSDK := agent.NewSDKSteps(a.bddContext)
+
+	err := agentSDK.CreateAgentWithHTTPDIDResolver(participants, inboundHost, inboundPort, endpointURL, acceptDidMethod)
+	if err != nil {
+		return err
+	}
+
+	if err := didresolver.CreateDIDDocument(a.bddContext, participants, acceptDidMethod); err != nil {
+		return err
+	}
+
+	a.didExchangeSDKS = bddDIDExchange.NewDIDExchangeSDKSteps(a.bddContext)
+
+	if err := a.didExchangeSDKS.WaitForPublicDID(participants, 10); err != nil {
+		return err
+	}
+
+	if err := a.didExchangeSDKS.CreateDIDExchangeClient(participants); err != nil {
+		return err
+	}
+
+	if err := a.didExchangeSDKS.RegisterPostMsgEvent(participants, "completed"); err != nil {
+		return err
+	}
+
+	if err := a.didExchangeSDKS.CreateInvitationWithDID(introducer); err != nil {
+		return err
+	}
+
+	for _, introducee := range strings.Split(introducees, ",") {
+		if err := a.didExchangeSDKS.ReceiveInvitation(introducee, introducer); err != nil {
+			return err
+		}
+
+		if err := a.connectionEstablished(introducee, introducer); err != nil {
+			return err
+		}
+	}
+
+	return a.createIntroduceClient(participants)
+}
+
+func (a *SDKSteps) createIntroduceClient(agents string) error {
+	for _, agent := range strings.Split(agents, ",") {
+		if err := a.createClient(agent, &didexchange.Invitation{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (a *SDKSteps) createIntroduceClientWithInvitation(agentID string) error {
+	inv, err := a.bddContext.DIDExchangeClients[agentID].CreateInvitation(agentID)
+	if err != nil {
+		return err
+	}
+
+	return a.createClient(agentID, inv)
+}
+
+func (a *SDKSteps) createClient(agentID string, inv *didexchange.Invitation) error {
+	client, err := introduce.New(a.bddContext.AgentCtx[agentID], inv.Invitation)
+	if err != nil {
+		return err
+	}
+
+	if a.clients[agentID] != nil {
+		if err := a.clients[agentID].UnregisterActionEvent(a.actions[agentID]); err != nil {
+			return err
+		}
+
+		if err := a.clients[agentID].UnregisterMsgEvent(a.events[agentID]); err != nil {
+			return err
+		}
+	}
+
+	a.clients[agentID] = client
+	a.actions[agentID] = make(chan service.DIDCommAction, 1)
+	a.events[agentID] = make(chan service.StateMsg, 10)
+
+	if err := client.RegisterMsgEvent(a.events[agentID]); err != nil {
+		return err
+	}
+
+	return client.RegisterActionEvent(a.actions[agentID])
+}
+
+func (a *SDKSteps) checkHistoryEvents(agentID, events string) error {
+	for _, stateID := range strings.Split(events, ",") {
+		select {
+		case e := <-a.events[agentID]:
+			if stateID != e.StateID {
+				return fmt.Errorf("history of events doesn't meet the expectation %q != %q", stateID, e.StateID)
+			}
+		case <-time.After(time.Second * 1):
+			return fmt.Errorf("waited for %s: history of events doesn't meet the expectation", stateID)
+		}
+	}
+
+	return a.stopServices()
+}
+
+func (a *SDKSteps) stopServices() error {
+	for agent := range a.bddContext.AgentCtx {
+		svc, err := a.bddContext.AgentCtx[agent].Service(introduceService.Introduce)
+		if err != nil {
+			return err
+		}
+
+		if err := svc.(interface{ Stop() error }).Stop(); err != nil {
+			if !errors.Is(err, introduceService.ErrServerWasStopped) {
+				return err
+			}
+		}
+
+		if err := a.bddContext.AgentCtx[agent].StorageProvider().Close(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (a *SDKSteps) checkAndStop(agentID, introduceeID string) error {
+	select {
+	case e := <-a.actions[agentID]:
+		proposal := &introduceService.Proposal{}
+		if err := json.Unmarshal(e.Message.Payload, proposal); err != nil {
+			return err
+		}
+
+		if proposal.To.Name != introduceeID {
+			return fmt.Errorf("%q doesn't want to know %q but got %q", agentID, introduceeID, proposal.To.Name)
+		}
+
+		e.Stop(errors.New("stop the protocol"))
+	case <-time.After(time.Second * 1):
+		return fmt.Errorf("timeout continueWithProtocol %s", agentID)
+	}
+
+	return nil
+}
+
+func (a *SDKSteps) handleRequest(agentID, introducee string) error {
+	select {
+	case e := <-a.actions[agentID]:
+		request := &introduceService.Request{}
+		if err := json.Unmarshal(e.Message.Payload, request); err != nil {
+			return err
+		}
+
+		conn, err := a.getConnection(agentID, request.PleaseIntroduceTo.Name)
+		if err != nil {
+			return err
+		}
+
+		recipient := &introduceService.Recipient{
+			To:       &introduceService.To{Name: introducee},
+			MyDID:    conn.MyDID,
+			TheirDID: conn.TheirDID,
+		}
+
+		to := &introduceService.To{Name: request.PleaseIntroduceTo.Name}
+		// nolint: govet
+		if err := a.clients[agentID].HandleRequest(*e.Message, to, recipient); err != nil {
+			return err
+		}
+
+		thID, err := e.Message.ThreadID()
+		if err != nil {
+			return err
+		}
+
+		e.Continue(a.clients[agentID].InvitationEnvelope(thID))
+	case <-time.After(time.Second * 1):
+		return fmt.Errorf("timeout checkAndContinue %s", agentID)
+	}
+
+	return nil
+}
+
+func (a *SDKSteps) handleRequestWithInvitation(agentID string) error {
+	select {
+	case e := <-a.actions[agentID]:
+		request := &introduceService.Request{}
+		if err := json.Unmarshal(e.Message.Payload, request); err != nil {
+			return err
+		}
+
+		introduceTo := request.PleaseIntroduceTo.Name
+
+		inv, err := a.bddContext.DIDExchangeClients[introduceTo].CreateInvitation(introduceTo)
+		if err != nil {
+			return err
+		}
+
+		to := &introduceService.To{Name: inv.Label}
+		// nolint: govet
+		if err := a.clients[agentID].HandleRequestWithInvitation(*e.Message, inv.Invitation, to); err != nil {
+			return err
+		}
+
+		thID, err := e.Message.ThreadID()
+		if err != nil {
+			return err
+		}
+
+		e.Continue(a.clients[agentID].InvitationEnvelope(thID))
+	case <-time.After(time.Second * 1):
+		return fmt.Errorf("timeout checkAndContinue %s", agentID)
+	}
+
+	return nil
+}
+
+func (a *SDKSteps) checkAndContinue(agentID, introduceeID string) error {
+	select {
+	case e := <-a.actions[agentID]:
+		thID, err := e.Message.ThreadID()
+		if err != nil {
+			return err
+		}
+
+		proposal := &introduceService.Proposal{}
+		if err := json.Unmarshal(e.Message.Payload, proposal); err != nil {
+			return err
+		}
+
+		if proposal.To.Name != introduceeID {
+			return fmt.Errorf("%q wants to know %q but got %q", agentID, introduceeID, proposal.To.Name)
+		}
+
+		e.Continue(a.clients[agentID].InvitationEnvelope(thID))
+	case <-time.After(time.Second * 1):
+		return fmt.Errorf("timeout checkAndContinue %s", agentID)
+	}
+
+	return nil
+}
+
+func (a *SDKSteps) continueWithProtocol(agentID string) error {
+	select {
+	case e := <-a.actions[agentID]:
+		thID, err := e.Message.ThreadID()
+		if err != nil {
+			return err
+		}
+
+		e.Continue(a.clients[agentID].InvitationEnvelope(thID))
+	case <-time.After(time.Second * 1):
+		return fmt.Errorf("timeout continueWithProtocol %s", agentID)
+	}
+
+	return nil
+}
+
+func (a *SDKSteps) stopProtocol(agentID string) error {
+	select {
+	case e := <-a.actions[agentID]:
+		e.Stop(errors.New("stop the protocol"))
+	case <-time.After(time.Second * 1):
+		return fmt.Errorf("timeout stopProtocol %s", agentID)
+	}
+
+	return nil
+}
+
+func (a *SDKSteps) getConnection(agent1, agent2 string) (*didexchange.Connection, error) {
+	connections, err := a.bddContext.DIDExchangeClients[agent1].QueryConnections(&didexchange.QueryConnectionsParams{})
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range connections {
+		if connections[i].TheirLabel == agent2 {
+			return connections[i], nil
+		}
+	}
+
+	return nil, errors.New("no connection between agents")
+}
+
+func (a *SDKSteps) sendProposal(introducer, introducee1, introducee2 string) error {
+	conn1, err := a.getConnection(introducer, introducee1)
+	if err != nil {
+		return err
+	}
+
+	conn2, err := a.getConnection(introducer, introducee2)
+	if err != nil {
+		return err
+	}
+
+	return a.clients[introducer].SendProposal(&introduceService.Recipient{
+		To:       &introduceService.To{Name: conn2.TheirLabel},
+		MyDID:    conn1.MyDID,
+		TheirDID: conn1.TheirDID,
+	}, &introduceService.Recipient{
+		To:       &introduceService.To{Name: conn1.TheirLabel},
+		MyDID:    conn2.MyDID,
+		TheirDID: conn2.TheirDID,
+	})
+}
+
+func (a *SDKSteps) sendProposalWithInvitation(introducer, introducee1, introducee2 string) error {
+	conn1, err := a.getConnection(introducer, introducee1)
+	if err != nil {
+		return err
+	}
+
+	inv, err := a.bddContext.DIDExchangeClients[introducee2].CreateInvitation(introducee2)
+	if err != nil {
+		return err
+	}
+
+	return a.clients[introducer].SendProposalWithInvitation(inv.Invitation, &introduceService.Recipient{
+		To:       &introduceService.To{Name: introducee2},
+		MyDID:    conn1.MyDID,
+		TheirDID: conn1.TheirDID,
+	})
+}
+
+func (a *SDKSteps) sendRequest(introducee1, introducer, introducee2 string) error {
+	conn1, err := a.getConnection(introducee1, introducer)
+	if err != nil {
+		return err
+	}
+
+	to := &introduceService.PleaseIntroduceTo{To: introduceService.To{Name: introducee2}}
+
+	return a.clients[introducee1].SendRequest(to, conn1.MyDID, conn1.TheirDID)
+}


### PR DESCRIPTION
Added BDD tests for the introduce protocol. Almost each BDD test represents unit test e.g `@skip_proposal` is equal to `SkipProposal` in a unit test.

* skip_proposal
* skip_proposal_with_request
* skip_proposal_stop
* skip_proposal_stop_with_request
* skip_proposal_introducer_stop
* skip_proposal_introducer_stop_with_request
* proposal
* proposal_with_request
* proposal_unusual
* proposal_unusual_with_request
* proposal_no_invitation
* proposal_no_invitation_with_request
* proposal_stop
* proposal_stop_with_request
* proposal_stop_unusual
* proposal_stop_unusual_with_request
* proposal_introducer_stop
* proposal_introducer_stop_with_request
* proposal_introducer_second_stop
* proposal_introducer_second_stop_with_request

Closes https://github.com/hyperledger/aries-framework-go/issues/979

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>