### PR TITLE
refactor: rename current kms to legacykms

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
 )
@@ -33,7 +33,7 @@ var ErrConnectionNotFound = errors.New("connection not found")
 // provider contains dependencies for the DID exchange protocol and is typically created by using aries.Context()
 type provider interface {
 	Service(id string) (interface{}, error)
-	KMS() kms.KeyManager
+	KMS() legacykms.KeyManager
 	InboundTransportEndpoint() string
 	StorageProvider() storage.Provider
 	TransientStorageProvider() storage.Provider
@@ -43,7 +43,7 @@ type provider interface {
 type Client struct {
 	service.Event
 	didexchangeSvc           protocolService
-	kms                      kms.KeyManager
+	kms                      legacykms.KeyManager
 	inboundTransportEndpoint string
 	connectionStore          *connection.Recorder
 }

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	mockprotocol "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
 	mocksvc "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/didexchange"
-	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms/legacykms"
 	mockprovider "github.com/hyperledger/aries-framework-go/pkg/internal/mock/provider"
 	mockstore "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 	mockvdri "github.com/hyperledger/aries-framework-go/pkg/internal/mock/vdri"

--- a/pkg/client/didexchange/example_test.go
+++ b/pkg/client/didexchange/example_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	mockprotocol "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
-	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms/legacykms"
 	mockprovider "github.com/hyperledger/aries-framework-go/pkg/internal/mock/provider"
 	mockstore "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 )

--- a/pkg/didcomm/packager/package_test.go
+++ b/pkg/didcomm/packager/package_test.go
@@ -22,13 +22,13 @@ import (
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm"
 	mockstorage "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
 func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 	t.Run("test failed to unmarshal encMessage", func(t *testing.T) {
-		w, err := kms.New(newMockKMSProvider(mockstorage.NewMockStoreProvider()))
+		w, err := legacykms.New(newMockKMSProvider(mockstorage.NewMockStoreProvider()))
 		require.NoError(t, err)
 
 		mockedProviders := &mockProvider{
@@ -49,7 +49,7 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 	})
 
 	t.Run("test bad encoding type", func(t *testing.T) {
-		w, err := kms.New(newMockKMSProvider(mockstorage.NewMockStoreProvider()))
+		w, err := legacykms.New(newMockKMSProvider(mockstorage.NewMockStoreProvider()))
 		require.NoError(t, err)
 
 		mockedProviders := &mockProvider{
@@ -86,7 +86,7 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 
 	t.Run("test key not found", func(t *testing.T) {
 		wp := newMockKMSProvider(mockstorage.NewMockStoreProvider())
-		w, err := kms.New(wp)
+		w, err := legacykms.New(wp)
 		require.NoError(t, err)
 
 		mockedProviders := &mockProvider{
@@ -127,7 +127,7 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 	})
 
 	t.Run("test Pack/Unpack fails", func(t *testing.T) {
-		w, err := kms.New(newMockKMSProvider(mockstorage.NewMockStoreProvider()))
+		w, err := legacykms.New(newMockKMSProvider(mockstorage.NewMockStoreProvider()))
 		require.NoError(t, err)
 
 		decryptValue := func(envelope []byte) (*transport.Envelope, error) {
@@ -197,7 +197,7 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 
 	t.Run("test Pack/Unpack success", func(t *testing.T) {
 		// create a mock KMS with storage as a map
-		w, err := kms.New(newMockKMSProvider(mockstorage.NewMockStoreProvider()))
+		w, err := legacykms.New(newMockKMSProvider(mockstorage.NewMockStoreProvider()))
 		require.NoError(t, err)
 		mockedProviders := &mockProvider{
 			storage:       mockstorage.NewMockStoreProvider(),
@@ -255,7 +255,7 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 
 	t.Run("test success - dids not found", func(t *testing.T) {
 		// create a mock KMS with storage as a map
-		w, err := kms.New(newMockKMSProvider(mockstorage.NewMockStoreProvider()))
+		w, err := legacykms.New(newMockKMSProvider(mockstorage.NewMockStoreProvider()))
 		require.NoError(t, err)
 		mockedProviders := &mockProvider{
 			storage:       mockstorage.NewMockStoreProvider(),
@@ -296,7 +296,7 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 	t.Run("test failure - did lookup broke", func(t *testing.T) {
 		// create a mock KMS with storage as a map
 
-		w, err := kms.New(newMockKMSProvider(mockstorage.NewMockStoreProvider()))
+		w, err := legacykms.New(newMockKMSProvider(mockstorage.NewMockStoreProvider()))
 		require.NoError(t, err)
 
 		mockedProviders := &mockProvider{
@@ -347,7 +347,7 @@ func newMockKMSProvider(storagePvdr *mockstorage.MockStoreProvider) *mockProvide
 // mockProvider mocks provider for KMS
 type mockProvider struct {
 	storage       *mockstorage.MockStoreProvider
-	kms           kms.KeyManager
+	kms           legacykms.KeyManager
 	packers       []packer.Packer
 	primaryPacker packer.Packer
 	vdriRegistry  vdriapi.Registry
@@ -357,7 +357,7 @@ func (m *mockProvider) Packers() []packer.Packer {
 	return m.packers
 }
 
-func (m *mockProvider) KMS() kms.KeyManager {
+func (m *mockProvider) KMS() legacykms.KeyManager {
 	return m.kms
 }
 

--- a/pkg/didcomm/packer/api.go
+++ b/pkg/didcomm/packer/api.go
@@ -8,12 +8,12 @@ package packer
 
 import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 )
 
 // Provider interface for Packer ctx
 type Provider interface {
-	KMS() kms.KeyManager
+	KMS() legacykms.KeyManager
 }
 
 // Creator method to create new Packer service

--- a/pkg/didcomm/packer/jwe/authcrypt/authcrypt.go
+++ b/pkg/didcomm/packer/jwe/authcrypt/authcrypt.go
@@ -14,7 +14,7 @@ import (
 	chacha "golang.org/x/crypto/chacha20poly1305"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/packer"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 )
 
 // This package deals with Authcrypt encryption for Packing/Unpacking DID Comm exchange
@@ -42,7 +42,7 @@ var errUnsupportedAlg = errors.New("algorithm not supported")
 type Packer struct {
 	alg        ContentEncryption
 	nonceSize  int
-	kms        kms.KeyManager
+	kms        legacykms.KeyManager
 	randReader io.Reader
 }
 

--- a/pkg/didcomm/packer/jwe/authcrypt/authcrypt_test.go
+++ b/pkg/didcomm/packer/jwe/authcrypt/authcrypt_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/internal/cryptoutil"
-	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms/legacykms"
 )
 
 func TestEncodingType(t *testing.T) {

--- a/pkg/didcomm/packer/jwe/authcrypt/decrypt_jwk_test.go
+++ b/pkg/didcomm/packer/jwe/authcrypt/decrypt_jwk_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	chacha "golang.org/x/crypto/chacha20poly1305"
 
-	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms/legacykms"
 )
 
 //nolint:lll

--- a/pkg/didcomm/packer/jwe/authcrypt/encrypt_jwk_test.go
+++ b/pkg/didcomm/packer/jwe/authcrypt/encrypt_jwk_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 	chacha "golang.org/x/crypto/chacha20poly1305"
 
-	mockKMS "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms/legacykms"
 )
 
 func TestNilEncryptSenderJwk(t *testing.T) {
-	mockKMSProvider, err := mockKMS.NewMockProvider()
+	mockKMSProvider, err := mockkms.NewMockProvider()
 	require.NoError(t, err)
 
 	packer, err := New(mockKMSProvider, XC20P)

--- a/pkg/didcomm/packer/legacy/authcrypt/authcrypt.go
+++ b/pkg/didcomm/packer/legacy/authcrypt/authcrypt.go
@@ -11,13 +11,13 @@ import (
 	"io"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/packer"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 )
 
 // Packer represents an Authcrypt Pack/Unpacker that outputs/reads legacy Aries envelopes
 type Packer struct {
 	randSource io.Reader
-	kms        kms.KeyManager
+	kms        legacykms.KeyManager
 }
 
 // encodingType is the `typ` string identifier in a message that identifies the format as being legacy

--- a/pkg/didcomm/packer/legacy/authcrypt/authcrypt_test.go
+++ b/pkg/didcomm/packer/legacy/authcrypt/authcrypt_test.go
@@ -21,9 +21,9 @@ import (
 	"golang.org/x/crypto/ed25519"
 
 	"github.com/hyperledger/aries-framework-go/pkg/internal/cryptoutil"
-	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms/legacykms"
 	mockStorage "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
@@ -56,21 +56,21 @@ func (fw *failReader) Read(out []byte) (int, error) {
 
 type provider struct {
 	storeProvider storage.Provider
-	crypto        kms.KeyManager
+	crypto        legacykms.KeyManager
 }
 
 func (p *provider) StorageProvider() storage.Provider {
 	return p.storeProvider
 }
 
-func newKMS(t *testing.T) (*kms.BaseKMS, storage.Store) {
+func newKMS(t *testing.T) (*legacykms.BaseKMS, storage.Store) {
 	msp := mockStorage.NewMockStoreProvider()
 	p := provider{storeProvider: msp}
 
 	store, err := p.StorageProvider().OpenStore("test-kms")
 	require.NoError(t, err)
 
-	ret, err := kms.New(&p)
+	ret, err := legacykms.New(&p)
 	require.NoError(t, err)
 
 	return ret, store
@@ -121,11 +121,11 @@ func persistKey(pub, priv string, store storage.Store) error {
 	return store.Put(pub, data)
 }
 
-func (p *provider) KMS() kms.KeyManager {
+func (p *provider) KMS() legacykms.KeyManager {
 	return p.crypto
 }
 
-func newWithKMS(k kms.KeyManager) *Packer {
+func newWithKMS(k legacykms.KeyManager) *Packer {
 	return New(&provider{
 		crypto: k,
 	})

--- a/pkg/didcomm/packer/legacy/authcrypt/pack.go
+++ b/pkg/didcomm/packer/legacy/authcrypt/pack.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/crypto/poly1305"
 
 	"github.com/hyperledger/aries-framework-go/pkg/internal/cryptoutil"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 )
 
 // Pack will encode the payload argument
@@ -138,7 +138,7 @@ func (p *Packer) buildRecipient(cek *[chacha.KeySize]byte, senderKey, recKey []b
 		return nil, err
 	}
 
-	box, err := kms.NewCryptoBox(p.kms)
+	box, err := legacykms.NewCryptoBox(p.kms)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/didcomm/packer/legacy/authcrypt/unpack.go
+++ b/pkg/didcomm/packer/legacy/authcrypt/unpack.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/cryptoutil"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 )
 
 // Unpack will decode the envelope using the legacy format
@@ -72,7 +72,7 @@ type keys struct {
 	myKey    []byte
 }
 
-func getCEK(recipients []recipient, km kms.KeyManager) (*keys, error) {
+func getCEK(recipients []recipient, km legacykms.KeyManager) (*keys, error) {
 	var candidateKeys []string
 
 	for _, candidate := range recipients {
@@ -107,7 +107,7 @@ func getCEK(recipients []recipient, km kms.KeyManager) (*keys, error) {
 		return nil, err
 	}
 
-	b, err := kms.NewCryptoBox(km)
+	b, err := legacykms.NewCryptoBox(km)
 	if err != nil {
 		return nil, err
 	}
@@ -128,13 +128,13 @@ func getCEK(recipients []recipient, km kms.KeyManager) (*keys, error) {
 	}, nil
 }
 
-func decodeSender(b64Sender string, pk []byte, km kms.KeyManager) ([]byte, []byte, error) {
+func decodeSender(b64Sender string, pk []byte, km legacykms.KeyManager) ([]byte, []byte, error) {
 	encSender, err := base64.URLEncoding.DecodeString(b64Sender)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	b, err := kms.NewCryptoBox(km)
+	b, err := legacykms.NewCryptoBox(km)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
 )
@@ -58,7 +58,7 @@ type provider interface {
 	OutboundDispatcher() dispatcher.Outbound
 	StorageProvider() storage.Provider
 	TransientStorageProvider() storage.Provider
-	Signer() kms.Signer
+	Signer() legacykms.Signer
 	VDRIRegistry() vdriapi.Registry
 }
 
@@ -81,7 +81,7 @@ type Service struct {
 
 type context struct {
 	outboundDispatcher dispatcher.Outbound
-	signer             kms.Signer
+	signer             legacykms.Signer
 	connectionStore    *connectionStore
 	vdriRegistry       vdriapi.Registry
 }

--- a/pkg/didcomm/protocol/route/service.go
+++ b/pkg/didcomm/protocol/route/service.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
@@ -67,7 +67,7 @@ type provider interface {
 	OutboundDispatcher() dispatcher.Outbound
 	StorageProvider() storage.Provider
 	InboundTransportEndpoint() string
-	KMS() kms.KeyManager
+	KMS() legacykms.KeyManager
 }
 
 // Service for Route Coordination protocol.
@@ -78,7 +78,7 @@ type Service struct {
 	routeStore storage.Store
 	outbound   dispatcher.Outbound
 	endpoint   string
-	kms        kms.KeyManager
+	kms        legacykms.KeyManager
 }
 
 // New return route coordination service.

--- a/pkg/didcomm/protocol/route/service_test.go
+++ b/pkg/didcomm/protocol/route/service_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
-	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms/legacykms"
 	mockprovider "github.com/hyperledger/aries-framework-go/pkg/internal/mock/provider"
 	mockstore "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 )

--- a/pkg/framework/aries/api/protocol.go
+++ b/pkg/framework/aries/api/protocol.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
@@ -25,12 +25,12 @@ type Provider interface {
 	OutboundDispatcher() dispatcher.Outbound
 	Service(id string) (interface{}, error)
 	StorageProvider() storage.Provider
-	KMS() kms.KeyManager
+	KMS() legacykms.KeyManager
 	Crypto() crypto.Crypto
 	Packager() transport.Packager
 	InboundTransportEndpoint() string
 	VDRIRegistry() vdriapi.Registry
-	Signer() kms.Signer
+	Signer() legacykms.Signer
 	TransientStorageProvider() storage.Provider
 }
 

--- a/pkg/framework/aries/api/wallet.go
+++ b/pkg/framework/aries/api/wallet.go
@@ -9,14 +9,14 @@ package api
 import (
 	"io"
 
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 )
 
 // CloseableKMS interface
 type CloseableKMS interface {
 	io.Closer
-	kms.KeyManager
-	kms.Signer
+	legacykms.KeyManager
+	legacykms.Signer
 }
 
 // KMSCreator method to create new key management service

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/route"
 	arieshttp "github.com/hyperledger/aries-framework-go/pkg/didcomm/transport/http"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 )
 
 // defFrameworkOpts provides default framework options
@@ -73,7 +73,7 @@ func newRouteSvc() api.ProtocolSvcCreator {
 func setAdditionalDefaultOpts(frameworkOpts *Aries) error {
 	if frameworkOpts.kmsCreator == nil {
 		frameworkOpts.kmsCreator = func(provider api.Provider) (api.CloseableKMS, error) {
-			return kms.New(provider)
+			return legacykms.New(provider)
 		}
 	}
 

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/msghandler"
 	mockdidexchange "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/didexchange"
-	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms/legacykms"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 	mockvdri "github.com/hyperledger/aries-framework-go/pkg/internal/mock/vdri"
 	"github.com/hyperledger/aries-framework-go/pkg/storage/leveldb"

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
@@ -27,7 +27,7 @@ type Provider struct {
 	msgSvcProvider           api.MessageServiceProvider
 	storeProvider            storage.Provider
 	transientStoreProvider   storage.Provider
-	kms                      kms.KMS
+	kms                      legacykms.KMS
 	crypto                   crypto.Crypto
 	packager                 commontransport.Packager
 	primaryPacker            packer.Packer
@@ -76,7 +76,7 @@ func (p *Provider) Service(id string) (interface{}, error) {
 }
 
 // KMS returns a kms service.
-func (p *Provider) KMS() kms.KeyManager {
+func (p *Provider) KMS() legacykms.KeyManager {
 	return p.kms
 }
 
@@ -101,7 +101,7 @@ func (p *Provider) PrimaryPacker() packer.Packer {
 }
 
 // Signer returns a kms signing service.
-func (p *Provider) Signer() kms.Signer {
+func (p *Provider) Signer() legacykms.Signer {
 	return p.kms
 }
 
@@ -200,7 +200,7 @@ func WithProtocolServices(services ...dispatcher.Service) ProviderOption {
 }
 
 // WithKMS injects a kms service into the context.
-func WithKMS(w kms.KMS) ProviderOption {
+func WithKMS(w legacykms.KMS) ProviderOption {
 	return func(opts *Provider) error {
 		opts.kms = w
 		return nil

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -25,7 +25,7 @@ import (
 	mockpackager "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/packager"
 	mockdidexchange "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/generic"
-	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms/legacykms"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 	mockvdri "github.com/hyperledger/aries-framework-go/pkg/internal/mock/vdri"
 )

--- a/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
@@ -16,10 +16,10 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
-	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms/legacykms"
 	mockstore "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 	mockvdri "github.com/hyperledger/aries-framework-go/pkg/internal/mock/vdri"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
@@ -167,7 +167,7 @@ func (p *MockProvider) TransientStorageProvider() storage.Provider {
 }
 
 // Signer is mock signer for DID exchange service
-func (p *MockProvider) Signer() kms.Signer {
+func (p *MockProvider) Signer() legacykms.Signer {
 	return &mockkms.CloseableKMS{}
 }
 

--- a/pkg/internal/mock/didcomm/protocol/mock_protocol.go
+++ b/pkg/internal/mock/didcomm/protocol/mock_protocol.go
@@ -10,10 +10,10 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
-	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms/legacykms"
 	mockstore "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 	mockvdri "github.com/hyperledger/aries-framework-go/pkg/internal/mock/vdri"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
@@ -48,7 +48,7 @@ func (p *MockProvider) TransientStorageProvider() storage.Provider {
 }
 
 // Signer is mock signer for DID exchange service
-func (p *MockProvider) Signer() kms.Signer {
+func (p *MockProvider) Signer() legacykms.Signer {
 	return &mockkms.CloseableKMS{}
 }
 

--- a/pkg/internal/mock/kms/legacykms/mock_kms.go
+++ b/pkg/internal/mock/kms/legacykms/mock_kms.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package kms
+package legacykms
 
 import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"

--- a/pkg/internal/mock/kms/legacykms/mock_kms_provider.go
+++ b/pkg/internal/mock/kms/legacykms/mock_kms_provider.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package kms
+package legacykms
 
 import (
 	"encoding/json"
@@ -14,7 +14,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/internal/cryptoutil"
 	mockprovider "github.com/hyperledger/aries-framework-go/pkg/internal/mock/provider"
 	mockstorage "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
@@ -39,7 +39,7 @@ func NewMockProvider(kp ...*cryptoutil.MessagingKeys) (*mockprovider.Provider, e
 			Store: store,
 		}}}
 
-	w, err := kms.New(mProvider)
+	w, err := legacykms.New(mProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/internal/mock/provider/mock_provider.go
+++ b/pkg/internal/mock/provider/mock_provider.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/packer"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
@@ -18,7 +18,7 @@ import (
 type Provider struct {
 	ServiceValue                  interface{}
 	ServiceErr                    error
-	KMSValue                      kms.KeyManager
+	KMSValue                      legacykms.KeyManager
 	InboundEndpointValue          string
 	StorageProviderValue          storage.Provider
 	TransientStorageProviderValue storage.Provider
@@ -34,7 +34,7 @@ func (p *Provider) Service(id string) (interface{}, error) {
 }
 
 // KMS returns a KMS instance
-func (p *Provider) KMS() kms.KeyManager {
+func (p *Provider) KMS() legacykms.KeyManager {
 	return p.KMSValue
 }
 

--- a/pkg/kms/legacykms/api.go
+++ b/pkg/kms/legacykms/api.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package kms
+package legacykms
 
 // TODO https://github.com/hyperledger/aries-framework-go/issues/752 Signer is not part of KMS and should be
 //  moved elsewhere, merge KMS and KeyManager interface when Signer is removed.

--- a/pkg/kms/legacykms/crypto_box.go
+++ b/pkg/kms/legacykms/crypto_box.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package kms
+package legacykms
 
 import (
 	"errors"

--- a/pkg/kms/legacykms/crypto_box_test.go
+++ b/pkg/kms/legacykms/crypto_box_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package kms
+package legacykms
 
 import (
 	"crypto/rand"

--- a/pkg/kms/legacykms/kms.go
+++ b/pkg/kms/legacykms/kms.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package kms
+package legacykms
 
 import (
 	"crypto/ed25519"

--- a/pkg/kms/legacykms/kms_test.go
+++ b/pkg/kms/legacykms/kms_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package kms
+package legacykms
 
 import (
 	"crypto/rand"

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/common/support"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 	resterrors "github.com/hyperledger/aries-framework-go/pkg/restapi/errors"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation/didexchange/models"
@@ -73,7 +73,7 @@ const (
 // provider contains dependencies for the Exchange protocol and is typically created by using aries.Context()
 type provider interface {
 	Service(id string) (interface{}, error)
-	KMS() kms.KeyManager
+	KMS() legacykms.KeyManager
 	InboundTransportEndpoint() string
 	StorageProvider() storage.Provider
 	TransientStorageProvider() storage.Provider

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -31,7 +31,7 @@ import (
 	didexsvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
 	mockdidexchange "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/didexchange"
-	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms/legacykms"
 	mockprovider "github.com/hyperledger/aries-framework-go/pkg/internal/mock/provider"
 	mockstore "github.com/hyperledger/aries-framework-go/pkg/internal/mock/storage"
 	mockvdri "github.com/hyperledger/aries-framework-go/pkg/internal/mock/vdri"

--- a/pkg/vdri/registry.go
+++ b/pkg/vdri/registry.go
@@ -13,7 +13,7 @@ import (
 
 	diddoc "github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 )
 
 const (
@@ -25,13 +25,13 @@ type Option func(opts *Registry)
 
 // provider contains dependencies for the did creator
 type provider interface {
-	KMS() kms.KeyManager
+	KMS() legacykms.KeyManager
 }
 
 // Registry vdri registry
 type Registry struct {
 	vdri               []vdriapi.VDRI
-	crypto             kms.KeyManager
+	crypto             legacykms.KeyManager
 	defServiceEndpoint string
 	defServiceType     string
 }

--- a/pkg/vdri/registry_test.go
+++ b/pkg/vdri/registry_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
-	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/internal/mock/kms/legacykms"
 	mockprovider "github.com/hyperledger/aries-framework-go/pkg/internal/mock/provider"
 	mockvdri "github.com/hyperledger/aries-framework-go/pkg/internal/mock/vdri"
 )


### PR DESCRIPTION
in order to prepare for #985, this patch renames
current kms packages to legacykms so the new framework
uses the proper package name. This change will also help
depreceate/remove this legacy kms in the future when it
becomes stale.

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
