### PR TITLE
feat: initial scaffolding for JS web worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 *.dll
 *.so
 *.dylib
+*.wasm
+wasm_exec.js
 cmd/aries-agent-rest/aries-agent-rest
 
 # Editor and go temporary files & folders

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 GO_CMD ?= go
 ARIES_AGENT_REST_PATH=cmd/aries-agent-rest
 ARIES_AGENT_WASM_PATH=cmd/aries-agent-wasm
+ARIES_JS_WORKER_WASM_PATH=cmd/aries-js-worker
 OPENAPI_DOCKER_IMG=quay.io/goswagger/swagger
 OPENAPI_SPEC_PATH=build/rest/openapi/spec
 OPENAPI_DOCKER_IMG_VERSION=v0.21.0
@@ -26,7 +27,7 @@ GOBIN_PATH=$(abspath .)/build/bin
 MOCKGEN = $(GOBIN_PATH)/gobin -run github.com/golang/mock/mockgen@1.3.1
 
 .PHONY: all
-all: clean checks unit-test bdd-test
+all: clean checks unit-test unit-test-wasm bdd-test
 
 .PHONY: checks
 checks: license lint generate-openapi-spec
@@ -97,6 +98,15 @@ agent-wasm:
 	@cp $(WASM_EXEC)  ./build/bin/wasm
 	@cp ${ARIES_AGENT_WASM_PATH}/index.html  ./build/bin/wasm
 	@cd ${ARIES_AGENT_WASM_PATH} && GOOS=js GOARCH=wasm go build -o ../../build/bin/wasm/aries-agent.wasm main.go
+
+.PHONY: agent-js-worker-wasm
+agent-js-worker-wasm:
+	@echo "Building aries-js-worker.wasm"
+	@mkdir -p ./build/bin/aries_js_worker_wasm
+	@cp $(WASM_EXEC) ./build/bin/aries_js_worker_wasm
+	@cp ${ARIES_JS_WORKER_WASM_PATH}/aries.js ./build/bin/aries_js_worker_wasm
+	@cp ${ARIES_JS_WORKER_WASM_PATH}/aries-worker.js ./build/bin/aries_js_worker_wasm
+	@cd ${ARIES_JS_WORKER_WASM_PATH} && GOOS=js GOARCH=wasm go build -o ../../build/bin/aries_js_worker_wasm/aries-js-worker.wasm main.go
 
 .PHONY: agent-rest-docker
 agent-rest-docker:

--- a/cmd/aries-js-worker/aries-worker.js
+++ b/cmd/aries-js-worker/aries-worker.js
@@ -1,0 +1,27 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+self.importScripts("wasm_exec.js")
+
+if (!WebAssembly.instantiateStreaming) { // polyfill
+    WebAssembly.instantiateStreaming = async (resp, importObject) => {
+        const source = await (await resp).arrayBuffer();
+        return await WebAssembly.instantiate(source, importObject);
+    };
+}
+
+const go = new Go();
+WebAssembly.instantiateStreaming(fetch("aries-js-worker.wasm"), go.importObject).then(
+    (result) => { go.run(result.instance); }
+);
+
+handleResult = function(r) {
+    postMessage(JSON.parse(r))
+}
+
+onmessage = function(m) {
+    handleMsg(JSON.stringify(m.data))
+}

--- a/cmd/aries-js-worker/aries.js
+++ b/cmd/aries-js-worker/aries.js
@@ -1,0 +1,65 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// TODO not all browsers support private members of classes
+/* @class Aries provides Aries SSI-agent functions. */
+const Aries = new function() {
+    // TODO synchronize access on this map?
+    this._pending = new Map()
+    this._worker = new Worker('aries-worker.js')
+    this._worker.onmessage = e => {
+        const result = e.data
+        const cb = this._pending.get(result.id)
+        this._pending.delete(result.id)
+        cb(result)
+    }
+
+    /**
+     * Test methods.
+     * TODO - remove. Used for testing.
+     */
+    this._test = new function() {
+
+        /**
+         * Returns the input text prepended with "echo: ".
+         * TODO - remove.
+         * @param text
+         * @returns {Promise<unknown>}
+         * @private
+         */
+        super.this._echo = async function(text) {
+            return Aries._invoke("test", "echo", text, "timeout while accepting invitation")
+        }
+    }
+
+    this._newMsg = function(pkg, fn, payload) {
+        return {
+            // TODO there are several approaches to generate random strings:
+            // - which should we implement? do we need cryptographic-grade randomness for this?
+            // - alternatively, should the generator be provided by the client?
+            id: Math.random().toString(36).slice(2),
+            pkg: pkg,
+            fn: fn,
+            payload: payload
+        }
+    }
+
+    this._invoke = async function(pkg, fn, arg, msgTimeout) {
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(_ => reject(new Error(msgTimeout)), 5000)
+            const msg = Aries._newMsg(pkg, fn, arg)
+            Aries._pending.set(msg.id, result => {
+                clearTimeout(timer)
+                if (result.isErr) {
+                    reject(new Error(result.errMsg))
+                }
+                resolve(result.payload)
+            })
+            Aries._worker.postMessage(msg)
+        })
+    }
+}
+

