### PR TITLE
feat: connection lookup logic moved out of didexhange service

### DIFF
--- a/pkg/client/didexchange/models.go
+++ b/pkg/client/didexchange/models.go
@@ -6,7 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package didexchange
 
-import "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/common/connectionstore"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
+)
 
 // QueryConnectionsParams model
 //
@@ -41,7 +44,7 @@ type QueryConnectionsParams struct {
 // This is used to represent query connection result
 //
 type Connection struct {
-	*didexchange.ConnectionRecord
+	*connectionstore.ConnectionRecord
 }
 
 // Invitation model for DID Exchange invitation.

--- a/pkg/common/connectionstore/connection_record.go
+++ b/pkg/common/connectionstore/connection_record.go
@@ -1,0 +1,202 @@
+/*
+ *
+ * Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * /
+ *
+ */
+
+package connectionstore
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+const (
+	nameSpace          = "didexchange"
+	keyPattern         = "%s_%s"
+	connIDKeyPrefix    = "conn"
+	connStateKeyPrefix = "connstate"
+	// limitPattern with `~` at the end for lte of given prefix (less than or equal)
+	limitPattern    = "%s~"
+	keySeparator    = "_"
+	stateIDEmptyErr = "stateID can't be empty"
+)
+
+// KeyPrefix is prefix builder for storage keys
+type KeyPrefix func(...string) string
+
+type provider interface {
+	TransientStorageProvider() storage.Provider
+	StorageProvider() storage.Provider
+}
+
+// ConnectionRecord contain info about did exchange connection
+type ConnectionRecord struct {
+	ConnectionID    string
+	State           string
+	ThreadID        string
+	TheirLabel      string
+	TheirDID        string
+	MyDID           string
+	ServiceEndPoint string
+	RecipientKeys   []string
+	InvitationID    string
+	InvitationDID   string
+	Implicit        bool
+	Namespace       string
+}
+
+// NewConnectionLookup returns new connection recorder instance
+func NewConnectionLookup(p provider) (*ConnectionLookup, error) {
+	store, err := p.StorageProvider().OpenStore(nameSpace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open permanent store to create new connection recorder: %w", err)
+	}
+
+	transientStore, err := p.TransientStorageProvider().OpenStore(nameSpace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open transient store to create new connection recorder: %w", err)
+	}
+
+	return &ConnectionLookup{transientStore: transientStore, store: store}, nil
+}
+
+// ConnectionLookup takes care of connection related persistence features
+type ConnectionLookup struct {
+	transientStore storage.Store
+	store          storage.Store
+}
+
+// GetConnectionRecord return connection record based on the connection ID
+func (c *ConnectionLookup) GetConnectionRecord(connectionID string) (*ConnectionRecord, error) {
+	rec, err := getAndUnmarshal(GetConnectionKeyPrefix()(connectionID), c.store)
+	if errors.Is(err, storage.ErrDataNotFound) {
+		return getAndUnmarshal(GetConnectionKeyPrefix()(connectionID), c.transientStore)
+	}
+
+	return rec, err
+}
+
+// QueryConnectionRecords returns connection records found in underlying store
+// for given query criteria
+func (c *ConnectionLookup) QueryConnectionRecords() ([]*ConnectionRecord, error) {
+	// TODO https://github.com/hyperledger/aries-framework-go/issues/655 query criteria to be added as part of issue
+	searchKey := GetConnectionKeyPrefix()("")
+
+	itr := c.store.Iterator(searchKey, fmt.Sprintf(limitPattern, searchKey))
+	defer itr.Release()
+
+	var records []*ConnectionRecord
+
+	keys := make(map[string]struct{})
+
+	for itr.Next() {
+		var record ConnectionRecord
+
+		err := json.Unmarshal(itr.Value(), &record)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query connection records, %w", err)
+		}
+
+		keys[string(itr.Key())] = struct{}{}
+
+		records = append(records, &record)
+	}
+
+	transientItr := c.transientStore.Iterator(searchKey, fmt.Sprintf(limitPattern, searchKey))
+	defer transientItr.Release()
+
+	for transientItr.Next() {
+		// don't fetch data from transient store if same record is present in permanent store
+		if _, ok := keys[string(transientItr.Key())]; ok {
+			continue
+		}
+
+		var record ConnectionRecord
+
+		if err := json.Unmarshal(transientItr.Value(), &record); err != nil {
+			return nil, fmt.Errorf("query connection records from transient store : %w", err)
+		}
+
+		records = append(records, &record)
+	}
+
+	return records, nil
+}
+
+// GetConnectionRecordAtState return connection record based on the connection ID and state.
+func (c *ConnectionLookup) GetConnectionRecordAtState(connectionID, stateID string) (*ConnectionRecord, error) {
+	if stateID == "" {
+		return nil, errors.New(stateIDEmptyErr)
+	}
+
+	return getAndUnmarshal(GetConnectionStateKeyPrefix()(connectionID, stateID), c.transientStore)
+}
+
+func getAndUnmarshal(k string, store storage.Store) (*ConnectionRecord, error) {
+	connRecordBytes, err := store.Get(k)
+	if err != nil {
+		return nil, err
+	}
+
+	return prepareConnectionRecord(connRecordBytes)
+}
+
+// GetConnectionRecordByNSThreadID return connection record via namespaced threadID
+func (c *ConnectionLookup) GetConnectionRecordByNSThreadID(nsThreadID string) (*ConnectionRecord, error) {
+	connectionIDBytes, err := c.transientStore.Get(nsThreadID)
+	if err != nil {
+		return nil, fmt.Errorf("get connectionID by namespaced threadID: %w", err)
+	}
+	// adding prefix for storing connection record
+	k := GetConnectionKeyPrefix()(string(connectionIDBytes))
+
+	connRecordBytes, err := c.transientStore.Get(k)
+	if err != nil {
+		return nil, fmt.Errorf("get connection record by connectionID: %w", err)
+	}
+
+	return prepareConnectionRecord(connRecordBytes)
+}
+
+// Store returns handle to underlying permanent store
+func (c *ConnectionLookup) Store() storage.Store {
+	return c.store
+}
+
+// TransientStore returns handle to underlying transient store
+func (c *ConnectionLookup) TransientStore() storage.Store {
+	return c.transientStore
+}
+
+// GetConnectionKeyPrefix key prefix for connection record persisted
+func GetConnectionKeyPrefix() KeyPrefix {
+	return func(key ...string) string {
+		return fmt.Sprintf(keyPattern, connIDKeyPrefix, strings.Join(key, keySeparator))
+	}
+}
+
+// GetConnectionStateKeyPrefix key prefix for state based connection record persisted
+func GetConnectionStateKeyPrefix() KeyPrefix {
+	return func(key ...string) string {
+		return fmt.Sprintf(keyPattern, connStateKeyPrefix, strings.Join(key, keySeparator))
+	}
+}
+
+func prepareConnectionRecord(connRecBytes []byte) (*ConnectionRecord, error) {
+	connRecord := &ConnectionRecord{}
+
+	err := json.Unmarshal(connRecBytes, connRecord)
+	if err != nil {
+		return nil, fmt.Errorf("prepare connection record: %w", err)
+	}
+
+	return connRecord, nil
+}

