### PR TITLE
feat: Replace DIDCommMsg type with map[string]interface{}

### DIFF
--- a/cmd/aries-agent-rest/go.sum
+++ b/cmd/aries-agent-rest/go.sum
@@ -78,6 +78,7 @@ github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8Rv
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771 h1:MHkK1uRtFbVqvAgvWxafZe54+5uBxLluGylDiKgdhwo=
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mr-tron/base58 v1.1.0/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=
 github.com/mr-tron/base58 v1.1.2 h1:ZEw4I2EgPKDJ2iEw0cNmLB3ROrEmkOtXIkaG7wZg+78=

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/tink v1.3.0-rc3
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.3
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/multiformats/go-multibase v0.0.1
 	github.com/multiformats/go-multihash v0.0.8
 	github.com/piprate/json-gold v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8RvIylQ358TN4wwqatJ8rNavkEINozVn9DtGI3dfQ=
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771 h1:MHkK1uRtFbVqvAgvWxafZe54+5uBxLluGylDiKgdhwo=
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
+github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mr-tron/base58 v1.1.0 h1:Y51FGVJ91WBqCEabAi5OPUz38eAx8DakuAm5svLcsfQ=
 github.com/mr-tron/base58 v1.1.0/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=
 github.com/mr-tron/base58 v1.1.2 h1:ZEw4I2EgPKDJ2iEw0cNmLB3ROrEmkOtXIkaG7wZg+78=

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -352,7 +352,7 @@ func TestClient_HandleInvitation(t *testing.T) {
 		c, err := New(&mockprovider.Provider{
 			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
 			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			ServiceValue: &mocksvc.MockDIDExchangeSvc{HandleFunc: func(msg *service.DIDCommMsg) (string, error) {
+			ServiceValue: &mocksvc.MockDIDExchangeSvc{HandleFunc: func(msg service.DIDCommMsg) (string, error) {
 				return "", fmt.Errorf("handle error")
 			}},
 			KMSValue: &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"}, InboundEndpointValue: "endpoint"})

--- a/pkg/client/introduce/client_test.go
+++ b/pkg/client/introduce/client_test.go
@@ -67,7 +67,7 @@ func TestClient_handleOutbound(t *testing.T) {
 	t.Run("invalid payload data format", func(t *testing.T) {
 		c := &Client{}
 		err := c.handleOutbound([]int{}, InvitationEnvelope{})
-		const errMsg = "invalid payload data format: json: cannot unmarshal array into Go value of type service.Header"
+		const errMsg = "invalid payload data format: json: cannot unmarshal array into Go value of type service.DIDCommMsgMap"
 		require.EqualError(t, errors.Unwrap(err), errMsg)
 	})
 
@@ -216,11 +216,11 @@ func TestClient_HandleRequest(t *testing.T) {
 		ID:   UUID,
 	}))
 	require.NoError(t, err)
-	require.NoError(t, client.HandleRequest(*msg, opts.Recps[0].To, opts.Recps[1]))
+	require.NoError(t, client.HandleRequest(msg, opts.Recps[0].To, opts.Recps[1]))
 
 	// cover error case
-	err = client.HandleRequest(service.DIDCommMsg{}, opts.Recps[0].To, opts.Recps[1])
-	require.EqualError(t, errors.Unwrap(err), service.ErrNoHeader.Error())
+	err = client.HandleRequest(service.DIDCommMsgMap{}, opts.Recps[0].To, opts.Recps[1])
+	require.EqualError(t, errors.Unwrap(err), service.ErrThreadIDNotFound.Error())
 }
 
 func TestClient_HandleRequestWithInvitation(t *testing.T) {
@@ -259,11 +259,11 @@ func TestClient_HandleRequestWithInvitation(t *testing.T) {
 		ID:   UUID,
 	}))
 	require.NoError(t, err)
-	require.NoError(t, client.HandleRequestWithInvitation(*msg, opts.Inv, opts.Recps[0].To))
+	require.NoError(t, client.HandleRequestWithInvitation(msg, opts.Inv, opts.Recps[0].To))
 
 	// cover error case
-	err = client.HandleRequestWithInvitation(service.DIDCommMsg{}, opts.Inv, opts.Recps[0].To)
-	require.EqualError(t, errors.Unwrap(err), service.ErrNoHeader.Error())
+	err = client.HandleRequestWithInvitation(service.DIDCommMsgMap{}, opts.Inv, opts.Recps[0].To)
+	require.EqualError(t, errors.Unwrap(err), service.ErrThreadIDNotFound.Error())
 }
 
 func TestClient_InvitationEnvelope(t *testing.T) {

--- a/pkg/didcomm/common/service/did_comm_msg.go
+++ b/pkg/didcomm/common/service/did_comm_msg.go
@@ -1,0 +1,138 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package service
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+)
+
+const (
+	jsonID       = "@id"
+	jsonType     = "@type"
+	jsonThread   = "~thread"
+	jsonThreadID = "thid"
+)
+
+// Header helper structure which keeps reusable fields
+// Deprecated: Use DIDCommMsg instead of Header
+// TODO: Remove deprecated Header structure https://github.com/hyperledger/aries-framework-go/issues/1075
+type Header struct {
+	ID     string           `json:"@id"`
+	Thread decorator.Thread `json:"~thread"`
+	Type   string           `json:"@type"`
+	// TODO revisit ~purpose, should be generic map [Issue #1037]
+	Purpose []string `json:"~purpose"`
+}
+
+// DIDCommMsgMap did comm msg
+type DIDCommMsgMap map[string]interface{}
+
+// NewDIDCommMsg returns DIDCommMsg with Header
+func NewDIDCommMsg(payload []byte) (DIDCommMsgMap, error) {
+	var msg DIDCommMsgMap
+
+	err := json.Unmarshal(payload, &msg)
+	if err != nil {
+		return nil, fmt.Errorf("invalid payload data format: %w", err)
+	}
+
+	return msg, nil
+}
+
+// ThreadID returns msg ~thread.thid if there is no ~thread.thid returns msg @id
+// message is invalid if ~thread.thid exist and @id is absent
+func (m DIDCommMsgMap) ThreadID() (string, error) {
+	if m == nil {
+		return "", ErrInvalidMessage
+	}
+
+	msgID := m.ID()
+	thread, ok := m[jsonThread].(map[string]interface{})
+
+	if ok && thread[jsonThreadID] != nil {
+		var thID string
+		if v, ok := thread[jsonThreadID].(string); ok {
+			thID = v
+		}
+
+		// if message has ~thread.thid but @id is absent this is invalid message
+		if len(thID) > 0 && msgID == "" {
+			return "", ErrInvalidMessage
+		}
+
+		if len(thID) > 0 {
+			return thID, nil
+		}
+	}
+
+	// we need to return it only if there is no ~thread.thid
+	if len(msgID) > 0 {
+		return msgID, nil
+	}
+
+	return "", ErrThreadIDNotFound
+}
+
+// Type returns the message type
+func (m DIDCommMsgMap) Type() string {
+	if m == nil || m[jsonType] == nil {
+		return ""
+	}
+
+	res, ok := m[jsonType].(string)
+	if !ok {
+		return ""
+	}
+
+	return res
+}
+
+// ID returns the message id
+func (m DIDCommMsgMap) ID() string {
+	if m == nil || m[jsonID] == nil {
+		return ""
+	}
+
+	res, ok := m[jsonID].(string)
+	if !ok {
+		return ""
+	}
+
+	return res
+}
+
+// Decode converts message to  struct
+func (m DIDCommMsgMap) Decode(v interface{}) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: func(rt1 reflect.Type, rt2 reflect.Type, v interface{}) (interface{}, error) {
+			if rt1.Kind() == reflect.String && rt2 == reflect.TypeOf(time.Time{}) {
+				return time.Parse(time.RFC3339, v.(string))
+			}
+
+			if rt1.Kind() == reflect.String && rt2.Kind() == reflect.Slice {
+				return base64.StdEncoding.DecodeString(v.(string))
+			}
+
+			return v, nil
+		},
+		WeaklyTypedInput: true,
+		Result:           v,
+		TagName:          "json",
+	})
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(m)
+}

