### PR TITLE
refactor: null values in optional fields of Verifiable Credential

### DIFF
--- a/pkg/doc/verifiable/common.go
+++ b/pkg/doc/verifiable/common.go
@@ -76,11 +76,11 @@ type TypedID struct {
 }
 
 // MarshalJSON defines custom marshalling of TypedID to JSON.
-func (tid *TypedID) MarshalJSON() ([]byte, error) {
+func (tid TypedID) MarshalJSON() ([]byte, error) {
 	// TODO hide this exported method
 	type Alias TypedID
 
-	alias := (*Alias)(tid)
+	alias := Alias(tid)
 
 	data, err := marshalWithCustomFields(alias, tid.CustomFields)
 	if err != nil {

--- a/pkg/doc/verifiable/credential_jws_test.go
+++ b/pkg/doc/verifiable/credential_jws_test.go
@@ -44,7 +44,7 @@ func TestJWTCredClaimsMarshalJWS(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, err)
-		require.Equal(t, vc.raw().stringJSON(t), vcRaw.stringJSON(t))
+		require.Equal(t, vc.stringJSON(t), vcRaw.stringJSON(t))
 	})
 
 	t.Run("Marshal signed JWT failed with invalid private key", func(t *testing.T) {
@@ -85,7 +85,7 @@ func TestCredJWSDecoderUnmarshal(t *testing.T) {
 
 		vc, _, err := NewCredential([]byte(jwtTestCredential))
 		require.NoError(t, err)
-		require.Equal(t, vc.raw().stringJSON(t), vcRaw.stringJSON(t))
+		require.Equal(t, vc.stringJSON(t), vcRaw.stringJSON(t))
 	})
 
 	t.Run("Invalid serialized JWS", func(t *testing.T) {

--- a/pkg/doc/verifiable/credential_jwt.go
+++ b/pkg/doc/verifiable/credential_jwt.go
@@ -57,9 +57,16 @@ func newJWTCredClaims(vc *Credential, minimizeVC bool) (*JWTCredClaims, error) {
 		vcCopy.Issuer.ID = ""
 		vcCopy.Issued = nil
 		vcCopy.ID = ""
-		raw = vcCopy.raw()
+
+		raw, err = vcCopy.raw()
+		if err != nil {
+			return nil, err
+		}
 	} else {
-		raw = vc.raw()
+		raw, err = vc.raw()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	vcMap, err := mergeCustomFields(raw, raw.CustomFields)

--- a/pkg/doc/verifiable/credential_jwt_unsecured_test.go
+++ b/pkg/doc/verifiable/credential_jwt_unsecured_test.go
@@ -32,7 +32,7 @@ func TestCredentialJWTClaimsMarshallingToUnsecuredJWT(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, err)
-	require.Equal(t, vc.raw().stringJSON(t), vcRaw.stringJSON(t))
+	require.Equal(t, vc.stringJSON(t), vcRaw.stringJSON(t))
 }
 
 func TestCredUnsecuredJWTDecoderParseJWTClaims(t *testing.T) {


### PR DESCRIPTION
closes #1041

Signed-off-by: Dima <dkinoshenko@gmail.com>

Additionally, support the case when `RefreshService` is defined as an array. 