--- a/pkg/common/connectionstore/connection_record_test.go
+++ b/pkg/common/connectionstore/connection_record_test.go
@@ -1,0 +1,390 @@
+/*
+ *
+ * Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * /
+ *
+ */
+
+package connectionstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/storage/mem"
+)
+
+const (
+	threadIDFmt  = "thID-%v"
+	connIDFmt    = "connValue-%v"
+	sampleErrMsg = "sample-error-message"
+)
+
+func TestNewConnectionReader(t *testing.T) {
+	t.Run("create new connection reader", func(t *testing.T) {
+		store, err := NewConnectionLookup(&mockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, store)
+		require.NotNil(t, store.TransientStore())
+		require.NotNil(t, store.Store())
+	})
+
+	t.Run("create new connection reader failure due to transient store error", func(t *testing.T) {
+		store, err := NewConnectionLookup(&mockProvider{transientStoreError: fmt.Errorf(sampleErrMsg)})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), sampleErrMsg)
+		require.Nil(t, store)
+	})
+
+	t.Run("create new connection reader failure due to store error", func(t *testing.T) {
+		store, err := NewConnectionLookup(&mockProvider{storeError: fmt.Errorf(sampleErrMsg)})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), sampleErrMsg)
+		require.Nil(t, store)
+	})
+}
+
+func TestConnectionReader_GetAndQueryConnectionRecord(t *testing.T) {
+	const noOfItems = 12
+	connectionIDS := make([]string, noOfItems)
+
+	for i := 0; i < noOfItems; i++ {
+		connectionIDS[i] = fmt.Sprintf(connIDFmt, i)
+	}
+
+	saveInStore := func(store storage.Store, ids []string) {
+		for _, id := range ids {
+			connRecBytes, err := json.Marshal(&ConnectionRecord{ConnectionID: id,
+				ThreadID: fmt.Sprintf(threadIDFmt, id)})
+			require.NoError(t, err)
+			err = store.Put(GetConnectionKeyPrefix()(id), connRecBytes)
+			require.NoError(t, err)
+		}
+	}
+
+	t.Run("get connection record - from store", func(t *testing.T) {
+		store, e := NewConnectionLookup(&mockProvider{})
+		require.NoError(t, e)
+		require.NotNil(t, store)
+
+		for _, connectionID := range connectionIDS {
+			connection, err := store.GetConnectionRecord(connectionID)
+			require.Error(t, err)
+			require.Equal(t, err, storage.ErrDataNotFound)
+			require.Nil(t, connection)
+		}
+
+		// prepare data
+		saveInStore(store.Store(), connectionIDS)
+
+		for _, connectionID := range connectionIDS {
+			connection, err := store.GetConnectionRecord(connectionID)
+			require.NoError(t, err)
+			require.NotNil(t, connection)
+			require.Equal(t, connectionID, connection.ConnectionID)
+			require.Equal(t, fmt.Sprintf(threadIDFmt, connectionID), connection.ThreadID)
+		}
+
+		records, e := store.QueryConnectionRecords()
+		require.NoError(t, e)
+		require.NotEmpty(t, records)
+		require.Len(t, records, noOfItems)
+	})
+
+	t.Run("get connection record - from transient store", func(t *testing.T) {
+		store, e := NewConnectionLookup(&mockProvider{})
+		require.NoError(t, e)
+		require.NotNil(t, store)
+
+		for _, connectionID := range connectionIDS {
+			connection, err := store.GetConnectionRecord(connectionID)
+			require.Error(t, err)
+			require.Equal(t, err, storage.ErrDataNotFound)
+			require.Nil(t, connection)
+		}
+
+		// prepare data
+		saveInStore(store.TransientStore(), connectionIDS)
+
+		for _, connectionID := range connectionIDS {
+			connection, err := store.GetConnectionRecord(connectionID)
+			require.NoError(t, err)
+			require.NotNil(t, connection)
+			require.Equal(t, connectionID, connection.ConnectionID)
+			require.Equal(t, fmt.Sprintf(threadIDFmt, connectionID), connection.ThreadID)
+		}
+
+		records, e := store.QueryConnectionRecords()
+		require.NoError(t, e)
+		require.NotEmpty(t, records)
+		require.Len(t, records, noOfItems)
+	})
+
+	t.Run("get connection record - error scenario", func(t *testing.T) {
+		provider := &mockProvider{}
+		provider.store = &mockstorage.MockStore{ErrGet: fmt.Errorf(sampleErrMsg),
+			Store: make(map[string][]byte)}
+		store, err := NewConnectionLookup(provider)
+		require.NoError(t, err)
+		require.NotNil(t, store)
+
+		// prepare data
+		saveInStore(store.Store(), connectionIDS)
+
+		for _, connectionID := range connectionIDS {
+			connection, err := store.GetConnectionRecord(connectionID)
+			require.Error(t, err)
+			require.Nil(t, connection)
+			require.EqualError(t, err, sampleErrMsg)
+		}
+	})
+}
+
+func TestConnectionReader_GetConnectionRecordAtState(t *testing.T) {
+	const state = "requested"
+
+	const noOfItems = 12
+
+	connectionIDS := make([]string, noOfItems)
+
+	for i := 0; i < noOfItems; i++ {
+		connectionIDS[i] = fmt.Sprintf(connIDFmt, i)
+	}
+
+	saveInStore := func(store storage.Store, ids []string) {
+		for _, id := range ids {
+			connRecBytes, err := json.Marshal(&ConnectionRecord{ConnectionID: id,
+				ThreadID: fmt.Sprintf(threadIDFmt, id)})
+			require.NoError(t, err)
+			err = store.Put(GetConnectionStateKeyPrefix()(id, state), connRecBytes)
+			require.NoError(t, err)
+		}
+	}
+
+	t.Run("get connection record at state", func(t *testing.T) {
+		store, err := NewConnectionLookup(&mockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, store)
+
+		// should fail since data doesn't exists
+		for _, connectionID := range connectionIDS {
+			connection, err := store.GetConnectionRecordAtState(connectionID, state)
+			require.Error(t, err)
+			require.Equal(t, err, storage.ErrDataNotFound)
+			require.Nil(t, connection)
+		}
+
+		// prepare data in store
+		saveInStore(store.Store(), connectionIDS)
+
+		// should fail since data doesn't exists in transient store
+		for _, connectionID := range connectionIDS {
+			connection, err := store.GetConnectionRecordAtState(connectionID, state)
+			require.Error(t, err)
+			require.Equal(t, err, storage.ErrDataNotFound)
+			require.Nil(t, connection)
+		}
+
+		// prepare data in transient store
+		saveInStore(store.TransientStore(), connectionIDS)
+
+		for _, connectionID := range connectionIDS {
+			connection, err := store.GetConnectionRecordAtState(connectionID, state)
+			require.NoError(t, err)
+			require.NotNil(t, connection)
+			require.Equal(t, connectionID, connection.ConnectionID)
+			require.Equal(t, fmt.Sprintf(threadIDFmt, connectionID), connection.ThreadID)
+		}
+	})
+
+	t.Run("get connection record at state - failure", func(t *testing.T) {
+		store, err := NewConnectionLookup(&mockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, store)
+
+		connection, err := store.GetConnectionRecordAtState("sampleID", "")
+		require.Error(t, err)
+		require.EqualError(t, err, stateIDEmptyErr)
+		require.Nil(t, connection)
+	})
+}
+
+func TestConnectionReader_GetConnectionRecordByNSThreadID(t *testing.T) {
+	const noOfItems = 12
+	nsThreadIDs := make([]string, noOfItems)
+
+	for i := 0; i < noOfItems; i++ {
+		nsThreadIDs[i] = fmt.Sprintf(threadIDFmt, i)
+	}
+
+	saveInStore := func(store storage.Store, ids []string, skipConnection bool) {
+		for _, id := range ids {
+			connID := fmt.Sprintf(connIDFmt, id)
+			connRecBytes, err := json.Marshal(&ConnectionRecord{ConnectionID: id,
+				ThreadID: id})
+			require.NoError(t, err)
+			err = store.Put(id, []byte(connID))
+			require.NoError(t, err)
+
+			if !skipConnection {
+				err = store.Put(GetConnectionKeyPrefix()(connID), connRecBytes)
+				require.NoError(t, err)
+			}
+		}
+	}
+
+	t.Run("get connection record by NS thread ID", func(t *testing.T) {
+		store, err := NewConnectionLookup(&mockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, store)
+
+		// should fail since data doesn't exists
+		for _, nsThreadID := range nsThreadIDs {
+			connection, err := store.GetConnectionRecordByNSThreadID(nsThreadID)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), storage.ErrDataNotFound.Error())
+			require.Nil(t, connection)
+		}
+
+		// prepare data in store
+		saveInStore(store.Store(), nsThreadIDs, false)
+
+		// should fail since data doesn't exists in transient store
+		for _, nsThreadID := range nsThreadIDs {
+			connection, err := store.GetConnectionRecordByNSThreadID(nsThreadID)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), storage.ErrDataNotFound.Error())
+			require.Nil(t, connection)
+		}
+
+		// prepare only ns thread data in transient store
+		// skip connection
+		saveInStore(store.TransientStore(), nsThreadIDs, true)
+
+		// should fail since data doesn't exists in transient store
+		for _, nsThreadID := range nsThreadIDs {
+			connection, err := store.GetConnectionRecordByNSThreadID(nsThreadID)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), storage.ErrDataNotFound.Error())
+			require.Nil(t, connection)
+		}
+
+		// prepare data in transient store
+		saveInStore(store.TransientStore(), nsThreadIDs, false)
+
+		// should fail since data doesn't exists in transient store
+		for _, nsThreadID := range nsThreadIDs {
+			connection, err := store.GetConnectionRecordByNSThreadID(nsThreadID)
+			require.NoError(t, err)
+			require.NotNil(t, connection)
+			require.Equal(t, nsThreadID, connection.ThreadID)
+		}
+	})
+}
+
+func TestConnectionRecorder_PrepareConnectionRecord(t *testing.T) {
+	t.Run(" prepare connection record  error", func(t *testing.T) {
+		transientStore := &mockstorage.MockStore{Store: make(map[string][]byte)}
+		record, err := NewConnectionLookup(&mockProvider{store: nil, transientStore: transientStore})
+		require.NoError(t, err)
+		require.NotNil(t, record)
+		connRec, err := prepareConnectionRecord(nil)
+		require.Contains(t, err.Error(), "prepare connection record")
+		require.Nil(t, connRec)
+	})
+}
+
+func TestConnectionRecorder_QueryConnectionRecord(t *testing.T) {
+	t.Run("test query connection record", func(t *testing.T) {
+		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
+
+		transientStore, err := mem.NewProvider().OpenStore(nameSpace)
+		require.NoError(t, err)
+
+		const (
+			storeCount          = 5
+			overlap             = 3
+			transientStoreCount = 4
+		)
+
+		for i := 0; i < storeCount+overlap; i++ {
+			val, jsonErr := json.Marshal(&ConnectionRecord{
+				ConnectionID: string(i),
+			})
+			require.NoError(t, jsonErr)
+
+			err = store.Put(fmt.Sprintf("%s_abc%d", connIDKeyPrefix, i), val)
+			require.NoError(t, err)
+		}
+		for i := overlap; i < transientStoreCount+storeCount; i++ {
+			val, jsonErr := json.Marshal(&ConnectionRecord{
+				ConnectionID: string(i),
+			})
+			require.NoError(t, jsonErr)
+
+			err = transientStore.Put(fmt.Sprintf("%s_abc%d", connIDKeyPrefix, i), val)
+			require.NoError(t, err)
+		}
+
+		recorder, err := NewConnectionLookup(&mockProvider{store: store, transientStore: transientStore})
+		require.NoError(t, err)
+		require.NotNil(t, recorder)
+		result, err := recorder.QueryConnectionRecords()
+		require.NoError(t, err)
+		require.Len(t, result, storeCount+transientStoreCount)
+	})
+
+	t.Run("test query connection record failure", func(t *testing.T) {
+		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
+		err := store.Put(fmt.Sprintf("%s_abc123", connIDKeyPrefix), []byte("-----"))
+		require.NoError(t, err)
+
+		recorder, err := NewConnectionLookup(&mockProvider{store: store})
+		require.NoError(t, err)
+		require.NotNil(t, recorder)
+		result, err := recorder.QueryConnectionRecords()
+		require.Error(t, err)
+		require.Empty(t, result)
+	})
+}
+
+// mockProvider for connection recorder
+type mockProvider struct {
+	transientStoreError error
+	storeError          error
+	store               storage.Store
+	transientStore      storage.Store
+}
+
+// TransientStorageProvider is mock transient storage provider for connection recorder
+func (p *mockProvider) TransientStorageProvider() storage.Provider {
+	if p.transientStoreError != nil {
+		return &mockstorage.MockStoreProvider{ErrOpenStoreHandle: p.transientStoreError}
+	}
+
+	if p.transientStore != nil {
+		return mockstorage.NewCustomMockStoreProvider(p.transientStore)
+	}
+
+	return mockstorage.NewMockStoreProvider()
+}
+
+// StorageProvider is mock storage provider for connection recorder
+func (p *mockProvider) StorageProvider() storage.Provider {
+	if p.storeError != nil {
+		return &mockstorage.MockStoreProvider{ErrOpenStoreHandle: p.storeError}
+	}
+
+	if p.store != nil {
+		return mockstorage.NewCustomMockStoreProvider(p.store)
+	}
+
+	return mockstorage.NewMockStoreProvider()
+}

