### PR TITLE
refactor: Introduce - fixed issues in the client, framework, and service

### DIFF
--- a/pkg/client/introduce/client_test.go
+++ b/pkg/client/introduce/client_test.go
@@ -354,16 +354,14 @@ func TestClient_SendRequest(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 
-	DIDComm := serviceMocks.NewMockDIDComm(ctrl)
-	DIDComm.EXPECT().HandleOutbound(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-
 	opts := InvitationEnvelope{
 		Recps: []*introduce.Recipient{
 			{MyDID: "My_DID", TheirDID: "THEIR_DID"},
 		},
 	}
-	store.EXPECT().Put(invitationEnvelopePrefix+UUID, toBytes(t, opts)).Return(nil)
-	store.EXPECT().Put(invitationEnvelopePrefix+UUID, toBytes(t, opts)).Return(errors.New("test error"))
+
+	DIDComm := serviceMocks.NewMockDIDComm(ctrl)
+	DIDComm.EXPECT().HandleOutbound(gomock.Any(), opts.Recps[0].MyDID, opts.Recps[0].TheirDID).Return(nil)
 
 	provider := mocks.NewMockProvider(ctrl)
 	provider.EXPECT().Service(introduce.Introduce).Return(DIDComm, nil)
@@ -373,10 +371,7 @@ func TestClient_SendRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	client.newUUID = func() string { return UUID }
-	require.NoError(t, client.SendRequest(opts.Recps[0].MyDID, opts.Recps[0].TheirDID))
-
-	// with error
-	require.EqualError(t, client.SendRequest(opts.Recps[0].MyDID, opts.Recps[0].TheirDID), "test error")
+	require.NoError(t, client.SendRequest(nil, opts.Recps[0].MyDID, opts.Recps[0].TheirDID))
 }
 
 func toBytes(t *testing.T, v interface{}) []byte {

--- a/pkg/didcomm/common/service/service.go
+++ b/pkg/didcomm/common/service/service.go
@@ -45,7 +45,8 @@ func (h *Header) clone() *Header {
 	return &Header{
 		ID: h.ID,
 		Thread: decorator.Thread{
-			ID: h.Thread.ID,
+			ID:  h.Thread.ID,
+			PID: h.Thread.PID,
 		},
 		Type: h.Type,
 	}

--- a/pkg/didcomm/protocol/didexchange/states_test.go
+++ b/pkg/didcomm/protocol/didexchange/states_test.go
@@ -894,7 +894,7 @@ func TestGetInvitationRecipientKey(t *testing.T) {
 		}
 		_, err := ctx.getInvitationRecipientKey(invitation)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "get invitation recipient key: not found")
+		require.Contains(t, err.Error(), "get invitation recipient key: DID not found")
 	})
 }
 

