### PR TITLE
feat: REST binding for message service registration and handling

### DIFF
--- a/cmd/aries-agent-rest/startcmd/start.go
+++ b/cmd/aries-agent-rest/startcmd/start.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
-
 	"github.com/rs/cors"
 	"github.com/spf13/cobra"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/defaults"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/context"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi"
+	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
 	"github.com/hyperledger/aries-framework-go/pkg/vdri/httpbinding"
 )
 
@@ -143,7 +143,7 @@ type agentParameters struct {
 	host, inboundHostInternal, inboundHostExternal, dbPath, defaultLabel, inboundTransport string
 	webhookURLs, httpResolvers, outboundTransports                                         []string
 	autoAccept                                                                             bool
-	msgHandler                                                                             restapi.MessageHandler
+	msgHandler                                                                             operation.MessageHandler
 }
 
 type server interface {

--- a/pkg/didcomm/msghandler/msghandler.go
+++ b/pkg/didcomm/msghandler/msghandler.go
@@ -44,7 +44,7 @@ func (m *Registrar) Services() []dispatcher.MessageService {
 	return svcs
 }
 
-// Register registers given message services to this handler
+// Register registers given message services to this handler,
 // returns error in case of duplicate registration
 func (m *Registrar) Register(msgServices ...dispatcher.MessageService) error {
 	if len(msgServices) == 0 {
@@ -74,7 +74,8 @@ func (m *Registrar) Register(msgServices ...dispatcher.MessageService) error {
 	return nil
 }
 
-// Unregister unregisters message service with given name from this message handler
+// Unregister unregisters message service with given name from this message handler,
+// returns error if given message service doesn't exists
 func (m *Registrar) Unregister(name string) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()

--- a/pkg/internal/mock/didcomm/msghandler/mock_msg_handler.go
+++ b/pkg/internal/mock/didcomm/msghandler/mock_msg_handler.go
@@ -10,10 +10,13 @@
 package msghandler
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 )
+
+const errNeverRegistered = "failed to unregister, unable to find registered message service with name `%s`"
 
 // NewMockMsgServiceProvider returns new custom mock message handler
 func NewMockMsgServiceProvider() *MockMsgSvcProvider {
@@ -62,6 +65,10 @@ func (m *MockMsgSvcProvider) Unregister(name string) error {
 			index = i
 			break
 		}
+	}
+
+	if index < 0 {
+		return fmt.Errorf(errNeverRegistered, name)
 	}
 
 	m.svcs = append(m.svcs[:index], m.svcs[index+1:]...)

--- a/pkg/restapi/internal/mocks/webhook/mock_webhook.go
+++ b/pkg/restapi/internal/mocks/webhook/mock_webhook.go
@@ -1,0 +1,29 @@
+/*
+ *
+ * Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * /
+ *
+ */
+
+package webhook
+
+// NewMockWebhookNotifier returns mock webhook notifier implementation
+func NewMockWebhookNotifier() *Notifier {
+	return &Notifier{}
+}
+
+// Notifier is mock implementation of webhook notifier
+type Notifier struct {
+	NotifyFunc func(topic string, message []byte) error
+}
+
+// Notify is mock implementation of webhook notifier Notify()
+func (n *Notifier) Notify(topic string, message []byte) error {
+	if n.NotifyFunc != nil {
+		return n.NotifyFunc(topic, message)
+	}
+
+	return nil
+}

--- a/pkg/restapi/operation/common/models.go
+++ b/pkg/restapi/operation/common/models.go
@@ -42,3 +42,63 @@ type CreatePublicDIDResponse struct {
 	// TODO return base64-encoded raw bytes of the DID doc [Issue: #855]
 	DID *did.Doc `json:"did"`
 }
+
+// RegisterMessageServiceRequest model
+//
+// This is used for operation to register a message service to message handler
+//
+// swagger:parameters registerMsgSvc
+type RegisterMessageServiceRequest struct {
+	// Params for registering message service
+	//
+	// in: body
+	Params *RegisterMsgSvcParams
+}
+
+// RegisterMsgSvcParams contains parameters for registering a message service to message handler
+type RegisterMsgSvcParams struct {
+	// Name of the message service
+	// required: true
+	Name string `json:"name"`
+
+	// Acceptance criteria for message service based on message purpose
+	// in case of multiple purposes, message will be dispatched if any one of the purpose matches
+	// with the purpose of incoming message.
+	// Can be provided in conjunction with other acceptance criteria.
+	Purpose []string `json:"purpose"`
+
+	// Acceptance criteria for message service based on message type.
+	// Can be provided in conjunction with other acceptance criteria.
+	Type string `json:"type"`
+}
+
+// UnregisterMessageServiceRequest model
+//
+// This is used for operation to unregister a message service from message handler
+//
+// swagger:parameters unregisterMsgSvc
+type UnregisterMessageServiceRequest struct {
+	// Params for unregistering a message service
+	//
+	// in: body
+	Params *UnregisterMsgSvcParams
+}
+
+// UnregisterMsgSvcParams contains parameters for unregistering a message service from message handler
+type UnregisterMsgSvcParams struct {
+	// Name of the message service to be unregistered
+	// required: true
+	Name string `json:"name"`
+}
+
+// RegisteredServicesResponse model
+//
+// This is used for returning list of registered service names
+//
+// swagger:response registeredServicesResponse
+type RegisteredServicesResponse struct {
+	// Registered service names
+	//
+	// in: body
+	Names []string `json:"names"`
+}

--- a/pkg/restapi/operation/common/msgservice.go
+++ b/pkg/restapi/operation/common/msgservice.go
@@ -1,0 +1,86 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/restapi/webhook"
+)
+
+const (
+	errMsgSvcHandleFailed = "failed to handle inbound : %w"
+	errTopicNotFound      = "failed to get topic to send notification"
+)
+
+// inboundMsg is the message to be sent to message service webhook
+type inboundMsg struct {
+	Message  *service.DIDCommMsg `json:"message"`
+	MyDID    string              `json:"mydid"`
+	TheirDID string              `json:"theirdid"`
+}
+
+// newMessageService returns new message service instance
+func newMessageService(params *RegisterMsgSvcParams, notifier webhook.Notifier) *msgService {
+	return &msgService{
+		name:     params.Name,
+		purpose:  params.Purpose,
+		msgType:  params.Type,
+		notifier: notifier,
+	}
+}
+
+// msgService is basic message service implementation
+// which delegates handling to registered webhook notifier
+type msgService struct {
+	name     string
+	purpose  []string
+	msgType  string
+	notifier webhook.Notifier
+}
+
+func (m *msgService) Name() string {
+	return m.name
+}
+
+func (m *msgService) Accept(header *service.Header) bool {
+	var purposeMatched, typeMatched = len(m.purpose) == 0, m.msgType == ""
+
+	if purposeMatched && typeMatched {
+		return false
+	}
+
+	for _, purposeCriteria := range m.purpose {
+		for _, msgPurpose := range header.Purpose {
+			if purposeCriteria == msgPurpose {
+				purposeMatched = true
+				break
+			}
+		}
+	}
+
+	if m.msgType == header.Type {
+		typeMatched = true
+	}
+
+	return purposeMatched && typeMatched
+}
+
+func (m *msgService) HandleInbound(msg *service.DIDCommMsg, myDID, theirDID string) (string, error) {
+	if m.name == "" {
+		return "", fmt.Errorf(errTopicNotFound)
+	}
+
+	bytes, err := json.Marshal(&inboundMsg{Message: msg, MyDID: myDID, TheirDID: theirDID})
+	if err != nil {
+		return "", fmt.Errorf(errMsgSvcHandleFailed, err)
+	}
+
+	return "", m.notifier.Notify(m.name, bytes)
+}

--- a/pkg/restapi/operation/common/msgservice_test.go
+++ b/pkg/restapi/operation/common/msgservice_test.go
@@ -1,0 +1,242 @@
+/*
+ *
+ * Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * /
+ *
+ */
+
+package common
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	mockwebhook "github.com/hyperledger/aries-framework-go/pkg/restapi/internal/mocks/webhook"
+)
+
+func TestMsgService_AcceptAndName(t *testing.T) {
+	tests := []struct {
+		name     string
+		service  *RegisterMsgSvcParams
+		testdata []struct {
+			request *service.Header
+			result  bool
+		}
+	}{
+		{
+			name:    "msgService accept with message type and purpose",
+			service: &RegisterMsgSvcParams{Name: "test-01", Type: "msg-type-01", Purpose: []string{"prp-01-01", "prp-01-02"}},
+			testdata: []struct {
+				request *service.Header
+				result  bool
+			}{
+				{
+					&service.Header{Type: "msg-type-01", Purpose: []string{"prp-01-01", "prp-01-02"}},
+					true,
+				},
+				{
+					&service.Header{Type: "msg-type-01", Purpose: []string{"prp-01-02"}},
+					true,
+				},
+				{
+					&service.Header{Type: "msg-type-01", Purpose: []string{"prp-01-01"}},
+					true,
+				},
+				{
+					&service.Header{Type: "msg-type-01", Purpose: []string{"prp-01-01", "prp-01-03", "prp-01-04"}},
+					true,
+				},
+				{
+					&service.Header{Purpose: []string{"prp-01-01", "prp-01-02"}},
+					false,
+				},
+				{
+					&service.Header{Purpose: []string{"prp-01-02"}},
+					false,
+				},
+				{
+					&service.Header{Type: "msg-type-01"},
+					false,
+				},
+				{
+					&service.Header{Type: "msg-type-02", Purpose: []string{"prp-02-01", "prp-02-02"}},
+					false,
+				},
+			},
+		},
+		{
+			name:    "msgService accept success with only purposes",
+			service: &RegisterMsgSvcParams{Name: "test-01", Purpose: []string{"prp-01-01", "prp-01-02"}},
+			testdata: []struct {
+				request *service.Header
+				result  bool
+			}{
+				{
+					&service.Header{Type: "msg-type-01", Purpose: []string{"prp-01-01", "prp-01-02"}},
+					true,
+				},
+				{
+					&service.Header{Type: "msg-type-01", Purpose: []string{"prp-01-02"}},
+					true,
+				},
+				{
+					&service.Header{Type: "msg-type-01", Purpose: []string{"prp-01-01"}},
+					true,
+				},
+				{
+					&service.Header{Type: "msg-type-01", Purpose: []string{"prp-01-01", "prp-01-03", "prp-01-04"}},
+					true,
+				},
+				{
+					&service.Header{Purpose: []string{"prp-01-01", "prp-01-02"}},
+					true,
+				},
+				{
+					&service.Header{Purpose: []string{"prp-01-02"}},
+					true,
+				},
+				{
+					&service.Header{Purpose: []string{"prp-02-01", "prp-02-02"}},
+					false,
+				},
+				{
+					&service.Header{Type: "msg-type-01"},
+					false,
+				},
+				{
+					&service.Header{Type: "msg-type-02", Purpose: []string{"prp-02-01", "prp-02-02"}},
+					false,
+				},
+			},
+		},
+		{
+			name:    "msgService accept success with only message type",
+			service: &RegisterMsgSvcParams{Name: "test-01", Type: "msg-type-01"},
+			testdata: []struct {
+				request *service.Header
+				result  bool
+			}{
+				{
+					&service.Header{Type: "msg-type-01", Purpose: []string{"prp-01-01", "prp-01-02"}},
+					true,
+				},
+				{
+					&service.Header{Type: "msg-type-01", Purpose: []string{"prp-01-02"}},
+					true,
+				},
+				{
+					&service.Header{Purpose: []string{"prp-01-01", "prp-01-02"}},
+					false,
+				},
+				{
+					&service.Header{Purpose: []string{"prp-01-02"}},
+					false,
+				},
+				{
+					&service.Header{Type: "msg-type-02"},
+					false,
+				},
+			},
+		},
+		{
+			name:    "msgService accept failure with no criteria",
+			service: &RegisterMsgSvcParams{Name: "test-01"},
+			testdata: []struct {
+				request *service.Header
+				result  bool
+			}{
+				{
+					&service.Header{Type: "msg-type-01", Purpose: []string{"prp-01-01", "prp-01-02"}},
+					false,
+				},
+				{
+					&service.Header{Type: "msg-type-01", Purpose: []string{"prp-01-02"}},
+					false,
+				},
+				{
+					&service.Header{Purpose: []string{"prp-01-01", "prp-01-02"}},
+					false,
+				},
+				{
+					&service.Header{Type: "msg-type-02"},
+					false,
+				},
+			},
+		},
+	}
+
+	t.Parallel()
+
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.name, func(t *testing.T) {
+			msgsvc := newMessageService(tc.service, nil)
+			require.NotNil(t, msgsvc)
+			require.Equal(t, tc.service.Name, msgsvc.Name())
+
+			for _, testdata := range tc.testdata {
+				require.Equal(t, testdata.result, msgsvc.Accept(testdata.request),
+					"test failed header[%v] and criteria[%s]; expected[%v]", testdata.request, tc.service, testdata.result)
+			}
+		})
+	}
+}
+
+func TestMsgService_HandleInbound(t *testing.T) {
+	const sampleName = "sample-msgsvc-01"
+
+	const myDID = "sample-mydid-01"
+
+	const theirDID = "sample-theriDID-01"
+
+	t.Run("message service handle inbound success", func(t *testing.T) {
+		webhookCh := make(chan []byte)
+
+		msgsvc := newMessageService(&RegisterMsgSvcParams{Name: sampleName},
+			&mockwebhook.Notifier{
+				NotifyFunc: func(topic string, message []byte) error {
+					require.Equal(t, sampleName, topic)
+					webhookCh <- message
+					return nil
+				},
+			})
+		require.NotNil(t, msgsvc)
+
+		go func() {
+			s, err := msgsvc.HandleInbound(&service.DIDCommMsg{Payload: []byte(sampleName)}, myDID, theirDID)
+			require.NoError(t, err)
+			require.Empty(t, s)
+		}()
+
+		select {
+		case msgBytes := <-webhookCh:
+			require.NotEmpty(t, msgBytes)
+
+			msg := inboundMsg{}
+			err := json.Unmarshal(msgBytes, &msg)
+			require.NoError(t, err)
+
+			require.NotNil(t, msg.Message)
+			require.Equal(t, msg.Message.Payload, []byte(sampleName))
+			require.Equal(t, msg.MyDID, myDID)
+			require.Equal(t, msg.TheirDID, theirDID)
+
+		case <-time.After(2 * time.Second):
+			require.Fail(t, "didn't receive topic [%s] to webhook", sampleName)
+		}
+	})
+
+	t.Run("message service handle inbound failure", func(t *testing.T) {
+		msgsvc := newMessageService(&RegisterMsgSvcParams{}, mockwebhook.NewMockWebhookNotifier())
+		s, err := msgsvc.HandleInbound(&service.DIDCommMsg{Payload: []byte(sampleName)}, myDID, theirDID)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errTopicNotFound)
+		require.Empty(t, s)
+	})
+}

