### PR TITLE
feat: connection recorder out of did exchange service

### DIFF
--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -215,10 +215,9 @@ func TestClient_QueryConnectionByID(t *testing.T) {
 		require.NoError(t, err)
 
 		connRec := &connectionstore.ConnectionRecord{ConnectionID: connID, ThreadID: threadID, State: "complete"}
-		connBytes, err := json.Marshal(connRec)
 
 		require.NoError(t, err)
-		require.NoError(t, c.connectionStore.TransientStore().Put("conn_id1", connBytes))
+		require.NoError(t, c.connectionStore.SaveConnectionRecord(connRec))
 		result, err := c.GetConnection(connID)
 		require.NoError(t, err)
 		require.Equal(t, "complete", result.State)
@@ -245,10 +244,9 @@ func TestClient_QueryConnectionByID(t *testing.T) {
 		require.NoError(t, err)
 
 		connRec := &connectionstore.ConnectionRecord{ConnectionID: connID, ThreadID: threadID, State: "complete"}
-		connBytes, err := json.Marshal(connRec)
 
 		require.NoError(t, err)
-		require.NoError(t, c.connectionStore.TransientStore().Put("conn_id1", connBytes))
+		require.NoError(t, c.connectionStore.SaveConnectionRecord(connRec))
 		_, err = c.GetConnection(connID)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errMsg)

--- a/pkg/common/connectionstore/connection_recorder.go
+++ b/pkg/common/connectionstore/connection_recorder.go
@@ -1,0 +1,157 @@
+/*
+ *
+ * Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * /
+ *
+ */
+
+package connectionstore
+
+import (
+	"crypto"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+const (
+	stateNameCompleted = "completed"
+	myNSPrefix         = "my"
+	// TODO: https://github.com/hyperledger/aries-framework-go/issues/556 It will not be constant, this namespace
+	//  will need to be figured with verification key
+	theirNSPrefix    = "their"
+	errMsgInvalidKey = "invalid key"
+)
+
+// NewConnectionRecorder returns new connection recorder.
+// ConnectionRecorder is read-write connection store which provides
+// write features on top query features from ConnectionLookup
+func NewConnectionRecorder(p provider) (*ConnectionRecorder, error) {
+	lookup, err := NewConnectionLookup(p)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new connection recorder : %w", err)
+	}
+
+	return &ConnectionRecorder{lookup}, nil
+}
+
+// ConnectionRecorder is read-write connection store
+type ConnectionRecorder struct {
+	*ConnectionLookup
+}
+
+// SaveInvitation saves invitation in permanent store for given key
+// TODO should avoid using target of type `interface{}` [Issue #1030]
+func (c *ConnectionRecorder) SaveInvitation(id string, invitation interface{}) error {
+	if id == "" {
+		return fmt.Errorf(errMsgInvalidKey)
+	}
+
+	return marshalAndSave(getInvitationKeyPrefix()(id), invitation, c.store)
+}
+
+// SaveConnectionRecord saves given connection records in underlying store
+func (c *ConnectionRecorder) SaveConnectionRecord(record *ConnectionRecord) error {
+	if err := marshalAndSave(getConnectionKeyPrefix()(record.ConnectionID),
+		record, c.transientStore); err != nil {
+		return fmt.Errorf("save connection record in transient store: %w", err)
+	}
+
+	if record.State != "" {
+		err := marshalAndSave(getConnectionStateKeyPrefix()(record.ConnectionID, record.State),
+			record, c.transientStore)
+		if err != nil {
+			return fmt.Errorf("save connection record with state in transient store: %w", err)
+		}
+	}
+
+	if record.State == stateNameCompleted {
+		if err := marshalAndSave(getConnectionKeyPrefix()(record.ConnectionID),
+			record, c.store); err != nil {
+			return fmt.Errorf("save connection record in permanent store: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// SaveConnectionRecordWithMappings saves newly created connection record against the connection id in the store
+// and it creates mapping from namespaced ThreadID to connection ID
+func (c *ConnectionRecorder) SaveConnectionRecordWithMappings(record *ConnectionRecord) error {
+	err := isValidConnection(record)
+	if err != nil {
+		return fmt.Errorf("validation failed while saving connection record with mapping: %w", err)
+	}
+
+	err = c.SaveConnectionRecord(record)
+	if err != nil {
+		return fmt.Errorf("failed to save connection record with mappings: %w", err)
+	}
+
+	err = c.SaveNamespaceThreadID(record.ThreadID, record.Namespace, record.ConnectionID)
+	if err != nil {
+		return fmt.Errorf("failed to save connection record with namespace mappings: %w", err)
+	}
+
+	return nil
+}
+
+// SaveEvent saves event related data for given connection ID
+// TODO connection event data shouldn't be transient [Issues #1029]
+func (c *ConnectionRecorder) SaveEvent(connectionID string, data []byte) error {
+	return c.transientStore.Put(getEventDataKeyPrefix()(connectionID), data)
+}
+
+// SaveNamespaceThreadID saves given namespace, threadID and connection ID mapping in transient store
+func (c *ConnectionRecorder) SaveNamespaceThreadID(threadID, namespace, connectionID string) error {
+	if namespace != myNSPrefix && namespace != theirNSPrefix {
+		return fmt.Errorf("namespace not supported")
+	}
+
+	prefix := myNSPrefix
+	if namespace == theirNSPrefix {
+		prefix = theirNSPrefix
+	}
+
+	key, err := computeHash([]byte(threadID))
+	if err != nil {
+		return err
+	}
+
+	return c.transientStore.Put(getNamespaceKeyPrefix(prefix)(key), []byte(connectionID))
+}
+
+func marshalAndSave(k string, v interface{}, store storage.Store) error {
+	bytes, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("save connection record: %w", err)
+	}
+
+	return store.Put(k, bytes)
+}
+
+// isValidConnection validates connection record
+func isValidConnection(r *ConnectionRecord) error {
+	if r.ThreadID == "" || r.ConnectionID == "" || r.Namespace == "" {
+		return fmt.Errorf("input parameters thid : %s and connectionId : %s namespace : %s cannot be empty",
+			r.ThreadID, r.ConnectionID, r.Namespace)
+	}
+
+	return nil
+}
+
+// computeHash will compute the hash for the supplied bytes
+func computeHash(bytes []byte) (string, error) {
+	if len(bytes) == 0 {
+		return "", errors.New("unable to compute hash, empty bytes")
+	}
+
+	h := crypto.SHA256.New()
+	hash := h.Sum(bytes)
+
+	return fmt.Sprintf("%x", hash), nil
+}

--- a/pkg/common/connectionstore/connection_recorder_test.go
+++ b/pkg/common/connectionstore/connection_recorder_test.go
@@ -1,0 +1,517 @@
+/*
+ *
+ * Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * /
+ *
+ */
+
+package connectionstore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+const (
+	threadIDValue    = "xyz"
+	sampleConnID     = "sample-conn-ID"
+	stateNameInvited = "invited"
+)
+
+func Test_NewConnectionRecorder(t *testing.T) {
+	t.Run("create create new recorder - success", func(t *testing.T) {
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, recorder)
+	})
+
+	t.Run("create new connection recorder - transient store error", func(t *testing.T) {
+		lookup, err := NewConnectionRecorder(&mockProvider{transientStoreError: fmt.Errorf(sampleErrMsg)})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), sampleErrMsg)
+		require.Nil(t, lookup)
+	})
+
+	t.Run("create new connection recorder - permanent store error", func(t *testing.T) {
+		lookup, err := NewConnectionRecorder(&mockProvider{storeError: fmt.Errorf(sampleErrMsg)})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), sampleErrMsg)
+		require.Nil(t, lookup)
+	})
+}
+
+func Test_ComputeHash(t *testing.T) {
+	h1, err := computeHash([]byte("sample-bytes-123"))
+	require.NoError(t, err)
+	require.NotEmpty(t, h1)
+
+	h2, err := computeHash([]byte("sample-bytes-321"))
+	require.NoError(t, err)
+	require.NotEmpty(t, h2)
+
+	h3, err := computeHash([]byte("sample-bytes-123"))
+	require.NoError(t, err)
+	require.NotEmpty(t, h1)
+
+	require.NotEqual(t, h1, h2)
+	require.Equal(t, h1, h3)
+
+	h4, err := computeHash([]byte(""))
+	require.Error(t, err)
+	require.Empty(t, h4)
+}
+
+func TestConnectionStore_SaveInvitation(t *testing.T) {
+	const id = "sample-inv-id"
+
+	t.Run("test save invitation success", func(t *testing.T) {
+		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{
+			StoreProvider: mockstorage.NewCustomMockStoreProvider(store),
+		})
+		require.NoError(t, err)
+
+		require.NotNil(t, recorder)
+
+		value := &mockInvitation{
+			ID:    id,
+			Label: "sample-label1",
+		}
+
+		err = recorder.SaveInvitation(value.ID, value)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, store)
+
+		k := getInvitationKeyPrefix()(value.ID)
+
+		v, err := recorder.ConnectionLookup.store.Get(k)
+		require.NoError(t, err)
+		require.NotEmpty(t, v)
+
+		var v1 mockInvitation
+		err = getAndUnmarshal(k, &v1, recorder.store)
+		require.NoError(t, err)
+		require.Equal(t, value, &v1)
+
+		var v2 mockInvitation
+		err = getAndUnmarshal(k, &v2, recorder.transientStore)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "data not found")
+	})
+
+	t.Run("test save invitation failure due to invalid key", func(t *testing.T) {
+		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{
+			StoreProvider: mockstorage.NewCustomMockStoreProvider(store),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, recorder)
+
+		value := &mockInvitation{
+			Label: "sample-label2",
+		}
+		err = recorder.SaveInvitation("", value)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid key")
+	})
+}
+
+func TestConnectionStore_GetInvitation(t *testing.T) {
+	t.Run("test get invitation - success", func(t *testing.T) {
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, recorder)
+
+		valueStored := &mockInvitation{
+			ID:    "sample-id-3",
+			Label: "sample-label-3",
+		}
+
+		err = recorder.SaveInvitation(valueStored.ID, valueStored)
+		require.NoError(t, err)
+
+		var valueFound mockInvitation
+		err = recorder.GetInvitation(valueStored.ID, &valueFound)
+		require.NoError(t, err)
+		require.Equal(t, valueStored, &valueFound)
+	})
+
+	t.Run("test get invitation - not found scenario", func(t *testing.T) {
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, recorder)
+
+		var valueFound mockInvitation
+		err = recorder.GetInvitation("sample-key4", &valueFound)
+		require.Error(t, err)
+		require.Equal(t, err, storage.ErrDataNotFound)
+	})
+
+	t.Run("test get invitation - invalid key scenario", func(t *testing.T) {
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, recorder)
+
+		var valueFound mockInvitation
+		err = recorder.GetInvitation("", &valueFound)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errMsgInvalidKey)
+	})
+}
+
+func TestConnectionStore_SaveAndGetEventData(t *testing.T) {
+	t.Run("test save and get event data - success", func(t *testing.T) {
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, recorder)
+
+		valueStored := []byte("sample-event-data")
+
+		err = recorder.SaveEvent(sampleConnID, valueStored)
+		require.NoError(t, err)
+
+		valueFound, err := recorder.GetEvent(sampleConnID)
+		require.NoError(t, err)
+		require.Equal(t, valueStored, valueFound)
+	})
+
+	t.Run("test get invitation - not found scenario", func(t *testing.T) {
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, recorder)
+
+		value, err := recorder.GetEvent(sampleConnID)
+		require.Error(t, err)
+		require.Equal(t, err, storage.ErrDataNotFound)
+		require.Nil(t, value)
+	})
+
+	t.Run("test get invitation - invalid key scenario", func(t *testing.T) {
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, recorder)
+
+		value, err := recorder.GetEvent("")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errMsgInvalidKey)
+		require.Nil(t, value)
+	})
+}
+
+func TestConnectionRecordByState(t *testing.T) {
+	recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+	require.NoError(t, err)
+
+	connRec := &ConnectionRecord{ConnectionID: uuid.New().String(), ThreadID: threadIDValue,
+		Namespace: myNSPrefix, State: "requested"}
+	err = recorder.SaveConnectionRecord(connRec)
+	require.NoError(t, err)
+
+	// data exists
+	storedConnRec, err := recorder.GetConnectionRecordAtState(connRec.ConnectionID, "requested")
+	require.NoError(t, err)
+	require.Equal(t, storedConnRec, connRec)
+
+	// data doesn't exists
+	_, err = recorder.GetConnectionRecordAtState(connRec.ConnectionID, "invalid")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "data not found")
+
+	// data with no state details
+	connRec = &ConnectionRecord{ConnectionID: uuid.New().String(), ThreadID: threadIDValue,
+		Namespace: myNSPrefix}
+	err = recorder.SaveConnectionRecord(connRec)
+	require.NoError(t, err)
+	_, err = recorder.GetConnectionRecordAtState(connRec.ConnectionID, "requested")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "data not found")
+
+	// get with empty stateID
+	_, err = recorder.GetConnectionRecordAtState(connRec.ConnectionID, "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stateID can't be empty")
+}
+
+func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
+	t.Run("save connection record with invited state - success", func(t *testing.T) {
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, recorder)
+
+		record := &ConnectionRecord{ThreadID: threadIDValue,
+			ConnectionID: uuid.New().String(), State: stateNameInvited, Namespace: theirNSPrefix}
+		err = recorder.SaveConnectionRecord(record)
+		require.NoError(t, err)
+
+		recordFound, err := recorder.GetConnectionRecord(record.ConnectionID)
+		require.NoError(t, err)
+		require.NotNil(t, recordFound)
+		require.Equal(t, record, recordFound)
+
+		// make sure it exists only in transient store
+		var r1 ConnectionRecord
+		err = getAndUnmarshal(getConnectionKeyPrefix()(record.ConnectionID), &r1, recorder.store)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "data not found")
+
+		var r2 ConnectionRecord
+		err = getAndUnmarshal(getConnectionKeyPrefix()(record.ConnectionID), &r2, recorder.transientStore)
+		require.NoError(t, err)
+		require.Equal(t, record, &r2)
+	})
+
+	t.Run("save connection record with invited state - completed", func(t *testing.T) {
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, recorder)
+
+		record := &ConnectionRecord{ThreadID: threadIDValue,
+			ConnectionID: uuid.New().String(), State: stateNameCompleted, Namespace: theirNSPrefix}
+		err = recorder.SaveConnectionRecord(record)
+		require.NoError(t, err)
+
+		recordFound, err := recorder.GetConnectionRecord(record.ConnectionID)
+		require.NoError(t, err)
+		require.NotNil(t, recordFound)
+		require.Equal(t, record, recordFound)
+
+		// make sure it exists only in both permanent and transient store
+		var r1 ConnectionRecord
+		err = getAndUnmarshal(getConnectionKeyPrefix()(record.ConnectionID), &r1, recorder.transientStore)
+		require.NoError(t, err)
+		require.Equal(t, record, &r1)
+
+		var r2 ConnectionRecord
+		err = getAndUnmarshal(getConnectionKeyPrefix()(record.ConnectionID), &r2, recorder.store)
+		require.NoError(t, err)
+		require.Equal(t, record, &r2)
+	})
+
+	t.Run("save connection record error scenario 1", func(t *testing.T) {
+		const errMsg = "get error"
+		record, err := NewConnectionRecorder(&protocol.MockProvider{
+			TransientStoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
+				Store:  make(map[string][]byte),
+				ErrPut: fmt.Errorf(errMsg),
+			}),
+		})
+		require.NoError(t, err)
+		connRec := &ConnectionRecord{ThreadID: "",
+			ConnectionID: "test", State: stateNameInvited, Namespace: theirNSPrefix}
+		err = record.SaveConnectionRecord(connRec)
+		require.Contains(t, err.Error(), errMsg)
+	})
+
+	t.Run("save connection record error scenario 2", func(t *testing.T) {
+		const errMsg = "get error"
+		record, err := NewConnectionRecorder(&protocol.MockProvider{
+			StoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
+				Store:  make(map[string][]byte),
+				ErrPut: fmt.Errorf(errMsg),
+			}),
+		})
+		require.NoError(t, err)
+		connRec := &ConnectionRecord{ThreadID: "",
+			ConnectionID: "test", State: stateNameCompleted, Namespace: theirNSPrefix}
+		err = record.SaveConnectionRecord(connRec)
+		require.Contains(t, err.Error(), errMsg)
+	})
+}
+
+func TestConnectionRecorder_ConnectionRecordMappings(t *testing.T) {
+	t.Run("get connection record by namespace threadID in my namespace", func(t *testing.T) {
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+
+		require.NotNil(t, recorder)
+		connRec := &ConnectionRecord{ThreadID: threadIDValue,
+			ConnectionID: sampleConnID, State: stateNameInvited, Namespace: myNSPrefix}
+		err = recorder.SaveConnectionRecordWithMappings(connRec)
+		require.NoError(t, err)
+
+		nsThreadID, err := CreateNamespaceKey(myNSPrefix, threadIDValue)
+		require.NoError(t, err)
+
+		storedRecord, err := recorder.GetConnectionRecordByNSThreadID(nsThreadID)
+		require.NoError(t, err)
+		require.Equal(t, connRec, storedRecord)
+	})
+	t.Run("get connection record by namespace threadID their namespace", func(t *testing.T) {
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, recorder)
+		connRec := &ConnectionRecord{ThreadID: threadIDValue,
+			ConnectionID: sampleConnID, State: stateNameInvited, Namespace: theirNSPrefix}
+		err = recorder.SaveConnectionRecordWithMappings(connRec)
+		require.NoError(t, err)
+
+		nsThreadID, err := CreateNamespaceKey(theirNSPrefix, threadIDValue)
+		require.NoError(t, err)
+
+		storedRecord, err := recorder.GetConnectionRecordByNSThreadID(nsThreadID)
+		require.NoError(t, err)
+		require.Equal(t, connRec, storedRecord)
+	})
+	t.Run("save connection record with mapping - validation failure", func(t *testing.T) {
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+
+		require.NotNil(t, recorder)
+		connRec := &ConnectionRecord{ThreadID: "",
+			ConnectionID: sampleConnID, State: stateNameInvited, Namespace: myNSPrefix}
+		err = recorder.SaveConnectionRecordWithMappings(connRec)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "validation failed")
+	})
+	t.Run("save connection record with mapping - store failure", func(t *testing.T) {
+		const errMsg = "put error"
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{
+			TransientStoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
+				Store:  make(map[string][]byte),
+				ErrPut: fmt.Errorf(errMsg),
+			}),
+		})
+
+		require.NotNil(t, recorder)
+		require.NoError(t, err)
+
+		connRec := &ConnectionRecord{ThreadID: threadIDValue,
+			ConnectionID: sampleConnID, State: stateNameInvited, Namespace: myNSPrefix}
+		err = recorder.SaveConnectionRecordWithMappings(connRec)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errMsg)
+	})
+	t.Run("save connection record with mapping - namespace error", func(t *testing.T) {
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+
+		require.NotNil(t, recorder)
+		connRec := &ConnectionRecord{ThreadID: threadIDValue,
+			ConnectionID: sampleConnID, State: stateNameInvited, Namespace: "invalid-ns"}
+		err = recorder.SaveConnectionRecordWithMappings(connRec)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "namespace not supported")
+	})
+	t.Run("data not found error due to missing input parameter", func(t *testing.T) {
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+		require.NotNil(t, recorder)
+		connRec, err := recorder.GetConnectionRecordByNSThreadID("")
+		require.Contains(t, err.Error(), "data not found")
+		require.Nil(t, connRec)
+	})
+}
+
+func TestConnectionRecorder_CreateNSKeys(t *testing.T) {
+	t.Run("creating their namespace key success", func(t *testing.T) {
+		key, err := CreateNamespaceKey(theirNSPrefix, threadIDValue)
+		require.NoError(t, err)
+		require.NotNil(t, key)
+	})
+	t.Run("check error while creating my namespace key", func(t *testing.T) {
+		_, err := CreateNamespaceKey(myNSPrefix, "")
+		require.Contains(t, err.Error(), "empty bytes")
+	})
+}
+
+func TestConnectionRecorder_SaveNamespaceThreadID(t *testing.T) {
+	t.Run("missing required parameters", func(t *testing.T) {
+		recorder, err := NewConnectionRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+
+		require.NotNil(t, recorder)
+		err = recorder.SaveNamespaceThreadID("", theirNSPrefix, sampleConnID)
+		require.Error(t, err)
+		err = recorder.SaveNamespaceThreadID("", myNSPrefix, sampleConnID)
+		require.Error(t, err)
+		err = recorder.SaveNamespaceThreadID(threadIDValue, "", sampleConnID)
+		require.Error(t, err)
+	})
+}
+
+func TestConnectionRecorder_SaveAndGet(t *testing.T) {
+	const noOfRecords = 12
+
+	records := make([]*mockInvitation, noOfRecords)
+	for i := 0; i < noOfRecords; i++ {
+		records[i] = &mockInvitation{ID: fmt.Sprintf("conn-%d", i)}
+	}
+
+	t.Run("save and get in store - success", func(t *testing.T) {
+		require.NotEmpty(t, records)
+		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
+
+		for _, record := range records {
+			err := marshalAndSave(record.ID, record, store)
+			require.NoError(t, err)
+		}
+
+		for _, record := range records {
+			var recordFound1 mockInvitation
+			err := getAndUnmarshal(record.ID, &recordFound1, store)
+			require.NoError(t, err)
+			require.Equal(t, record, &recordFound1)
+		}
+	})
+
+	t.Run("save and get in store - store failure", func(t *testing.T) {
+		const errMsg = "put error"
+
+		store := &mockstorage.MockStore{
+			Store:  make(map[string][]byte),
+			ErrPut: fmt.Errorf(errMsg),
+			ErrGet: fmt.Errorf(errMsg),
+		}
+
+		require.NotEmpty(t, records)
+
+		for _, record := range records {
+			err := marshalAndSave(record.ID, record, store)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), errMsg)
+		}
+
+		for _, record := range records {
+			var recordFound1 mockInvitation
+			err := getAndUnmarshal(record.ID, &recordFound1, store)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), errMsg)
+		}
+	})
+
+	t.Run("save and get in store - failure", func(t *testing.T) {
+		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
+
+		err := marshalAndSave("sample-id", make(chan int), store)
+		require.Error(t, err)
+
+		err = marshalAndSave("sample-id", []byte("XYZ"), store)
+		require.NoError(t, err)
+
+		err = getAndUnmarshal("sample-id", make(chan int), store)
+		require.Error(t, err)
+	})
+}
+
+type mockInvitation struct {
+	ImageURL        string            `json:"imageUrl,omitempty"`
+	ServiceEndpoint string            `json:"serviceEndpoint,omitempty"`
+	RecipientKeys   []string          `json:"recipientKeys,omitempty"`
+	ID              string            `json:"@id,omitempty"`
+	Label           string            `json:"label,omitempty"`
+	DID             string            `json:"did,omitempty"`
+	RoutingKeys     []string          `json:"routingKeys,omitempty"`
+	Type            string            `json:"@type,omitempty"`
+	Thread          *decorator.Thread `json:"~thread,omitempty"`
+}

