### PR TITLE
ci: update golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,6 +69,7 @@ linters-settings:
       - opinionated
     disabled-checks:
       - unnamedResult
+      - whyNoLint # TODO enable.
   funlen:
     lines: 60
     statements: 40
@@ -84,6 +85,7 @@ linters:
   disable:
     - maligned
     - prealloc
+    - gomnd # TODO enable.
 
 issues:
   exclude-use-default: false

--- a/cmd/aries-js-worker/main.go
+++ b/cmd/aries-js-worker/main.go
@@ -1,3 +1,5 @@
+// +build js,wasm
+
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
 
@@ -74,6 +76,7 @@ func takeFrom(in chan *command) func(js.Value, []js.Value) interface{} {
 			)
 		}
 		in <- cmd
+
 		return nil
 	}
 }

--- a/cmd/aries-js-worker/main_test.go
+++ b/cmd/aries-js-worker/main_test.go
@@ -1,3 +1,5 @@
+// +build js,wasm
+
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
 
@@ -88,6 +90,7 @@ func acceptResults(in chan *result) func(js.Value, []js.Value) interface{} {
 			panic(err)
 		}
 		in <- r
+
 		return nil
 	}
 }

--- a/pkg/didcomm/transport/ws/support_test.go
+++ b/pkg/didcomm/transport/ws/support_test.go
@@ -35,9 +35,11 @@ type mockProvider struct {
 func (p *mockProvider) InboundMessageHandler() transport.InboundMessageHandler {
 	return func(message []byte, myDID, theirDID string) error {
 		logger.Infof("message received is %s", string(message))
+
 		if string(message) == "invalid-data" {
 			return errors.New("error")
 		}
+
 		return nil
 	}
 }

--- a/pkg/doc/verifiable/credential.go
+++ b/pkg/doc/verifiable/credential.go
@@ -523,12 +523,14 @@ func WithBaseContextExtendedValidation(customContexts, customTypes []string) Cre
 		for _, context := range customContexts {
 			opts.allowedCustomContexts[context] = true
 		}
+
 		opts.allowedCustomContexts[baseContext] = true
 
 		opts.allowedCustomTypes = make(map[string]bool)
 		for _, context := range customTypes {
 			opts.allowedCustomTypes[context] = true
 		}
+
 		opts.allowedCustomTypes[vcType] = true
 	}
 }

--- a/pkg/framework/aries/defaults/defaults.go
+++ b/pkg/framework/aries/defaults/defaults.go
@@ -22,6 +22,7 @@ func WithInboundHTTPAddr(internalAddr, externalAddr string) aries.Option {
 		if err != nil {
 			return fmt.Errorf("http inbound transport initialization failed : %w", err)
 		}
+
 		return aries.WithInboundTransport(inbound)(opts)
 	}
 }
@@ -33,6 +34,7 @@ func WithInboundWSAddr(internalAddr, externalAddr string) aries.Option {
 		if err != nil {
 			return fmt.Errorf("ws inbound transport initialization failed : %w", err)
 		}
+
 		return aries.WithInboundTransport(inbound)(opts)
 	}
 }

--- a/pkg/framework/aries/defaults/defaults_js_wasm.go
+++ b/pkg/framework/aries/defaults/defaults_js_wasm.go
@@ -18,6 +18,7 @@ func WithStorePath(storePath string) aries.Option {
 		if err != nil {
 			return err
 		}
+
 		return aries.WithStoreProvider(store)(opts)
 	}
 }

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -156,6 +156,7 @@ func WithTransportReturnRoute(transportReturnRoute string) Option {
 		}
 
 		opts.transportReturnRoute = transportReturnRoute
+
 		return nil
 	}
 }
@@ -223,6 +224,7 @@ func WithPacker(primary packer.Creator, additionalPackers ...packer.Creator) Opt
 	return func(opts *Aries) error {
 		opts.packerCreator = primary
 		opts.packerCreators = append(opts.packerCreators, additionalPackers...)
+
 		return nil
 	}
 }

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -131,6 +131,7 @@ func (p *Provider) InboundMessageHandler() transport.InboundMessageHandler {
 		for _, svc := range p.msgSvcProvider.Services() {
 			h := &service.Header{}
 			err = msg.Decode(h)
+
 			if err != nil {
 				return err
 			}
@@ -268,6 +269,7 @@ func WithPacker(primary packer.Packer, additionalPackers ...packer.Packer) Provi
 	return func(opts *Provider) error {
 		opts.primaryPacker = primary
 		opts.packers = append(opts.packers, additionalPackers...)
+
 		return nil
 	}
 }

--- a/pkg/restapi/webhook/webhook_test.go
+++ b/pkg/restapi/webhook/webhook_test.go
@@ -276,6 +276,7 @@ func listenAndStopAfterReceivingNotification(addr string) error {
 		err := srv.ListenAndServe()
 		if err != nil {
 			errorChannel <- err
+
 			cancel()
 		}
 	}()

--- a/scripts/check_lint.sh
+++ b/scripts/check_lint.sh
@@ -10,12 +10,13 @@ set -e
 echo "Running $0"
 
 DOCKER_CMD=${DOCKER_CMD:-docker}
+GOLANGCI_LINT_IMAGE="golangci/golangci-lint:v1.23.1"
 
 if [ ! $(command -v ${DOCKER_CMD}) ]; then
     exit 0
 fi
 
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace golangci/golangci-lint:v1.21 golangci-lint run
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY}  -e GOOS=js -e GOARCH=wasm -v $(pwd):/opt/workspace -w /opt/workspace golangci/golangci-lint:v1.21 golangci-lint run
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/cmd/aries-agent-rest golangci/golangci-lint:v1.21 golangci-lint run -c ../../.golangci.yml
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/test/bdd golangci/golangci-lint:v1.21 golangci-lint run -c ../../.golangci.yml
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace ${GOLANGCI_LINT_IMAGE} golangci-lint run
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY}  -e GOOS=js -e GOARCH=wasm -v $(pwd):/opt/workspace -w /opt/workspace ${GOLANGCI_LINT_IMAGE} golangci-lint run
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/cmd/aries-agent-rest ${GOLANGCI_LINT_IMAGE} golangci-lint run -c ../../.golangci.yml
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/test/bdd ${GOLANGCI_LINT_IMAGE} golangci-lint run -c ../../.golangci.yml

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -69,6 +69,7 @@ func TestMain(m *testing.M) {
 	os.Exit(status)
 }
 
+//nolint:gocognit
 func runBddTests(tags, format string) int {
 	return godog.RunWithOptions("godogs", func(s *godog.Suite) {
 		s.BeforeSuite(func() {


### PR DESCRIPTION
- update golangci-lint to v1.23.1
- fix lint warnings
- fix build constraints on WASM js worker
- todo: fix lint warnings for new linters (currently disabled).

Signed-off-by: Troy Ronda <troy@troyronda.com>

