### PR TITLE
feat: generic inbound handler

### DIFF
--- a/pkg/didcomm/common/service/service.go
+++ b/pkg/didcomm/common/service/service.go
@@ -13,12 +13,22 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 )
 
-// Handler provides protocol service handle api.
-type Handler interface {
+// InboundHandler is handler for inbound messages
+type InboundHandler interface {
 	// HandleInbound handles inbound messages.
-	HandleInbound(msg *DIDCommMsg, myDID string, theirDID string) (string, error)
+	HandleInbound(msg *DIDCommMsg, myDID, theirDID string) (string, error)
+}
+
+// OutboundHandler is handler for outbound messages
+type OutboundHandler interface {
 	// HandleOutbound handles outbound messages.
 	HandleOutbound(msg *DIDCommMsg, myDID, theirDID string) error
+}
+
+// Handler provides protocol service handle api.
+type Handler interface {
+	InboundHandler
+	OutboundHandler
 }
 
 // DIDComm defines service APIs.
@@ -34,6 +44,8 @@ type Header struct {
 	ID     string           `json:"@id"`
 	Thread decorator.Thread `json:"~thread"`
 	Type   string           `json:"@type"`
+	// TODO revisit ~purpose, should be generic map [Issue #1037]
+	Purpose []string `json:"~purpose"`
 }
 
 func (h *Header) clone() *Header {

--- a/pkg/didcomm/common/service/service_test.go
+++ b/pkg/didcomm/common/service/service_test.go
@@ -137,3 +137,51 @@ func TestDIDCommMsg_Clone(t *testing.T) {
 	cloned = didMsg.Clone()
 	require.Equal(t, didMsg, cloned)
 }
+
+func TestDIDCommMsg_Purpose(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		typeVal string
+		purpose []string
+		payload []byte
+		err     string
+	}{{
+		name: "empty payload test",
+		err:  "invalid payload data format: unexpected end of JSON input",
+	}, {
+		name:    "valid payload test",
+		id:      "ID",
+		purpose: []string{"team:01453", "delivery", "geotag", "cred"},
+		typeVal: "sample-type",
+		payload: []byte(`{"@id":"ID", "@type":"sample-type", "~purpose":["team:01453", "delivery", "geotag", "cred"], 
+"id":"ID", "data-type":"data-type-01"}`),
+		err: "",
+	}, {
+		name:    "invalid payload",
+		payload: []byte(`[]`),
+		err:     `invalid payload data format: json: cannot unmarshal array into Go value of type service.Header`,
+	}}
+
+	t.Parallel()
+
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := NewDIDCommMsg(tc.payload)
+
+			if tc.err != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.err)
+				require.Nil(t, val)
+				return
+			}
+
+			require.Equal(t, tc.id, val.Header.ID)
+			require.Equal(t, tc.typeVal, val.Header.Type)
+			require.Equal(t, tc.purpose, val.Header.Purpose)
+
+			require.NotNil(t, val)
+		})
+	}
+}

--- a/pkg/didcomm/dispatcher/api.go
+++ b/pkg/didcomm/dispatcher/api.go
@@ -17,6 +17,13 @@ type Service interface {
 	Name() string
 }
 
+// MessageService is service for handling generic messages
+// matching accept criteria
+type MessageService interface {
+	service.InboundHandler
+	Accept(header *service.Header) bool
+}
+
 // Outbound interface
 type Outbound interface {
 	// Sends the message after packing with the sender key and recipient keys.

--- a/pkg/didcomm/protocol/introduce/service_test.go
+++ b/pkg/didcomm/protocol/introduce/service_test.go
@@ -2175,7 +2175,7 @@ func setupIntroducee(f *flow) (*introduce.Service, *introduceMocks.MockInvitatio
 	return svc, dep, didChan
 }
 
-func handleInbound(t *testing.T, svc *introduce.Service, msg interface{}, myDID, theirDID string) {
+func handleInbound(t *testing.T, svc service.InboundHandler, msg interface{}, myDID, theirDID string) {
 	t.Helper()
 
 	resp, err := service.NewDIDCommMsg(toBytes(t, msg))

--- a/pkg/internal/mock/didcomm/protocol/generic/mock_generic_svc.go
+++ b/pkg/internal/mock/didcomm/protocol/generic/mock_generic_svc.go
@@ -1,0 +1,40 @@
+/*
+ *
+ * Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * /
+ *
+ */
+
+package generic
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+)
+
+// MockGenericSvc is mock generic service
+type MockGenericSvc struct {
+	HandleFunc func(*service.DIDCommMsg) (string, error)
+	AcceptFunc func(header *service.Header) bool
+}
+
+// HandleInbound msg
+func (m *MockGenericSvc) HandleInbound(msg *service.DIDCommMsg, myDID, theirDID string) (string, error) {
+	if m.HandleFunc != nil {
+		return m.HandleFunc(msg)
+	}
+
+	return uuid.New().String(), nil
+}
+
+// Accept msg checks the msg type
+func (m *MockGenericSvc) Accept(header *service.Header) bool {
+	if m.AcceptFunc != nil {
+		return m.AcceptFunc(header)
+	}
+
+	return true
+}


### PR DESCRIPTION
- generic message handler when no registered service handles
given message type
- current Accept logic is based on message header.
- closes #1032

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>