--- a/pkg/didcomm/protocol/didexchange/persistence.go
+++ b/pkg/didcomm/protocol/didexchange/persistence.go
@@ -7,21 +7,15 @@ SPDX-License-Identifier: Apache-2.0
 package didexchange
 
 import (
-	"crypto"
-	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/connectionstore"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/didconnection"
-	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
 const (
-	keyPattern   = "%s_%s"
-	invKeyPrefix = "inv"
-	myNSPrefix   = "my"
+	myNSPrefix = "my"
 	// TODO: https://github.com/hyperledger/aries-framework-go/issues/556 It will not be constant, this namespace
 	//  will need to be figured with verification key
 	theirNSPrefix = "their"
@@ -29,193 +23,50 @@ const (
 
 // newConnectionStore returns new connection store instance
 func newConnectionStore(p provider) (*connectionStore, error) {
-	reader, err := connectionstore.NewConnectionLookup(p)
+	recorder, err := connectionstore.NewConnectionRecorder(p)
 	if err != nil {
 		return nil, err
 	}
 
-	return &connectionStore{ConnectionLookup: reader, didStore: p.DIDConnectionStore()}, nil
+	return &connectionStore{ConnectionRecorder: recorder, Store: p.DIDConnectionStore()}, nil
 }
 
 // connectionStore takes care of connection and DID related persistence features
-// TODO this should be moved to separate package as Writable connection store [Issue #1021]
 // TODO merge connection stores [Issue #1004]
 type connectionStore struct {
-	*connectionstore.ConnectionLookup
-	didStore didconnection.Store
-}
-
-// SaveInvitation saves connection invitation to underlying store
-//
-// Args:
-//
-// invitation: invitation to be stored
-//
-// Returns:
-//
-// error: error
-func (c *connectionStore) SaveInvitation(invitation *Invitation) error {
-	k, err := invitationKey(invitation.ID)
-	if err != nil {
-		return err
-	}
-
-	bytes, err := json.Marshal(invitation)
-	if err != nil {
-		return err
-	}
-
-	return c.Store().Put(k, bytes)
-}
-
-// GetInvitation returns invitation for given key from underlying store and
-// stores the result in the value pointed to by v
-//
-// Args:
-//
-// id: invitation id
-//
-// Returns:
-//
-// invitation found
-// error: error
-func (c *connectionStore) GetInvitation(id string) (*Invitation, error) {
-	k, err := invitationKey(id)
-	if err != nil {
-		return nil, err
-	}
-
-	bytes, err := c.Store().Get(k)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &Invitation{}
-
-	err = json.Unmarshal(bytes, result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	*connectionstore.ConnectionRecorder
+	didconnection.Store
 }
 
 // saveConnectionRecord saves the connection record against the connection id  in the store
 func (c *connectionStore) saveConnectionRecord(record *connectionstore.ConnectionRecord) error {
-	if err := marshalAndSave(connectionstore.GetConnectionKeyPrefix()(record.ConnectionID),
-		record, c.TransientStore()); err != nil {
-		return fmt.Errorf("save connection record in transient store: %w", err)
-	}
-
-	if record.State != "" {
-		err := marshalAndSave(connectionstore.GetConnectionStateKeyPrefix()(record.ConnectionID, record.State),
-			record, c.TransientStore())
-		if err != nil {
-			return fmt.Errorf("save connection record with state in transient store: %w", err)
-		}
+	err := c.SaveConnectionRecord(record)
+	if err != nil {
+		return fmt.Errorf(" failed to save connection record : %w", err)
 	}
 
 	if record.State == stateNameCompleted {
-		if err := marshalAndSave(connectionstore.GetConnectionKeyPrefix()(record.ConnectionID),
-			record, c.Store()); err != nil {
-			return fmt.Errorf("save connection record in permanent store: %w", err)
-		}
-
-		if err := c.didStore.SaveDIDByResolving(record.TheirDID, record.RecipientKeys...); err != nil {
-			return err
+		if err := c.SaveDIDByResolving(record.TheirDID, record.RecipientKeys...); err != nil {
+			return fmt.Errorf(" failed to save DID by resolving : %w", err)
 		}
 	}
 
 	return nil
 }
 
-func marshalAndSave(k string, v *connectionstore.ConnectionRecord, store storage.Store) error {
-	bytes, err := json.Marshal(v)
-
-	if err != nil {
-		return fmt.Errorf("save connection record: %w", err)
-	}
-
-	return store.Put(k, bytes)
-}
-
-// saveNewConnectionRecord saves newly created connection record against the connection id in the store
+// saveConnectionRecordWithMapping saves newly created connection record against the connection id in the store
 // and it creates mapping from namespaced ThreadID to connection ID
-func (c *connectionStore) saveNewConnectionRecord(record *connectionstore.ConnectionRecord) error {
-	err := isValidConnection(record)
+func (c *connectionStore) saveConnectionRecordWithMapping(record *connectionstore.ConnectionRecord) error {
+	err := c.SaveConnectionRecordWithMappings(record)
 	if err != nil {
 		return err
-	}
-
-	err = c.saveConnectionRecord(record)
-	if err != nil {
-		return fmt.Errorf("save new connection record: %w", err)
 	}
 
 	if record.MyDID != "" {
-		if err := c.didStore.SaveDIDByResolving(record.MyDID); err != nil {
+		if err := c.SaveDIDByResolving(record.MyDID); err != nil {
 			return err
 		}
 	}
 
-	return c.saveNSThreadID(record.ThreadID, record.Namespace, record.ConnectionID)
-}
-
-func (c *connectionStore) saveNSThreadID(thid, namespace, connectionID string) error {
-	if namespace != myNSPrefix && namespace != theirNSPrefix {
-		return fmt.Errorf("namespace not supported")
-	}
-
-	prefix := myNSPrefix
-	if namespace == theirNSPrefix {
-		prefix = theirNSPrefix
-	}
-
-	k, err := createNSKey(prefix, thid)
-	if err != nil {
-		return err
-	}
-
-	return c.TransientStore().Put(k, []byte(connectionID))
-}
-
-// invitationKey computes key for invitation object
-func invitationKey(invID string) (string, error) {
-	storeKey, err := computeHash([]byte(invID))
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf(keyPattern, invKeyPrefix, storeKey), nil
-}
-
-// createNSKey computes key for storing the mapping with the namespace
-func createNSKey(prefix, id string) (string, error) {
-	storeKey, err := computeHash([]byte(id))
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf(keyPattern, prefix, storeKey), nil
-}
-
-func isValidConnection(r *connectionstore.ConnectionRecord) error {
-	if r.ThreadID == "" || r.ConnectionID == "" || r.Namespace == "" {
-		return fmt.Errorf("input parameters thid : %s and connectionId : %s namespace : %s cannot be empty",
-			r.ThreadID, r.ConnectionID, r.Namespace)
-	}
-
 	return nil
-}
-
-// computeHash will compute the hash for the supplied bytes
-func computeHash(bytes []byte) (string, error) {
-	if len(bytes) == 0 {
-		return "", errors.New("unable to compute hash, empty bytes")
-	}
-
-	h := crypto.SHA256.New()
-	hash := h.Sum(bytes)
-
-	return fmt.Sprintf("%x", hash), nil
 }

--- a/pkg/didcomm/protocol/didexchange/persistence_test.go
+++ b/pkg/didcomm/protocol/didexchange/persistence_test.go
@@ -16,34 +16,12 @@ import (
 	mockdidconnection "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/didconnection"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
 	mockstorage "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
 const (
 	threadIDValue = "xyz"
 	connIDValue   = "connValue"
 )
-
-func Test_ComputeHash(t *testing.T) {
-	h1, err := computeHash([]byte("sample-bytes-123"))
-	require.NoError(t, err)
-	require.NotEmpty(t, h1)
-
-	h2, err := computeHash([]byte("sample-bytes-321"))
-	require.NoError(t, err)
-	require.NotEmpty(t, h2)
-
-	h3, err := computeHash([]byte("sample-bytes-123"))
-	require.NoError(t, err)
-	require.NotEmpty(t, h1)
-
-	require.NotEqual(t, h1, h2)
-	require.Equal(t, h1, h3)
-
-	h4, err := computeHash([]byte(""))
-	require.Error(t, err)
-	require.Empty(t, h4)
-}
 
 func TestNewConnectionStore(t *testing.T) {
 	t.Run("test create connection store", func(t *testing.T) {
@@ -62,128 +40,6 @@ func TestNewConnectionStore(t *testing.T) {
 	})
 }
 
-func TestConnectionStore_SaveInvitation(t *testing.T) {
-	t.Run("test save invitation success", func(t *testing.T) {
-		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record, err := newConnectionStore(&protocol.MockProvider{
-			StoreProvider: mockstorage.NewCustomMockStoreProvider(store),
-		})
-		require.NoError(t, err)
-
-		require.NotNil(t, record)
-
-		value := &Invitation{
-			ID:    "sample-id1",
-			Label: "sample-label1",
-		}
-
-		err = record.SaveInvitation(value)
-		require.NoError(t, err)
-
-		require.NotEmpty(t, store)
-
-		k, err := invitationKey(value.ID)
-		require.NoError(t, err)
-		require.NotEmpty(t, k)
-
-		v, err := record.Store().Get(k)
-		require.NoError(t, err)
-		require.NotEmpty(t, v)
-	})
-
-	t.Run("test save invitation failure due to invalid key", func(t *testing.T) {
-		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
-		record, err := newConnectionStore(&protocol.MockProvider{
-			StoreProvider: mockstorage.NewCustomMockStoreProvider(store),
-		})
-		require.NoError(t, err)
-		require.NotNil(t, record)
-
-		value := &Invitation{
-			Label: "sample-label2",
-		}
-		err = record.SaveInvitation(value)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "empty bytes")
-	})
-}
-
-func TestConnectionStore_GetInvitation(t *testing.T) {
-	t.Run("test get invitation - success", func(t *testing.T) {
-		record, err := newConnectionStore(&protocol.MockProvider{})
-		require.NoError(t, err)
-		require.NotNil(t, record)
-
-		valueStored := &Invitation{
-			ID:    "sample-id-3",
-			Label: "sample-label-3",
-		}
-
-		err = record.SaveInvitation(valueStored)
-		require.NoError(t, err)
-
-		valueFound, err := record.GetInvitation(valueStored.ID)
-		require.NoError(t, err)
-		require.Equal(t, valueStored, valueFound)
-	})
-
-	t.Run("test get invitation - not found scenario", func(t *testing.T) {
-		record, err := newConnectionStore(&protocol.MockProvider{})
-		require.NoError(t, err)
-		require.NotNil(t, record)
-
-		valueFound, err := record.GetInvitation("sample-key4")
-		require.Error(t, err)
-		require.Equal(t, err, storage.ErrDataNotFound)
-		require.Nil(t, valueFound)
-	})
-
-	t.Run("test get invitation - invalid key scenario", func(t *testing.T) {
-		record, err := newConnectionStore(&protocol.MockProvider{})
-		require.NoError(t, err)
-		require.NotNil(t, record)
-
-		valueFound, err := record.GetInvitation("")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "empty bytes")
-		require.Nil(t, valueFound)
-	})
-}
-
-func TestConnectionRecordByState(t *testing.T) {
-	record, err := newConnectionStore(&protocol.MockProvider{})
-	require.NoError(t, err)
-
-	connRec := &connectionstore.ConnectionRecord{ConnectionID: generateRandomID(), ThreadID: threadIDValue,
-		Namespace: myNSPrefix, State: "requested"}
-	err = record.saveConnectionRecord(connRec)
-	require.NoError(t, err)
-
-	// data exists
-	storedConnRec, err := record.GetConnectionRecordAtState(connRec.ConnectionID, "requested")
-	require.NoError(t, err)
-	require.Equal(t, storedConnRec, connRec)
-
-	// data doesn't exists
-	_, err = record.GetConnectionRecordAtState(connRec.ConnectionID, "invalid")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "data not found")
-
-	// data with no state details
-	connRec = &connectionstore.ConnectionRecord{ConnectionID: generateRandomID(), ThreadID: threadIDValue,
-		Namespace: myNSPrefix}
-	err = record.saveConnectionRecord(connRec)
-	require.NoError(t, err)
-	_, err = record.GetConnectionRecordAtState(connRec.ConnectionID, "requested")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "data not found")
-
-	// get with empty stateID
-	_, err = record.GetConnectionRecordAtState(connRec.ConnectionID, "")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "stateID can't be empty")
-}
-
 func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 	t.Run("save connection record and get connection Record success", func(t *testing.T) {
 		record, err := newConnectionStore(&protocol.MockProvider{})
@@ -191,7 +47,7 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 		connRec := &connectionstore.ConnectionRecord{ThreadID: threadIDValue,
 
 			ConnectionID: connIDValue, State: stateNameInvited, Namespace: theirNSPrefix}
-		err = record.saveNewConnectionRecord(connRec)
+		err = record.saveConnectionRecordWithMapping(connRec)
 		require.NoError(t, err)
 
 		storedRecord, err := record.GetConnectionRecord(connRec.ConnectionID)
@@ -204,7 +60,7 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 		connRec := &connectionstore.ConnectionRecord{ThreadID: threadIDValue,
 
 			ConnectionID: connIDValue, State: stateNameInvited}
-		err = record.saveNewConnectionRecord(connRec)
+		err = record.saveConnectionRecordWithMapping(connRec)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "empty")
 	})
@@ -233,7 +89,7 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 		require.NoError(t, err)
 		connRec := &connectionstore.ConnectionRecord{ThreadID: threadIDValue,
 			ConnectionID: connIDValue, State: stateNameInvited, Namespace: theirNSPrefix}
-		err = record.saveNewConnectionRecord(connRec)
+		err = record.saveConnectionRecordWithMapping(connRec)
 		require.Contains(t, err.Error(), errMsg)
 	})
 	t.Run("save connection record in permanent store error", func(t *testing.T) {
@@ -249,8 +105,28 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 		require.NotNil(t, record)
 		connRec := &connectionstore.ConnectionRecord{ThreadID: threadIDValue,
 			ConnectionID: connIDValue, State: stateNameCompleted, Namespace: theirNSPrefix}
-		err = record.saveNewConnectionRecord(connRec)
+		err = record.saveConnectionRecordWithMapping(connRec)
 		require.Contains(t, err.Error(), errMsg)
+	})
+	t.Run("save with mapping - error saving DID by resolving", func(t *testing.T) {
+		record, err := newConnectionStore(&protocol.MockProvider{
+			DIDConnectionStoreValue: &mockdidconnection.MockDIDConnection{
+				ResolveDIDErr: fmt.Errorf("save error"),
+			},
+		})
+		require.NotNil(t, record)
+		require.NoError(t, err)
+
+		connRec := &connectionstore.ConnectionRecord{ThreadID: threadIDValue, MyDID: "did:foo",
+			ConnectionID: connIDValue, State: stateNameCompleted, Namespace: theirNSPrefix}
+		err = record.saveConnectionRecordWithMapping(connRec)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "save error")
+
+		// note: record is still stored, since error happens afterwards
+		storedRecord, err := record.GetConnectionRecord(connRec.ConnectionID)
+		require.NoError(t, err)
+		require.Equal(t, connRec, storedRecord)
 	})
 	t.Run("error saving DID by resolving", func(t *testing.T) {
 		record, err := newConnectionStore(&protocol.MockProvider{
@@ -263,7 +139,7 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 
 		connRec := &connectionstore.ConnectionRecord{ThreadID: threadIDValue, MyDID: "did:foo",
 			ConnectionID: connIDValue, State: stateNameCompleted, Namespace: theirNSPrefix}
-		err = record.saveNewConnectionRecord(connRec)
+		err = record.saveConnectionRecord(connRec)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "save error")
 
@@ -282,10 +158,10 @@ func TestConnectionRecorder_GetConnectionRecordByNSThreadID(t *testing.T) {
 		require.NotNil(t, record)
 		connRec := &connectionstore.ConnectionRecord{ThreadID: threadIDValue,
 			ConnectionID: connIDValue, State: stateNameInvited, Namespace: myNSPrefix}
-		err = record.saveNewConnectionRecord(connRec)
+		err = record.saveConnectionRecordWithMapping(connRec)
 		require.NoError(t, err)
 
-		nsThreadID, err := createNSKey(myNSPrefix, threadIDValue)
+		nsThreadID, err := connectionstore.CreateNamespaceKey(myNSPrefix, threadIDValue)
 		require.NoError(t, err)
 
 		storedRecord, err := record.GetConnectionRecordByNSThreadID(nsThreadID)
@@ -298,10 +174,10 @@ func TestConnectionRecorder_GetConnectionRecordByNSThreadID(t *testing.T) {
 		require.NotNil(t, record)
 		connRec := &connectionstore.ConnectionRecord{ThreadID: threadIDValue,
 			ConnectionID: connIDValue, State: stateNameInvited, Namespace: theirNSPrefix}
-		err = record.saveNewConnectionRecord(connRec)
+		err = record.saveConnectionRecordWithMapping(connRec)
 		require.NoError(t, err)
 
-		nsThreadID, err := createNSKey(theirNSPrefix, threadIDValue)
+		nsThreadID, err := connectionstore.CreateNamespaceKey(theirNSPrefix, threadIDValue)
 		require.NoError(t, err)
 
 		storedRecord, err := record.GetConnectionRecordByNSThreadID(nsThreadID)
@@ -315,32 +191,5 @@ func TestConnectionRecorder_GetConnectionRecordByNSThreadID(t *testing.T) {
 		connRec, err := record.GetConnectionRecordByNSThreadID("")
 		require.Contains(t, err.Error(), "data not found")
 		require.Nil(t, connRec)
-	})
-}
-
-func TestConnectionRecorder_CreateNSKeys(t *testing.T) {
-	t.Run(" creating their namespace key success", func(t *testing.T) {
-		key, err := createNSKey(theirNSPrefix, threadIDValue)
-		require.NoError(t, err)
-		require.NotNil(t, key)
-	})
-	t.Run(" check error while creating my namespace key", func(t *testing.T) {
-		_, err := createNSKey(myNSPrefix, "")
-		require.Contains(t, err.Error(), "empty bytes")
-	})
-}
-
-func TestConnectionRecorder_SaveNSThreadID(t *testing.T) {
-	t.Run("missing required parameters", func(t *testing.T) {
-		record, err := newConnectionStore(&protocol.MockProvider{})
-		require.NoError(t, err)
-
-		require.NotNil(t, record)
-		err = record.saveNSThreadID("", theirNSPrefix, connIDValue)
-		require.Error(t, err)
-		err = record.saveNSThreadID("", myNSPrefix, connIDValue)
-		require.Error(t, err)
-		err = record.saveNSThreadID(threadIDValue, "", connIDValue)
-		require.Error(t, err)
 	})
 }

--- a/pkg/didcomm/protocol/didexchange/states_test.go
+++ b/pkg/didcomm/protocol/didexchange/states_test.go
@@ -361,7 +361,7 @@ func TestRespondedState_Execute(t *testing.T) {
 		}
 		err = ctx.connectionStore.saveConnectionRecord(connRec)
 		require.NoError(t, err)
-		err = ctx.connectionStore.saveNSThreadID(request.ID, findNameSpace(ResponseMsgType), connRec.ConnectionID)
+		err = ctx.connectionStore.SaveNamespaceThreadID(request.ID, findNamespace(ResponseMsgType), connRec.ConnectionID)
 		require.NoError(t, err)
 		connRec, followup, _, e := (&responded{}).ExecuteInbound(
 			&stateMachineMsg{
@@ -452,7 +452,7 @@ func TestCompletedState_Execute(t *testing.T) {
 			InvitationID:  invitation.ID,
 			RecipientKeys: []string{pubKey},
 		}
-		err = ctx.connectionStore.saveNewConnectionRecord(connRec)
+		err = ctx.connectionStore.saveConnectionRecordWithMapping(connRec)
 		require.NoError(t, err)
 		ctx.vdriRegistry = &mockvdri.MockVDRIRegistry{ResolveValue: mockdiddoc.GetMockDIDDoc()}
 		require.NoError(t, err)
@@ -473,7 +473,7 @@ func TestCompletedState_Execute(t *testing.T) {
 		}
 		err = ctx.connectionStore.saveConnectionRecord(connRec)
 		require.NoError(t, err)
-		err = ctx.connectionStore.saveNSThreadID(response.Thread.ID, findNameSpace(AckMsgType), connRec.ConnectionID)
+		err = ctx.connectionStore.SaveNamespaceThreadID(response.Thread.ID, findNamespace(AckMsgType), connRec.ConnectionID)
 		require.NoError(t, err)
 		ack := &model.Ack{
 			Type:   AckMsgType,
@@ -712,7 +712,7 @@ func TestPrepareConnectionSignature(t *testing.T) {
 			ID:   randomString(),
 			DID:  "test",
 		}
-		err := ctx.connectionStore.SaveInvitation(invitation)
+		err := ctx.connectionStore.SaveInvitation(invitation.ID, invitation)
 		require.NoError(t, err)
 		connectionSignature, err := ctx.prepareConnectionSignature(connection, inv.ID)
 		require.Error(t, err)
@@ -1175,7 +1175,7 @@ func saveMockConnectionRecord(request *Request, ctx *context) (*Response, error)
 		return nil, err
 	}
 
-	err = ctx.connectionStore.saveNSThreadID(response.Thread.ID, findNameSpace(ResponseMsgType),
+	err = ctx.connectionStore.SaveNamespaceThreadID(response.Thread.ID, findNamespace(ResponseMsgType),
 		connRec.ConnectionID)
 	if err != nil {
 		return nil, err
@@ -1201,7 +1201,7 @@ func createMockInvitation(pubKey string, ctx *context) (*Invitation, error) {
 		RecipientKeys:   []string{pubKey},
 		ServiceEndpoint: "http://alice.agent.example.com:8081",
 	}
-	err := ctx.connectionStore.SaveInvitation(invitation)
+	err := ctx.connectionStore.SaveInvitation(invitation.ID, invitation)
 
 	if err != nil {
 		return nil, err

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -135,7 +135,7 @@ func TestFramework(t *testing.T) {
 
 	t.Run("test error create vdri", func(t *testing.T) {
 		_, err := New(
-			WithStoreProvider(&storage.MockStoreProvider{FailNameSpace: peer.StoreNamespace}),
+			WithStoreProvider(&storage.MockStoreProvider{FailNamespace: peer.StoreNamespace}),
 			WithInboundTransport(&mockInboundTransport{}))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "create new vdri peer failed")

--- a/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/didconnection"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	mockdidconnection "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/didconnection"
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
@@ -137,11 +136,6 @@ func (m *MockDIDExchangeSvc) CreateImplicitInvitation(inviterLabel, inviterDID, 
 	}
 
 	return "connection-id", nil
-}
-
-// SaveInvitation mock implementation of save inviation feature from did-exchange service
-func (m *MockDIDExchangeSvc) SaveInvitation(invitation *didexchange.Invitation) error {
-	return nil
 }
 
 // MockProvider is provider for DIDExchange Service

--- a/pkg/internal/mock/storage/mock_store.go
+++ b/pkg/internal/mock/storage/mock_store.go
@@ -19,7 +19,7 @@ type MockStoreProvider struct {
 	Store              *MockStore
 	Custom             storage.Store
 	ErrOpenStoreHandle error
-	FailNameSpace      string
+	FailNamespace      string
 }
 
 // NewMockStoreProvider new store provider instance.
@@ -37,7 +37,7 @@ func NewCustomMockStoreProvider(customStore storage.Store) *MockStoreProvider {
 
 // OpenStore opens and returns a store for given name space.
 func (s *MockStoreProvider) OpenStore(name string) (storage.Store, error) {
-	if name == s.FailNameSpace {
+	if name == s.FailNamespace {
 		return nil, fmt.Errorf("failed to open store for name space %s", name)
 	}
 
@@ -82,6 +82,10 @@ func (s *MockStore) Put(k string, v []byte) error {
 
 // Get fetches the record based on key
 func (s *MockStore) Get(k string) ([]byte, error) {
+	if s.ErrGet != nil {
+		return nil, s.ErrGet
+	}
+
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -682,7 +682,7 @@ func TestSendConnectionNotification(t *testing.T) {
 		connRec := &connectionstore.ConnectionRecord{State: testState, ConnectionID: connID, ThreadID: "th1234"}
 		connBytes, err := json.Marshal(connRec)
 		require.NoError(t, err)
-		require.NoError(t, store.Put(connectionstore.GetConnectionStateKeyPrefix()(connID, testState), connBytes))
+		require.NoError(t, store.Put(stateKey(connID, testState), connBytes))
 
 		op, err := New(&mockprovider.Provider{
 			TransientStorageProviderValue: &mockstore.MockStoreProvider{Store: store},
@@ -711,7 +711,7 @@ func TestSendConnectionNotification(t *testing.T) {
 		connRec := &connectionstore.ConnectionRecord{State: testState, ConnectionID: connID, ThreadID: "th1234"}
 		connBytes, err := json.Marshal(connRec)
 		require.NoError(t, err)
-		require.NoError(t, store.Put(connectionstore.GetConnectionStateKeyPrefix()(connID, testState), connBytes))
+		require.NoError(t, store.Put(stateKey(connID, testState), connBytes))
 
 		op, err := New(&mockprovider.Provider{
 			TransientStorageProviderValue: &mockstore.MockStoreProvider{Store: store},
@@ -741,6 +741,10 @@ func verifyRESTError(t *testing.T, code resterr.Code, data []byte) {
 	// verify response
 	require.EqualValues(t, code, errResponse.Code)
 	require.NotEmpty(t, errResponse.Message)
+}
+
+func stateKey(connID, state string) string {
+	return fmt.Sprintf("connstate_%s_%s", connID, state)
 }
 
 type mockNotifier struct {


### PR DESCRIPTION
- Connection Recorder, read-write connection store is moved out of
did-exchange service package.
- ConnectionRecorder extends ConnectionLookup, it adds write feature on
top of read-only ConnectionLook features.
- closes #1021

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