--- a/cmd/aries-js-worker/index.html
+++ b/cmd/aries-js-worker/index.html
@@ -1,0 +1,36 @@
+<!--
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+ -->
+
+<!--
+This is a test page for developers to test WASM integration.
+-->
+
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <script src="aries.js"></script>
+    <script>
+        async function handleInput() {
+            const invite = document.querySelector("#test-input").value
+            const connID = await Aries._test._echo(invite)
+            document.querySelector("#test-output").value = connID
+        }
+    </script>
+</head>
+<body>
+<div>
+    <label for="test-input">Input: </label>
+    <input type="text" id="test-input"></input>
+    <button onClick="handleInput()">echo</button>
+</div>
+<hr/>
+<div>
+     <label for="test-output">Output: </label>
+     <output id="test-output"></output>
+</div>
+</body>
+</html>
+

--- a/cmd/aries-js-worker/main.go
+++ b/cmd/aries-js-worker/main.go
@@ -1,0 +1,147 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"syscall/js"
+	"time"
+)
+
+// TODO Signal JS when WASM is loaded and ready.
+//      This is being used in tests for now.
+var ready = make(chan struct{}) //nolint:gochecknoglobals
+var isTest = false              //nolint:gochecknoglobals
+
+// command is received from JS
+type command struct {
+	ID      string `json:"id"`
+	Pkg     string `json:"pkg"`
+	Fn      string `json:"fn"`
+	Payload string `json:"payload"`
+}
+
+// result is sent back to JS
+type result struct {
+	ID      string `json:"id"`
+	IsErr   bool   `json:"isErr"`
+	ErrMsg  string `json:"errMsg"`
+	Payload string `json:"payload"`
+}
+
+// All supported command handlers.
+func handlers() map[string]map[string]func(*command) *result {
+	return map[string]map[string]func(*command) *result{
+		"test": {
+			"echo":       echo,
+			"throwError": throwError,
+			"timeout":    timeout,
+		},
+	}
+}
+
+// main registers the 'handleMsg' function in the JS context's global scope to receive commands.
+// results are posted back to the 'handleResult' JS function.
+func main() {
+	input := make(chan *command)
+	output := make(chan *result)
+
+	go pipe(input, output)
+
+	go sendTo(output)
+
+	js.Global().Set("handleMsg", js.FuncOf(takeFrom(input)))
+
+	if isTest {
+		ready <- struct{}{}
+	}
+
+	select {}
+}
+
+func takeFrom(in chan *command) func(js.Value, []js.Value) interface{} {
+	return func(_ js.Value, args []js.Value) interface{} {
+		cmd := &command{}
+		if err := json.Unmarshal([]byte(args[0].String()), cmd); err != nil {
+			js.Global().Get("console").Call(
+				"log",
+				fmt.Sprintf("aries wasm: unable to unmarshal input=%s. err=%s", args[0].String(), err),
+			)
+		}
+		in <- cmd
+		return nil
+	}
+}
+
+func pipe(input chan *command, output chan *result) {
+	handlers := handlers()
+
+	for c := range input {
+		if c.ID == "" {
+			js.Global().Get("console").Call(
+				"log",
+				fmt.Sprintf("aries wasm: missing ID for input: %v", c),
+			)
+		}
+
+		if pkg, found := handlers[c.Pkg]; found {
+			if fn, found := pkg[c.Fn]; found {
+				output <- fn(c)
+			} else {
+				output <- &result{
+					ID:     c.ID,
+					IsErr:  true,
+					ErrMsg: "invalid fn: " + c.Fn,
+				}
+			}
+		} else {
+			output <- &result{
+				ID:     c.ID,
+				IsErr:  true,
+				ErrMsg: "invalid pkg: " + c.Pkg,
+			}
+		}
+	}
+}
+
+func sendTo(out chan *result) {
+	for r := range out {
+		out, err := json.Marshal(r)
+		if err != nil {
+			js.Global().Get("console").Call(
+				"log",
+				fmt.Sprintf("aries wasm: failed to marshal response for id=%s err=%s ", r.ID, err),
+			)
+		}
+
+		js.Global().Call("handleResult", string(out))
+	}
+}
+
+// test handler
+func echo(c *command) *result {
+	return &result{
+		ID:      c.ID,
+		Payload: "echo: " + c.Payload,
+	}
+}
+
+// test handler
+func throwError(c *command) *result {
+	return &result{
+		ID:     c.ID,
+		IsErr:  true,
+		ErrMsg: "an error!",
+	}
+}
+
+// test handler
+func timeout(c *command) *result {
+	time.Sleep(10 * time.Second)
+	return echo(c)
+}