--- a/pkg/didcomm/protocol/didexchange/persistence.go
+++ b/pkg/didcomm/protocol/didexchange/persistence.go
@@ -12,58 +12,37 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/connectionstore"
+
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/didconnection"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
 const (
-	keyPattern         = "%s_%s"
-	invKeyPrefix       = "inv"
-	connIDKeyPrefix    = "conn"
-	connStateKeyPrefix = "connstate"
-	myNSPrefix         = "my"
+	keyPattern   = "%s_%s"
+	invKeyPrefix = "inv"
+	myNSPrefix   = "my"
 	// TODO: https://github.com/hyperledger/aries-framework-go/issues/556 It will not be constant, this namespace
 	//  will need to be figured with verification key
 	theirNSPrefix = "their"
-	// limitPattern with `~` at the end for lte of given prefix (less than or equal)
-	limitPattern = "%s~"
 )
 
-// ConnectionRecord contain info about did exchange connection
-type ConnectionRecord struct {
-	ConnectionID    string
-	State           string
-	ThreadID        string
-	TheirLabel      string
-	TheirDID        string
-	MyDID           string
-	ServiceEndPoint string
-	RecipientKeys   []string
-	InvitationID    string
-	InvitationDID   string
-	Implicit        bool
-	Namespace       string
-}
-
-func (r *ConnectionRecord) isValid() error {
-	if r.ThreadID == "" || r.ConnectionID == "" || r.Namespace == "" {
-		return fmt.Errorf("input parameters thid : %s and connectionId : %s namespace : %s cannot be empty",
-			r.ThreadID, r.ConnectionID, r.Namespace)
+// newConnectionStore returns new connection store instance
+func newConnectionStore(p provider) (*connectionStore, error) {
+	reader, err := connectionstore.NewConnectionLookup(p)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil
+	return &connectionStore{ConnectionLookup: reader, didStore: p.DIDConnectionStore()}, nil
 }
 
-// NewConnectionRecorder returns new connection record instance
-func NewConnectionRecorder(transientStore, store storage.Store, didStore didconnection.Store) *ConnectionRecorder {
-	return &ConnectionRecorder{transientStore: transientStore, store: store, didStore: didStore}
-}
-
-// ConnectionRecorder takes care of connection related persistence features
-type ConnectionRecorder struct {
-	transientStore storage.Store
-	store          storage.Store
-	didStore       didconnection.Store
+// connectionStore takes care of connection and DID related persistence features
+// TODO this should be moved to separate package as Writable connection store [Issue #1021]
+// TODO merge connection stores [Issue #1004]
+type connectionStore struct {
+	*connectionstore.ConnectionLookup
+	didStore didconnection.Store
 }
 
 // SaveInvitation saves connection invitation to underlying store
@@ -75,7 +54,7 @@ type ConnectionRecorder struct {
 // Returns:
 //
 // error: error
-func (c *ConnectionRecorder) SaveInvitation(invitation *Invitation) error {
+func (c *connectionStore) SaveInvitation(invitation *Invitation) error {
 	k, err := invitationKey(invitation.ID)
 	if err != nil {
 		return err
@@ -86,7 +65,7 @@ func (c *ConnectionRecorder) SaveInvitation(invitation *Invitation) error {
 		return err
 	}
 
-	return c.store.Put(k, bytes)
+	return c.Store().Put(k, bytes)
 }
 
 // GetInvitation returns invitation for given key from underlying store and
@@ -100,13 +79,13 @@ func (c *ConnectionRecorder) SaveInvitation(invitation *Invitation) error {
 //
 // invitation found
 // error: error
-func (c *ConnectionRecorder) GetInvitation(id string) (*Invitation, error) {
+func (c *connectionStore) GetInvitation(id string) (*Invitation, error) {
 	k, err := invitationKey(id)
 	if err != nil {
 		return nil, err
 	}
 
-	bytes, err := c.store.Get(k)
+	bytes, err := c.Store().Get(k)
 	if err != nil {
 		return nil, err
 	}
@@ -121,116 +100,24 @@ func (c *ConnectionRecorder) GetInvitation(id string) (*Invitation, error) {
 	return result, nil
 }
 
-// GetConnectionRecord return connection record based on the connection ID
-func (c *ConnectionRecorder) GetConnectionRecord(connectionID string) (*ConnectionRecord, error) {
-	rec, err := getAndUnmarshal(connectionKeyPrefix(connectionID), c.store)
-	if err != nil {
-		if errors.Is(err, storage.ErrDataNotFound) {
-			return getAndUnmarshal(connectionKeyPrefix(connectionID), c.transientStore)
-		}
-
-		return nil, err
-	}
-
-	return rec, nil
-}
-
-// QueryConnectionRecords returns connection records found in underlying store
-// for given query criteria
-func (c *ConnectionRecorder) QueryConnectionRecords() ([]*ConnectionRecord, error) {
-	// TODO https://github.com/hyperledger/aries-framework-go/issues/655 query criteria to be added as part of issue
-	searchKey := connectionKeyPrefix("")
-
-	itr := c.store.Iterator(searchKey, fmt.Sprintf(limitPattern, searchKey))
-	defer itr.Release()
-
-	var records []*ConnectionRecord
-
-	keys := make(map[string]struct{})
-
-	for itr.Next() {
-		var record ConnectionRecord
-
-		err := json.Unmarshal(itr.Value(), &record)
-		if err != nil {
-			return nil, fmt.Errorf("failed to query connection records, %w", err)
-		}
-
-		keys[string(itr.Key())] = struct{}{}
-
-		records = append(records, &record)
-	}
-
-	transientItr := c.transientStore.Iterator(searchKey, fmt.Sprintf(limitPattern, searchKey))
-	defer transientItr.Release()
-
-	for transientItr.Next() {
-		// don't fetch data from transient store if same record is present in permanent store
-		if _, ok := keys[string(transientItr.Key())]; !ok {
-			var record ConnectionRecord
-
-			err := json.Unmarshal(transientItr.Value(), &record)
-			if err != nil {
-				return nil, fmt.Errorf("query connection records from transient store : %w", err)
-			}
-
-			records = append(records, &record)
-		}
-	}
-
-	return records, nil
-}
-
-// GetConnectionRecordAtState return connection record based on the connection ID and state.
-func (c *ConnectionRecorder) GetConnectionRecordAtState(connectionID, stateID string) (*ConnectionRecord, error) {
-	if stateID == "" {
-		return nil, errors.New("stateID can't be empty")
-	}
-
-	return getAndUnmarshal(connectionStateKeyPrefix(connectionID, stateID), c.transientStore)
-}
-
-func getAndUnmarshal(k string, store storage.Store) (*ConnectionRecord, error) {
-	connRecordBytes, err := store.Get(k)
-	if err != nil {
-		return nil, err
-	}
-
-	return prepareConnectionRecord(connRecordBytes)
-}
-
-// GetConnectionRecordByNSThreadID return connection record via namespaced threadID
-func (c *ConnectionRecorder) GetConnectionRecordByNSThreadID(nsThreadID string) (*ConnectionRecord, error) {
-	connectionIDBytes, err := c.transientStore.Get(nsThreadID)
-	if err != nil {
-		return nil, fmt.Errorf("get connectionID by namespaced threadID: %w", err)
-	}
-	// adding prefix for storing connection record
-	k := connectionKeyPrefix(string(connectionIDBytes))
-
-	connRecordBytes, err := c.transientStore.Get(k)
-	if err != nil {
-		return nil, fmt.Errorf("get connection record by connectionID: %w", err)
-	}
-
-	return prepareConnectionRecord(connRecordBytes)
-}
-
 // saveConnectionRecord saves the connection record against the connection id  in the store
-func (c *ConnectionRecorder) saveConnectionRecord(record *ConnectionRecord) error {
-	if err := marshalAndSave(connectionKeyPrefix(record.ConnectionID), record, c.transientStore); err != nil {
+func (c *connectionStore) saveConnectionRecord(record *connectionstore.ConnectionRecord) error {
+	if err := marshalAndSave(connectionstore.GetConnectionKeyPrefix()(record.ConnectionID),
+		record, c.TransientStore()); err != nil {
 		return fmt.Errorf("save connection record in transient store: %w", err)
 	}
 
 	if record.State != "" {
-		err := marshalAndSave(connectionStateKeyPrefix(record.ConnectionID, record.State), record, c.transientStore)
+		err := marshalAndSave(connectionstore.GetConnectionStateKeyPrefix()(record.ConnectionID, record.State),
+			record, c.TransientStore())
 		if err != nil {
 			return fmt.Errorf("save connection record with state in transient store: %w", err)
 		}
 	}
 
 	if record.State == stateNameCompleted {
-		if err := marshalAndSave(connectionKeyPrefix(record.ConnectionID), record, c.store); err != nil {
+		if err := marshalAndSave(connectionstore.GetConnectionKeyPrefix()(record.ConnectionID),
+			record, c.Store()); err != nil {
 			return fmt.Errorf("save connection record in permanent store: %w", err)
 		}
 
@@ -242,7 +129,7 @@ func (c *ConnectionRecorder) saveConnectionRecord(record *ConnectionRecord) erro
 	return nil
 }
 
-func marshalAndSave(k string, v *ConnectionRecord, store storage.Store) error {
+func marshalAndSave(k string, v *connectionstore.ConnectionRecord, store storage.Store) error {
 	bytes, err := json.Marshal(v)
 
 	if err != nil {
@@ -254,8 +141,8 @@ func marshalAndSave(k string, v *ConnectionRecord, store storage.Store) error {
 
 // saveNewConnectionRecord saves newly created connection record against the connection id in the store
 // and it creates mapping from namespaced ThreadID to connection ID
-func (c *ConnectionRecorder) saveNewConnectionRecord(record *ConnectionRecord) error {
-	err := record.isValid()
+func (c *connectionStore) saveNewConnectionRecord(record *connectionstore.ConnectionRecord) error {
+	err := isValidConnection(record)
 	if err != nil {
 		return err
 	}
@@ -274,7 +161,7 @@ func (c *ConnectionRecorder) saveNewConnectionRecord(record *ConnectionRecord) e
 	return c.saveNSThreadID(record.ThreadID, record.Namespace, record.ConnectionID)
 }
 
-func (c *ConnectionRecorder) saveNSThreadID(thid, namespace, connectionID string) error {
+func (c *connectionStore) saveNSThreadID(thid, namespace, connectionID string) error {
 	if namespace != myNSPrefix && namespace != theirNSPrefix {
 		return fmt.Errorf("namespace not supported")
 	}
@@ -289,18 +176,7 @@ func (c *ConnectionRecorder) saveNSThreadID(thid, namespace, connectionID string
 		return err
 	}
 
-	return c.transientStore.Put(k, []byte(connectionID))
-}
-
-func prepareConnectionRecord(connRecBytes []byte) (*ConnectionRecord, error) {
-	connRecord := &ConnectionRecord{}
-
-	err := json.Unmarshal(connRecBytes, connRecord)
-	if err != nil {
-		return nil, fmt.Errorf("prepare connection record: %w", err)
-	}
-
-	return connRecord, nil
+	return c.TransientStore().Put(k, []byte(connectionID))
 }
 
 // invitationKey computes key for invitation object
@@ -313,6 +189,25 @@ func invitationKey(invID string) (string, error) {
 	return fmt.Sprintf(keyPattern, invKeyPrefix, storeKey), nil
 }
 
+// createNSKey computes key for storing the mapping with the namespace
+func createNSKey(prefix, id string) (string, error) {
+	storeKey, err := computeHash([]byte(id))
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(keyPattern, prefix, storeKey), nil
+}
+
+func isValidConnection(r *connectionstore.ConnectionRecord) error {
+	if r.ThreadID == "" || r.ConnectionID == "" || r.Namespace == "" {
+		return fmt.Errorf("input parameters thid : %s and connectionId : %s namespace : %s cannot be empty",
+			r.ThreadID, r.ConnectionID, r.Namespace)
+	}
+
+	return nil
+}
+
 // computeHash will compute the hash for the supplied bytes
 func computeHash(bytes []byte) (string, error) {
 	if len(bytes) == 0 {
@@ -323,24 +218,4 @@ func computeHash(bytes []byte) (string, error) {
 	hash := h.Sum(bytes)
 
 	return fmt.Sprintf("%x", hash), nil
-}
-
-// connectionKeyPrefix computes key for connection record object
-func connectionKeyPrefix(connectionID string) string {
-	return fmt.Sprintf(keyPattern, connIDKeyPrefix, connectionID)
-}
-
-// connectionStateKeyPrefix computes key for connection record data associated with state.
-func connectionStateKeyPrefix(connectionID, stateID string) string {
-	return fmt.Sprintf(keyPattern, connStateKeyPrefix, connectionID+stateID)
-}
-
-// createNSKey computes key for storing the mapping with the namespace
-func createNSKey(prefix, id string) (string, error) {
-	storeKey, err := computeHash([]byte(id))
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf(keyPattern, prefix, storeKey), nil
 }

--- a/pkg/didcomm/protocol/didexchange/persistence_test.go
+++ b/pkg/didcomm/protocol/didexchange/persistence_test.go
@@ -7,16 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package didexchange
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/connectionstore"
 	mockdidconnection "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/didconnection"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
 	mockstorage "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/storage/mem"
 )
 
 const (
@@ -45,10 +45,31 @@ func Test_ComputeHash(t *testing.T) {
 	require.Empty(t, h4)
 }
 
-func TestConnectionRecord_SaveInvitation(t *testing.T) {
+func TestNewConnectionStore(t *testing.T) {
+	t.Run("test create connection store", func(t *testing.T) {
+		record, err := newConnectionStore(&protocol.MockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, record)
+	})
+	t.Run("test create connection store - error", func(t *testing.T) {
+		record, err := newConnectionStore(&protocol.MockProvider{
+			StoreProvider: &mockstorage.MockStoreProvider{
+				ErrOpenStoreHandle: fmt.Errorf("sample-error"),
+			},
+		})
+		require.Error(t, err)
+		require.Nil(t, record)
+	})
+}
+
+func TestConnectionStore_SaveInvitation(t *testing.T) {
 	t.Run("test save invitation success", func(t *testing.T) {
 		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(nil, store, nil)
+		record, err := newConnectionStore(&protocol.MockProvider{
+			StoreProvider: mockstorage.NewCustomMockStoreProvider(store),
+		})
+		require.NoError(t, err)
+
 		require.NotNil(t, record)
 
 		value := &Invitation{
@@ -56,7 +77,7 @@ func TestConnectionRecord_SaveInvitation(t *testing.T) {
 			Label: "sample-label1",
 		}
 
-		err := record.SaveInvitation(value)
+		err = record.SaveInvitation(value)
 		require.NoError(t, err)
 
 		require.NotEmpty(t, store)
@@ -65,29 +86,32 @@ func TestConnectionRecord_SaveInvitation(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, k)
 
-		v, err := record.store.Get(k)
+		v, err := record.Store().Get(k)
 		require.NoError(t, err)
 		require.NotEmpty(t, v)
 	})
 
 	t.Run("test save invitation failure due to invalid key", func(t *testing.T) {
 		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(nil, store, nil)
+		record, err := newConnectionStore(&protocol.MockProvider{
+			StoreProvider: mockstorage.NewCustomMockStoreProvider(store),
+		})
+		require.NoError(t, err)
 		require.NotNil(t, record)
 
 		value := &Invitation{
 			Label: "sample-label2",
 		}
-		err := record.SaveInvitation(value)
+		err = record.SaveInvitation(value)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "empty bytes")
 	})
 }
 
-func TestConnectionRecorder_GetInvitation(t *testing.T) {
+func TestConnectionStore_GetInvitation(t *testing.T) {
 	t.Run("test get invitation - success", func(t *testing.T) {
-		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(nil, store, nil)
+		record, err := newConnectionStore(&protocol.MockProvider{})
+		require.NoError(t, err)
 		require.NotNil(t, record)
 
 		valueStored := &Invitation{
@@ -95,7 +119,7 @@ func TestConnectionRecorder_GetInvitation(t *testing.T) {
 			Label: "sample-label-3",
 		}
 
-		err := record.SaveInvitation(valueStored)
+		err = record.SaveInvitation(valueStored)
 		require.NoError(t, err)
 
 		valueFound, err := record.GetInvitation(valueStored.ID)
@@ -104,8 +128,8 @@ func TestConnectionRecorder_GetInvitation(t *testing.T) {
 	})
 
 	t.Run("test get invitation - not found scenario", func(t *testing.T) {
-		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(nil, store, nil)
+		record, err := newConnectionStore(&protocol.MockProvider{})
+		require.NoError(t, err)
 		require.NotNil(t, record)
 
 		valueFound, err := record.GetInvitation("sample-key4")
@@ -115,8 +139,8 @@ func TestConnectionRecorder_GetInvitation(t *testing.T) {
 	})
 
 	t.Run("test get invitation - invalid key scenario", func(t *testing.T) {
-		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(nil, store, nil)
+		record, err := newConnectionStore(&protocol.MockProvider{})
+		require.NoError(t, err)
 		require.NotNil(t, record)
 
 		valueFound, err := record.GetInvitation("")
@@ -126,85 +150,13 @@ func TestConnectionRecorder_GetInvitation(t *testing.T) {
 	})
 }
 
-func TestConnectionRecorder_GetConnectionRecord(t *testing.T) {
-	t.Run("test success found data in transient store ", func(t *testing.T) {
-		transientStore := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(transientStore, store, nil)
-		require.NotNil(t, record)
-		connRec := &ConnectionRecord{ConnectionID: connIDValue, ThreadID: threadIDValue,
-			Namespace: myNSPrefix}
-		connRecBytes, err := json.Marshal(connRec)
-		require.NoError(t, err)
-		connKey := connectionKeyPrefix(connIDValue)
-		require.NoError(t, transientStore.Put(connKey, connRecBytes))
-		nsThreadID, err := createNSKey(myNSPrefix, threadIDValue)
-		require.NoError(t, err)
-		require.NoError(t, transientStore.Put(nsThreadID, []byte(connIDValue)))
-
-		storedConnRec, err := record.GetConnectionRecord(connIDValue)
-		require.NoError(t, err)
-		require.Equal(t, storedConnRec, connRec)
-	})
-	t.Run("test success found data in store ", func(t *testing.T) {
-		transientStore := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(transientStore, store, nil)
-		require.NotNil(t, record)
-		connRec := &ConnectionRecord{ConnectionID: connIDValue, ThreadID: threadIDValue,
-			Namespace: myNSPrefix}
-		connRecBytes, err := json.Marshal(connRec)
-		require.NoError(t, err)
-		connKey := connectionKeyPrefix(connIDValue)
-		require.NoError(t, store.Put(connKey, connRecBytes))
-		nsThreadID, err := createNSKey(myNSPrefix, threadIDValue)
-		require.NoError(t, err)
-		require.NoError(t, store.Put(nsThreadID, []byte(connIDValue)))
-
-		storedConnRec, err := record.GetConnectionRecord(connIDValue)
-		require.NoError(t, err)
-		require.Equal(t, storedConnRec, connRec)
-	})
-	t.Run("test error from transient store", func(t *testing.T) {
-		transientStore := &mockstorage.MockStore{
-			Store:  make(map[string][]byte),
-			ErrGet: fmt.Errorf("get error transientstore")}
-		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(transientStore, store, nil)
-		require.NotNil(t, record)
-		connRecBytes, err := json.Marshal(&ConnectionRecord{ConnectionID: connIDValue, ThreadID: threadIDValue,
-			Namespace: myNSPrefix})
-		require.NoError(t, err)
-		connKey := connectionKeyPrefix(connIDValue)
-		require.NoError(t, transientStore.Put(connKey, connRecBytes))
-		_, err = record.GetConnectionRecord(connIDValue)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "get error transientstore")
-	})
-	t.Run("test error from store", func(t *testing.T) {
-		transientStore := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		store := &mockstorage.MockStore{Store: make(map[string][]byte), ErrGet: fmt.Errorf("get error store")}
-		record := NewConnectionRecorder(transientStore, store, nil)
-		require.NotNil(t, record)
-		connRecBytes, err := json.Marshal(&ConnectionRecord{ConnectionID: connIDValue, ThreadID: threadIDValue,
-			Namespace: myNSPrefix})
-		require.NoError(t, err)
-		connKey := connectionKeyPrefix(connIDValue)
-		require.NoError(t, store.Put(connKey, connRecBytes))
-		_, err = record.GetConnectionRecord(connIDValue)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "get error store")
-	})
-}
-
 func TestConnectionRecordByState(t *testing.T) {
-	transientStore := &mockstorage.MockStore{Store: make(map[string][]byte), ErrGet: nil}
-	record := NewConnectionRecorder(transientStore, nil, nil)
-	require.NotNil(t, record)
+	record, err := newConnectionStore(&protocol.MockProvider{})
+	require.NoError(t, err)
 
-	connRec := &ConnectionRecord{ConnectionID: generateRandomID(), ThreadID: threadIDValue,
+	connRec := &connectionstore.ConnectionRecord{ConnectionID: generateRandomID(), ThreadID: threadIDValue,
 		Namespace: myNSPrefix, State: "requested"}
-	err := record.saveConnectionRecord(connRec)
+	err = record.saveConnectionRecord(connRec)
 	require.NoError(t, err)
 
 	// data exists
@@ -218,7 +170,7 @@ func TestConnectionRecordByState(t *testing.T) {
 	require.Contains(t, err.Error(), "data not found")
 
 	// data with no state details
-	connRec = &ConnectionRecord{ConnectionID: generateRandomID(), ThreadID: threadIDValue,
+	connRec = &connectionstore.ConnectionRecord{ConnectionID: generateRandomID(), ThreadID: threadIDValue,
 		Namespace: myNSPrefix}
 	err = record.saveConnectionRecord(connRec)
 	require.NoError(t, err)
@@ -234,13 +186,12 @@ func TestConnectionRecordByState(t *testing.T) {
 
 func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 	t.Run("save connection record and get connection Record success", func(t *testing.T) {
-		transientStore := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(transientStore, store, nil)
-		require.NotNil(t, record)
-		connRec := &ConnectionRecord{ThreadID: threadIDValue,
+		record, err := newConnectionStore(&protocol.MockProvider{})
+		require.NoError(t, err)
+		connRec := &connectionstore.ConnectionRecord{ThreadID: threadIDValue,
+
 			ConnectionID: connIDValue, State: stateNameInvited, Namespace: theirNSPrefix}
-		err := record.saveNewConnectionRecord(connRec)
+		err = record.saveNewConnectionRecord(connRec)
 		require.NoError(t, err)
 
 		storedRecord, err := record.GetConnectionRecord(connRec.ConnectionID)
@@ -248,53 +199,71 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 		require.Equal(t, connRec, storedRecord)
 	})
 	t.Run("save connection record and fetch from no namespace error", func(t *testing.T) {
-		transientStore := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(transientStore, nil, nil)
-		require.NotNil(t, record)
-		connRec := &ConnectionRecord{ThreadID: threadIDValue,
+		record, err := newConnectionStore(&protocol.MockProvider{})
+		require.NoError(t, err)
+		connRec := &connectionstore.ConnectionRecord{ThreadID: threadIDValue,
+
 			ConnectionID: connIDValue, State: stateNameInvited}
-		err := record.saveNewConnectionRecord(connRec)
+		err = record.saveNewConnectionRecord(connRec)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "empty")
 	})
 	t.Run("save connection record error", func(t *testing.T) {
-		transientStore := &mockstorage.MockStore{Store: make(map[string][]byte), ErrPut: fmt.Errorf("get error")}
-		record := NewConnectionRecorder(transientStore, nil, nil)
-		require.NotNil(t, record)
-		connRec := &ConnectionRecord{ThreadID: "",
+		const errMsg = "get error"
+		record, err := newConnectionStore(&protocol.MockProvider{
+			TransientStoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
+				Store:  make(map[string][]byte),
+				ErrPut: fmt.Errorf(errMsg),
+			}),
+		})
+		require.NoError(t, err)
+		connRec := &connectionstore.ConnectionRecord{ThreadID: "",
 			ConnectionID: "test", State: stateNameInvited, Namespace: theirNSPrefix}
-		err := record.saveConnectionRecord(connRec)
-		require.Contains(t, err.Error(), "get error")
+		err = record.saveConnectionRecord(connRec)
+		require.Contains(t, err.Error(), errMsg)
 	})
 	t.Run("save connection record error", func(t *testing.T) {
-		transientStore := &mockstorage.MockStore{Store: make(map[string][]byte), ErrPut: fmt.Errorf("get error")}
-		record := NewConnectionRecorder(transientStore, nil, nil)
-		require.NotNil(t, record)
-		connRec := &ConnectionRecord{ThreadID: threadIDValue,
+		const errMsg = "get error"
+		record, err := newConnectionStore(&protocol.MockProvider{
+			TransientStoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
+				Store:  make(map[string][]byte),
+				ErrPut: fmt.Errorf(errMsg),
+			}),
+		})
+		require.NoError(t, err)
+		connRec := &connectionstore.ConnectionRecord{ThreadID: threadIDValue,
 			ConnectionID: connIDValue, State: stateNameInvited, Namespace: theirNSPrefix}
-		err := record.saveNewConnectionRecord(connRec)
-		require.Contains(t, err.Error(), "get error")
+		err = record.saveNewConnectionRecord(connRec)
+		require.Contains(t, err.Error(), errMsg)
 	})
 	t.Run("save connection record in permanent store error", func(t *testing.T) {
-		transientStore := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		store := &mockstorage.MockStore{Store: make(map[string][]byte), ErrPut: fmt.Errorf("get error")}
-		record := NewConnectionRecorder(transientStore, store, nil)
+		const errMsg = "get error"
+		record, err := newConnectionStore(&protocol.MockProvider{
+			StoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
+				Store:  make(map[string][]byte),
+				ErrPut: fmt.Errorf(errMsg),
+			}),
+		})
+		require.NoError(t, err)
+
 		require.NotNil(t, record)
-		connRec := &ConnectionRecord{ThreadID: threadIDValue,
+		connRec := &connectionstore.ConnectionRecord{ThreadID: threadIDValue,
 			ConnectionID: connIDValue, State: stateNameCompleted, Namespace: theirNSPrefix}
-		err := record.saveNewConnectionRecord(connRec)
-		require.Contains(t, err.Error(), "get error")
+		err = record.saveNewConnectionRecord(connRec)
+		require.Contains(t, err.Error(), errMsg)
 	})
 	t.Run("error saving DID by resolving", func(t *testing.T) {
-		transientStore := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(transientStore, store, &mockdidconnection.MockDIDConnection{
-			ResolveDIDErr: fmt.Errorf("save error"),
+		record, err := newConnectionStore(&protocol.MockProvider{
+			DIDConnectionStoreValue: &mockdidconnection.MockDIDConnection{
+				ResolveDIDErr: fmt.Errorf("save error"),
+			},
 		})
 		require.NotNil(t, record)
-		connRec := &ConnectionRecord{ThreadID: threadIDValue, MyDID: "did:foo",
+		require.NoError(t, err)
+
+		connRec := &connectionstore.ConnectionRecord{ThreadID: threadIDValue, MyDID: "did:foo",
 			ConnectionID: connIDValue, State: stateNameCompleted, Namespace: theirNSPrefix}
-		err := record.saveNewConnectionRecord(connRec)
+		err = record.saveNewConnectionRecord(connRec)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "save error")
 
@@ -307,12 +276,13 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 
 func TestConnectionRecorder_GetConnectionRecordByNSThreadID(t *testing.T) {
 	t.Run(" get connection record by namespace threadID in my namespace", func(t *testing.T) {
-		transientStore := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(transientStore, nil, nil)
+		record, err := newConnectionStore(&protocol.MockProvider{})
+		require.NoError(t, err)
+
 		require.NotNil(t, record)
-		connRec := &ConnectionRecord{ThreadID: threadIDValue,
+		connRec := &connectionstore.ConnectionRecord{ThreadID: threadIDValue,
 			ConnectionID: connIDValue, State: stateNameInvited, Namespace: myNSPrefix}
-		err := record.saveNewConnectionRecord(connRec)
+		err = record.saveNewConnectionRecord(connRec)
 		require.NoError(t, err)
 
 		nsThreadID, err := createNSKey(myNSPrefix, threadIDValue)
@@ -323,12 +293,12 @@ func TestConnectionRecorder_GetConnectionRecordByNSThreadID(t *testing.T) {
 		require.Equal(t, connRec, storedRecord)
 	})
 	t.Run(" get connection record by namespace threadID their namespace", func(t *testing.T) {
-		transientStore := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(transientStore, nil, nil)
+		record, err := newConnectionStore(&protocol.MockProvider{})
+		require.NoError(t, err)
 		require.NotNil(t, record)
-		connRec := &ConnectionRecord{ThreadID: threadIDValue,
+		connRec := &connectionstore.ConnectionRecord{ThreadID: threadIDValue,
 			ConnectionID: connIDValue, State: stateNameInvited, Namespace: theirNSPrefix}
-		err := record.saveNewConnectionRecord(connRec)
+		err = record.saveNewConnectionRecord(connRec)
 		require.NoError(t, err)
 
 		nsThreadID, err := createNSKey(theirNSPrefix, threadIDValue)
@@ -339,22 +309,11 @@ func TestConnectionRecorder_GetConnectionRecordByNSThreadID(t *testing.T) {
 		require.Equal(t, connRec, storedRecord)
 	})
 	t.Run(" data not found error due to missing input parameter", func(t *testing.T) {
-		transientStore := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(transientStore, nil, nil)
+		record, err := newConnectionStore(&protocol.MockProvider{})
+		require.NoError(t, err)
 		require.NotNil(t, record)
 		connRec, err := record.GetConnectionRecordByNSThreadID("")
 		require.Contains(t, err.Error(), "data not found")
-		require.Nil(t, connRec)
-	})
-}
-
-func TestConnectionRecorder_PrepareConnectionRecord(t *testing.T) {
-	t.Run(" prepare connection record  error", func(t *testing.T) {
-		transientStore := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(transientStore, nil, nil)
-		require.NotNil(t, record)
-		connRec, err := prepareConnectionRecord(nil)
-		require.Contains(t, err.Error(), "prepare connection record")
 		require.Nil(t, connRec)
 	})
 }
@@ -373,66 +332,15 @@ func TestConnectionRecorder_CreateNSKeys(t *testing.T) {
 
 func TestConnectionRecorder_SaveNSThreadID(t *testing.T) {
 	t.Run("missing required parameters", func(t *testing.T) {
-		transientStore := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record := NewConnectionRecorder(transientStore, nil, nil)
+		record, err := newConnectionStore(&protocol.MockProvider{})
+		require.NoError(t, err)
+
 		require.NotNil(t, record)
-		err := record.saveNSThreadID("", theirNSPrefix, connIDValue)
+		err = record.saveNSThreadID("", theirNSPrefix, connIDValue)
 		require.Error(t, err)
 		err = record.saveNSThreadID("", myNSPrefix, connIDValue)
 		require.Error(t, err)
 		err = record.saveNSThreadID(threadIDValue, "", connIDValue)
 		require.Error(t, err)
-	})
-}
-
-func TestConnectionRecorder_QueryConnectionRecord(t *testing.T) {
-	t.Run("test query connection record", func(t *testing.T) {
-		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
-
-		transientStore, err := mem.NewProvider().OpenStore(DIDExchange)
-		require.NoError(t, err)
-
-		const (
-			storeCount          = 5
-			overlap             = 3
-			transientStoreCount = 4
-		)
-
-		for i := 0; i < storeCount+overlap; i++ {
-			val, jsonErr := json.Marshal(&ConnectionRecord{
-				ConnectionID: string(i),
-			})
-			require.NoError(t, jsonErr)
-
-			err = store.Put(fmt.Sprintf("%s_abc%d", connIDKeyPrefix, i), val)
-			require.NoError(t, err)
-		}
-		for i := overlap; i < transientStoreCount+storeCount; i++ {
-			val, jsonErr := json.Marshal(&ConnectionRecord{
-				ConnectionID: string(i),
-			})
-			require.NoError(t, jsonErr)
-
-			err = transientStore.Put(fmt.Sprintf("%s_abc%d", connIDKeyPrefix, i), val)
-			require.NoError(t, err)
-		}
-
-		recorder := NewConnectionRecorder(transientStore, store, nil)
-		require.NotNil(t, recorder)
-		result, err := recorder.QueryConnectionRecords()
-		require.NoError(t, err)
-		require.Len(t, result, storeCount+transientStoreCount)
-	})
-
-	t.Run("test query connection record failure", func(t *testing.T) {
-		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		err := store.Put(fmt.Sprintf("%s_abc123", connIDKeyPrefix), []byte("-----"))
-		require.NoError(t, err)
-
-		recorder := NewConnectionRecorder(nil, store, nil)
-		require.NotNil(t, recorder)
-		result, err := recorder.QueryConnectionRecords()
-		require.Error(t, err)
-		require.Empty(t, result)
 	})
 }

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm"
-	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
+	mockdidexchange "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/didexchange"
 	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 	mockvdri "github.com/hyperledger/aries-framework-go/pkg/internal/mock/vdri"
@@ -198,7 +198,7 @@ func TestFramework(t *testing.T) {
 
 	t.Run("test protocol svc - with user provided protocol", func(t *testing.T) {
 		newMockSvc := func(prv api.Provider) (dispatcher.Service, error) {
-			return &protocol.MockDIDExchangeSvc{
+			return &mockdidexchange.MockDIDExchangeSvc{
 				ProtocolName: "mockProtocolSvc",
 			}, nil
 		}
@@ -222,7 +222,7 @@ func TestFramework(t *testing.T) {
 
 	t.Run("test new with protocol service", func(t *testing.T) {
 		mockSvcCreator := func(prv api.Provider) (dispatcher.Service, error) {
-			return &protocol.MockDIDExchangeSvc{
+			return &mockdidexchange.MockDIDExchangeSvc{
 				ProtocolName: "mockProtocolSvc",
 			}, nil
 		}

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -21,7 +21,7 @@ import (
 	mockdidconnection "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/didconnection"
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
 	mockpackager "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/packager"
-	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
+	mockdidexchange "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/didexchange"
 	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 	mockvdri "github.com/hyperledger/aries-framework-go/pkg/internal/mock/vdri"
@@ -48,7 +48,7 @@ func TestNewProvider(t *testing.T) {
 	})
 
 	t.Run("test new with protocol service", func(t *testing.T) {
-		prov, err := New(WithProtocolServices(&protocol.MockDIDExchangeSvc{
+		prov, err := New(WithProtocolServices(&mockdidexchange.MockDIDExchangeSvc{
 			ProtocolName: "mockProtocolSvc",
 			AcceptFunc: func(msgType string) bool {
 				return msgType == "valid-message-type"
@@ -64,7 +64,7 @@ func TestNewProvider(t *testing.T) {
 	})
 
 	t.Run("test inbound message handlers/dispatchers", func(t *testing.T) {
-		ctx, err := New(WithProtocolServices(&protocol.MockDIDExchangeSvc{
+		ctx, err := New(WithProtocolServices(&mockdidexchange.MockDIDExchangeSvc{
 			ProtocolName: "mockProtocolSvc",
 			AcceptFunc: func(msgType string) bool {
 				return msgType == "valid-message-type"

--- a/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
@@ -1,10 +1,13 @@
 /*
-Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * /
+ *
+ */
 
-SPDX-License-Identifier: Apache-2.0
-*/
-
-package protocol
+package didexchange
 
 import (
 	"github.com/google/uuid"
@@ -12,6 +15,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/didconnection"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	mockdidconnection "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/didconnection"
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
@@ -133,6 +137,11 @@ func (m *MockDIDExchangeSvc) CreateImplicitInvitation(inviterLabel, inviterDID, 
 	}
 
 	return "connection-id", nil
+}
+
+// SaveInvitation mock implementation of save inviation feature from did-exchange service
+func (m *MockDIDExchangeSvc) SaveInvitation(invitation *didexchange.Invitation) error {
+	return nil
 }
 
 // MockProvider is provider for DIDExchange Service

--- a/pkg/internal/mock/didcomm/protocol/mock_protocol.go
+++ b/pkg/internal/mock/didcomm/protocol/mock_protocol.go
@@ -1,0 +1,74 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package protocol
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/didconnection"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
+	mockdidconnection "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/didconnection"
+	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
+	mockstore "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
+	mockvdri "github.com/hyperledger/aries-framework-go/pkg/internal/mock/vdri"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+// MockProvider is provider for DIDExchange Service
+type MockProvider struct {
+	StoreProvider           *mockstore.MockStoreProvider
+	TransientStoreProvider  *mockstore.MockStoreProvider
+	CustomVDRI              vdriapi.Registry
+	DIDConnectionStoreValue *mockdidconnection.MockDIDConnection
+}
+
+// OutboundDispatcher is mock outbound dispatcher for DID exchange service
+func (p *MockProvider) OutboundDispatcher() dispatcher.Outbound {
+	return &mockdispatcher.MockOutbound{}
+}
+
+// StorageProvider is mock storage provider for DID exchange service
+func (p *MockProvider) StorageProvider() storage.Provider {
+	if p.StoreProvider != nil {
+		return p.StoreProvider
+	}
+
+	return mockstore.NewMockStoreProvider()
+}
+
+// TransientStorageProvider is mock transient storage provider for DID exchange service
+func (p *MockProvider) TransientStorageProvider() storage.Provider {
+	if p.TransientStoreProvider != nil {
+		return p.TransientStoreProvider
+	}
+
+	return mockstore.NewMockStoreProvider()
+}
+
+// Signer is mock signer for DID exchange service
+func (p *MockProvider) Signer() kms.Signer {
+	return &mockkms.CloseableKMS{}
+}
+
+// VDRIRegistry is mock vdri registry
+func (p *MockProvider) VDRIRegistry() vdriapi.Registry {
+	if p.CustomVDRI != nil {
+		return p.CustomVDRI
+	}
+
+	return &mockvdri.MockVDRIRegistry{}
+}
+
+// DIDConnectionStore returns the did lookup store
+func (p *MockProvider) DIDConnectionStore() didconnection.Store {
+	if p.DIDConnectionStoreValue == nil {
+		return &mockdidconnection.MockDIDConnection{}
+	}
+
+	return p.DIDConnectionStoreValue
+}

--- a/pkg/internal/mock/storage/mock_store.go
+++ b/pkg/internal/mock/storage/mock_store.go
@@ -17,6 +17,7 @@ import (
 // MockStoreProvider mock store provider.
 type MockStoreProvider struct {
 	Store              *MockStore
+	Custom             storage.Store
 	ErrOpenStoreHandle error
 	FailNameSpace      string
 }
@@ -28,10 +29,20 @@ func NewMockStoreProvider() *MockStoreProvider {
 	}}
 }
 
+// NewCustomMockStoreProvider new mock store provider instance
+// from existing mock store
+func NewCustomMockStoreProvider(customStore storage.Store) *MockStoreProvider {
+	return &MockStoreProvider{Custom: customStore}
+}
+
 // OpenStore opens and returns a store for given name space.
 func (s *MockStoreProvider) OpenStore(name string) (storage.Store, error) {
 	if name == s.FailNameSpace {
 		return nil, fmt.Errorf("failed to open store for name space %s", name)
+	}
+
+	if s.Custom != nil {
+		return s.Custom, s.ErrOpenStoreHandle
 	}
 
 	return s.Store, s.ErrOpenStoreHandle


### PR DESCRIPTION
- moved connection lookup logic out of DID exchange service to common package, so that it can be reused by client packages to lookup connection records.
- closes #1015


TODO: 

- save/updates logic to be moved as part of https://github.com/hyperledger/aries-framework-go/issues/1021
- connection and DID store to be merged as part of https://github.com/hyperledger/aries-framework-go/issues/1021




Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