--- a/pkg/restapi/operation/common/operation.go
+++ b/pkg/restapi/operation/common/operation.go
@@ -16,27 +16,46 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/hyperledger/aries-framework-go/pkg/restapi/webhook"
+
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/common/support"
-	"github.com/hyperledger/aries-framework-go/pkg/restapi/errors"
+	resterrors "github.com/hyperledger/aries-framework-go/pkg/restapi/errors"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
 )
 
 var logger = log.New("aries-framework/controller/common")
 
 const (
+	// vdri endpoints
 	vdriOperationID     = "/vdri"
 	createPublicDIDPath = vdriOperationID + "/create-public-did"
+
+	// message service endpoints
+	msgServiceOperationID = "/message"
+	registerMsgService    = msgServiceOperationID + "/register-service"
+	unregisterMsgService  = msgServiceOperationID + "/unregister-service"
+	msgServiceList        = msgServiceOperationID + "/services"
+
+	// error messages
+	errMsgSvcNameRequired       = "service name is required"
+	errMsgInvalidAcceptanceCrit = "invalid acceptance criteria"
 )
 
 // Error codes
 const (
 	// InvalidRequestErrorCode is typically a code for invalid requests
-	InvalidRequestErrorCode = errors.Code(iota + errors.Common)
+	InvalidRequestErrorCode = resterrors.Code(iota + resterrors.Common)
 
 	// CreatePublicDIDError is for failures while creating public DIDs
 	CreatePublicDIDError
+
+	// RegisterMsgSvcError is for failures while registering new message service
+	RegisterMsgSvcError
+
+	// UnregisterMsgSvcError is for failures while unregistering a message service
+	UnregisterMsgSvcError
 )
 
 // provider contains dependencies for the common controller operations
