### PR TITLE
refactor: Rename NewDIDCommMsg function to NewDIDCommMsgMap

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -144,7 +144,7 @@ func (c *Client) HandleInvitation(invitation *Invitation) (string, error) {
 		return "", fmt.Errorf("failed marshal invitation: %w", err)
 	}
 
-	msg, err := service.NewDIDCommMsg(payload)
+	msg, err := service.NewDIDCommMsgMap(payload)
 	if err != nil {
 		return "", fmt.Errorf("failed to create DIDCommMsg: %w", err)
 	}

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -618,7 +618,7 @@ func TestServiceEvents(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	msg, err := service.NewDIDCommMsg(request)
+	msg, err := service.NewDIDCommMsgMap(request)
 	require.NoError(t, err)
 	_, err = didExSvc.HandleInbound(msg, "", "")
 	require.NoError(t, err)
@@ -708,7 +708,7 @@ func TestAcceptExchangeRequest(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	msg, err := service.NewDIDCommMsg(request)
+	msg, err := service.NewDIDCommMsgMap(request)
 	require.NoError(t, err)
 	_, err = didExSvc.HandleInbound(msg, "", "")
 	require.NoError(t, err)
@@ -789,7 +789,7 @@ func TestAcceptInvitation(t *testing.T) {
 		)
 		require.NoError(t, jsonErr)
 
-		msg, svcErr := service.NewDIDCommMsg(invitation)
+		msg, svcErr := service.NewDIDCommMsgMap(invitation)
 		require.NoError(t, svcErr)
 		_, err = didExSvc.HandleInbound(msg, "", "")
 		require.NoError(t, err)

--- a/pkg/client/introduce/client.go
+++ b/pkg/client/introduce/client.go
@@ -151,7 +151,7 @@ func (c *Client) handleOutbound(msg interface{}, o InvitationEnvelope) error {
 		return fmt.Errorf("marshal outbound msg: %w", err)
 	}
 
-	didMsg, err := service.NewDIDCommMsg(payload)
+	didMsg, err := service.NewDIDCommMsgMap(payload)
 	if err != nil {
 		return fmt.Errorf("new outbound DIDCommMsg msg: %w", err)
 	}

--- a/pkg/client/introduce/client_test.go
+++ b/pkg/client/introduce/client_test.go
@@ -211,7 +211,7 @@ func TestClient_HandleRequest(t *testing.T) {
 
 	client.newUUID = func() string { return UUID }
 
-	msg, err := service.NewDIDCommMsg(toBytes(t, &introduce.Request{
+	msg, err := service.NewDIDCommMsgMap(toBytes(t, &introduce.Request{
 		Type: introduce.RequestMsgType,
 		ID:   UUID,
 	}))
@@ -254,7 +254,7 @@ func TestClient_HandleRequestWithInvitation(t *testing.T) {
 	client.newUUID = func() string { return UUID }
 
 	require.NoError(t, err)
-	msg, err := service.NewDIDCommMsg(toBytes(t, &introduce.Request{
+	msg, err := service.NewDIDCommMsgMap(toBytes(t, &introduce.Request{
 		Type: introduce.RequestMsgType,
 		ID:   UUID,
 	}))

--- a/pkg/didcomm/common/service/did_comm_msg.go
+++ b/pkg/didcomm/common/service/did_comm_msg.go
@@ -38,8 +38,8 @@ type Header struct {
 // DIDCommMsgMap did comm msg
 type DIDCommMsgMap map[string]interface{}
 
-// NewDIDCommMsg returns DIDCommMsg with Header
-func NewDIDCommMsg(payload []byte) (DIDCommMsgMap, error) {
+// NewDIDCommMsgMap returns DIDCommMsg with Header
+func NewDIDCommMsgMap(payload []byte) (DIDCommMsgMap, error) {
 	var msg DIDCommMsgMap
 
 	err := json.Unmarshal(payload, &msg)

--- a/pkg/didcomm/common/service/did_comm_msg_test.go
+++ b/pkg/didcomm/common/service/did_comm_msg_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDIDCommMsg_ID(t *testing.T) {
+func TestDIDCommMsgMap_ID(t *testing.T) {
 	tests := []struct {
 		name     string
 		expected string
@@ -46,7 +46,7 @@ func TestDIDCommMsg_ID(t *testing.T) {
 	}
 }
 
-func TestDIDCommMsg_Type(t *testing.T) {
+func TestDIDCommMsgMap_Type(t *testing.T) {
 	tests := []struct {
 		name     string
 		expected string
@@ -78,7 +78,7 @@ func TestDIDCommMsg_Type(t *testing.T) {
 	}
 }
 
-func TestDIDCommMsg_ToStruct(t *testing.T) {
+func TestDIDCommMsgMap_ToStruct(t *testing.T) {
 	type Test struct {
 		Time  time.Time
 		Bytes []byte
@@ -92,7 +92,7 @@ func TestDIDCommMsg_ToStruct(t *testing.T) {
 	b, err := json.Marshal(expected)
 	require.NoError(t, err)
 
-	msg, err := NewDIDCommMsg(b)
+	msg, err := NewDIDCommMsgMap(b)
 	require.NoError(t, err)
 
 	actual := Test{}

--- a/pkg/didcomm/common/service/service_test.go
+++ b/pkg/didcomm/common/service/service_test.go
@@ -39,7 +39,7 @@ func TestNewDIDCommMsg(t *testing.T) {
 	for _, test := range tests {
 		tc := test
 		t.Run(tc.name, func(t *testing.T) {
-			val, err := NewDIDCommMsg(tc.payload)
+			val, err := NewDIDCommMsgMap(tc.payload)
 			if err != nil {
 				require.Contains(t, err.Error(), tc.err)
 				require.Nil(t, val)

--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -664,6 +664,7 @@ func (s *Service) CreateImplicitInvitation(inviterLabel, inviterDID, inviteeLabe
 		return "", fmt.Errorf("failed to create DIDCommMsg for implicit invitation: %w", err)
 	}
 
+	// TODO: get rid of this  msg.(service.DIDCommMsgMap)
 	next := &requested{}
 	internalMsg := &message{
 		Msg:           msg.(service.DIDCommMsgMap),
@@ -688,5 +689,5 @@ func createDIDCommMsg(invitation *Invitation) (service.DIDCommMsg, error) {
 		return nil, fmt.Errorf("marshal invitation: %w", err)
 	}
 
-	return service.NewDIDCommMsg(payload)
+	return service.NewDIDCommMsgMap(payload)
 }

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -132,7 +132,7 @@ func TestService_Handle_Inviter(t *testing.T) {
 			},
 		})
 	require.NoError(t, err)
-	msg, err := service.NewDIDCommMsg(payloadBytes)
+	msg, err := service.NewDIDCommMsgMap(payloadBytes)
 	require.NoError(t, err)
 	_, err = s.HandleInbound(msg, newDidDoc.ID, "")
 	require.NoError(t, err)
@@ -153,7 +153,7 @@ func TestService_Handle_Inviter(t *testing.T) {
 		})
 	require.NoError(t, err)
 
-	didMsg, err := service.NewDIDCommMsg(payloadBytes)
+	didMsg, err := service.NewDIDCommMsgMap(payloadBytes)
 	require.NoError(t, err)
 
 	_, err = s.HandleInbound(didMsg, newDidDoc.ID, "theirDID")
@@ -258,7 +258,7 @@ func TestService_Handle_Invitee(t *testing.T) {
 	payloadBytes, err := json.Marshal(invitation)
 	require.NoError(t, err)
 
-	didMsg, err := service.NewDIDCommMsg(payloadBytes)
+	didMsg, err := service.NewDIDCommMsgMap(payloadBytes)
 	require.NoError(t, err)
 
 	_, err = s.HandleInbound(didMsg, "", "")
@@ -300,7 +300,7 @@ func TestService_Handle_Invitee(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	didMsg, err = service.NewDIDCommMsg(payloadBytes)
+	didMsg, err = service.NewDIDCommMsgMap(payloadBytes)
 	require.NoError(t, err)
 
 	_, err = s.HandleInbound(didMsg, "", "")
@@ -352,7 +352,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		didMsg, err := service.NewDIDCommMsg(response)
+		didMsg, err := service.NewDIDCommMsgMap(response)
 		require.NoError(t, err)
 
 		_, err = s.HandleInbound(didMsg, "", "")
@@ -373,7 +373,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		didMsg, err := service.NewDIDCommMsg(requestBytes)
+		didMsg, err := service.NewDIDCommMsgMap(requestBytes)
 		require.NoError(t, err)
 
 		_, err = svc.HandleInbound(didMsg, "", "")
@@ -435,7 +435,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 		require.NoError(t, err)
 
 		// send invite
-		didMsg, err := service.NewDIDCommMsg(requestBytes)
+		didMsg, err := service.NewDIDCommMsgMap(requestBytes)
 		require.NoError(t, err)
 
 		_, err = svc.HandleInbound(didMsg, "", "")
@@ -455,7 +455,7 @@ func TestService_Accept(t *testing.T) {
 
 func TestService_threadID(t *testing.T) {
 	t.Run("returns new thid for ", func(t *testing.T) {
-		didMsg, err := service.NewDIDCommMsg(toBytes(t, &service.Header{Type: InvitationMsgType}))
+		didMsg, err := service.NewDIDCommMsgMap(toBytes(t, &service.Header{Type: InvitationMsgType}))
 		require.NoError(t, err)
 		thid, err := threadID(didMsg)
 		require.NoError(t, err)
@@ -463,7 +463,7 @@ func TestService_threadID(t *testing.T) {
 	})
 
 	t.Run("returns unmarshall error", func(t *testing.T) {
-		didMsg, err := service.NewDIDCommMsg(toBytes(t, &service.Header{Type: RequestMsgType}))
+		didMsg, err := service.NewDIDCommMsgMap(toBytes(t, &service.Header{Type: RequestMsgType}))
 		require.NoError(t, err)
 		_, err = threadID(didMsg)
 		require.Error(t, err)
@@ -628,7 +628,7 @@ func TestEventsSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// send invite
-	didMsg, err := service.NewDIDCommMsg(invite)
+	didMsg, err := service.NewDIDCommMsgMap(invite)
 	require.NoError(t, err)
 
 	_, err = svc.HandleInbound(didMsg, "", "")
@@ -665,7 +665,7 @@ func TestContinueWithPublicDID(t *testing.T) {
 	require.NoError(t, err)
 
 	// send invite
-	didMsg, err := service.NewDIDCommMsg(invite)
+	didMsg, err := service.NewDIDCommMsgMap(invite)
 	require.NoError(t, err)
 
 	_, err = svc.HandleInbound(didMsg, "", "")
@@ -761,7 +761,7 @@ func TestEventProcessCallback(t *testing.T) {
 	svc, err := New(&protocol.MockProvider{})
 	require.NoError(t, err)
 
-	didMsg, err := service.NewDIDCommMsg(toBytes(t, &service.Header{Type: AckMsgType}))
+	didMsg, err := service.NewDIDCommMsgMap(toBytes(t, &service.Header{Type: AckMsgType}))
 	require.NoError(t, err)
 
 	msg := &message{
@@ -796,7 +796,7 @@ func TestServiceErrors(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	msg, err := service.NewDIDCommMsg(requestBytes)
+	msg, err := service.NewDIDCommMsgMap(requestBytes)
 	require.NoError(t, err)
 
 	svc, err := New(&protocol.MockProvider{})
@@ -874,7 +874,7 @@ func TestConnectionRecord(t *testing.T) {
 		Type: "invalid-type",
 	})
 	require.NoError(t, err)
-	msg, err := service.NewDIDCommMsg(requestBytes)
+	msg, err := service.NewDIDCommMsgMap(requestBytes)
 	require.NoError(t, err)
 
 	_, err = svc.connectionRecord(msg)
@@ -894,7 +894,7 @@ func TestInvitationRecord(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	msg, err := service.NewDIDCommMsg(invitationBytes)
+	msg, err := service.NewDIDCommMsgMap(invitationBytes)
 	require.NoError(t, err)
 
 	conn, err := svc.invitationMsgRecord(msg)
@@ -906,7 +906,7 @@ func TestInvitationRecord(t *testing.T) {
 		Type: "invalid-type",
 	})
 	require.NoError(t, err)
-	msg, err = service.NewDIDCommMsg(invitationBytes)
+	msg, err = service.NewDIDCommMsgMap(invitationBytes)
 	require.NoError(t, err)
 
 	_, err = svc.invitationMsgRecord(msg)
@@ -929,7 +929,7 @@ func TestInvitationRecord(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	msg, err = service.NewDIDCommMsg(invitationBytes)
+	msg, err = service.NewDIDCommMsgMap(invitationBytes)
 	require.NoError(t, err)
 
 	_, err = svc.invitationMsgRecord(msg)
@@ -1124,7 +1124,7 @@ func TestAcceptInvitation(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		didMsg, err := service.NewDIDCommMsg(invitationBytes)
+		didMsg, err := service.NewDIDCommMsgMap(invitationBytes)
 		require.NoError(t, err)
 
 		_, err = svc.HandleInbound(didMsg, "", "")
@@ -1239,7 +1239,7 @@ func TestAcceptInvitationWithPublicDID(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		didMsg, err := service.NewDIDCommMsg(invitationBytes)
+		didMsg, err := service.NewDIDCommMsgMap(invitationBytes)
 		require.NoError(t, err)
 
 		_, err = svc.HandleInbound(didMsg, "", "")
@@ -1424,7 +1424,7 @@ func generateRequestMsgPayload(t *testing.T, prov provider, id, invitationID str
 	})
 	require.NoError(t, err)
 
-	didMsg, err := service.NewDIDCommMsg(requestBytes)
+	didMsg, err := service.NewDIDCommMsgMap(requestBytes)
 	require.NoError(t, err)
 
 	return didMsg

--- a/pkg/didcomm/protocol/didexchange/states_test.go
+++ b/pkg/didcomm/protocol/didexchange/states_test.go
@@ -271,7 +271,7 @@ func TestRequestedState_Execute(t *testing.T) {
 	})
 	t.Run("handle inbound invitations", func(t *testing.T) {
 		ctx := getContext(t, prov)
-		msg, err := service.NewDIDCommMsg(invitationPayloadBytes)
+		msg, err := service.NewDIDCommMsgMap(invitationPayloadBytes)
 		require.NoError(t, err)
 		// nolint: govet
 		thid, err := threadID(msg)
@@ -1213,14 +1213,14 @@ func createMockInvitation(pubKey string, ctx *context) (*Invitation, error) {
 }
 
 func toDIDCommMsg(t *testing.T, v interface{}) service.DIDCommMsgMap {
-	msg, err := service.NewDIDCommMsg(toBytes(t, v))
+	msg, err := service.NewDIDCommMsgMap(toBytes(t, v))
 	require.NoError(t, err)
 
 	return msg
 }
 
 func bytesToDIDCommMsg(t *testing.T, v []byte) service.DIDCommMsg {
-	msg, err := service.NewDIDCommMsg(v)
+	msg, err := service.NewDIDCommMsgMap(v)
 	require.NoError(t, err)
 
 	return msg

--- a/pkg/didcomm/protocol/introduce/service.go
+++ b/pkg/didcomm/protocol/introduce/service.go
@@ -293,7 +293,7 @@ func (s *Service) InvitationReceived(msg service.StateMsg) error {
 		return fmt.Errorf("invitation received marshal: %w", err)
 	}
 
-	didMsg, err := service.NewDIDCommMsg(payload)
+	didMsg, err := service.NewDIDCommMsgMap(payload)
 	if err != nil {
 		return fmt.Errorf("invitation received new DIDComm msg: %w", err)
 	}

--- a/pkg/didcomm/protocol/introduce/service_test.go
+++ b/pkg/didcomm/protocol/introduce/service_test.go
@@ -177,7 +177,7 @@ func TestService_HandleOutbound(t *testing.T) {
 		svc, err := introduce.New(provider)
 		require.NoError(t, err)
 		defer stop(t, svc)
-		msg, err := service.NewDIDCommMsg([]byte(fmt.Sprintf(`{"@id":"ID","@type":%q}`, introduce.ResponseMsgType)))
+		msg, err := service.NewDIDCommMsgMap([]byte(fmt.Sprintf(`{"@id":"ID","@type":%q}`, introduce.ResponseMsgType)))
 		require.NoError(t, err)
 		const errMsg = "json: cannot unmarshal array into Go value of type introduce.record"
 		require.EqualError(t, svc.HandleOutbound(msg, "", ""), errMsg)
@@ -207,7 +207,7 @@ func TestService_HandleOutbound(t *testing.T) {
 
 		require.NoError(t, err)
 		defer stop(t, svc)
-		msg, err := service.NewDIDCommMsg([]byte(fmt.Sprintf(`{"@id":"ID","@type":%q}`, introduce.ProposalMsgType)))
+		msg, err := service.NewDIDCommMsgMap([]byte(fmt.Sprintf(`{"@id":"ID","@type":%q}`, introduce.ProposalMsgType)))
 		require.NoError(t, err)
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
@@ -238,7 +238,7 @@ func TestService_HandleOutbound(t *testing.T) {
 
 		defer stop(t, svc)
 
-		didMsg, err := service.NewDIDCommMsg(toBytes(t, &service.Header{
+		didMsg, err := service.NewDIDCommMsgMap(toBytes(t, &service.Header{
 			ID:     "ID",
 			Thread: decorator.Thread{ID: "thID"},
 			Type:   introduce.ResponseMsgType,
@@ -280,7 +280,7 @@ func TestService_HandleOutbound(t *testing.T) {
 
 		require.NoError(t, svc.RegisterActionEvent(make(chan service.DIDCommAction, 1)))
 
-		didMsg, err := service.NewDIDCommMsg(toBytes(t, &service.Header{
+		didMsg, err := service.NewDIDCommMsgMap(toBytes(t, &service.Header{
 			ID:     "ID",
 			Thread: decorator.Thread{ID: "thID"},
 			Type:   introduce.AckMsgType,
@@ -317,7 +317,7 @@ func TestService_HandleOutbound(t *testing.T) {
 		require.NoError(t, err)
 
 		defer stop(t, svc)
-		didMsg, err := service.NewDIDCommMsg(toBytes(t, &service.Header{
+		didMsg, err := service.NewDIDCommMsgMap(toBytes(t, &service.Header{
 			ID:     "ID",
 			Thread: decorator.Thread{ID: "thID"},
 			Type:   introduce.ResponseMsgType,
@@ -378,7 +378,7 @@ func TestService_HandleInbound(t *testing.T) {
 		svc, err := introduce.New(provider)
 		require.NoError(t, err)
 		defer stop(t, svc)
-		msg, err := service.NewDIDCommMsg([]byte(`{}`))
+		msg, err := service.NewDIDCommMsgMap([]byte(`{}`))
 		require.NoError(t, err)
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
@@ -411,7 +411,7 @@ func TestService_HandleInbound(t *testing.T) {
 		svc, err := introduce.New(provider)
 		require.NoError(t, err)
 		defer stop(t, svc)
-		msg, err := service.NewDIDCommMsg([]byte(fmt.Sprintf(`{"@id":"ID","@type":%q}`, introduce.ProposalMsgType)))
+		msg, err := service.NewDIDCommMsgMap([]byte(fmt.Sprintf(`{"@id":"ID","@type":%q}`, introduce.ProposalMsgType)))
 		require.NoError(t, err)
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
@@ -443,7 +443,7 @@ func TestService_HandleInbound(t *testing.T) {
 		require.NoError(t, err)
 		defer stop(t, svc)
 
-		msg, err := service.NewDIDCommMsg([]byte(fmt.Sprintf(`{"@id":"ID","@type":%q}`, introduce.ProposalMsgType)))
+		msg, err := service.NewDIDCommMsgMap([]byte(fmt.Sprintf(`{"@id":"ID","@type":%q}`, introduce.ProposalMsgType)))
 		require.NoError(t, err)
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
@@ -474,7 +474,7 @@ func TestService_HandleInbound(t *testing.T) {
 		svc, err := introduce.New(provider)
 		require.NoError(t, err)
 		defer stop(t, svc)
-		msg, err := service.NewDIDCommMsg([]byte(`{"@id":"ID","@type":"unknown"}`))
+		msg, err := service.NewDIDCommMsgMap([]byte(`{"@id":"ID","@type":"unknown"}`))
 		require.NoError(t, err)
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
@@ -2189,7 +2189,7 @@ func setupIntroducee(f *flow) (*introduce.Service, *introduceMocks.MockInvitatio
 func handleInbound(t *testing.T, svc service.InboundHandler, msg interface{}, myDID, theirDID string) {
 	t.Helper()
 
-	resp, err := service.NewDIDCommMsg(toBytes(t, msg))
+	resp, err := service.NewDIDCommMsgMap(toBytes(t, msg))
 	require.NoError(t, err)
 	_, err = svc.HandleInbound(resp, myDID, theirDID)
 	require.NoError(t, err)
@@ -2209,7 +2209,7 @@ func checkAndHandle(f *flow) {
 
 	if f.startWithRequest {
 		// creates request msg
-		request, err := service.NewDIDCommMsg(toBytes(f.t, introduce.Request{
+		request, err := service.NewDIDCommMsgMap(toBytes(f.t, introduce.Request{
 			Type: introduce.RequestMsgType,
 			// creates threadID
 			ID: uuid.New().String(),
@@ -2226,7 +2226,7 @@ func checkAndHandle(f *flow) {
 
 	if f.startWithProposal {
 		// creates proposal msg
-		proposal, err := service.NewDIDCommMsg(toBytes(f.t, introduce.Proposal{
+		proposal, err := service.NewDIDCommMsgMap(toBytes(f.t, introduce.Proposal{
 			Type: introduce.ProposalMsgType,
 			// creates threadID
 			ID: uuid.New().String(),
@@ -2392,7 +2392,7 @@ func checkAndHandle(f *flow) {
 			return
 		case *didexchange.Invitation:
 			go func() {
-				inv, err := service.NewDIDCommMsg(toBytes(f.t, iMsg))
+				inv, err := service.NewDIDCommMsgMap(toBytes(f.t, iMsg))
 				require.NoError(f.t, err)
 				_, err = inv.ThreadID()
 				require.NoError(f.t, err)
@@ -2517,7 +2517,7 @@ func stop(t *testing.T, s stopper) {
 func TestService_InvitationReceived(t *testing.T) {
 	t.Run("PreState is not correct", func(t *testing.T) {
 		svc := &introduce.Service{}
-		msg, err := service.NewDIDCommMsg(toBytes(t, &didexchange.Invitation{Thread: &decorator.Thread{ID: "ID"}}))
+		msg, err := service.NewDIDCommMsgMap(toBytes(t, &didexchange.Invitation{Thread: &decorator.Thread{ID: "ID"}}))
 		require.NoError(t, err)
 		require.NoError(t, svc.InvitationReceived(service.StateMsg{
 			Type:    service.PreState,
@@ -2529,7 +2529,7 @@ func TestService_InvitationReceived(t *testing.T) {
 	t.Run("StateID is not correct", func(t *testing.T) {
 		// should not panic
 		svc := &introduce.Service{}
-		msg, err := service.NewDIDCommMsg(toBytes(t, &didexchange.Invitation{}))
+		msg, err := service.NewDIDCommMsgMap(toBytes(t, &didexchange.Invitation{}))
 		require.NoError(t, err)
 		require.NoError(t, svc.InvitationReceived(service.StateMsg{
 			Type: service.PostState,
@@ -2540,7 +2540,7 @@ func TestService_InvitationReceived(t *testing.T) {
 	t.Run("Thread is nil", func(t *testing.T) {
 		// should not panic
 		svc := &introduce.Service{}
-		msg, err := service.NewDIDCommMsg(toBytes(t, &didexchange.Invitation{}))
+		msg, err := service.NewDIDCommMsgMap(toBytes(t, &didexchange.Invitation{}))
 		require.NoError(t, err)
 		require.NoError(t, svc.InvitationReceived(service.StateMsg{
 			Type:    service.PostState,
@@ -2551,7 +2551,7 @@ func TestService_InvitationReceived(t *testing.T) {
 
 	t.Run("No PID in Thread", func(t *testing.T) {
 		svc := &introduce.Service{}
-		msg, err := service.NewDIDCommMsg(toBytes(t, &didexchange.Invitation{Thread: &decorator.Thread{ID: "ID"}}))
+		msg, err := service.NewDIDCommMsgMap(toBytes(t, &didexchange.Invitation{Thread: &decorator.Thread{ID: "ID"}}))
 		require.NoError(t, err)
 		require.NoError(t, svc.InvitationReceived(service.StateMsg{
 			Type:    service.PostState,

--- a/pkg/didcomm/protocol/introduce/states_test.go
+++ b/pkg/didcomm/protocol/introduce/states_test.go
@@ -123,7 +123,7 @@ func TestArranging_ExecuteOutbound(t *testing.T) {
 	dispatcher := dispatcherMocks.NewMockOutbound(ctrl)
 	dispatcher.EXPECT().SendToDID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
-	didmsg, err := service.NewDIDCommMsg(toBytes(t, struct{}{}))
+	didmsg, err := service.NewDIDCommMsgMap(toBytes(t, struct{}{}))
 	require.NoError(t, err)
 
 	followup, err := (&arranging{}).ExecuteOutbound(dispatcher, &metaData{
@@ -213,7 +213,7 @@ func TestAbandoning_ExecuteInbound(t *testing.T) {
 		dispatcher := dispatcherMocks.NewMockOutbound(ctrl)
 		dispatcher.EXPECT().SendToDID(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("test error"))
 
-		didmsg, err := service.NewDIDCommMsg(toBytes(t, &service.Header{Type: RequestMsgType}))
+		didmsg, err := service.NewDIDCommMsgMap(toBytes(t, &service.Header{Type: RequestMsgType}))
 		require.NoError(t, err)
 
 		followup, err := (&abandoning{}).ExecuteInbound(dispatcher, &metaData{

--- a/pkg/didcomm/protocol/route/service_test.go
+++ b/pkg/didcomm/protocol/route/service_test.go
@@ -544,7 +544,7 @@ func generateRequestMsgPayload(t *testing.T, id string) service.DIDCommMsg {
 	})
 	require.NoError(t, err)
 
-	didMsg, err := service.NewDIDCommMsg(requestBytes)
+	didMsg, err := service.NewDIDCommMsgMap(requestBytes)
 	require.NoError(t, err)
 
 	return didMsg
@@ -557,7 +557,7 @@ func generateGrantMsgPayload(t *testing.T, id string) service.DIDCommMsg {
 	})
 	require.NoError(t, err)
 
-	didMsg, err := service.NewDIDCommMsg(grantBytes)
+	didMsg, err := service.NewDIDCommMsgMap(grantBytes)
 	require.NoError(t, err)
 
 	return didMsg
@@ -571,7 +571,7 @@ func generateKeyUpdateListMsgPayload(t *testing.T, id string, updates []Update) 
 	})
 	require.NoError(t, err)
 
-	didMsg, err := service.NewDIDCommMsg(requestBytes)
+	didMsg, err := service.NewDIDCommMsgMap(requestBytes)
 	require.NoError(t, err)
 
 	return didMsg
@@ -585,7 +585,7 @@ func generateKeylistUpdateResponseMsgPayload(t *testing.T, id string, updates []
 	})
 	require.NoError(t, err)
 
-	didMsg, err := service.NewDIDCommMsg(respBytes)
+	didMsg, err := service.NewDIDCommMsgMap(respBytes)
 	require.NoError(t, err)
 
 	return didMsg
@@ -600,7 +600,7 @@ func generateForwardMsgPayload(t *testing.T, id, to string, msg interface{}) ser
 	})
 	require.NoError(t, err)
 
-	didMsg, err := service.NewDIDCommMsg(requestBytes)
+	didMsg, err := service.NewDIDCommMsgMap(requestBytes)
 	require.NoError(t, err)
 
 	return didMsg

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -113,7 +113,7 @@ func (p *Provider) InboundTransportEndpoint() string {
 // InboundMessageHandler return an inbound message handler.
 func (p *Provider) InboundMessageHandler() transport.InboundMessageHandler {
 	return func(message []byte, myDID, theirDID string) error {
-		msg, err := service.NewDIDCommMsg(message)
+		msg, err := service.NewDIDCommMsgMap(message)
 		if err != nil {
 			return err
 		}

--- a/pkg/restapi/operation/common/msgservice.go
+++ b/pkg/restapi/operation/common/msgservice.go
@@ -77,6 +77,7 @@ func (m *msgService) HandleInbound(msg service.DIDCommMsg, myDID, theirDID strin
 		return "", fmt.Errorf(errTopicNotFound)
 	}
 
+	// TODO: get rid of this  msg.(service.DIDCommMsgMap)
 	bytes, err := json.Marshal(&inboundMsg{Message: msg.(service.DIDCommMsgMap), MyDID: myDID, TheirDID: theirDID})
 	if err != nil {
 		return "", fmt.Errorf(errMsgSvcHandleFailed, err)

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -514,7 +514,7 @@ func TestAcceptExchangeRequest(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	msg, err := service.NewDIDCommMsg(request)
+	msg, err := service.NewDIDCommMsgMap(request)
 	require.NoError(t, err)
 
 	_, err = didExSvc.HandleInbound(msg, "", "")
@@ -586,7 +586,7 @@ func TestAcceptInvitation(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	msg, err := service.NewDIDCommMsg(invitation)
+	msg, err := service.NewDIDCommMsgMap(invitation)
 	require.NoError(t, err)
 
 	_, err = didExSvc.HandleInbound(msg, "", "")


### PR DESCRIPTION
The function was renamed according to the returned value.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>