--- a/pkg/didcomm/common/service/did_comm_msg_test.go
+++ b/pkg/didcomm/common/service/did_comm_msg_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package service
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDIDCommMsg_ID(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		msg      DIDCommMsgMap
+	}{
+		{
+			name:     "Empty (nil msg)",
+			expected: "",
+		},
+		{
+			name:     "Empty",
+			msg:      DIDCommMsgMap{},
+			expected: "",
+		},
+		{
+			name:     "Bad type ID",
+			msg:      DIDCommMsgMap{jsonID: map[int]int{}},
+			expected: "",
+		},
+		{
+			name:     "Success",
+			msg:      DIDCommMsgMap{jsonID: "ID"},
+			expected: "ID",
+		},
+	}
+
+	for i := range tests {
+		require.Equal(t, tests[i].expected, tests[i].msg.ID())
+	}
+}
+
+func TestDIDCommMsg_Type(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		msg      DIDCommMsgMap
+	}{
+		{
+			name:     "Empty (nil msg)",
+			expected: "",
+		},
+		{
+			name:     "Empty",
+			msg:      DIDCommMsgMap{},
+			expected: "",
+		},
+		{
+			name:     "Bad type Type",
+			msg:      DIDCommMsgMap{jsonType: map[int]int{}},
+			expected: "",
+		},
+		{
+			name:     "Success",
+			msg:      DIDCommMsgMap{jsonType: "Type"},
+			expected: "Type",
+		},
+	}
+
+	for i := range tests {
+		require.Equal(t, tests[i].expected, tests[i].msg.Type())
+	}
+}
+
+func TestDIDCommMsg_ToStruct(t *testing.T) {
+	type Test struct {
+		Time  time.Time
+		Bytes []byte
+	}
+
+	expected := Test{
+		Time:  time.Now().UTC(),
+		Bytes: []byte("payload"),
+	}
+
+	b, err := json.Marshal(expected)
+	require.NoError(t, err)
+
+	msg, err := NewDIDCommMsg(b)
+	require.NoError(t, err)
+
+	actual := Test{}
+	require.NoError(t, msg.Decode(&actual))
+	require.Equal(t, expected, actual)
+}