@@ -47,19 +66,23 @@ type provider interface {
 
 // Operation contains basic common operations provided by controller REST API
 type Operation struct {
-	ctx      provider
-	handlers []operation.Handler
+	ctx          provider
+	handlers     []operation.Handler
+	msgRegistrar operation.MessageHandler
+	notifier     webhook.Notifier
 }
 
 // New returns new common operations rest client instance
-func New(ctx provider) *Operation {
-	o := &Operation{ctx: ctx}
+func New(ctx provider, registrar operation.MessageHandler, notifier webhook.Notifier) *Operation {
+	o := &Operation{
+		ctx:          ctx,
+		msgRegistrar: registrar,
+		notifier:     notifier,
+	}
 	defer o.registerHandler()
 
 	return o
 }
-
-//
 
 // GetRESTHandlers get all controller API handler available for this service
 func (o *Operation) GetRESTHandlers() []operation.Handler {
@@ -71,6 +94,9 @@ func (o *Operation) registerHandler() {
 	// Add more protocol endpoints here to expose them as controller API endpoints
 	o.handlers = []operation.Handler{
 		support.NewHTTPHandler(createPublicDIDPath, http.MethodPost, o.CreatePublicDID),
+		support.NewHTTPHandler(registerMsgService, http.MethodPost, o.RegisterMessageService),
+		support.NewHTTPHandler(unregisterMsgService, http.MethodPost, o.UnregisterMessageService),
+		support.NewHTTPHandler(msgServiceList, http.MethodGet, o.RegisteredServices),
 	}
 }
 
@@ -86,12 +112,12 @@ func (o *Operation) CreatePublicDID(rw http.ResponseWriter, req *http.Request) {
 
 	err := getQueryParams(&request, req.URL.Query())
 	if err != nil {
-		errors.SendHTTPBadRequest(rw, InvalidRequestErrorCode, err)
+		resterrors.SendHTTPBadRequest(rw, InvalidRequestErrorCode, err)
 		return
 	}
 
 	if request.CreatePublicDIDParams == nil || request.Method == "" {
-		errors.SendHTTPBadRequest(rw, InvalidRequestErrorCode, fmt.Errorf("invalid method name"))
+		resterrors.SendHTTPBadRequest(rw, InvalidRequestErrorCode, fmt.Errorf("invalid method name"))
 		return
 	}
 
@@ -100,11 +126,90 @@ func (o *Operation) CreatePublicDID(rw http.ResponseWriter, req *http.Request) {
 	doc, err := o.ctx.VDRIRegistry().Create(strings.ToLower(request.Method),
 		vdriapi.WithRequestBuilder(getBasicRequestBuilder(request.RequestHeader)))
 	if err != nil {
-		errors.SendHTTPInternalServerError(rw, CreatePublicDIDError, err)
+		resterrors.SendHTTPInternalServerError(rw, CreatePublicDIDError, err)
 		return
 	}
 
 	o.writeResponse(rw, CreatePublicDIDResponse{DID: doc})
+}
+
+// RegisterMessageService swagger:route POST /message/register-service message registerMsgSvc
+//
+// registers new message service to message handler registrar
+//
+// Responses:
+//    default: genericError
+func (o *Operation) RegisterMessageService(rw http.ResponseWriter, req *http.Request) {
+	var request RegisterMessageServiceRequest
+
+	err := json.NewDecoder(req.Body).Decode(&request.Params)
+	if err != nil {
+		resterrors.SendHTTPBadRequest(rw, InvalidRequestErrorCode, err)
+		return
+	}
+
+	if request.Params.Name == "" {
+		resterrors.SendHTTPBadRequest(rw, InvalidRequestErrorCode, fmt.Errorf(errMsgSvcNameRequired))
+		return
+	}
+
+	if len(request.Params.Purpose) == 0 || request.Params.Type == "" {
+		resterrors.SendHTTPBadRequest(rw, InvalidRequestErrorCode, fmt.Errorf(errMsgInvalidAcceptanceCrit))
+		return
+	}
+
+	err = o.msgRegistrar.Register(newMessageService(request.Params, o.notifier))
+	if err != nil {
+		resterrors.SendHTTPInternalServerError(rw, RegisterMsgSvcError, err)
+		return
+	}
+
+	rw.WriteHeader(http.StatusOK)
+}
+
+// UnregisterMessageService swagger:route POST /message/unregister-service message unregisterMsgSvc
+//
+// unregisters given message service handler registrar
+//
+// Responses:
+//    default: genericError
+func (o *Operation) UnregisterMessageService(rw http.ResponseWriter, req *http.Request) {
+	var request UnregisterMessageServiceRequest
+
+	err := json.NewDecoder(req.Body).Decode(&request.Params)
+	if err != nil {
+		resterrors.SendHTTPBadRequest(rw, InvalidRequestErrorCode, err)
+		return
+	}
+
+	if request.Params.Name == "" {
+		resterrors.SendHTTPBadRequest(rw, InvalidRequestErrorCode, fmt.Errorf(errMsgSvcNameRequired))
+		return
+	}
+
+	err = o.msgRegistrar.Unregister(request.Params.Name)
+	if err != nil {
+		resterrors.SendHTTPInternalServerError(rw, UnregisterMsgSvcError, err)
+		return
+	}
+
+	rw.WriteHeader(http.StatusOK)
+}
+
+// RegisteredServices swagger:route GET /message/services message services
+//
+// returns list of registered service names
+//
+// Responses:
+//    default: genericError
+//    200: registeredServicesResponse
+func (o *Operation) RegisteredServices(rw http.ResponseWriter, req *http.Request) {
+	names := []string{}
+	for _, svc := range o.msgRegistrar.Services() {
+		names = append(names, svc.Name())
+	}
+
+	o.writeResponse(rw, RegisteredServicesResponse{Names: names})
 }
 
 // writeResponse writes interface value to response

--- a/pkg/restapi/operation/common/operation_test.go
+++ b/pkg/restapi/operation/common/operation_test.go
@@ -18,14 +18,19 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/msghandler"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/generic"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/vdri"
 	resterrs "github.com/hyperledger/aries-framework-go/pkg/restapi/errors"
+	"github.com/hyperledger/aries-framework-go/pkg/restapi/internal/mocks/webhook"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
 )
 
 func TestOperation_GetAPIHandlers(t *testing.T) {
-	svc := New(&protocol.MockProvider{})
+	svc := New(&protocol.MockProvider{}, msghandler.NewMockMsgServiceProvider(), webhook.NewMockWebhookNotifier())
 	require.NotNil(t, svc)
 
 	handlers := svc.GetRESTHandlers()
@@ -34,10 +39,10 @@ func TestOperation_GetAPIHandlers(t *testing.T) {
 
 func TestOperation_CreatePublicDID(t *testing.T) {
 	t.Run("Successful Create public DID", func(t *testing.T) {
-		svc := New(&protocol.MockProvider{})
+		svc := New(&protocol.MockProvider{}, msghandler.NewMockMsgServiceProvider(), webhook.NewMockWebhookNotifier())
 		require.NotNil(t, svc)
 
-		handler := lookupCreatePublicDIDHandler(t, svc)
+		handler := lookupCreatePublicDIDHandler(t, svc, createPublicDIDPath)
 		buf, err := getSuccessResponseFromHandler(handler, nil, handler.Path()+"?method=sidetree")
 		require.NoError(t, err)
 
@@ -54,32 +59,229 @@ func TestOperation_CreatePublicDID(t *testing.T) {
 	})
 
 	t.Run("Failed Create public DID", func(t *testing.T) {
-		svc := New(&protocol.MockProvider{})
+		svc := New(&protocol.MockProvider{}, msghandler.NewMockMsgServiceProvider(), webhook.NewMockWebhookNotifier())
 		require.NotNil(t, svc)
 
-		handler := lookupCreatePublicDIDHandler(t, svc)
+		handler := lookupCreatePublicDIDHandler(t, svc, createPublicDIDPath)
 		buf, code, err := sendRequestToHandler(handler, nil, handler.Path())
 		require.NoError(t, err)
 		require.Equal(t, http.StatusBadRequest, code)
-		verifyError(t, InvalidRequestErrorCode, buf.Bytes())
+		verifyError(t, InvalidRequestErrorCode, "", buf.Bytes())
 
-		handler = lookupCreatePublicDIDHandler(t, svc)
+		handler = lookupCreatePublicDIDHandler(t, svc, createPublicDIDPath)
 		buf, code, err = sendRequestToHandler(handler, nil, handler.Path()+"?-----")
 		require.NoError(t, err)
 		require.Equal(t, http.StatusBadRequest, code)
-		verifyError(t, InvalidRequestErrorCode, buf.Bytes())
+		verifyError(t, InvalidRequestErrorCode, "", buf.Bytes())
 	})
 
 	t.Run("Failed Create public DID, VDRI error", func(t *testing.T) {
-		svc := New(&protocol.MockProvider{CustomVDRI: &vdri.MockVDRIRegistry{CreateErr: fmt.Errorf("just-fail-it")}})
+		svc := New(&protocol.MockProvider{CustomVDRI: &vdri.MockVDRIRegistry{CreateErr: fmt.Errorf("just-fail-it")}},
+			msghandler.NewMockMsgServiceProvider(), webhook.NewMockWebhookNotifier())
 		require.NotNil(t, svc)
 
-		handler := lookupCreatePublicDIDHandler(t, svc)
+		handler := lookupCreatePublicDIDHandler(t, svc, createPublicDIDPath)
 		buf, code, err := sendRequestToHandler(handler, nil, handler.Path()+"?method=valid")
 		require.NoError(t, err)
 		require.Equal(t, http.StatusInternalServerError, code)
-		verifyError(t, CreatePublicDIDError, buf.Bytes())
+		verifyError(t, CreatePublicDIDError, "", buf.Bytes())
 	})
+}
+
+func TestOperation_RegisterMessageService(t *testing.T) {
+	t.Run("Successful Register Message Service", func(t *testing.T) {
+		mhandler := msghandler.NewMockMsgServiceProvider()
+		svc := New(&protocol.MockProvider{}, mhandler, webhook.NewMockWebhookNotifier())
+		require.NotNil(t, svc)
+
+		var jsonStr = []byte(`{
+		"name":"json-msg-01",
+    	"type": "https://didcomm.org/json/1.0/msg",
+    	"purpose": ["prp-01","prp-02"]
+  	}`)
+
+		handler := lookupCreatePublicDIDHandler(t, svc, registerMsgService)
+		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
+		require.NoError(t, err)
+		require.Empty(t, buf)
+
+		// verify if new service is registered
+		require.NotEmpty(t, mhandler.Services())
+		require.Equal(t, "json-msg-01", mhandler.Services()[0].Name())
+		require.True(t, mhandler.Services()[0].Accept(
+			&service.Header{Type: "https://didcomm.org/json/1.0/msg",
+				Purpose: []string{"prp-01", "prp-02"}},
+		))
+	})
+
+	t.Run("Register Message Service Input validation", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			json      string
+			errorCode resterrs.Code
+			errorMsg  string
+		}{
+			{
+				name:      "missing name test",
+				json:      `{"type": "https://didcomm.org/json/1.0/msg","purpose": ["prp-01","prp-02"]}`,
+				errorCode: InvalidRequestErrorCode,
+				errorMsg:  errMsgSvcNameRequired,
+			},
+			{
+				name:      "missing name test",
+				json:      `{"name": "svx-001"}`,
+				errorCode: InvalidRequestErrorCode,
+				errorMsg:  errMsgInvalidAcceptanceCrit,
+			},
+			{
+				name:      "missing name test",
+				json:      `-----`,
+				errorCode: InvalidRequestErrorCode,
+				errorMsg:  "invalid character",
+			},
+		}
+
+		t.Parallel()
+
+		for _, test := range tests {
+			tc := test
+			t.Run(tc.name, func(t *testing.T) {
+				svc := New(&protocol.MockProvider{}, msghandler.NewMockMsgServiceProvider(), webhook.NewMockWebhookNotifier())
+				require.NotNil(t, svc)
+
+				handler := lookupCreatePublicDIDHandler(t, svc, registerMsgService)
+				buf, code, err := sendRequestToHandler(handler, bytes.NewBufferString(tc.json), handler.Path())
+				require.NoError(t, err)
+				require.NotEmpty(t, buf)
+				require.Equal(t, http.StatusBadRequest, code)
+				verifyError(t, InvalidRequestErrorCode, tc.errorMsg, buf.Bytes())
+			})
+		}
+	})
+
+	t.Run("Register Message Service failure", func(t *testing.T) {
+		const errMsg = "sample-error"
+		mhandler := msghandler.NewMockMsgServiceProvider()
+		mhandler.RegisterErr = fmt.Errorf(errMsg)
+
+		svc := New(&protocol.MockProvider{}, mhandler, webhook.NewMockWebhookNotifier())
+		require.NotNil(t, svc)
+
+		var jsonStr = []byte(`{
+		"name":"json-msg-01",
+    	"type": "https://didcomm.org/json/1.0/msg",
+    	"purpose": ["prp-01","prp-02"]
+  	}`)
+
+		handler := lookupCreatePublicDIDHandler(t, svc, registerMsgService)
+		buf, code, err := sendRequestToHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
+		require.NoError(t, err)
+		require.NotEmpty(t, buf)
+		require.Equal(t, http.StatusInternalServerError, code)
+		verifyError(t, RegisterMsgSvcError, errMsg, buf.Bytes())
+	})
+}
+
+func TestOperation_UnregisterMessageService(t *testing.T) {
+	t.Run("Unregistering non existing message service", func(t *testing.T) {
+		svc := New(&protocol.MockProvider{}, msghandler.NewMockMsgServiceProvider(), webhook.NewMockWebhookNotifier())
+		require.NotNil(t, svc)
+
+		var jsonStr = []byte(`{
+		"name":"json-msg-01"
+  	}`)
+
+		handler := lookupCreatePublicDIDHandler(t, svc, unregisterMsgService)
+		buf, code, err := sendRequestToHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
+		require.NoError(t, err)
+		require.NotEmpty(t, buf)
+		require.Equal(t, http.StatusInternalServerError, code)
+		verifyError(t, UnregisterMsgSvcError, "failed to unregister", buf.Bytes())
+	})
+
+	t.Run("Unregistering message service input validation", func(t *testing.T) {
+		svc := New(&protocol.MockProvider{}, msghandler.NewMockMsgServiceProvider(), webhook.NewMockWebhookNotifier())
+		require.NotNil(t, svc)
+
+		var jsonStr = []byte(`{
+		"name":""
+  	}`)
+
+		handler := lookupCreatePublicDIDHandler(t, svc, unregisterMsgService)
+		buf, code, err := sendRequestToHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
+		require.NoError(t, err)
+		require.NotEmpty(t, buf)
+		require.Equal(t, http.StatusBadRequest, code)
+		verifyError(t, InvalidRequestErrorCode, errMsgSvcNameRequired, buf.Bytes())
+	})
+
+	t.Run("Unregistering message service successfully", func(t *testing.T) {
+		svc := New(&protocol.MockProvider{}, msghandler.NewMockMsgServiceProvider(), webhook.NewMockWebhookNotifier())
+		require.NotNil(t, svc)
+
+		svcNames := []string{"svc-01", "svc-02", "svc-03", "svc-04"}
+		for _, svcName := range svcNames {
+			err := svc.msgRegistrar.Register(generic.NewCustomMockMessageSvc("test", svcName))
+			require.NoError(t, err)
+		}
+
+		jsonStr := `{"name":"%s"}`
+		for _, svcName := range svcNames {
+			handler := lookupCreatePublicDIDHandler(t, svc, unregisterMsgService)
+			buf, err := getSuccessResponseFromHandler(handler,
+				bytes.NewBufferString(fmt.Sprintf(jsonStr, svcName)),
+				handler.Path())
+			require.NoError(t, err)
+			require.Empty(t, buf)
+		}
+	})
+
+	t.Run("Unregistering message service input decode failure", func(t *testing.T) {
+		svc := New(&protocol.MockProvider{}, msghandler.NewMockMsgServiceProvider(), webhook.NewMockWebhookNotifier())
+		require.NotNil(t, svc)
+
+		var jsonStr = []byte(`{--`)
+
+		handler := lookupCreatePublicDIDHandler(t, svc, unregisterMsgService)
+		buf, code, err := sendRequestToHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
+		require.NoError(t, err)
+		require.NotEmpty(t, buf)
+		require.Equal(t, http.StatusBadRequest, code)
+		verifyError(t, InvalidRequestErrorCode, "invalid character", buf.Bytes())
+	})
+}
+
+func TestOperation_RegisteredServices(t *testing.T) {
+	svc := New(&protocol.MockProvider{}, msghandler.NewMockMsgServiceProvider(), webhook.NewMockWebhookNotifier())
+	require.NotNil(t, svc)
+
+	verifyResponse := func(buf *bytes.Buffer, count int) {
+		response := RegisteredServicesResponse{}
+		err := json.Unmarshal(buf.Bytes(), &response)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, response)
+		require.Len(t, response.Names, count)
+	}
+
+	handler := lookupCreatePublicDIDHandler(t, svc, msgServiceList)
+	buf, err := getSuccessResponseFromHandler(handler, nil, handler.Path())
+	require.NoError(t, err)
+	verifyResponse(buf, 0)
+
+	testMsgSvcs := []dispatcher.MessageService{
+		generic.NewCustomMockMessageSvc("type-01", "svc-name-01"),
+		generic.NewCustomMockMessageSvc("type-02", "svc-name-02"),
+		generic.NewCustomMockMessageSvc("type-03", "svc-name-03"),
+		generic.NewCustomMockMessageSvc("type-04", "svc-name-04"),
+		generic.NewCustomMockMessageSvc("type-05", "svc-name-05"),
+	}
+	err = svc.msgRegistrar.Register(testMsgSvcs...)
+	require.NoError(t, err)
+
+	buf, err = getSuccessResponseFromHandler(handler, nil, handler.Path())
+	require.NoError(t, err)
+	verifyResponse(buf, len(testMsgSvcs))
 }
 
 func TestBuildSideTreeRequest(t *testing.T) {
@@ -97,17 +299,17 @@ func TestBuildSideTreeRequest(t *testing.T) {
 }
 
 func TestOperation_WriteResponse(t *testing.T) {
-	svc := New(&protocol.MockProvider{})
+	svc := New(&protocol.MockProvider{}, msghandler.NewMockMsgServiceProvider(), webhook.NewMockWebhookNotifier())
 	require.NotNil(t, svc)
 	svc.writeResponse(&mockWriter{}, CreatePublicDIDResponse{})
 }
 
-func lookupCreatePublicDIDHandler(t *testing.T, op *Operation) operation.Handler {
+func lookupCreatePublicDIDHandler(t *testing.T, op *Operation, path string) operation.Handler {
 	handlers := op.GetRESTHandlers()
 	require.NotEmpty(t, handlers)
 
 	for _, h := range handlers {
-		if h.Path() == createPublicDIDPath {
+		if h.Path() == path {
 			return h
 		}
 	}
@@ -152,7 +354,7 @@ func sendRequestToHandler(handler operation.Handler, requestBody io.Reader, path
 	return rr.Body, rr.Code, nil
 }
 
-func verifyError(t *testing.T, code resterrs.Code, data []byte) {
+func verifyError(t *testing.T, expectedCode resterrs.Code, expectedMsg string, data []byte) {
 	// Parser generic error response
 	errResponse := struct {
 		Code    int    `json:"code"`
@@ -162,8 +364,12 @@ func verifyError(t *testing.T, code resterrs.Code, data []byte) {
 	require.NoError(t, err)
 
 	// verify response
-	require.NotEmpty(t, code, errResponse.Code)
+	require.EqualValues(t, expectedCode, errResponse.Code)
 	require.NotEmpty(t, errResponse.Message)
+
+	if expectedMsg != "" {
+		require.Contains(t, errResponse.Message, expectedMsg)
+	}
 }
 
 type mockWriter struct {

--- a/pkg/restapi/operation/handler.go
+++ b/pkg/restapi/operation/handler.go
@@ -6,11 +6,26 @@ SPDX-License-Identifier: Apache-2.0
 
 package operation
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+)
 
 // Handler http handler for each controller API endpoint
 type Handler interface {
 	Path() string
 	Method() string
 	Handle() http.HandlerFunc
+}
+
+// MessageHandler maintains registered message services
+// and it allows dynamic registration of message services
+type MessageHandler interface {
+	// Services returns list of available message services in this message handler
+	Services() []dispatcher.MessageService
+	// Register registers given message services to this message handler
+	Register(msgSvcs ...dispatcher.MessageService) error
+	// Unregister unregisters message service with given name from this message handler
+	Unregister(name string) error
 }

--- a/pkg/restapi/restapi.go
+++ b/pkg/restapi/restapi.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package restapi
 
 import (
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
-
 	"github.com/hyperledger/aries-framework-go/pkg/framework/context"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation"
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation/common"
@@ -16,22 +14,11 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/restapi/webhook"
 )
 
-// MessageHandler maintains registered message services
-// and it allows dynamic registration of message services
-type MessageHandler interface {
-	// Services returns list of available message services in this message handler
-	Services() []dispatcher.MessageService
-	// Register registers given message services to this message handler
-	Register(msgSvcs ...dispatcher.MessageService) error
-	// Unregister unregisters message service with given name from this message handler
-	Unregister(name string) error
-}
-
 type allOpts struct {
 	webhookURLs  []string
 	defaultLabel string
 	autoAccept   bool
-	msgHandler   MessageHandler
+	msgHandler   operation.MessageHandler
 }
 
 // Opt represents a REST Api option.
@@ -59,7 +46,7 @@ func WithAutoAccept(autoAccept bool) Opt {
 }
 
 // WithMessageHandler is an option allowing for the message handler to be set.
-func WithMessageHandler(handler MessageHandler) Opt {
+func WithMessageHandler(handler operation.MessageHandler) Opt {
 	return func(opts *allOpts) {
 		opts.msgHandler = handler
 	}
@@ -83,7 +70,7 @@ func New(ctx *context.Provider, opts ...Opt) (*Controller, error) {
 	}
 
 	// Add common Rest Handlers
-	general := common.New(ctx)
+	general := common.New(ctx, restAPIOpts.msgHandler, webhook.NewHTTPNotifier(restAPIOpts.webhookURLs))
 
 	allHandlers = append(allHandlers, exchange.GetRESTHandlers()...)
 	allHandlers = append(allHandlers, general.GetRESTHandlers()...)


### PR DESCRIPTION
- added below endpoints for message service register, unregister and
registered service list

`POST /message/register-service`
`POST /message/unregister-service`
`GET /message/services`

- closes #973

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