--- a/pkg/didcomm/protocol/introduce/models.go
+++ b/pkg/didcomm/protocol/introduce/models.go
@@ -73,11 +73,11 @@ type PleaseIntroduceTo struct {
 // TODO: need to clarify about decorator ~please_ack and problem_report
 // 		 should Request contain those fields? What type it should be for each field?
 type Request struct {
-	Type              string            `json:"@type,omitempty"`
-	ID                string            `json:"@id,omitempty"`
-	PleaseIntroduceTo PleaseIntroduceTo `json:"please_introduce_to,omitempty"`
-	NWise             bool              `json:"nwise,omitempty"`
-	Timing            *decorator.Timing `json:"~timing,omitempty"`
+	Type              string             `json:"@type,omitempty"`
+	ID                string             `json:"@id,omitempty"`
+	PleaseIntroduceTo *PleaseIntroduceTo `json:"please_introduce_to,omitempty"`
+	NWise             bool               `json:"nwise,omitempty"`
+	Timing            *decorator.Timing  `json:"~timing,omitempty"`
 }
 
 // Response message that introducee usually sends in response to an introduction proposal

--- a/pkg/didcomm/protocol/introduce/service_test.go
+++ b/pkg/didcomm/protocol/introduce/service_test.go
@@ -2170,6 +2170,7 @@ func setupIntroducee(f *flow) (*introduce.Service, *introduceMocks.MockInvitatio
 
 	dep := introduceMocks.NewMockInvitationEnvelope(ctrl)
 	dep.EXPECT().Invitation().Return(f.inv).AnyTimes()
+	dep.EXPECT().Recipients().Return(f.recipients).AnyTimes()
 
 	return svc, dep, didChan
 }

--- a/pkg/didcomm/protocol/introduce/states_test.go
+++ b/pkg/didcomm/protocol/introduce/states_test.go
@@ -57,13 +57,13 @@ func TestStart_CanTransitionTo(t *testing.T) {
 	require.True(t, st.CanTransitionTo(&arranging{}))
 	require.True(t, st.CanTransitionTo(&deciding{}))
 	require.True(t, st.CanTransitionTo(&requesting{}))
+	require.True(t, st.CanTransitionTo(&abandoning{}))
 
 	require.False(t, st.CanTransitionTo(&delivering{}))
 	require.False(t, st.CanTransitionTo(&noOp{}))
 	require.False(t, st.CanTransitionTo(&start{}))
 	require.False(t, st.CanTransitionTo(&done{}))
 	require.False(t, st.CanTransitionTo(&confirming{}))
-	require.False(t, st.CanTransitionTo(&abandoning{}))
 	require.False(t, st.CanTransitionTo(&waiting{}))
 }
 
@@ -231,6 +231,7 @@ func TestDeciding_CanTransitionTo(t *testing.T) {
 
 	require.True(t, st.CanTransitionTo(&waiting{}))
 	require.True(t, st.CanTransitionTo(&done{}))
+	require.True(t, st.CanTransitionTo(&abandoning{}))
 
 	require.False(t, st.CanTransitionTo(&noOp{}))
 	require.False(t, st.CanTransitionTo(&start{}))
@@ -238,7 +239,6 @@ func TestDeciding_CanTransitionTo(t *testing.T) {
 	require.False(t, st.CanTransitionTo(&arranging{}))
 	require.False(t, st.CanTransitionTo(&confirming{}))
 	require.False(t, st.CanTransitionTo(&deciding{}))
-	require.False(t, st.CanTransitionTo(&abandoning{}))
 	require.False(t, st.CanTransitionTo(&requesting{}))
 }
 

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -17,6 +17,7 @@ import (
 	jwe "github.com/hyperledger/aries-framework-go/pkg/didcomm/packer/jwe/authcrypt"
 	legacy "github.com/hyperledger/aries-framework-go/pkg/didcomm/packer/legacy/authcrypt"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/introduce"
 	arieshttp "github.com/hyperledger/aries-framework-go/pkg/didcomm/transport/http"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
@@ -43,7 +44,7 @@ func defFrameworkOpts(frameworkOpts *Aries) error {
 		frameworkOpts.storeProvider = storeProv
 	}
 
-	frameworkOpts.protocolSvcCreators = append(frameworkOpts.protocolSvcCreators, newExchangeSvc())
+	frameworkOpts.protocolSvcCreators = append(frameworkOpts.protocolSvcCreators, newExchangeSvc(), newIntroduceSvc())
 
 	return setAdditionalDefaultOpts(frameworkOpts)
 }
@@ -51,6 +52,12 @@ func defFrameworkOpts(frameworkOpts *Aries) error {
 func newExchangeSvc() api.ProtocolSvcCreator {
 	return func(prv api.Provider) (dispatcher.Service, error) {
 		return didexchange.New(prv)
+	}
+}
+
+func newIntroduceSvc() api.ProtocolSvcCreator {
+	return func(prv api.Provider) (dispatcher.Service, error) {
+		return introduce.New(prv)
 	}
 }
 

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -406,6 +406,11 @@ func loadServices(frameworkOpts *Aries) error {
 		}
 
 		frameworkOpts.services = append(frameworkOpts.services, svc)
+		// after service was successfully created we need to add it to the context
+		// since the introduce protocol depends on did-exchange
+		if err := context.WithProtocolServices(frameworkOpts.services...)(ctx); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/internal/mock/vdri/mock_registry.go
+++ b/pkg/internal/mock/vdri/mock_registry.go
@@ -9,7 +9,6 @@ package vdri
 import (
 	"crypto/ed25519"
 	"crypto/rand"
-	"errors"
 	"time"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
@@ -66,7 +65,7 @@ func (m *MockVDRIRegistry) Resolve(didID string, opts ...vdriapi.ResolveOpts) (*
 	}
 
 	if m.ResolveValue == nil {
-		return nil, errors.New("not found")
+		return nil, vdriapi.ErrNotFound
 	}
 
 	return m.ResolveValue, nil


### PR DESCRIPTION
* added the Introduce service to the framework
* parent threadID was missing in the `Copy` function
* removed useless logging

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>