### PR TITLE
feat: Linked Data proof of Verifiable Credential

### DIFF
--- a/pkg/doc/signature/proof/utils.go
+++ b/pkg/doc/signature/proof/utils.go
@@ -20,9 +20,14 @@ func GetProofs(jsonLdObject map[string]interface{}) ([]*Proof, error) {
 		return nil, ErrProofNotFound
 	}
 
-	typedEntry, ok := entry.([]interface{})
-	if !ok {
-		return nil, errors.New("expecting []interface{}, got something else")
+	var typedEntry []interface{}
+	switch te := entry.(type) {
+	case []interface{}:
+		typedEntry = te
+	case map[string]interface{}:
+		typedEntry = []interface{}{te}
+	default:
+		return nil, errors.New("expecting []interface{} or map[string]interface{}, got something else")
 	}
 
 	var result []*Proof
@@ -51,11 +56,11 @@ func AddProof(jsonLdObject map[string]interface{}, proof *Proof) error {
 	entry, exists := jsonLdObject[jsonldProof]
 
 	if exists {
-		var ok bool
-
-		proofs, ok = entry.([]interface{})
-		if !ok {
-			return errors.New("expecting []interface{}, got something else")
+		switch p := entry.(type) {
+		case []interface{}:
+			proofs = p
+		default:
+			proofs = []interface{}{p}
 		}
 	}
 

--- a/pkg/doc/signature/proof/utils_test.go
+++ b/pkg/doc/signature/proof/utils_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAddProof(t *testing.T) {
+func TestAddManyProofs(t *testing.T) {
 	doc := getDefaultDoc()
 	proofs, err := GetProofs(doc)
 	require.Equal(t, err, ErrProofNotFound)
@@ -61,7 +61,7 @@ func TestGetCopyWithoutProof(t *testing.T) {
 	require.True(t, reflect.DeepEqual(docCopy, getDefaultDoc()))
 }
 
-func TestInvalidProofFormat(t *testing.T) {
+func TestAddSingleProof(t *testing.T) {
 	doc := map[string]interface{}{
 		"test": "test",
 		"proof": map[string]interface{}{
@@ -72,9 +72,10 @@ func TestInvalidProofFormat(t *testing.T) {
 		},
 	}
 	proofs, err := GetProofs(doc)
-	require.NotNil(t, err)
-	require.Nil(t, proofs)
-	require.Contains(t, err.Error(), "expecting []interface{}")
+	require.NoError(t, err)
+	require.NotNil(t, proofs)
+	require.Equal(t, 1, len(proofs))
+	require.Equal(t, "creator", proofs[0].Creator)
 
 	now := time.Now()
 	proof := Proof{Creator: "creator-2",
@@ -83,8 +84,7 @@ func TestInvalidProofFormat(t *testing.T) {
 		Type:       "Ed25519Signature2018"}
 
 	err = AddProof(doc, &proof)
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "expecting []interface{}")
+	require.NoError(t, err)
 }
 
 func getDefaultDoc() map[string]interface{} {

--- a/pkg/doc/verifiable/common_test.go
+++ b/pkg/doc/verifiable/common_test.go
@@ -186,3 +186,37 @@ func TestDecodeContext(t *testing.T) {
 		require.Nil(t, extraContexts)
 	})
 }
+
+func Test_safeStringValue(t *testing.T) {
+	var i interface{} = "str"
+
+	require.Equal(t, "str", safeStringValue(i))
+
+	i = nil
+	require.Equal(t, "", safeStringValue(i))
+}
+
+func Test_proofsToRaw(t *testing.T) {
+	singleProof := []Proof{{
+		"proofValue": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..67TTULBvibJaJ2oZf3tGYhxZqxYS89qGQykL5hfCoh-MF0vrwQqzciZhjNrAGTAgHtDZsnSQVwJ8bO_7Sc0ECw", //nolint:lll
+	}}
+
+	singleProofBytes, err := proofsToRaw(singleProof)
+	require.NoError(t, err)
+
+	var singleProofMap map[string]interface{}
+
+	err = json.Unmarshal(singleProofBytes, &singleProofMap)
+	require.NoError(t, err)
+
+	severalProofs := []Proof{
+		singleProof[0],
+		{"proofValue": "if8ooA+32YZc4SQBvIDDY9tgTatPoq4IZ8Kr+We1t38LR2RuURmaVu9D4shbi4VvND87PUqq5/0vsNFEGIIEDA=="},
+	}
+	severalProofsBytes, err := proofsToRaw(severalProofs)
+	require.NoError(t, err)
+
+	var severalProofsMap []map[string]interface{}
+	err = json.Unmarshal(severalProofsBytes, &severalProofsMap)
+	require.NoError(t, err)
+}

--- a/pkg/doc/verifiable/credential_extension_test.go
+++ b/pkg/doc/verifiable/credential_extension_test.go
@@ -85,14 +85,6 @@ func TestCredentialExtensibility(t *testing.T) {
 
   "issuanceDate": "2010-01-01T19:23:24Z",
 
-  "proof": {
-    "type": "RsaSignature2018",
-    "created": "2018-06-18T21:19:10Z",
-    "proofPurpose": "assertionMethod",
-    "verificationMethod": "https://example.com/jdoe/keys/1",
-    "jws": "eyJhbGciOiJQUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DJBMvvFAIC00nSGB6Tn0XKbbF9XrsaJZREWvR2aONYTQQxnyXirtXnlewJMBBn2h9hfcGZrvnC1b6PgWmukzFJ1IiH1dWgnDIS81BH-IxXnPkbuYDeySorc4QU9MJxdVkY5EL4HYbcIfwKj6X4LBQ2_ZHZIu1jdqLcRZqHcsDF5KKylKc1THn5VRWy5WhYg_gBnyWny8E6Qkrze53MR7OuAmmNJ1m1nN8SxDrG6a08L78J0-Fbas5OjAQz3c17GY8mVuDPOBIOVjMEghBlgl3nOi1ysxbRGhHLEK4s0KKbeRogZdgt1DkQxDFxxn41QWDw_mmMCjs9qxg0zcZzqEJw"
-  },
-
   "expirationDate": "2020-01-01T19:23:24Z",
 
   "credentialStatus": {

--- a/pkg/doc/verifiable/credential_jwt.go
+++ b/pkg/doc/verifiable/credential_jwt.go
@@ -59,14 +59,12 @@ func newJWTCredClaims(vc *Credential, minimizeVC bool) (*JWTCredClaims, error) {
 		vcCopy.ID = ""
 
 		raw, err = vcCopy.raw()
-		if err != nil {
-			return nil, err
-		}
 	} else {
 		raw, err = vc.raw()
-		if err != nil {
-			return nil, err
-		}
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	vcMap, err := mergeCustomFields(raw, raw.CustomFields)

--- a/pkg/doc/verifiable/credential_ldp.go
+++ b/pkg/doc/verifiable/credential_ldp.go
@@ -1,0 +1,22 @@
+package verifiable
+
+import (
+	"fmt"
+)
+
+// AddLinkedDataProof appends proof to the Verifiable Credential.
+func (vc *Credential) AddLinkedDataProof(context *LinkedDataProofContext) error {
+	vcBytes, err := vc.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("add linked data proof to VC: %w", err)
+	}
+
+	proofs, err := addLinkedDataProof(context, vcBytes)
+	if err != nil {
+		return err
+	}
+
+	vc.Proofs = proofs
+
+	return nil
+}

--- a/pkg/doc/verifiable/credential_ldp_test.go
+++ b/pkg/doc/verifiable/credential_ldp_test.go
@@ -1,0 +1,109 @@
+package verifiable
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/ed25519signature2018"
+)
+
+func TestNewCredentialFromLinkedDataProof(t *testing.T) {
+	r := require.New(t)
+
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	r.NoError(err)
+
+	ldpContext := &LinkedDataProofContext{
+		Creator:       "John",
+		SignatureType: "Ed25519Signature2018",
+		Suite:         ed25519signature2018.New(),
+		PrivateKey:    privKey,
+	}
+
+	vc, _, err := NewCredential([]byte(validCredential))
+	r.NoError(err)
+
+	err = vc.AddLinkedDataProof(ldpContext)
+	r.NoError(err)
+
+	vcBytes, err := json.Marshal(vc)
+	r.NoError(err)
+
+	vcWithLdp, _, err := NewCredential(vcBytes,
+		WithEmbeddedSignatureSuites(ed25519signature2018.New()),
+		WithPublicKeyFetcher(SingleKey([]byte(pubKey))))
+	r.NoError(err)
+
+	r.NoError(err)
+	r.Equal(vc, vcWithLdp)
+}
+
+// TODO add a scenario when a new proof is appended to already existent one.
+func TestCredential_AddLinkedDataProof(t *testing.T) {
+	r := require.New(t)
+
+	_, privKey, err := ed25519.GenerateKey(rand.Reader)
+	r.NoError(err)
+
+	ldpContext := &LinkedDataProofContext{
+		Creator:       "John",
+		SignatureType: "Ed25519Signature2018",
+		Suite:         ed25519signature2018.New(),
+		PrivateKey:    privKey,
+	}
+
+	t.Run("Add a valid Linked Data proof to VC", func(t *testing.T) {
+		vc, _, err := NewCredential([]byte(validCredential))
+		r.NoError(err)
+
+		originalVCMap, err := toMap(vc)
+		r.NoError(err)
+
+		err = vc.AddLinkedDataProof(ldpContext)
+		r.NoError(err)
+
+		vcJSON, err := vc.MarshalJSON()
+		r.NoError(err)
+
+		vcMap, err := toMap(vcJSON)
+		r.NoError(err)
+
+		r.Contains(vcMap, "proof")
+		vcProof := vcMap["proof"]
+		vcProofMap, ok := vcProof.(map[string]interface{})
+		r.True(ok)
+		r.Contains(vcProofMap, "created")
+		r.Contains(vcProofMap, "proofValue")
+		r.Equal("Ed25519Signature2018", vcProofMap["type"])
+
+		// check that only "proof" element was added as a result of AddLinkedDataProof().
+		delete(vcMap, "proof")
+		r.Equal(originalVCMap, vcMap)
+	})
+
+	t.Run("Add invalid Linked Data proof to VC", func(t *testing.T) {
+		vc, _, err := NewCredential([]byte(validCredential))
+		require.NoError(t, err)
+
+		vc.CustomFields = map[string]interface{}{
+			"invalidField": make(chan int),
+		}
+
+		err = vc.AddLinkedDataProof(ldpContext)
+		r.Error(err)
+
+		vc.CustomFields = nil
+		ldpContextWithMissingSignatureType := &LinkedDataProofContext{
+			Creator:    "John",
+			Suite:      ed25519signature2018.New(),
+			PrivateKey: privKey,
+		}
+
+		err = vc.AddLinkedDataProof(ldpContextWithMissingSignatureType)
+		r.Error(err)
+	})
+}

--- a/pkg/doc/verifiable/embedded_proof.go
+++ b/pkg/doc/verifiable/embedded_proof.go
@@ -1,0 +1,74 @@
+package verifiable
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+type embeddedProofType int
+
+const (
+	linkedDataProof embeddedProofType = iota
+)
+
+// nolint:gochecknoglobals
+var proofTypesMapping = map[string]embeddedProofType{
+	"Ed25519Signature2018": linkedDataProof,
+}
+
+func parseEmbeddedProof(proofMap map[string]interface{}) (embeddedProofType, error) {
+	proofType, ok := proofMap["type"]
+	if !ok {
+		return -1, errors.New("proof type is missing")
+	}
+
+	embeddedProofType, ok := proofTypesMapping[safeStringValue(proofType)]
+	if !ok {
+		return -1, fmt.Errorf("unsupported proof type: %s", proofType)
+	}
+
+	return embeddedProofType, nil
+}
+
+func checkEmbeddedProof(docBytes []byte, vcOpts *credentialOpts) ([]byte, error) {
+	if vcOpts.disabledProofCheck {
+		return docBytes, nil
+	}
+
+	var jsonldDoc map[string]interface{}
+
+	err := json.Unmarshal(docBytes, &jsonldDoc)
+	if err != nil {
+		return nil, fmt.Errorf("embedded proof is not JSON: %w", err)
+	}
+
+	proofElement, ok := jsonldDoc["proof"]
+	if !ok || proofElement == nil {
+		// do not make a check if there is no proof defined as proof presence is not mandatory
+		return docBytes, nil
+	}
+
+	proofMap, ok := proofElement.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("check embedded proof: expecting [string]interface{}, got something else")
+	}
+
+	proofType, err := parseEmbeddedProof(proofMap)
+	if err != nil {
+		return nil, err
+	}
+
+	switch proofType {
+	case linkedDataProof:
+		err = checkLinkedDataProof(docBytes, vcOpts.ldpSuites, vcOpts.publicKeyFetcher)
+	default:
+		err = fmt.Errorf("unsupported proof type: %v", proofType)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("check embedded proof: %w", err)
+	}
+
+	return docBytes, nil
+}

--- a/pkg/doc/verifiable/embedded_proof_test.go
+++ b/pkg/doc/verifiable/embedded_proof_test.go
@@ -1,0 +1,99 @@
+package verifiable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_parseEmbeddedProof(t *testing.T) {
+	t.Run("parse linked data proof with \"Ed25519Signature2018\" proof type", func(t *testing.T) {
+		proofType, err := parseEmbeddedProof(map[string]interface{}{
+			"type": "Ed25519Signature2018",
+		})
+		require.NoError(t, err)
+		require.Equal(t, linkedDataProof, proofType)
+	})
+
+	t.Run("parse embedded proof without \"type\" element", func(t *testing.T) {
+		_, err := parseEmbeddedProof(map[string]interface{}{})
+		require.Error(t, err)
+		require.EqualError(t, err, "proof type is missing")
+	})
+
+	t.Run("parse embedded proof with unsupported type", func(t *testing.T) {
+		_, err := parseEmbeddedProof(map[string]interface{}{
+			"type": "SomethingUnsupported",
+		})
+		require.Error(t, err)
+		require.EqualError(t, err, "unsupported proof type: SomethingUnsupported")
+	})
+}
+
+func Test_checkEmbeddedProof(t *testing.T) {
+	r := require.New(t)
+	nonJSONBytes := []byte("not JSON")
+	defaultVCOpts := &credentialOpts{}
+
+	t.Run("Does not check the embedded proof if credentialOpts.disabledProofCheck", func(t *testing.T) {
+		docBytes, err := checkEmbeddedProof(nonJSONBytes, &credentialOpts{disabledProofCheck: true})
+		r.NoError(err)
+		r.NotNil(docBytes)
+	})
+
+	t.Run("error on checking non-JSON embedded proof", func(t *testing.T) {
+		docBytes, err := checkEmbeddedProof(nonJSONBytes, defaultVCOpts)
+		r.Error(err)
+		r.Contains(err.Error(), "embedded proof is not JSON")
+		r.Nil(docBytes)
+	})
+
+	t.Run("check embedded proof without \"proof\" element", func(t *testing.T) {
+		docWithoutProof := `{
+  "@context": "https://www.w3.org/2018/credentials/v1"
+}`
+		docBytes, err := checkEmbeddedProof([]byte(docWithoutProof), defaultVCOpts)
+		r.NoError(err)
+		r.NotNil(docBytes)
+	})
+
+	t.Run("error on not map \"proof\" element", func(t *testing.T) {
+		docWithNotMapProof := `{
+  "@context": "https://www.w3.org/2018/credentials/v1",
+  "proof": "some string proof"
+}`
+		docBytes, err := checkEmbeddedProof([]byte(docWithNotMapProof), defaultVCOpts)
+		r.Error(err)
+		r.EqualError(err, "check embedded proof: expecting [string]interface{}, got something else")
+		r.Nil(docBytes)
+	})
+
+	t.Run("error on not supported type of embedded proof", func(t *testing.T) {
+		docWithNotSupportedProof := `{
+  "@context": "https://www.w3.org/2018/credentials/v1",
+  "proof": {
+	"type": "SomethingUnsupported"
+  }
+}`
+		docBytes, err := checkEmbeddedProof([]byte(docWithNotSupportedProof), defaultVCOpts)
+		r.Error(err)
+		r.EqualError(err, "unsupported proof type: SomethingUnsupported")
+		r.Nil(docBytes)
+	})
+
+	t.Run("error on invalid proof of Linked Data embedded proof", func(t *testing.T) {
+		docWithNotSupportedProof := `{
+  "@context": "https://www.w3.org/2018/credentials/v1",
+  "proof": {
+	"type": "Ed25519Signature2018",
+    "created": "2020-01-21T12:59:31+02:00",
+    "creator": "John",
+    "proofValue": "invalid value"
+  }
+}`
+		docBytes, err := checkEmbeddedProof([]byte(docWithNotSupportedProof), defaultVCOpts)
+		r.Error(err)
+		r.Contains(err.Error(), "check embedded proof")
+		r.Nil(docBytes)
+	})
+}

--- a/pkg/doc/verifiable/jsonld.go
+++ b/pkg/doc/verifiable/jsonld.go
@@ -354,13 +354,13 @@ func credentialSubjectsMap(credentialSubject interface{}) map[string]credentialS
 
 	switch cs := credentialSubject.(type) {
 	case map[string]interface{}:
-		csMap[cs["id"].(string)] = cs
+		csMap[safeStringValue(cs["id"])] = cs
 	case string:
 		csMap[cs] = credentialSubjectMap{"id": cs}
 	case []interface{}:
 		for i := range cs {
 			subjectMap, _ := cs[i].(map[string]interface{}) //nolint:errcheck
-			csMap[subjectMap["id"].(string)] = subjectMap
+			csMap[safeStringValue(subjectMap["id"])] = subjectMap
 		}
 	}
 

--- a/pkg/doc/verifiable/linked_data_proof.go
+++ b/pkg/doc/verifiable/linked_data_proof.go
@@ -1,0 +1,130 @@
+package verifiable
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/signer"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
+)
+
+// signatureSuite encapsulates signature suite methods required for signing documents
+type signatureSuite interface {
+
+	// GetCanonicalDocument will return normalized/canonical version of the document
+	GetCanonicalDocument(doc map[string]interface{}) ([]byte, error)
+
+	// GetDigest returns document digest
+	GetDigest(doc []byte) []byte
+
+	// Accept registers this signature suite with the given signature type
+	Accept(signatureType string) bool
+}
+
+type verifierSignatureSuite interface {
+	signatureSuite
+
+	// Verify will verify signature against public key
+	Verify(pubKey []byte, doc []byte, signature []byte) error
+}
+
+type signerSignatureSuite interface {
+	signatureSuite
+
+	// Sign  will sign JSON LD document
+	// todo refactor, do not pass privateKey (https://github.com/hyperledger/aries-framework-go/issues/339)
+	Sign(jsonLdDoc, privKey []byte) ([]byte, error)
+}
+
+type keyResolverAdapter struct {
+	pubKeyFetcher PublicKeyFetcher
+}
+
+func (k *keyResolverAdapter) Resolve(id string) ([]byte, error) {
+	fetcher, err := k.pubKeyFetcher("", id)
+	if err != nil {
+		return nil, err
+	}
+
+	pubKeyBytes, ok := fetcher.([]byte)
+	if !ok {
+		return nil, errors.New("expecting []byte public key, got something else")
+	}
+
+	return pubKeyBytes, nil
+}
+
+// LinkedDataProofContext holds options needed to build a Linked Data Proof.
+// todo refactor, do not pass privateKey (https://github.com/hyperledger/aries-framework-go/issues/339)
+type LinkedDataProofContext struct {
+	SignatureType string               // required
+	Suite         signerSignatureSuite // required
+	PrivateKey    []byte               // required
+	Creator       string               // required
+	Created       *time.Time           // optional
+}
+
+func checkLinkedDataProof(jsonldBytes []byte, _ []verifierSignatureSuite, pubKeyFetcher PublicKeyFetcher) error {
+	// todo pass signature suites to the document verifier - current its API does not allow that
+	documentVerifier := verifier.New(&keyResolverAdapter{pubKeyFetcher})
+
+	err := documentVerifier.Verify(jsonldBytes)
+	if err != nil {
+		return fmt.Errorf("check linked data proof: %w", err)
+	}
+
+	return nil
+}
+
+type rawProof struct {
+	Proof json.RawMessage `json:"proof,omitempty"`
+}
+
+func addLinkedDataProof(context *LinkedDataProofContext, jsonldBytes []byte) ([]Proof, error) {
+	documentSigner := signer.New()
+
+	vcWithNewProofBytes, err := documentSigner.Sign(mapContext(context), jsonldBytes)
+	if err != nil {
+		return nil, fmt.Errorf("add linked data proof: %w", err)
+	}
+
+	// Get a proof from json-ld document.
+	var rProof rawProof
+
+	err = json.Unmarshal(vcWithNewProofBytes, &rProof)
+	if err != nil {
+		return nil, err
+	}
+
+	proofs, err := decodeProof(rProof.Proof)
+	if err != nil {
+		return nil, err
+	}
+
+	return proofs, nil
+}
+
+type signerWrapper struct {
+	suite   signerSignatureSuite
+	privKey []byte
+}
+
+func (sw *signerWrapper) Sign(doc []byte) ([]byte, error) {
+	return sw.suite.Sign(sw.privKey, doc)
+}
+
+func mapContext(context *LinkedDataProofContext) *signer.Context {
+	sw := &signerWrapper{
+		suite:   context.Suite,
+		privKey: context.PrivateKey}
+
+	return &signer.Context{
+		SignatureType: context.SignatureType,
+		Signer:        sw,
+		Created:       context.Created,
+		Creator:       context.Creator,
+	}
+}

--- a/pkg/doc/verifiable/linked_data_proof_test.go
+++ b/pkg/doc/verifiable/linked_data_proof_test.go
@@ -1,0 +1,42 @@
+package verifiable
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_keyResolverAdapter_Resolve(t *testing.T) {
+	t.Run("successful public key resolving", func(t *testing.T) {
+		pubKey, _, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+		kra := &keyResolverAdapter{pubKeyFetcher: SingleKey([]byte(pubKey))}
+		resolvedPubKey, err := kra.Resolve("any")
+		require.NoError(t, err)
+		require.Equal(t, []byte(pubKey), resolvedPubKey)
+	})
+
+	t.Run("error at public key resolving (e.g. not found)", func(t *testing.T) {
+		kra := &keyResolverAdapter{pubKeyFetcher: func(issuerID, keyID string) (interface{}, error) {
+			return nil, errors.New("no key found")
+		}}
+		resolvedPubKey, err := kra.Resolve("any")
+		require.Error(t, err)
+		require.EqualError(t, err, "no key found")
+		require.Nil(t, resolvedPubKey)
+	})
+
+	t.Run("returned public key is not []byte", func(t *testing.T) {
+		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		kra := &keyResolverAdapter{pubKeyFetcher: SingleKey(privateKey.Public())}
+		resolvedPubKey, err := kra.Resolve("any")
+		require.Error(t, err)
+		require.EqualError(t, err, "expecting []byte public key, got something else")
+		require.Nil(t, resolvedPubKey)
+	})
+}

--- a/pkg/doc/verifiable/presentation_jws_test.go
+++ b/pkg/doc/verifiable/presentation_jws_test.go
@@ -23,7 +23,7 @@ func TestJWTPresClaims_MarshalJWS(t *testing.T) {
 	_, rawVC, err := decodeVPFromJWS([]byte(jws), true, holderPublicKeyFetcher(t))
 
 	require.NoError(t, err)
-	require.Equal(t, vp.raw().stringJSON(t), rawVC.stringJSON(t))
+	require.Equal(t, vp.stringJSON(t), rawVC.stringJSON(t))
 }
 
 type invalidPresClaims struct {
@@ -43,7 +43,7 @@ func TestUnmarshalPresJWSClaims(t *testing.T) {
 
 		claims, err := unmarshalPresJWSClaims([]byte(jws), true, testFetcher)
 		require.NoError(t, err)
-		require.Equal(t, vp.raw().stringJSON(t), claims.Presentation.stringJSON(t))
+		require.Equal(t, vp.stringJSON(t), claims.Presentation.stringJSON(t))
 	})
 
 	t.Run("Invalid serialized JWS", func(t *testing.T) {
@@ -100,7 +100,8 @@ func createCredJWS(t *testing.T, vp *Presentation) string {
 	privateKey, err := readPrivateKey(filepath.Join(certPrefix, "holder_private.pem"))
 	require.NoError(t, err)
 
-	claims := newJWTPresClaims(vp, []string{}, false)
+	claims, err := newJWTPresClaims(vp, []string{}, false)
+	require.NoError(t, err)
 	require.NotNil(t, claims)
 
 	jws, err := claims.MarshalJWS(RS256, privateKey, "any")

--- a/pkg/doc/verifiable/presentation_jwt_proof_test.go
+++ b/pkg/doc/verifiable/presentation_jwt_proof_test.go
@@ -93,7 +93,9 @@ func TestNewPresentationFromJWS_EdDSA(t *testing.T) {
 	require.NoError(t, err)
 
 	// marshal presentation into JWS using EdDSA (Ed25519 signature algorithm).
-	jwtClaims := vp.JWTClaims([]string{}, false)
+	jwtClaims, err := vp.JWTClaims([]string{}, false)
+	require.NoError(t, err)
+
 	vpJWSStr, err := jwtClaims.MarshalJWS(EdDSA, privKey, vp.Holder+"#keys-"+keyID)
 	require.NoError(t, err)
 
@@ -191,7 +193,10 @@ func TestNewPresentationWithVCJWT(t *testing.T) {
 		holderPubKey, holderPrivKey, err := ed25519.GenerateKey(rand.Reader)
 		r.NoError(err)
 
-		vpJWS, err := vp.JWTClaims([]string{}, true).MarshalJWS(
+		jwtClaims, err := vp.JWTClaims([]string{}, true)
+		require.NoError(t, err)
+
+		vpJWS, err := jwtClaims.MarshalJWS(
 			EdDSA, holderPrivKey, "holder-key")
 		r.NoError(err)
 
@@ -233,7 +238,10 @@ func TestNewPresentationWithVCJWT(t *testing.T) {
 		holderPubKey, holderPrivKey, err := ed25519.GenerateKey(rand.Reader)
 		r.NoError(err)
 
-		vpJWS, err := vp.JWTClaims([]string{}, true).MarshalJWS(
+		jwtClaims, err := vp.JWTClaims([]string{}, true)
+		require.NoError(t, err)
+
+		vpJWS, err := jwtClaims.MarshalJWS(
 			EdDSA, holderPrivKey, "holder-key")
 		r.NoError(err)
 
@@ -265,7 +273,10 @@ func TestNewPresentationWithVCJWT(t *testing.T) {
 		holderPubKey, holderPrivKey, err := ed25519.GenerateKey(rand.Reader)
 		r.NoError(err)
 
-		vpJWS, err := vp.JWTClaims([]string{}, true).MarshalJWS(
+		jwtClaims, err := vp.JWTClaims([]string{}, true)
+		require.NoError(t, err)
+
+		vpJWS, err := jwtClaims.MarshalJWS(
 			EdDSA, holderPrivKey, "holder-key")
 		r.NoError(err)
 
@@ -299,7 +310,9 @@ func createPresJWS(t *testing.T, vpBytes []byte, minimize bool) []byte {
 	privateKey, err := readPrivateKey(filepath.Join(certPrefix, "holder_private.pem"))
 	require.NoError(t, err)
 
-	jwtClaims := vp.JWTClaims([]string{}, minimize)
+	jwtClaims, err := vp.JWTClaims([]string{}, minimize)
+	require.NoError(t, err)
+
 	vpJWT, err := jwtClaims.MarshalJWS(RS256, privateKey, vp.Holder+"#keys-"+keyID)
 	require.NoError(t, err)
 
@@ -323,7 +336,8 @@ func createPresUnsecuredJWT(t *testing.T, cred []byte, minimize bool) []byte {
 	vp, err := NewPresentation(cred)
 	require.NoError(t, err)
 
-	jwtClaims := vp.JWTClaims([]string{}, minimize)
+	jwtClaims, err := vp.JWTClaims([]string{}, minimize)
+	require.NoError(t, err)
 
 	vpJWT, err := jwtClaims.MarshalUnsecuredJWT()
 	require.NoError(t, err)

--- a/pkg/doc/verifiable/presentation_jwt_test.go
+++ b/pkg/doc/verifiable/presentation_jwt_test.go
@@ -18,7 +18,8 @@ func TestNewJWTPresClaims(t *testing.T) {
 	audience := []string{"did:example:4a57546973436f6f6c4a4a57573"}
 
 	t.Run("new JWT claims of VP with minimization", func(t *testing.T) {
-		claims := newJWTPresClaims(vp, audience, true)
+		claims, err := newJWTPresClaims(vp, audience, true)
+		require.NoError(t, err)
 		require.NotNil(t, claims)
 
 		// issuer, ID and audience are filled in JWT claims
@@ -38,7 +39,8 @@ func TestNewJWTPresClaims(t *testing.T) {
 	})
 
 	t.Run("new JWT claims of VP without minimization", func(t *testing.T) {
-		claims := newJWTPresClaims(vp, audience, false)
+		claims, err := newJWTPresClaims(vp, audience, false)
+		require.NoError(t, err)
 		require.NotNil(t, claims)
 
 		// issuer, ID and audience are filled in JWT claims

--- a/pkg/doc/verifiable/presentation_jwt_unsecured_test.go
+++ b/pkg/doc/verifiable/presentation_jwt_unsecured_test.go
@@ -21,7 +21,7 @@ func TestJWTPresClaims_MarshalUnsecuredJWT(t *testing.T) {
 	_, rawVC, err := decodeVPFromUnsecuredJWT([]byte(jws))
 
 	require.NoError(t, err)
-	require.Equal(t, vp.raw().stringJSON(t), rawVC.stringJSON(t))
+	require.Equal(t, vp.stringJSON(t), rawVC.stringJSON(t))
 }
 
 func TestDecodeVPFromUnsecuredJWT(t *testing.T) {
@@ -34,7 +34,7 @@ func TestDecodeVPFromUnsecuredJWT(t *testing.T) {
 		vpDecodedBytes, vpRaw, err := decodeVPFromUnsecuredJWT([]byte(jws))
 		require.NoError(t, err)
 		require.NotNil(t, vpDecodedBytes)
-		require.Equal(t, vp.raw().stringJSON(t), vpRaw.stringJSON(t))
+		require.Equal(t, vp.stringJSON(t), vpRaw.stringJSON(t))
 	})
 
 	t.Run("Invalid serialized unsecured JWT", func(t *testing.T) {
@@ -63,7 +63,8 @@ func TestDecodeVPFromUnsecuredJWT(t *testing.T) {
 }
 
 func createCredUnsecuredJWT(t *testing.T, vp *Presentation) string {
-	claims := newJWTPresClaims(vp, []string{}, false)
+	claims, err := newJWTPresClaims(vp, []string{}, false)
+	require.NoError(t, err)
 	require.NotNil(t, claims)
 
 	unsecuredJWT, err := claims.MarshalUnsecuredJWT()

--- a/pkg/doc/verifiable/presentation_ldp.go
+++ b/pkg/doc/verifiable/presentation_ldp.go
@@ -1,0 +1,22 @@
+package verifiable
+
+import (
+	"fmt"
+)
+
+// AddLinkedDataProof appends proof to the Verifiable Presentation.
+func (vp *Presentation) AddLinkedDataProof(context *LinkedDataProofContext) error {
+	vcBytes, err := vp.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("add linked data proof to VP: %w", err)
+	}
+
+	proofs, err := addLinkedDataProof(context, vcBytes)
+	if err != nil {
+		return err
+	}
+
+	vp.Proofs = proofs
+
+	return nil
+}

--- a/pkg/doc/verifiable/presentation_ldp_test.go
+++ b/pkg/doc/verifiable/presentation_ldp_test.go
@@ -1,0 +1,106 @@
+package verifiable
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/ed25519signature2018"
+)
+
+func TestNewPresentationFromLinkedDataProof(t *testing.T) {
+	r := require.New(t)
+
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	r.NoError(err)
+
+	ldpContext := &LinkedDataProofContext{
+		Creator:       "John",
+		SignatureType: "Ed25519Signature2018",
+		Suite:         ed25519signature2018.New(),
+		PrivateKey:    privKey,
+	}
+
+	vc, err := NewPresentation([]byte(validPresentation))
+	r.NoError(err)
+
+	err = vc.AddLinkedDataProof(ldpContext)
+	r.NoError(err)
+
+	vcBytes, err := json.Marshal(vc)
+	r.NoError(err)
+
+	vcWithLdp, err := NewPresentation(vcBytes,
+		WithPresEmbeddedSignatureSuites(ed25519signature2018.New()),
+		WithPresPublicKeyFetcher(SingleKey([]byte(pubKey))))
+	r.NoError(err)
+
+	r.NoError(err)
+	r.Equal(vc, vcWithLdp)
+}
+
+func TestPresentation_AddLinkedDataProof(t *testing.T) {
+	r := require.New(t)
+
+	_, privKey, err := ed25519.GenerateKey(rand.Reader)
+	r.NoError(err)
+
+	ldpContext := &LinkedDataProofContext{
+		Creator:       "Bill",
+		SignatureType: "Ed25519Signature2018",
+		Suite:         ed25519signature2018.New(),
+		PrivateKey:    privKey,
+	}
+
+	t.Run("Add a valid Linked Data proof to VC", func(t *testing.T) {
+		vp, err := NewPresentation([]byte(validPresentation))
+		r.NoError(err)
+
+		err = vp.AddLinkedDataProof(ldpContext)
+		r.NoError(err)
+
+		vpJSON, err := vp.MarshalJSON()
+		r.NoError(err)
+
+		vpMap, err := toMap(vpJSON)
+		r.NoError(err)
+
+		r.Contains(vpMap, "proof")
+		vpProof := vpMap["proof"]
+		vpProofs, ok := vpProof.([]interface{})
+		r.True(ok)
+		r.Len(vpProofs, 2)
+		newVPProof, ok := vpProofs[1].(map[string]interface{})
+		r.True(ok)
+		r.Contains(newVPProof, "created")
+		r.Contains(newVPProof, "proofValue")
+		r.Equal("Ed25519Signature2018", newVPProof["type"])
+	})
+
+	t.Run("Add invalid Linked Data proof to VC", func(t *testing.T) {
+		vp, err := NewPresentation([]byte(validPresentation))
+		require.NoError(t, err)
+
+		vp.RefreshService = &TypedID{
+			CustomFields: map[string]interface{}{
+				"invalidField": make(chan int),
+			},
+		}
+
+		err = vp.AddLinkedDataProof(ldpContext)
+		r.Error(err)
+
+		vp.RefreshService = nil
+		ldpContextWithMissingSignatureType := &LinkedDataProofContext{
+			Creator:    "Bill",
+			Suite:      ed25519signature2018.New(),
+			PrivateKey: privKey,
+		}
+
+		err = vp.AddLinkedDataProof(ldpContextWithMissingSignatureType)
+		r.Error(err)
+	})
+}

--- a/pkg/doc/verifiable/support_test.go
+++ b/pkg/doc/verifiable/support_test.go
@@ -34,13 +34,6 @@ const validCredential = `{
     "name": "Example University"
   },
   "issuanceDate": "2010-01-01T19:23:24Z",
-  "proof": {
-    "type": "RsaSignature2018",
-    "created": "2018-06-18T21:19:10Z",
-    "proofPurpose": "assertionMethod",
-    "verificationMethod": "https://example.com/jdoe/keys/1",
-    "jws": "eyJhbGciOiJQUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DJBMvvFAIC00nSGB6Tn0XKbbF9XrsaJZREWvR2aONYTQQxnyXirtXnlewJMBBn2h9hfcGZrvnC1b6PgWmukzFJ1IiH1dWgnDIS81BH-IxXnPkbuYDeySorc4QU9MJxdVkY5EL4HYbcIfwKj6X4LBQ2_ZHZIu1jdqLcRZqHcsDF5KKylKc1THn5VRWy5WhYg_gBnyWny8E6Qkrze53MR7OuAmmNJ1m1nN8SxDrG6a08L78J0-Fbas5OjAQz3c17GY8mVuDPOBIOVjMEghBlgl3nOi1ysxbRGhHLEK4s0KKbeRogZdgt1DkQxDFxxn41QWDw_mmMCjs9qxg0zcZzqEJw"
-  },
   "expirationDate": "2020-01-01T19:23:24Z",
   "credentialStatus": {
     "id": "https://example.edu/status/24",
@@ -158,6 +151,13 @@ func (vc *Credential) byteJSON(t *testing.T) []byte {
 
 func (raw *rawPresentation) stringJSON(t *testing.T) string {
 	bytes, err := json.Marshal(raw)
+	require.NoError(t, err)
+
+	return string(bytes)
+}
+
+func (vp *Presentation) stringJSON(t *testing.T) string {
+	bytes, err := json.Marshal(vp)
 	require.NoError(t, err)
 
 	return string(bytes)

--- a/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
+++ b/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
@@ -75,7 +75,7 @@ func main() {
 }
 
 func encodeVCToJWS(vcBytes []byte, privateKey interface{}) {
-	credential, _, err := verifiable.NewCredential(vcBytes)
+	credential, _, err := verifiable.NewCredential(vcBytes, verifiable.WithNoProofCheck())
 	if err != nil {
 		abort("failed to decode credential: %v", err)
 	}
@@ -103,7 +103,10 @@ func encodeVPToJWS(vpBytes []byte, audience string, privateKey, publicKey interf
 		abort("failed to decode presentation: %v", err)
 	}
 
-	jwtClaims := vp.JWTClaims([]string{audience}, true)
+	jwtClaims, err := vp.JWTClaims([]string{audience}, true)
+	if err != nil {
+		abort("failed to build JWT claims: %v", err)
+	}
 
 	jws, err := jwtClaims.MarshalJWS(verifiable.RS256, privateKey, "any")
 	if err != nil {
@@ -114,7 +117,7 @@ func encodeVPToJWS(vpBytes []byte, audience string, privateKey, publicKey interf
 }
 
 func encodeVCToJWTUnsecured(vcBytes []byte) {
-	credential, _, err := verifiable.NewCredential(vcBytes)
+	credential, _, err := verifiable.NewCredential(vcBytes, verifiable.WithNoProofCheck())
 	if err != nil {
 		abort("failed to decode credential: %v", err)
 	}
@@ -194,7 +197,7 @@ func parseKeys(packedKeys string) (private, public interface{}) {
 }
 
 func encodeVCToJSON(vcBytes []byte, testFileName string) {
-	vcOpts := []verifiable.CredentialOpt{verifiable.WithNoCustomSchemaCheck()}
+	vcOpts := []verifiable.CredentialOpt{verifiable.WithNoCustomSchemaCheck(), verifiable.WithNoProofCheck()}
 
 	// This are special test cases which should be made more precise in VC Test Suite.
 	// See https://github.com/w3c/vc-test-suite/issues/96 for more information.

--- a/pkg/store/verifiable/store_test.go
+++ b/pkg/store/verifiable/store_test.go
@@ -47,14 +47,6 @@ var udCredential = `
 
   "issuanceDate": "2010-01-01T19:23:24Z",
 
-  "proof": {
-    "type": "RsaSignature2018",
-    "created": "2018-06-18T21:19:10Z",
-    "proofPurpose": "assertionMethod",
-    "verificationMethod": "https://example.com/jdoe/keys/1",
-    "jws": "eyJhbGciOiJQUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DJBMvvFAIC00nSGB6Tn0XKbbF9XrsaJZREWvR2aONYTQQxnyXirtXnlewJMBBn2h9hfcGZrvnC1b6PgWmukzFJ1IiH1dWgnDIS81BH-IxXnPkbuYDeySorc4QU9MJxdVkY5EL4HYbcIfwKj6X4LBQ2_ZHZIu1jdqLcRZqHcsDF5KKylKc1THn5VRWy5WhYg_gBnyWny8E6Qkrze53MR7OuAmmNJ1m1nN8SxDrG6a08L78J0-Fbas5OjAQz3c17GY8mVuDPOBIOVjMEghBlgl3nOi1ysxbRGhHLEK4s0KKbeRogZdgt1DkQxDFxxn41QWDw_mmMCjs9qxg0zcZzqEJw"
-  },
-
   "expirationDate": "2020-01-01T19:23:24Z",
 
   "credentialStatus": {

--- a/scripts/run_vc_test_suite.sh
+++ b/scripts/run_vc_test_suite.sh
@@ -20,6 +20,7 @@ SUITE_DIR="${BUILD_DIR}/${VC_TEST_SUITE}/suite"
 # build the app to test
 cd $GENERATOR_DIR
 # rename test file in order to be able to build it
+rm -rf tmp
 mkdir tmp
 cp verifiable_suite_test.go tmp/vc_test_suite_app.go
 cd tmp


### PR DESCRIPTION
closes #174

Signed-off-by: Dima <dkinoshenko@gmail.com>

Support of Linked Data proofs with `Ed25519Signature2018 ` type and proof value inside `proofValue` element of the `proof`.
The follow-up PR to support JWS-based proof values is #1093 .