### PR TITLE
ci: enable gomnd (magic number linting)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,7 +85,6 @@ linters:
   disable:
     - maligned
     - prealloc
-    - gomnd # TODO enable.
 
 issues:
   exclude-use-default: false
@@ -94,6 +93,7 @@ issues:
       linters:
         - dupl
         - funlen
+        - gomnd
 
   exclude:
     # Allow package logger variables (for now)
@@ -106,3 +106,5 @@ issues:
     -  Line contains TODO/BUG/FIXME
     # Add comments for package
     -  at least one file in a package should have a package comment
+    # Allow magic number 1
+    - Magic number[:] 1[^\d]

--- a/cmd/aries-agent-rest/startcmd/start.go
+++ b/cmd/aries-agent-rest/startcmd/start.go
@@ -320,10 +320,12 @@ func getUserSetVars(cmd *cobra.Command, hostFlagName,
 func getResolverOpts(httpResolvers []string) ([]aries.Option, error) {
 	var opts []aries.Option
 
+	const numPartsResolverOption = 2
+
 	if len(httpResolvers) > 0 {
 		for _, httpResolver := range httpResolvers {
 			r := strings.Split(httpResolver, "@")
-			if len(r) != 2 {
+			if len(r) != numPartsResolverOption {
 				return nil, fmt.Errorf("invalid http resolver options found")
 			}
 

--- a/cmd/aries-js-worker/main.go
+++ b/cmd/aries-js-worker/main.go
@@ -145,6 +145,9 @@ func throwError(c *command) *result {
 
 // test handler
 func timeout(c *command) *result {
-	time.Sleep(10 * time.Second)
+	const echoTimeout = 10 * time.Second
+
+	time.Sleep(echoTimeout)
+
 	return echo(c)
 }

--- a/pkg/didcomm/packer/jwe/authcrypt/decrypt_jwk.go
+++ b/pkg/didcomm/packer/jwe/authcrypt/decrypt_jwk.go
@@ -19,8 +19,10 @@ import (
 // the sender's public key as a jwk). It uses the recipent's private/public keypair for decryption
 // the returned decrypted value is the sender's public key
 func (p *Packer) decryptSPK(recipientPubKey *[chacha.KeySize]byte, spk string) ([]byte, error) {
+	const jweNumComponents = 5
+
 	jwe := strings.Split(spk, ".")
-	if len(jwe) != 5 {
+	if len(jwe) != jweNumComponents {
 		return nil, fmt.Errorf("bad SPK format")
 	}
 

--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -101,6 +101,8 @@ func New(prov provider) (*Service, error) {
 		return nil, fmt.Errorf("failed to initialize connection store : %w", err)
 	}
 
+	const callbackChannelSize = 10
+
 	svc := &Service{
 		ctx: &context{
 			outboundDispatcher: prov.OutboundDispatcher(),
@@ -109,7 +111,7 @@ func New(prov provider) (*Service, error) {
 			connectionStore:    connRecorder,
 		},
 		// TODO channel size - https://github.com/hyperledger/aries-framework-go/issues/246
-		callbackChannel: make(chan *message, 10),
+		callbackChannel: make(chan *message, callbackChannelSize),
 		connectionStore: connRecorder,
 	}
 

--- a/pkg/didcomm/protocol/route/service.go
+++ b/pkg/didcomm/protocol/route/service.go
@@ -74,6 +74,10 @@ const (
 	routeConfigDataKey = "route-config"
 )
 
+const (
+	updateTimeout = 5 * time.Second
+)
+
 // ErrConnectionNotFound connection not found error
 var ErrConnectionNotFound = errors.New("connection not found")
 
@@ -377,7 +381,7 @@ func (s *Service) Register(connectionID string) error {
 			return fmt.Errorf("save route config : %w", err)
 		}
 	// TODO https://github.com/hyperledger/aries-framework-go/issues/948 configure this timeout at decorator level
-	case <-time.After(5 * time.Second):
+	case <-time.After(updateTimeout):
 		return errors.New("timeout waiting for grant from the router")
 	}
 
@@ -436,7 +440,7 @@ func (s *Service) AddKey(recKey string) error {
 			return err
 		}
 	// TODO https://github.com/hyperledger/aries-framework-go/issues/948 configure this timeout at decorator level
-	case <-time.After(5 * time.Second):
+	case <-time.After(updateTimeout):
 		return errors.New("timeout waiting for keylist update response from the router")
 	}
 

--- a/pkg/doc/verifiable/credential.go
+++ b/pkg/doc/verifiable/credential.go
@@ -351,12 +351,14 @@ func (b *CredentialSchemaLoaderBuilder) Build() *CredentialSchemaLoader {
 func (sc *ExpirableSchemaCache) Put(k string, v []byte) {
 	expires := time.Now().Add(sc.expiration).Unix()
 
-	b := make([]byte, 8)
+	const numBytesTime = 8
+
+	b := make([]byte, numBytesTime)
 	binary.LittleEndian.PutUint64(b, uint64(expires))
 
-	ve := make([]byte, 8+len(v))
-	copy(ve[:8], b)
-	copy(ve[8:], v)
+	ve := make([]byte, numBytesTime+len(v))
+	copy(ve[:numBytesTime], b)
+	copy(ve[numBytesTime:], v)
 
 	sc.cache.Set([]byte(k), ve)
 }
@@ -369,14 +371,16 @@ func (sc *ExpirableSchemaCache) Get(k string) ([]byte, bool) {
 		return nil, false
 	}
 
-	expires := int64(binary.LittleEndian.Uint64(b[:8]))
+	const numBytesTime = 8
+
+	expires := int64(binary.LittleEndian.Uint64(b[:numBytesTime]))
 	if expires < time.Now().Unix() {
 		// cache expires
 		sc.cache.Del([]byte(k))
 		return nil, false
 	}
 
-	return b[8:], true
+	return b[numBytesTime:], true
 }
 
 // Evidence defines evidence of Verifiable Credential

--- a/pkg/doc/verifiable/jwt_unsecured.go
+++ b/pkg/doc/verifiable/jwt_unsecured.go
@@ -33,9 +33,11 @@ func marshalUnsecuredJWT(headers map[string]string, claims interface{}) (string,
 
 // unmarshalUnsecuredJWT unmarshals serialized JWT in unsecured form into jose headers and claims body.
 func unmarshalUnsecuredJWT(rawJWT []byte) (joseHeaders map[string]string, bytesClaim []byte, err error) {
+	const numPartsJWT = 3
+
 	parts := strings.Split(string(rawJWT), ".")
 
-	if len(parts) != 3 {
+	if len(parts) != numPartsJWT {
 		return nil, nil, errors.New("JWT format must have three parts")
 	}
 

--- a/pkg/internal/common/logging/modlog/deflog.go
+++ b/pkg/internal/common/logging/modlog/deflog.go
@@ -82,10 +82,12 @@ func (l *DefLog) SetOutput(output io.Writer) {
 }
 
 func (l *DefLog) logf(level metadata.Level, format string, args ...interface{}) {
+	const callDepth = 2
+
 	// Format prefix to show function name and log level and to indicate that timezone used is UTC
 	customPrefix := fmt.Sprintf(logLevelFormatter, l.getCallerInfo(level), metadata.ParseString(level))
 
-	err := l.logger.Output(2, customPrefix+fmt.Sprintf(format, args...))
+	err := l.logger.Output(callDepth, customPrefix+fmt.Sprintf(format, args...))
 	if err != nil {
 		fmt.Printf("error from logger.Output %v\n", err)
 	}

--- a/pkg/internal/cryptoutil/legacy_utils.go
+++ b/pkg/internal/cryptoutil/legacy_utils.go
@@ -12,7 +12,7 @@ import "golang.org/x/crypto/blake2b"
 func Nonce(pub1, pub2 []byte) (*[NonceSize]byte, error) {
 	var nonce [NonceSize]byte
 	// generate an equivalent nonce to libsodium's (see link above)
-	nonceWriter, err := blake2b.New(24, nil)
+	nonceWriter, err := blake2b.New(NonceSize, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/jsindexeddb/jsindexeddb.go
+++ b/pkg/storage/jsindexeddb/jsindexeddb.go
@@ -181,6 +181,8 @@ func getResult(req js.Value) (*js.Value, error) {
 	onsuccess := make(chan js.Value)
 	onerror := make(chan js.Value)
 
+	const timeout = 3
+
 	req.Set("onsuccess", js.FuncOf(func(this js.Value, inputs []js.Value) interface{} {
 		onsuccess <- this.Get("result")
 		return nil
@@ -195,7 +197,7 @@ func getResult(req js.Value) (*js.Value, error) {
 	case value := <-onerror:
 		return nil, fmt.Errorf("%s %s", value.Get("name").String(),
 			value.Get("message").String())
-	case <-time.After(3 * time.Second):
+	case <-time.After(timeout * time.Second):
 		return nil, errors.New("timeout waiting for eve")
 	}
 }

--- a/pkg/vdri/registry.go
+++ b/pkg/vdri/registry.go
@@ -190,8 +190,10 @@ func getDidMethod(didID string) (string, error) {
 	// TODO https://github.com/hyperledger/aries-framework-go/issues/20 Validate that the input DID conforms to
 	//  the did rule of the Generic DID Syntax. Reference: https://w3c-ccg.github.io/did-spec/#generic-did-syntax
 	// For now we do simple validation
-	didParts := strings.SplitN(didID, ":", 3)
-	if len(didParts) != 3 {
+	const numPartsDID = 3
+
+	didParts := strings.SplitN(didID, ":", numPartsDID)
+	if len(didParts) != numPartsDID {
 		return "", fmt.Errorf("wrong format did input: %s", didID)
 	}
 

--- a/test/bdd/agent/agent_sdk_steps.go
+++ b/test/bdd/agent/agent_sdk_steps.go
@@ -118,8 +118,13 @@ func (a *SDKSteps) createEdgeAgent(agentID, scheme, routeOpt string) error {
 }
 
 func (a *SDKSteps) create(agentID, inboundHost, inboundPort, scheme string, opts ...aries.Option) error {
+	const (
+		portAttempts  = 5
+		listenTimeout = 2 * time.Second
+	)
+
 	if inboundPort == "random" {
-		inboundPort = strconv.Itoa(mustGetRandomPort(5))
+		inboundPort = strconv.Itoa(mustGetRandomPort(portAttempts))
 	}
 
 	inboundAddr := fmt.Sprintf("%s:%s", inboundHost, inboundPort)
@@ -143,7 +148,7 @@ func (a *SDKSteps) create(agentID, inboundHost, inboundPort, scheme string, opts
 		return fmt.Errorf("failed to create new agent: %w", err)
 	}
 
-	if err := listenFor(fmt.Sprintf("%s:%s", inboundHost, inboundPort), 2*time.Second); err != nil {
+	if err := listenFor(fmt.Sprintf("%s:%s", inboundHost, inboundPort), listenTimeout); err != nil {
 		return err
 	}
 

--- a/test/bdd/dockerutil/compose.go
+++ b/test/bdd/dockerutil/compose.go
@@ -194,10 +194,10 @@ func GenerateBytesUUID() []byte {
 	}
 
 	// variant bits; see section 4.1.1
-	uuid[8] = uuid[8]&^0xc0 | 0x80
+	uuid[8] = uuid[8]&^0xc0 | 0x80 //nolint:gomnd
 
 	// version 4 (pseudo-random); see section 4.1.3
-	uuid[6] = uuid[6]&^0xf0 | 0x40
+	uuid[6] = uuid[6]&^0xf0 | 0x40 //nolint:gomnd
 
 	return uuid
 }

--- a/test/bdd/pkg/didexchange/didexchange_controller_steps.go
+++ b/test/bdd/pkg/didexchange/didexchange_controller_steps.go
@@ -509,6 +509,8 @@ func (a *ControllerSteps) createPublicDID(agentID, didMethod string) error {
 
 // waitForPublicDID wait for public DID to be available before throw error after timeout
 func (a *ControllerSteps) waitForPublicDID(id string) error {
+	const retryDelay = 500 * time.Millisecond
+
 	endpointURL, ok := a.bddContext.Args[sideTreeURL]
 	if !ok {
 		return fmt.Errorf("failed to find sidetree URL to resolve sidetree public DID")
@@ -524,7 +526,7 @@ func (a *ControllerSteps) waitForPublicDID(id string) error {
 		err := sendHTTP(http.MethodGet, endpointURL+"/"+id, nil, nil)
 		if err != nil {
 			logger.Warnf("Failed to resolve public DID, due to error [%s] will retry", err)
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(retryDelay)
 
 			continue
 		}

--- a/test/bdd/pkg/didexchange/didexchange_sdk_steps.go
+++ b/test/bdd/pkg/didexchange/didexchange_sdk_steps.go
@@ -138,11 +138,13 @@ func (d *SDKSteps) ReceiveInvitation(inviteeAgentID, inviterAgentID string) erro
 
 // WaitForPostEvent waits for post event
 func (d *SDKSteps) WaitForPostEvent(agents, statesValue string) error {
+	const timeout = 5 * time.Second
+
 	for _, agentID := range strings.Split(agents, ",") {
 		for _, state := range strings.Split(statesValue, ",") {
 			select {
 			case <-d.postStatesFlag[agentID][state]:
-			case <-time.After(5 * time.Second):
+			case <-time.After(timeout):
 				return fmt.Errorf("timeout waiting for post state event %s", state)
 			}
 		}

--- a/test/bdd/pkg/introduce/introduce_sdk_steps.go
+++ b/test/bdd/pkg/introduce/introduce_sdk_steps.go
@@ -144,6 +144,8 @@ func (a *SDKSteps) createIntroduceClientWithInvitation(agentID string) error {
 }
 
 func (a *SDKSteps) createClient(agentID string, inv *didexchange.Invitation) error {
+	const stateMsgChanSize = 10
+
 	client, err := introduce.New(a.bddContext.AgentCtx[agentID], inv.Invitation)
 	if err != nil {
 		return err
@@ -161,7 +163,7 @@ func (a *SDKSteps) createClient(agentID string, inv *didexchange.Invitation) err
 
 	a.clients[agentID] = client
 	a.actions[agentID] = make(chan service.DIDCommAction, 1)
-	a.events[agentID] = make(chan service.StateMsg, 10)
+	a.events[agentID] = make(chan service.StateMsg, stateMsgChanSize)
 
 	if err := client.RegisterMsgEvent(a.events[agentID]); err != nil {
 		return err

--- a/test/bdd/pkg/messaging/msgservice.go
+++ b/test/bdd/pkg/messaging/msgservice.go
@@ -84,13 +84,15 @@ func (m *msgService) pushMessage(msg service.DIDCommMsg) {
 }
 
 func (m *msgService) popMessage() (*genericInviteMsg, error) {
+	const timeout = 5 * time.Second
+
 	select {
 	case msg := <-m.msgQueue:
 		inviteMsg := genericInviteMsg{}
 		err := msg.Decode(&inviteMsg)
 
 		return &inviteMsg, err
-	case <-time.After(5 * time.Second):
+	case <-time.After(timeout):
 		return nil, fmt.Errorf(errTimeoutWaitingForMsg)
 	}
 }

--- a/test/bdd/webhook/main.go
+++ b/test/bdd/webhook/main.go
@@ -27,9 +27,11 @@ const (
 	connectionsPath   = "/connections"
 	checkTopicsPath   = "/checktopics"
 	genericInvitePath = "/generic-invite"
+	topicsSize        = 50
+	topicTimeout      = 100 * time.Millisecond
 )
 
-var topics = make(chan []byte, 50) //nolint:gochecknoglobals
+var topics = make(chan []byte, topicsSize) //nolint:gochecknoglobals
 
 func connections(w http.ResponseWriter, r *http.Request) {
 	msg, err := ioutil.ReadAll(r.Body)
@@ -56,7 +58,7 @@ func checkTopics(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			fmt.Fprintf(w, `{"error":"failed to pull topics, cause: %s"}`, err)
 		}
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(topicTimeout):
 		fmt.Fprintf(w, `{"error":"no topic found in queue"}`)
 	}
 }


### PR DESCRIPTION
- Enables gomnd linter rules outside test files.
- Linter will catch magic numbers other than 0 and 1.

Signed-off-by: Troy Ronda <troy@troyronda.com>