--- a/cmd/aries-js-worker/main_test.go
+++ b/cmd/aries-js-worker/main_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"syscall/js"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// test callbacks
+var callbacks = make(map[string]chan *result) // nolint:gochecknoglobals
+
+func TestMain(m *testing.M) {
+	isTest = true
+
+	go main()
+
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		panic(errors.New("go main() timed out"))
+	}
+
+	results := make(chan *result)
+
+	js.Global().Set("handleResult", js.FuncOf(acceptResults(results)))
+
+	go dispatchResults(results)
+	os.Exit(m.Run())
+}
+
+func TestEchoCmd(t *testing.T) {
+	echo := newCommand("test", "echo")
+	result := make(chan *result)
+
+	callbacks[echo.ID] = result
+	defer delete(callbacks, echo.ID)
+
+	js.Global().Call("handleMsg", toString(t, echo))
+
+	select {
+	case r := <-result:
+		assert.Equal(t, echo.ID, r.ID)
+		assert.False(t, r.IsErr)
+		assert.Empty(t, r.ErrMsg)
+		assert.Contains(t, r.Payload, echo.Payload)
+	case <-time.After(5 * time.Second):
+		t.Error("test timeout")
+	}
+}
+
+func TestErrorCmd(t *testing.T) {
+	errCmd := newCommand("test", "throwError")
+	result := make(chan *result)
+	callbacks[errCmd.ID] = result
+
+	defer delete(callbacks, errCmd.ID)
+
+	js.Global().Call("handleMsg", toString(t, errCmd))
+
+	select {
+	case r := <-result:
+		assert.Equal(t, errCmd.ID, r.ID)
+		assert.True(t, r.IsErr)
+		assert.NotEmpty(t, r.ErrMsg)
+		assert.Empty(t, r.Payload)
+	case <-time.After(5 * time.Second):
+		t.Error("test timeout")
+	}
+}
+
+func acceptResults(in chan *result) func(js.Value, []js.Value) interface{} {
+	return func(_ js.Value, args []js.Value) interface{} {
+		r := &result{}
+		if err := json.Unmarshal([]byte(args[0].String()), r); err != nil {
+			panic(err)
+		}
+		in <- r
+		return nil
+	}
+}
+
+func dispatchResults(in chan *result) {
+	for r := range in {
+		cb, found := callbacks[r.ID]
+		if !found {
+			panic(fmt.Errorf("callback with ID %s not found", r.ID))
+		}
+		cb <- r
+	}
+}
+
+func newCommand(pkg, fn string) *command {
+	return &command{
+		ID:      uuid.New().String(),
+		Pkg:     pkg,
+		Fn:      fn,
+		Payload: uuid.New().String(),
+	}
+}
+
+func toString(t *testing.T, c *command) string {
+	s, err := json.Marshal(c)
+	if err != nil {
+		t.Errorf("failed to marshal: %v", c)
+	}
+
+	return string(s)
+}

--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -12,7 +12,7 @@ function filterExcludedFiles {
   | grep -v .pem$ | grep -v .block$ | grep -v .tx$ | grep -v ^LICENSE$ | grep -v _sk$ \
   | grep -v .key$ | grep -v .crt$ | grep -v \\.gen.go$ | grep -v \\.json$ | grep -v Gopkg.lock$ \
   | grep -v .md$ | grep -v ^vendor/ | grep -v ^build/ | grep -v .pb.go$ | grep -v ci.properties$ \
-  | grep -v go.sum$ |sort -u`
+  | grep -v go.sum$ | grep -v gomocks | sort -u`
 }
 
 CHECK=$(git diff --name-only --diff-filter=ACMRTUXB HEAD)

--- a/scripts/check_unit.sh
+++ b/scripts/check_unit.sh
@@ -21,7 +21,8 @@ fi
 
 # Running aries-framework-go unit test
 PKGS=`go list github.com/hyperledger/aries-framework-go/... 2> /dev/null | \
-                                                 grep -v /mocks`
+                                                 grep -v /mocks | \
+                                                 grep -v /aries-js-worker`
 go test $PKGS -count=1 -race -coverprofile=profile.out -covermode=atomic -timeout=10m
 amend_coverage_file
 

--- a/scripts/check_unit_wasm.sh
+++ b/scripts/check_unit_wasm.sh
@@ -11,6 +11,9 @@ echo "Running $0"
 # Running wasm unit test
 # TODO Support collecting code coverage  https://github.com/agnivade/wasmbrowsertest/issues/5
 # TODO Fail CI if headless chrome isn't available https://github.com/hyperledger/aries-framework-go/issues/843
-PKGS="github.com/hyperledger/aries-framework-go/pkg/storage/jsindexeddb"
+
+PKGS="github.com/hyperledger/aries-framework-go/pkg/storage/jsindexeddb
+github.com/hyperledger/aries-framework-go/cmd/aries-js-worker"
+
 PATH="$GOBIN:$PATH" GOOS=js GOARCH=wasm go test $PKGS -count=1 -exec=wasmbrowsertest -cover -timeout=10m
 


### PR DESCRIPTION
Part of #1064 

* WASM callable with 'handleMsg'
* WASM posts results to 'handleResult'
* aries-worker.js: simple Web Worker wrapper around WASM
* aries.js: exposes user-facing APIs
* excluded `/gomocks` from the license check. Gomocks are auto-generated and are now being committed to the repo with the merge of #1068

The overall design is similar to that of the service events pattern: user-facing APIs submit a msg with an ID to the WASM and listen for a result referencing that same ID.

Signed-off-by: George Aristy <george.aristy@securekey.com>