### PR TITLE
feat: message handler for message service registration

### DIFF
--- a/cmd/aries-agent-rest/startcmd/start.go
+++ b/cmd/aries-agent-rest/startcmd/start.go
@@ -14,10 +14,13 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+
 	"github.com/rs/cors"
 	"github.com/spf13/cobra"
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/msghandler"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	arieshttp "github.com/hyperledger/aries-framework-go/pkg/didcomm/transport/http"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport/ws"
@@ -141,6 +144,7 @@ type agentParameters struct {
 	host, inboundHostInternal, inboundHostExternal, dbPath, defaultLabel, inboundTransport string
 	webhookURLs, httpResolvers, outboundTransports                                         []string
 	autoAccept                                                                             bool
+	msgHandler                                                                             dispatcher.MessageHandler
 }
 
 type server interface {
@@ -390,6 +394,9 @@ func startAgent(parameters *agentParameters) error {
 		return errMissingInboundHost
 	}
 
+	// set message handler
+	parameters.msgHandler = msghandler.NewRegistrar()
+
 	ctx, err := createAriesAgent(parameters)
 	if err != nil {
 		return err
@@ -397,7 +404,8 @@ func startAgent(parameters *agentParameters) error {
 
 	// get all HTTP REST API handlers available for controller API
 	restService, err := restapi.New(ctx, restapi.WithWebhookURLs(parameters.webhookURLs...),
-		restapi.WithDefaultLabel(parameters.defaultLabel), restapi.WithAutoAccept(parameters.autoAccept))
+		restapi.WithDefaultLabel(parameters.defaultLabel), restapi.WithAutoAccept(parameters.autoAccept),
+		restapi.WithMessageHandler(parameters.msgHandler))
 	if err != nil {
 		return fmt.Errorf("failed to start aries agent rest on port [%s], failed to get rest service api :  %w",
 			parameters.host, err)
@@ -453,6 +461,7 @@ func createAriesAgent(parameters *agentParameters) (*context.Provider, error) {
 	}
 
 	opts = append(opts, outboundTransportOpts...)
+	opts = append(opts, aries.WithMessageServiceProvider(parameters.msgHandler))
 
 	framework, err := aries.New(opts...)
 	if err != nil {

--- a/pkg/didcomm/dispatcher/api.go
+++ b/pkg/didcomm/dispatcher/api.go
@@ -22,6 +22,18 @@ type Service interface {
 type MessageService interface {
 	service.InboundHandler
 	Accept(header *service.Header) bool
+	Name() string
+}
+
+// MessageHandler maintains registered message services
+// and it allows dynamic registration of message services
+type MessageHandler interface {
+	// Services returns list of available message services in this message handler
+	Services() []MessageService
+	// Register registers given message services to this message handler
+	Register(msgSvcs ...MessageService) error
+	// Unregister unregisters message service with given name from this message handler
+	Unregister(name string) error
 }
 
 // Outbound interface

--- a/pkg/didcomm/msghandler/msghandler.go
+++ b/pkg/didcomm/msghandler/msghandler.go
@@ -1,0 +1,95 @@
+/*
+ *
+ * Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * /
+ *
+ */
+
+package msghandler
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+)
+
+const (
+	errAlreadyRegistered = "registration failed, message service with name `%s` already registered"
+	errNeverRegistered   = "failed to unregister, unable to find registered message service with name `%s`"
+)
+
+// NewRegistrar returns new message registrar instance
+func NewRegistrar() *Registrar {
+	return &Registrar{}
+}
+
+// Registrar is message handler implementation which maintains list of registered message service
+// and also allows dynamic register/unregister of message services
+type Registrar struct {
+	services []dispatcher.MessageService
+	lock     sync.RWMutex
+}
+
+// Services returns list of message services registered to this handler
+func (m *Registrar) Services() []dispatcher.MessageService {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	return m.services
+}
+
+// Register registers given message services to this handler
+// returns error in case of duplicate registration
+func (m *Registrar) Register(msgServices ...dispatcher.MessageService) error {
+	if len(msgServices) == 0 {
+		return nil
+	}
+
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	// if current list is empty, add all
+	if len(m.services) == 0 {
+		m.services = append(m.services, msgServices...)
+		return nil
+	}
+
+	// if current list is not empty, then look for duplicates before adding
+	for _, newMsgSvc := range msgServices {
+		for _, existingSvc := range m.services {
+			if existingSvc.Name() == newMsgSvc.Name() {
+				return fmt.Errorf(errAlreadyRegistered, newMsgSvc.Name())
+			}
+		}
+	}
+
+	m.services = append(m.services, msgServices...)
+
+	return nil
+}
+
+// Unregister unregisters message service with given name from this message handler
+func (m *Registrar) Unregister(name string) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	index := -1
+
+	for i, svc := range m.services {
+		if svc.Name() == name {
+			index = i
+			break
+		}
+	}
+
+	if index < 0 {
+		return fmt.Errorf(errNeverRegistered, name)
+	}
+
+	m.services = append(m.services[:index], m.services[index+1:]...)
+
+	return nil
+}

--- a/pkg/didcomm/msghandler/msghandler_test.go
+++ b/pkg/didcomm/msghandler/msghandler_test.go
@@ -1,0 +1,150 @@
+/*
+ *
+ * Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * /
+ *
+ */
+
+package msghandler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/generic"
+)
+
+func Test_MessageHandlerRegister(t *testing.T) {
+	tests := []struct {
+		testName string
+		svcs     []dispatcher.MessageService
+		err      string
+	}{{
+		testName: "empty msg services",
+	}, {
+		testName: "add multiple msg services on empty list- test success",
+		svcs: []dispatcher.MessageService{
+			generic.NewCustomMockMessageSvc("test1", "sample-name-01"),
+			generic.NewCustomMockMessageSvc("test2", "sample-name-02"),
+			generic.NewCustomMockMessageSvc("test3", "sample-name-03"),
+		},
+	},
+		{
+			testName: "add multiple msg services on non empty list- test success",
+			svcs: []dispatcher.MessageService{
+				generic.NewCustomMockMessageSvc("test1", "sample-name-11"),
+				generic.NewCustomMockMessageSvc("test2", "sample-name-12"),
+				generic.NewCustomMockMessageSvc("test3", "sample-name-13"),
+			},
+		},
+		{
+			testName: "add multiple msg services - test duplicate scenario-1",
+			svcs: []dispatcher.MessageService{
+				generic.NewCustomMockMessageSvc("test1", "sample-name-21"),
+				generic.NewCustomMockMessageSvc("test2", "sample-name-11"),
+				generic.NewCustomMockMessageSvc("test3", "sample-name-23"),
+			},
+			err: fmt.Sprintf(errAlreadyRegistered, "sample-name-11"),
+		},
+		{
+			testName: "add multiple msg services - test duplicate scenario-2",
+			svcs: []dispatcher.MessageService{
+				generic.NewCustomMockMessageSvc("test1", "sample-name-21"),
+				generic.NewCustomMockMessageSvc("test2", "sample-name-22"),
+				generic.NewCustomMockMessageSvc("test3", "sample-name-23"),
+			},
+		},
+		{
+			testName: "add multiple msg services of same type - test success",
+			svcs: []dispatcher.MessageService{
+				generic.NewCustomMockMessageSvc("test", "sample-name-31"),
+				generic.NewCustomMockMessageSvc("test", "sample-name-32"),
+				generic.NewCustomMockMessageSvc("test", "sample-name-33"),
+			},
+		},
+	}
+
+	handler := NewRegistrar()
+	require.NotNil(t, handler)
+
+	for _, test := range tests {
+		tc := test
+
+		t.Run(tc.testName, func(t *testing.T) {
+			b4Count := len(handler.services)
+			err := handler.Register(tc.svcs...)
+
+			if tc.err != "" {
+				require.Error(t, err, "expected error: %s", tc.err)
+				require.Contains(t, err.Error(), tc.err)
+				require.Len(t, handler.Services(), b4Count)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, handler.Services(), b4Count+len(tc.svcs))
+		})
+	}
+}
+
+func Test_MessageHandlerUnregister(t *testing.T) {
+	tests := []struct {
+		testName      string
+		register      []dispatcher.MessageService
+		unregister    []string
+		err           string
+		expectedCount int
+	}{{
+		testName:   "unregister on empty msg services",
+		unregister: []string{"sample-name-01"},
+		err:        fmt.Sprintf(errNeverRegistered, "sample-name-01"),
+	}, {
+		testName: "add multiple msg services on empty list- test success",
+		register: []dispatcher.MessageService{
+			generic.NewCustomMockMessageSvc("test1", "sample-name-01"),
+			generic.NewCustomMockMessageSvc("test2", "sample-name-02"),
+			generic.NewCustomMockMessageSvc("test3", "sample-name-03"),
+		},
+		unregister:    []string{"sample-name-01", "sample-name-02"},
+		expectedCount: 1,
+	},
+		{
+			testName:   "unregister on empty msg services",
+			unregister: []string{"sample-name-01"},
+			err:        fmt.Sprintf(errNeverRegistered, "sample-name-01"),
+		},
+	}
+
+	handler := NewRegistrar()
+	require.NotNil(t, handler)
+
+	for _, test := range tests {
+		tc := test
+
+		t.Run(tc.testName, func(t *testing.T) {
+			err := handler.Register(tc.register...)
+			require.NoError(t, err)
+
+			for _, name := range tc.unregister {
+				b4Count := len(handler.services)
+				err = handler.Unregister(name)
+
+				if tc.err != "" {
+					require.Error(t, err, "expected error: %s", tc.err)
+					require.Contains(t, err.Error(), tc.err)
+					require.Len(t, handler.Services(), b4Count)
+					return
+				}
+
+				require.NoError(t, err)
+			}
+
+			require.Len(t, handler.Services(), tc.expectedCount)
+		})
+	}
+}

--- a/pkg/framework/aries/api/protocol.go
+++ b/pkg/framework/aries/api/protocol.go
@@ -36,3 +36,9 @@ type Provider interface {
 
 // ProtocolSvcCreator method to create new protocol service
 type ProtocolSvcCreator func(prv Provider) (dispatcher.Service, error)
+
+// MessageServiceProvider is provider of message services
+type MessageServiceProvider interface {
+	// Services returns list of available message services in this message handler
+	Services() []dispatcher.MessageService
+}

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -117,5 +117,17 @@ func setAdditionalDefaultOpts(frameworkOpts *Aries) error {
 		}
 	}
 
+	if frameworkOpts.msgSvcProvider == nil {
+		frameworkOpts.msgSvcProvider = &noOpMessageServiceProvider{}
+	}
+
 	return nil
+}
+
+// noOpMessageServiceProvider returns noop message service provider
+type noOpMessageServiceProvider struct{}
+
+// Services returns empty list of services for noOpMessageServiceProvider
+func (n *noOpMessageServiceProvider) Services() []dispatcher.MessageService {
+	return []dispatcher.MessageService{}
 }

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -39,6 +39,7 @@ type Aries struct {
 	transientStoreProvider storage.Provider
 	protocolSvcCreators    []api.ProtocolSvcCreator
 	services               []dispatcher.Service
+	msgSvcProvider         api.MessageServiceProvider
 	outboundDispatcher     dispatcher.Outbound
 	outboundTransports     []transport.OutboundTransport
 	inboundTransport       transport.InboundTransport
@@ -203,6 +204,14 @@ func WithCrypto(c crypto.Crypto) Option {
 func WithVDRI(v vdriapi.VDRI) Option {
 	return func(opts *Aries) error {
 		opts.vdri = append(opts.vdri, v)
+		return nil
+	}
+}
+
+// WithMessageServiceProvider injects a message service provider to the Aries framework
+func WithMessageServiceProvider(msv api.MessageServiceProvider) Option {
+	return func(opts *Aries) error {
+		opts.msgSvcProvider = msv
 		return nil
 	}
 }

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	mockcrypto "github.com/hyperledger/aries-framework-go/pkg/internal/mock/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/msghandler"
 	mockdidexchange "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/didexchange"
 	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
@@ -442,6 +443,17 @@ func TestFramework(t *testing.T) {
 		_, err = New(WithTransportReturnRoute(transportReturnRoute))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid transport return route option : "+transportReturnRoute)
+	})
+
+	t.Run("test message service provider option", func(t *testing.T) {
+		path, cleanup := generateTempDir(t)
+		defer cleanup()
+		dbPath = path
+
+		aries, err := New(WithMessageServiceProvider(msghandler.NewMockMsgServiceProvider()))
+		require.NoError(t, err)
+		require.NotNil(t, aries)
+		require.NotNil(t, aries.msgSvcProvider)
 	})
 }
 

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -24,7 +24,7 @@ import (
 // Provider supplies the framework configuration to client objects.
 type Provider struct {
 	services                 []dispatcher.Service
-	messageServices          []dispatcher.MessageService
+	msgSvcProvider           api.MessageServiceProvider
 	storeProvider            storage.Provider
 	transientStoreProvider   storage.Provider
 	kms                      kms.KMS
@@ -128,7 +128,7 @@ func (p *Provider) InboundMessageHandler() transport.InboundMessageHandler {
 
 		// in case of no services are registered for given message type,
 		// find generic inbound services registered for given message header
-		for _, svc := range p.messageServices {
+		for _, svc := range p.msgSvcProvider.Services() {
 			if svc.Accept(msg.Header) {
 				_, err = svc.HandleInbound(msg, myDID, theirDID)
 				return err
@@ -195,14 +195,6 @@ func WithTransportReturnRoute(transportReturnRoute string) ProviderOption {
 func WithProtocolServices(services ...dispatcher.Service) ProviderOption {
 	return func(opts *Provider) error {
 		opts.services = services
-		return nil
-	}
-}
-
-// WithMessageServices injects services for handling generic messages.
-func WithMessageServices(services ...dispatcher.MessageService) ProviderOption {
-	return func(opts *Provider) error {
-		opts.messageServices = services
 		return nil
 	}
 }
@@ -280,6 +272,14 @@ func WithPacker(primary packer.Packer, additionalPackers ...packer.Packer) Provi
 func WithAriesFrameworkID(id string) ProviderOption {
 	return func(opts *Provider) error {
 		opts.frameworkID = id
+		return nil
+	}
+}
+
+// WithMessageServiceProvider injects a message service provider into the context
+func WithMessageServiceProvider(msv api.MessageServiceProvider) ProviderOption {
+	return func(opts *Provider) error {
+		opts.msgSvcProvider = msv
 		return nil
 	}
 }

--- a/pkg/internal/mock/didcomm/msghandler/mock_msg_handler.go
+++ b/pkg/internal/mock/didcomm/msghandler/mock_msg_handler.go
@@ -1,0 +1,70 @@
+/*
+ *
+ * Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * /
+ *
+ */
+
+package msghandler
+
+import (
+	"sync"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+)
+
+// NewMockMsgServiceProvider returns new custom mock message handler
+func NewMockMsgServiceProvider() *MockMsgSvcProvider {
+	return &MockMsgSvcProvider{svcs: []dispatcher.MessageService{}}
+}
+
+// MockMsgSvcProvider is mock message handler
+type MockMsgSvcProvider struct {
+	svcs          []dispatcher.MessageService
+	RegisterErr   error
+	UnregisterErr error
+	lock          sync.RWMutex
+}
+
+// Services returns message services registered to this mock message handler
+func (m *MockMsgSvcProvider) Services() []dispatcher.MessageService {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	return m.svcs
+}
+
+// Register registers given message services to this mock message handler
+func (m *MockMsgSvcProvider) Register(msgSvcs ...dispatcher.MessageService) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.svcs = append(m.svcs, msgSvcs...)
+
+	return m.RegisterErr
+}
+
+// Unregister unregisters given message services from this mock message handler
+func (m *MockMsgSvcProvider) Unregister(name string) error {
+	if m.UnregisterErr != nil {
+		return m.UnregisterErr
+	}
+
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	index := -1
+
+	for i, msgSvc := range m.svcs {
+		if msgSvc.Name() == name {
+			index = i
+			break
+		}
+	}
+
+	m.svcs = append(m.svcs[:index], m.svcs[index+1:]...)
+
+	return nil
+}

--- a/pkg/internal/mock/didcomm/protocol/generic/mock_generic_svc.go
+++ b/pkg/internal/mock/didcomm/protocol/generic/mock_generic_svc.go
@@ -15,14 +15,28 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 )
 
-// MockGenericSvc is mock generic service
-type MockGenericSvc struct {
+// NewCustomMockMessageSvc returns new custom mock message service
+func NewCustomMockMessageSvc(msgType, name string) *MockMessageSvc {
+	return &MockMessageSvc{
+		HandleFunc: func(*service.DIDCommMsg) (string, error) {
+			return "", nil
+		},
+		AcceptFunc: func(header *service.Header) bool {
+			return header.Type == msgType
+		},
+		NameVal: name,
+	}
+}
+
+// MockMessageSvc is mock generic service
+type MockMessageSvc struct {
 	HandleFunc func(*service.DIDCommMsg) (string, error)
 	AcceptFunc func(header *service.Header) bool
+	NameVal    string
 }
 
 // HandleInbound msg
-func (m *MockGenericSvc) HandleInbound(msg *service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (m *MockMessageSvc) HandleInbound(msg *service.DIDCommMsg, myDID, theirDID string) (string, error) {
 	if m.HandleFunc != nil {
 		return m.HandleFunc(msg)
 	}
@@ -31,10 +45,15 @@ func (m *MockGenericSvc) HandleInbound(msg *service.DIDCommMsg, myDID, theirDID 
 }
 
 // Accept msg checks the msg type
-func (m *MockGenericSvc) Accept(header *service.Header) bool {
+func (m *MockMessageSvc) Accept(header *service.Header) bool {
 	if m.AcceptFunc != nil {
 		return m.AcceptFunc(header)
 	}
 
 	return true
+}
+
+// Name name of message service
+func (m *MockMessageSvc) Name() string {
+	return m.NameVal
 }

--- a/pkg/restapi/restapi.go
+++ b/pkg/restapi/restapi.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package restapi
 
 import (
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+
 	"github.com/hyperledger/aries-framework-go/pkg/framework/context"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation/common"
@@ -18,6 +20,7 @@ type allOpts struct {
 	webhookURLs  []string
 	defaultLabel string
 	autoAccept   bool
+	msgHandler   dispatcher.MessageHandler
 }
 
 // Opt represents a REST Api option.
@@ -41,6 +44,13 @@ func WithDefaultLabel(defaultLabel string) Opt {
 func WithAutoAccept(autoAccept bool) Opt {
 	return func(opts *allOpts) {
 		opts.autoAccept = autoAccept
+	}
+}
+
+// WithMessageHandler is an option allowing for the message handler to be set.
+func WithMessageHandler(handler dispatcher.MessageHandler) Opt {
+	return func(opts *allOpts) {
+		opts.msgHandler = handler
 	}
 }
 

--- a/pkg/restapi/restapi_test.go
+++ b/pkg/restapi/restapi_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/defaults"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/context"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/msghandler"
 )
 
 func TestNew_Failure(t *testing.T) {
@@ -46,6 +47,15 @@ func TestNew_Success(t *testing.T) {
 	require.NotNil(t, ctx)
 
 	controller, err := New(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, controller)
+
+	require.NotEmpty(t, controller.GetOperations())
+
+	// test with options
+	controller, err = New(ctx, WithMessageHandler(msghandler.NewMockMsgServiceProvider()),
+		WithAutoAccept(true), WithDefaultLabel("sample-label"),
+		WithWebhookURLs("sample-wh-url"))
 	require.NoError(t, err)
 	require.NotNil(t, controller)
 
@@ -82,6 +92,16 @@ func TestWithAutoAcceptOption(t *testing.T) {
 	opt(restAPIOpts)
 
 	require.Equal(t, true, restAPIOpts.autoAccept)
+}
+
+func TestWithMessageHandler(t *testing.T) {
+	restAPIOpts := &allOpts{}
+
+	opt := WithMessageHandler(msghandler.NewMockMsgServiceProvider())
+
+	opt(restAPIOpts)
+
+	require.NotNil(t, restAPIOpts.msgHandler)
 }
 
 func generateTempDir(t testing.TB) (string, func()) {


### PR DESCRIPTION
- Added MessageHandler which is dynamic registrar for message service
registration
- MessageHandler option for Aries framework instantiation and REST API
instantiation.
- Context InboundHandler will dispatch handling to message services
registered to message handler if no matching protocol service found for
given message type
- closes #970

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>