--- a/pkg/didcomm/common/service/errors.go
+++ b/pkg/didcomm/common/service/errors.go
@@ -13,7 +13,6 @@ const (
 	ErrInvalidChannel    = serviceError("invalid channel passed to unregister the action event")
 	ErrThreadIDNotFound  = serviceError("threadID not found")
 	ErrInvalidMessage    = serviceError("invalid message")
-	ErrNoHeader          = serviceError("the header is not provided")
 )
 
 // serviceError defines service error

--- a/pkg/didcomm/common/service/event.go
+++ b/pkg/didcomm/common/service/event.go
@@ -33,7 +33,7 @@ type StateMsg struct {
 	StateID string
 
 	// DIDComm message along with message type
-	Msg *DIDCommMsg
+	Msg DIDCommMsg
 
 	// Properties contains value based on specific protocol. The consumers need to call the protocol client
 	// functions to get the data.
@@ -52,7 +52,7 @@ type DIDCommAction struct {
 	ProtocolName string
 
 	// DIDComm message
-	Message *DIDCommMsg
+	Message DIDCommMsg
 
 	// Continue function to be called by the consumer for further processing the message.
 	Continue func(args interface{})

--- a/pkg/didcomm/common/service/gomocks/mocks.go
+++ b/pkg/didcomm/common/service/gomocks/mocks.go
@@ -34,7 +34,7 @@ func (m *MockDIDComm) EXPECT() *MockDIDCommMockRecorder {
 }
 
 // HandleInbound mocks base method
-func (m *MockDIDComm) HandleInbound(arg0 *service.DIDCommMsg, arg1, arg2 string) (string, error) {
+func (m *MockDIDComm) HandleInbound(arg0 service.DIDCommMsg, arg1, arg2 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleInbound", arg0, arg1, arg2)
 	ret0, _ := ret[0].(string)
@@ -49,7 +49,7 @@ func (mr *MockDIDCommMockRecorder) HandleInbound(arg0, arg1, arg2 interface{}) *
 }
 
 // HandleOutbound mocks base method
-func (m *MockDIDComm) HandleOutbound(arg0 *service.DIDCommMsg, arg1, arg2 string) error {
+func (m *MockDIDComm) HandleOutbound(arg0 service.DIDCommMsg, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleOutbound", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/pkg/didcomm/common/service/messenger.go
+++ b/pkg/didcomm/common/service/messenger.go
@@ -1,0 +1,39 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package service
+
+// DIDCommMsg describes message interface
+type DIDCommMsg interface {
+	ID() string
+	Type() string
+
+	ThreadID() (string, error)
+	Decode(v interface{}) error
+}
+
+// The messenger package is responsible for the handling of communication between agents.
+// It takes care of threading, timing, etc.
+// Each message that we are going to send should be DIDCommMsg type.
+// e.g we have type model.Ack{Type: "type", ID: "id"}
+// it should be converted to: map[@id:id @type:type]
+// NOTE: The package modifies message data by JSON tag name according to aries-rfcs.
+//       Fields like @id, ~thread , etc. are redundant and may be rewritten.
+
+// Messenger provides methods for the communication
+type Messenger interface {
+	// ReplyTo replies to the message by given msgID.
+	// Keeps threadID in the *decorator.Thread.
+	// Using this function means that communication will be on the same thread.
+	ReplyTo(msgID string, msg DIDCommMsgMap)
+
+	// Send sends the message by starting a new thread.
+	Send(msg DIDCommMsgMap, myDID, theirDID string)
+
+	// ReplyToNested sends the message by starting a new thread.
+	// Keeps parent threadID in the *decorator.Thread
+	ReplyToNested(threadID string, msg DIDCommMsgMap)
+}

--- a/pkg/didcomm/common/service/service.go
+++ b/pkg/didcomm/common/service/service.go
@@ -6,23 +6,16 @@ SPDX-License-Identifier: Apache-2.0
 
 package service
 
-import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
-)
-
 // InboundHandler is handler for inbound messages
 type InboundHandler interface {
 	// HandleInbound handles inbound messages.
-	HandleInbound(msg *DIDCommMsg, myDID, theirDID string) (string, error)
+	HandleInbound(msg DIDCommMsg, myDID, theirDID string) (string, error)
 }
 
 // OutboundHandler is handler for outbound messages
 type OutboundHandler interface {
 	// HandleOutbound handles outbound messages.
-	HandleOutbound(msg *DIDCommMsg, myDID, theirDID string) error
+	HandleOutbound(msg DIDCommMsg, myDID, theirDID string) error
 }
 
 // Handler provides protocol service handle api.
@@ -37,101 +30,4 @@ type DIDComm interface {
 	Handler
 	// event service
 	Event
-}
-
-// Header helper structure which keeps reusable fields
-type Header struct {
-	ID     string           `json:"@id"`
-	Thread decorator.Thread `json:"~thread"`
-	Type   string           `json:"@type"`
-	// TODO revisit ~purpose, should be generic map [Issue #1037]
-	// TODO ~purpose should be out of header [Issue #1058, #1040]
-	Purpose []string `json:"~purpose"`
-}
-
-func (h *Header) clone() *Header {
-	if h == nil {
-		return nil
-	}
-
-	return &Header{
-		ID: h.ID,
-		Thread: decorator.Thread{
-			ID:          h.Thread.ID,
-			PID:         h.Thread.PID,
-			SenderOrder: h.Thread.SenderOrder,
-			// copies ReceivedOrders value
-			ReceivedOrders: func() map[string]int {
-				if h.Thread.ReceivedOrders == nil {
-					return nil
-				}
-
-				orders := make(map[string]int, len(h.Thread.ReceivedOrders))
-
-				for k, v := range h.Thread.ReceivedOrders {
-					orders[k] = v
-				}
-
-				return orders
-			}(),
-		},
-		Type: h.Type,
-	}
-}
-
-// DIDCommMsg did comm msg
-type DIDCommMsg struct {
-	Header  *Header
-	Payload []byte
-}
-
-// Clone creates new DIDCommMsg with the same data
-// the cloned message is safe for delivering to the client
-// it prevents modifying by the client
-func (m *DIDCommMsg) Clone() *DIDCommMsg {
-	if m == nil {
-		return nil
-	}
-
-	return &DIDCommMsg{
-		Header:  m.Header.clone(),
-		Payload: append(m.Payload[:0:0], m.Payload...),
-	}
-}
-
-// NewDIDCommMsg returns DIDCommMsg with Header
-func NewDIDCommMsg(payload []byte) (*DIDCommMsg, error) {
-	msg := &DIDCommMsg{Payload: payload}
-
-	err := json.Unmarshal(msg.Payload, &msg.Header)
-	if err != nil {
-		return nil, fmt.Errorf("invalid payload data format: %w", err)
-	}
-
-	return msg, nil
-}
-
-// ThreadID returns msg ~thread.thid if there is no ~thread.thid returns msg @id
-// message is invalid if ~thread.thid exist and @id is absent
-// NOTE: Header field should be filled before calling ThreadID func
-// it can be done by using NewDIDCommMsg([]byte) func or directly set a Header value
-func (m *DIDCommMsg) ThreadID() (string, error) {
-	if m.Header == nil {
-		return "", ErrNoHeader
-	}
-	// if message has ~thread.thid but @id is absent this is invalid message
-	if len(m.Header.Thread.ID) > 0 && m.Header.ID == "" {
-		return "", ErrInvalidMessage
-	}
-
-	if len(m.Header.Thread.ID) > 0 {
-		return m.Header.Thread.ID, nil
-	}
-
-	// we need to return it only if there is no ~thread.thid
-	if len(m.Header.ID) > 0 {
-		return m.Header.ID, nil
-	}
-
-	return "", ErrThreadIDNotFound
 }

--- a/pkg/didcomm/protocol/didexchange/states.go
+++ b/pkg/didcomm/protocol/didexchange/states.go
@@ -144,8 +144,8 @@ func (s *invited) CanTransitionTo(next state) bool {
 
 func (s *invited) ExecuteInbound(msg *stateMachineMsg, thid string, ctx *context) (*connectionstore.Record,
 	state, stateAction, error) {
-	if msg.header.Type != InvitationMsgType {
-		return nil, nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.header.Type, s.Name())
+	if msg.Type() != InvitationMsgType {
+		return nil, nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.Type(), s.Name())
 	}
 
 	msg.connRecord.ThreadID = thid
@@ -167,11 +167,11 @@ func (s *requested) CanTransitionTo(next state) bool {
 
 func (s *requested) ExecuteInbound(msg *stateMachineMsg, thid string, ctx *context) (*connectionstore.Record,
 	state, stateAction, error) {
-	switch msg.header.Type {
+	switch msg.Type() {
 	case InvitationMsgType:
 		invitation := &Invitation{}
 
-		err := json.Unmarshal(msg.payload, invitation)
+		err := msg.Decode(invitation)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("JSON unmarshalling of invitation: %w", err)
 		}
@@ -185,7 +185,7 @@ func (s *requested) ExecuteInbound(msg *stateMachineMsg, thid string, ctx *conte
 	case RequestMsgType:
 		return msg.connRecord, &responded{}, func() error { return nil }, nil
 	default:
-		return nil, nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.header.Type, s.Name())
+		return nil, nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.Type(), s.Name())
 	}
 }
 
@@ -203,11 +203,11 @@ func (s *responded) CanTransitionTo(next state) bool {
 
 func (s *responded) ExecuteInbound(msg *stateMachineMsg, thid string, ctx *context) (*connectionstore.Record,
 	state, stateAction, error) {
-	switch msg.header.Type {
+	switch msg.Type() {
 	case RequestMsgType:
 		request := &Request{}
 
-		err := json.Unmarshal(msg.payload, request)
+		err := msg.Decode(request)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("JSON unmarshalling of request: %w", err)
 		}
@@ -221,7 +221,7 @@ func (s *responded) ExecuteInbound(msg *stateMachineMsg, thid string, ctx *conte
 	case ResponseMsgType:
 		return msg.connRecord, &completed{}, func() error { return nil }, nil
 	default:
-		return nil, nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.header.Type, s.Name())
+		return nil, nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.Type(), s.Name())
 	}
 }
 
@@ -239,11 +239,11 @@ func (s *completed) CanTransitionTo(next state) bool {
 
 func (s *completed) ExecuteInbound(msg *stateMachineMsg, thid string, ctx *context) (*connectionstore.Record,
 	state, stateAction, error) {
-	switch msg.header.Type {
+	switch msg.Type() {
 	case ResponseMsgType:
 		response := &Response{}
 
-		err := json.Unmarshal(msg.payload, response)
+		err := msg.Decode(response)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("JSON unmarshalling of response: %w", err)
 		}
@@ -258,7 +258,7 @@ func (s *completed) ExecuteInbound(msg *stateMachineMsg, thid string, ctx *conte
 		action := func() error { return nil }
 		return msg.connRecord, &noOp{}, action, nil
 	default:
-		return nil, nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.header.Type, s.Name())
+		return nil, nil, nil, fmt.Errorf("illegal msg type %s for state %s", msg.Type(), s.Name())
 	}
 }
 

--- a/pkg/didcomm/protocol/introduce/models.go
+++ b/pkg/didcomm/protocol/introduce/models.go
@@ -64,7 +64,8 @@ type Content struct {
 // PleaseIntroduceTo includes all field from To structure
 // also it has Discovered the field which should be provided by help-me-discover protocol
 type PleaseIntroduceTo struct {
-	To
+	// nolint: staticcheck
+	To `json:",squash"`
 	// Discovered    Discovered `json:"discovered,omitempty"`
 }
 

--- a/pkg/didcomm/protocol/route/service_test.go
+++ b/pkg/didcomm/protocol/route/service_test.go
@@ -78,9 +78,7 @@ func TestServiceHandleInbound(t *testing.T) {
 
 		msgID := randomID()
 
-		id, err := svc.HandleInbound(&service.DIDCommMsg{Header: &service.Header{
-			ID: msgID,
-		}}, "", "")
+		id, err := svc.HandleInbound(&service.DIDCommMsgMap{"@id": msgID}, "", "")
 		require.NoError(t, err)
 		require.Equal(t, msgID, id)
 	})
@@ -124,7 +122,7 @@ func TestServiceRequestMsg(t *testing.T) {
 			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
-		msg := &service.DIDCommMsg{Payload: []byte("invalid json")}
+		msg := &service.DIDCommMsgMap{"@id": map[int]int{}}
 
 		err = svc.handleRequest(msg, MYDID, THEIRDID)
 		require.Error(t, err)
@@ -187,7 +185,7 @@ func TestServiceGrantMsg(t *testing.T) {
 			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
-		msg := &service.DIDCommMsg{Payload: []byte("invalid json")}
+		msg := &service.DIDCommMsgMap{"@id": map[int]int{}}
 
 		err = svc.handleGrant(msg)
 		require.Error(t, err)
@@ -222,7 +220,7 @@ func TestServiceUpdateKeyListMsg(t *testing.T) {
 			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
-		msg := &service.DIDCommMsg{Payload: []byte("invalid json")}
+		msg := &service.DIDCommMsgMap{"@id": map[int]int{}}
 
 		err = svc.handleKeylistUpdate(msg, MYDID, THEIRDID)
 		require.Error(t, err)
@@ -304,7 +302,7 @@ func TestServiceKeylistUpdateResponseMsg(t *testing.T) {
 			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
-		msg := &service.DIDCommMsg{Payload: []byte("invalid json")}
+		msg := &service.DIDCommMsgMap{"@id": map[int]int{}}
 
 		err = svc.handleKeylistUpdateResponse(msg)
 		require.Error(t, err)
@@ -340,7 +338,7 @@ func TestServiceForwardMsg(t *testing.T) {
 			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
-		msg := &service.DIDCommMsg{Payload: []byte("invalid json")}
+		msg := &service.DIDCommMsgMap{"@id": map[int]int{}}
 
 		err = svc.handleForward(msg)
 		require.Error(t, err)
@@ -539,7 +537,7 @@ func TestRegister(t *testing.T) {
 	})
 }
 
-func generateRequestMsgPayload(t *testing.T, id string) *service.DIDCommMsg {
+func generateRequestMsgPayload(t *testing.T, id string) service.DIDCommMsg {
 	requestBytes, err := json.Marshal(&Request{
 		Type: RequestMsgType,
 		ID:   id,
@@ -552,7 +550,7 @@ func generateRequestMsgPayload(t *testing.T, id string) *service.DIDCommMsg {
 	return didMsg
 }
 
-func generateGrantMsgPayload(t *testing.T, id string) *service.DIDCommMsg {
+func generateGrantMsgPayload(t *testing.T, id string) service.DIDCommMsg {
 	grantBytes, err := json.Marshal(&Grant{
 		Type: GrantMsgType,
 		ID:   id,
@@ -565,7 +563,7 @@ func generateGrantMsgPayload(t *testing.T, id string) *service.DIDCommMsg {
 	return didMsg
 }
 
-func generateKeyUpdateListMsgPayload(t *testing.T, id string, updates []Update) *service.DIDCommMsg {
+func generateKeyUpdateListMsgPayload(t *testing.T, id string, updates []Update) service.DIDCommMsg {
 	requestBytes, err := json.Marshal(&KeylistUpdate{
 		Type:    KeylistUpdateMsgType,
 		ID:      id,
@@ -579,7 +577,7 @@ func generateKeyUpdateListMsgPayload(t *testing.T, id string, updates []Update) 
 	return didMsg
 }
 
-func generateKeylistUpdateResponseMsgPayload(t *testing.T, id string, updates []UpdateResponse) *service.DIDCommMsg {
+func generateKeylistUpdateResponseMsgPayload(t *testing.T, id string, updates []UpdateResponse) service.DIDCommMsg {
 	respBytes, err := json.Marshal(&KeylistUpdateResponse{
 		Type:    KeylistUpdateResponseMsgType,
 		ID:      id,
@@ -593,7 +591,7 @@ func generateKeylistUpdateResponseMsgPayload(t *testing.T, id string, updates []
 	return didMsg
 }
 
-func generateForwardMsgPayload(t *testing.T, id, to string, msg interface{}) *service.DIDCommMsg {
+func generateForwardMsgPayload(t *testing.T, id, to string, msg interface{}) service.DIDCommMsg {
 	requestBytes, err := json.Marshal(&Forward{
 		Type: ForwardMsgType,
 		ID:   id,

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -120,7 +120,7 @@ func (p *Provider) InboundMessageHandler() transport.InboundMessageHandler {
 
 		// find the service which accepts the message type
 		for _, svc := range p.services {
-			if svc.Accept(msg.Header.Type) {
+			if svc.Accept(msg.Type()) {
 				_, err = svc.HandleInbound(msg, myDID, theirDID)
 				return err
 			}
@@ -129,13 +129,19 @@ func (p *Provider) InboundMessageHandler() transport.InboundMessageHandler {
 		// in case of no services are registered for given message type,
 		// find generic inbound services registered for given message header
 		for _, svc := range p.msgSvcProvider.Services() {
-			if svc.Accept(msg.Header) {
+			h := &service.Header{}
+			err = msg.Decode(h)
+			if err != nil {
+				return err
+			}
+
+			if svc.Accept(h) {
 				_, err = svc.HandleInbound(msg, myDID, theirDID)
 				return err
 			}
 		}
 
-		return fmt.Errorf("no message handlers found for the message type: %s", msg.Header.Type)
+		return fmt.Errorf("no message handlers found for the message type: %s", msg.Type())
 	}
 }
 

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package context
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -72,12 +71,12 @@ func TestNewProvider(t *testing.T) {
 			AcceptFunc: func(msgType string) bool {
 				return msgType == "valid-message-type"
 			},
-			HandleFunc: func(msg *service.DIDCommMsg) (string, error) {
+			HandleFunc: func(msg service.DIDCommMsg) (string, error) {
 				payload := &struct {
 					Label string `json:"label,omitempty"`
 				}{}
 
-				err := json.Unmarshal(msg.Payload, payload)
+				err := msg.Decode(payload)
 				if err != nil {
 					return "", fmt.Errorf("invalid payload data format: %w", err)
 				}

--- a/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
@@ -26,8 +26,8 @@ import (
 // MockDIDExchangeSvc mock did exchange service
 type MockDIDExchangeSvc struct {
 	ProtocolName             string
-	HandleFunc               func(*service.DIDCommMsg) (string, error)
-	HandleOutboundFunc       func(msg *service.DIDCommMsg, myDID, theirDID string) error
+	HandleFunc               func(service.DIDCommMsg) (string, error)
+	HandleOutboundFunc       func(msg service.DIDCommMsg, myDID, theirDID string) error
 	AcceptFunc               func(string) bool
 	RegisterActionEventErr   error
 	UnregisterActionEventErr error
@@ -38,7 +38,7 @@ type MockDIDExchangeSvc struct {
 }
 
 // HandleInbound msg
-func (m *MockDIDExchangeSvc) HandleInbound(msg *service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (m *MockDIDExchangeSvc) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
 	if m.HandleFunc != nil {
 		return m.HandleFunc(msg)
 	}
@@ -47,7 +47,7 @@ func (m *MockDIDExchangeSvc) HandleInbound(msg *service.DIDCommMsg, myDID, their
 }
 
 // HandleOutbound msg
-func (m *MockDIDExchangeSvc) HandleOutbound(msg *service.DIDCommMsg, myDID, theirDID string) error {
+func (m *MockDIDExchangeSvc) HandleOutbound(msg service.DIDCommMsg, myDID, theirDID string) error {
 	if m.HandleOutboundFunc != nil {
 		return m.HandleOutboundFunc(msg, myDID, theirDID)
 	}

--- a/pkg/internal/mock/didcomm/protocol/generic/mock_generic_svc.go
+++ b/pkg/internal/mock/didcomm/protocol/generic/mock_generic_svc.go
@@ -36,9 +36,9 @@ type MockMessageSvc struct {
 }
 
 // HandleInbound msg
-func (m *MockMessageSvc) HandleInbound(msg *service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (m *MockMessageSvc) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
 	if m.HandleFunc != nil {
-		return m.HandleFunc(msg)
+		return m.HandleFunc(&msg)
 	}
 
 	return uuid.New().String(), nil

--- a/pkg/internal/mock/didcomm/protocol/route/mock_route.go
+++ b/pkg/internal/mock/didcomm/protocol/route/mock_route.go
@@ -15,14 +15,14 @@ import (
 // MockRouteSvc mock route service
 type MockRouteSvc struct {
 	ProtocolName       string
-	HandleFunc         func(*service.DIDCommMsg) (string, error)
-	HandleOutboundFunc func(msg *service.DIDCommMsg, myDID, theirDID string) error
+	HandleFunc         func(service.DIDCommMsg) (string, error)
+	HandleOutboundFunc func(msg service.DIDCommMsg, myDID, theirDID string) error
 	AcceptFunc         func(string) bool
 	SendRequestFunc    func(myDID, theirDID string) (string, error)
 }
 
 // HandleInbound msg
-func (m *MockRouteSvc) HandleInbound(msg *service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (m *MockRouteSvc) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
 	if m.HandleFunc != nil {
 		return m.HandleFunc(msg)
 	}
@@ -31,7 +31,7 @@ func (m *MockRouteSvc) HandleInbound(msg *service.DIDCommMsg, myDID, theirDID st
 }
 
 // HandleOutbound msg
-func (m *MockRouteSvc) HandleOutbound(msg *service.DIDCommMsg, myDID, theirDID string) error {
+func (m *MockRouteSvc) HandleOutbound(msg service.DIDCommMsg, myDID, theirDID string) error {
 	if m.HandleOutboundFunc != nil {
 		return m.HandleOutboundFunc(msg, myDID, theirDID)
 	}

--- a/pkg/restapi/operation/common/msgservice.go
+++ b/pkg/restapi/operation/common/msgservice.go
@@ -21,9 +21,9 @@ const (
 
 // inboundMsg is the message to be sent to message service webhook
 type inboundMsg struct {
-	Message  *service.DIDCommMsg `json:"message"`
-	MyDID    string              `json:"mydid"`
-	TheirDID string              `json:"theirdid"`
+	Message  service.DIDCommMsgMap `json:"message"`
+	MyDID    string                `json:"mydid"`
+	TheirDID string                `json:"theirdid"`
 }
 
 // newMessageService returns new message service instance
@@ -72,12 +72,12 @@ func (m *msgService) Accept(header *service.Header) bool {
 	return purposeMatched && typeMatched
 }
 
-func (m *msgService) HandleInbound(msg *service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (m *msgService) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
 	if m.name == "" {
 		return "", fmt.Errorf(errTopicNotFound)
 	}
 
-	bytes, err := json.Marshal(&inboundMsg{Message: msg, MyDID: myDID, TheirDID: theirDID})
+	bytes, err := json.Marshal(&inboundMsg{Message: msg.(service.DIDCommMsgMap), MyDID: myDID, TheirDID: theirDID})
 	if err != nil {
 		return "", fmt.Errorf(errMsgSvcHandleFailed, err)
 	}

--- a/pkg/restapi/operation/common/msgservice_test.go
+++ b/pkg/restapi/operation/common/msgservice_test.go
@@ -209,7 +209,7 @@ func TestMsgService_HandleInbound(t *testing.T) {
 		require.NotNil(t, msgsvc)
 
 		go func() {
-			s, err := msgsvc.HandleInbound(&service.DIDCommMsg{Payload: []byte(sampleName)}, myDID, theirDID)
+			s, err := msgsvc.HandleInbound(service.DIDCommMsgMap{"payload": sampleName}, myDID, theirDID)
 			require.NoError(t, err)
 			require.Empty(t, s)
 		}()
@@ -223,7 +223,7 @@ func TestMsgService_HandleInbound(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NotNil(t, msg.Message)
-			require.Equal(t, msg.Message.Payload, []byte(sampleName))
+			require.Equal(t, msg.Message["payload"], sampleName)
 			require.Equal(t, msg.MyDID, myDID)
 			require.Equal(t, msg.TheirDID, theirDID)
 
@@ -234,7 +234,7 @@ func TestMsgService_HandleInbound(t *testing.T) {
 
 	t.Run("message service handle inbound failure", func(t *testing.T) {
 		msgsvc := newMessageService(&RegisterMsgSvcParams{}, mockwebhook.NewMockWebhookNotifier())
-		s, err := msgsvc.HandleInbound(&service.DIDCommMsg{Payload: []byte(sampleName)}, myDID, theirDID)
+		s, err := msgsvc.HandleInbound(service.DIDCommMsgMap{"payload": []byte(sampleName)}, myDID, theirDID)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errTopicNotFound)
 		require.Empty(t, s)

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -415,7 +415,7 @@ func getHandlerWithError(t *testing.T, lookup string, handleErr, acceptErr, impl
 	svc, err := New(&mockprovider.Provider{
 		ServiceValue: &mockdidexchange.MockDIDExchangeSvc{
 			ProtocolName: "mockProtocolSvc",
-			HandleFunc: func(msg *service.DIDCommMsg) (string, error) {
+			HandleFunc: func(msg service.DIDCommMsg) (string, error) {
 				return uuid.New().String(), handleErr
 			},
 			AcceptError:           acceptErr,

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -106,6 +106,8 @@ github.com/minio/sha256-simd v0.0.0-20190131020904-2d45a736cd16 h1:5W7KhL8HVF3XC
 github.com/minio/sha256-simd v0.0.0-20190131020904-2d45a736cd16/go.mod h1:2FMWW+8GMoPweT6+pI63m9YE3Lmw4J71hV56Chs1E/U=
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771 h1:MHkK1uRtFbVqvAgvWxafZe54+5uBxLluGylDiKgdhwo=
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
+github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c h1:nXxl5PrvVm2L/wCy8dQu6DMTwH4oIuGN8GJDAlqDdVE=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mr-tron/base58 v1.1.0/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=

--- a/test/bdd/pkg/didexchange/didexchange_sdk_steps.go
+++ b/test/bdd/pkg/didexchange/didexchange_sdk_steps.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package didexchange
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -296,13 +295,8 @@ func (d *SDKSteps) eventListener(statusCh chan service.StateMsg, agentID string,
 		}
 
 		if e.Type == service.PostState {
-			dst := &bytes.Buffer{}
-			if err := json.Indent(dst, e.Msg.Payload, "", "  "); err != nil {
-				panic(err)
-			}
-
 			if e.StateID != "invited" {
-				logger.Debugf("Agent %s done processing %s message \n%s\n*****", agentID, e.Msg.Header.Type, dst)
+				logger.Debugf("Agent %s done processing %s message \n%s\n*****", agentID, e.Msg.Type(), e.Msg)
 			}
 
 			for _, state := range states {

--- a/test/bdd/pkg/introduce/introduce_sdk_steps.go
+++ b/test/bdd/pkg/introduce/introduce_sdk_steps.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package introduce
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -211,7 +210,7 @@ func (a *SDKSteps) checkAndStop(agentID, introduceeID string) error {
 	select {
 	case e := <-a.actions[agentID]:
 		proposal := &introduceService.Proposal{}
-		if err := json.Unmarshal(e.Message.Payload, proposal); err != nil {
+		if err := e.Message.Decode(proposal); err != nil {
 			return err
 		}
 
@@ -231,7 +230,7 @@ func (a *SDKSteps) handleRequest(agentID, introducee string) error {
 	select {
 	case e := <-a.actions[agentID]:
 		request := &introduceService.Request{}
-		if err := json.Unmarshal(e.Message.Payload, request); err != nil {
+		if err := e.Message.Decode(request); err != nil {
 			return err
 		}
 
@@ -248,7 +247,7 @@ func (a *SDKSteps) handleRequest(agentID, introducee string) error {
 
 		to := &introduceService.To{Name: request.PleaseIntroduceTo.Name}
 		// nolint: govet
-		if err := a.clients[agentID].HandleRequest(*e.Message, to, recipient); err != nil {
+		if err := a.clients[agentID].HandleRequest(e.Message, to, recipient); err != nil {
 			return err
 		}
 
@@ -269,7 +268,7 @@ func (a *SDKSteps) handleRequestWithInvitation(agentID string) error {
 	select {
 	case e := <-a.actions[agentID]:
 		request := &introduceService.Request{}
-		if err := json.Unmarshal(e.Message.Payload, request); err != nil {
+		if err := e.Message.Decode(request); err != nil {
 			return err
 		}
 
@@ -282,7 +281,7 @@ func (a *SDKSteps) handleRequestWithInvitation(agentID string) error {
 
 		to := &introduceService.To{Name: inv.Label}
 		// nolint: govet
-		if err := a.clients[agentID].HandleRequestWithInvitation(*e.Message, inv.Invitation, to); err != nil {
+		if err := a.clients[agentID].HandleRequestWithInvitation(e.Message, inv.Invitation, to); err != nil {
 			return err
 		}
 
@@ -308,7 +307,7 @@ func (a *SDKSteps) checkAndContinue(agentID, introduceeID string) error {
 		}
 
 		proposal := &introduceService.Proposal{}
-		if err := json.Unmarshal(e.Message.Payload, proposal); err != nil {
+		if err := e.Message.Decode(proposal); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
The intention of this PR is to generalize all messages in the system/framework. Because our messages are JSON based messages the structure map[string]interface is enough to make messages with the same type. The benefit of this can be:
* we cannot send an array/string etc.
* the new message type provides common functions ID(),Type() etc.
* message can be modified directly by key (without knowing the structure)

Since the message is a map, it can be modified by some other package/client. To prevent this we need to expose only the message interface. The interface provides Type and Scan functions. Having these functions any package/client may convert a message into a specific structure.

```
type DIDMsg interface {
	ID() string
	Type() string

	ThreadID() (string, error)
	Scan(v interface{}) error
}
```

The usage:
In our current logic, we send events to the client/user. DIDCommAction and StateMsg accordingly. In that case, we cannot expose the message to the client. Because we are using DIDCommMsg message in our services (background handling e.g Continue function).  So, instead of exposing DIDCommMsg we should expose an interface DIDMsg.

Closes https://github.com/hyperledger/aries-framework-go/issues/1065 https://github.com/hyperledger/aries-framework-go/issues/1039