### PR TITLE
feat: Messenger - implement ReplyTo and Send functions

### DIFF
--- a/pkg/didcomm/messenger/messenger.go
+++ b/pkg/didcomm/messenger/messenger.go
@@ -7,46 +7,162 @@ SPDX-License-Identifier: Apache-2.0
 package messenger
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 
+	"github.com/google/uuid"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
+
+const (
+	messengerStore = "messenger_store"
+
+	jsonID             = "@id"
+	jsonThread         = "~thread"
+	jsonThreadID       = "thid"
+	jsonParentThreadID = "pthid"
+)
+
+var logger = log.New("aries-framework/didcomm/messenger")
+
+// record is an internal structure and keeps payload about inbound message
+type record struct {
+	MyDID    string
+	TheirDID string
+	ThreadID string
+}
 
 // Provider contains dependencies for the Messenger
 type Provider interface {
 	OutboundDispatcher() dispatcher.Outbound
+	StorageProvider() storage.Provider
 }
 
 // Messenger describes the messenger structure
 type Messenger struct {
+	store      storage.Store
 	dispatcher dispatcher.Outbound
 }
 
 // NewMessenger returns a new instance of the Messenger
-func NewMessenger(ctx Provider) *Messenger {
-	return &Messenger{
-		dispatcher: ctx.OutboundDispatcher(),
+func NewMessenger(ctx Provider) (*Messenger, error) {
+	store, err := ctx.StorageProvider().OpenStore(messengerStore)
+	if err != nil {
+		return nil, fmt.Errorf("open store: %w", err)
 	}
+
+	return &Messenger{
+		store:      store,
+		dispatcher: ctx.OutboundDispatcher(),
+	}, nil
 }
 
 // HandleInbound handles all inbound messages
-// function behavior is flexible and can be modified by providing options
-func (*Messenger) HandleInbound(msg service.DIDCommMsgMap, myDID, theirDID string) error {
-	return nil
+func (m *Messenger) HandleInbound(msg service.DIDCommMsgMap, myDID, theirDID string) error {
+	// an incoming message cannot be without id
+	if msg.ID() == "" {
+		return errors.New("message-id is absent and can't be processed")
+	}
+
+	// get message threadID
+	thID, err := msg.ThreadID()
+	if err != nil {
+		// since we are checking ID above this should never happen
+		// even if ~thread decorator is absent the message ID should be returned as a threadID
+		return fmt.Errorf("threadID: %w", err)
+	}
+
+	// saves message payload
+	return m.saveRecord(msg.ID(), record{MyDID: myDID, TheirDID: theirDID, ThreadID: thID})
 }
 
 // Send sends the message by starting a new thread.
+// Do not provide a message with ~thread decorator. It will be removed.
+// Use ReplyTo function instead. It will keep ~thread decorator automatically.
 func (m *Messenger) Send(msg service.DIDCommMsgMap, myDID, theirDID string) error {
+	fillIfMissing(msg)
+
+	if msg[jsonThread] != nil {
+		logger.Warnf("do not pass message with %s decorator, it will be ignored with the next change", jsonThread)
+	}
+
 	return m.dispatcher.SendToDID(msg, myDID, theirDID)
 }
 
 // ReplyTo replies to the message by given msgID.
-func (*Messenger) ReplyTo(msgID string, msg service.DIDCommMsgMap) error {
-	return errors.New("does not implemented yet")
+// The function adds ~thread decorator to the message according to the given msgID.
+// Do not provide a message with ~thread decorator. It will be rewritten.
+func (m *Messenger) ReplyTo(msgID string, msg service.DIDCommMsgMap) error {
+	// fills missing fields
+	fillIfMissing(msg)
+
+	rec, err := m.getRecord(msgID)
+	if err != nil {
+		return fmt.Errorf("get record: %w", err)
+	}
+
+	if msg[jsonThread] != nil {
+		logger.Warnf("do not pass message with %s decorator, the package will rewrite it", jsonThread)
+	}
+
+	// sets threadID
+	msg[jsonThread] = map[string]interface{}{jsonThreadID: rec.ThreadID}
+
+	return m.dispatcher.SendToDID(msg, rec.MyDID, rec.TheirDID)
 }
 
 // ReplyToNested sends the message by starting a new thread.
-func (*Messenger) ReplyToNested(threadID string, msg service.DIDCommMsgMap, myDID, theirDID string) error {
-	return errors.New("does not implemented yet")
+// Do not provide a message with ~thread decorator. It will be rewritten.
+// The function adds ~thread decorator to the message according to the given threadID.
+// NOTE: Given threadID becomes parent threadID.
+func (m *Messenger) ReplyToNested(threadID string, msg service.DIDCommMsgMap, myDID, theirDID string) error {
+	// fills missing fields
+	fillIfMissing(msg)
+
+	if msg[jsonThread] != nil {
+		logger.Warnf("do not pass message with %s decorator, the package will rewrite it", jsonThread)
+	}
+
+	// sets parent threadID
+	msg[jsonThread] = map[string]interface{}{jsonParentThreadID: threadID}
+
+	return m.dispatcher.SendToDID(msg, myDID, theirDID)
+}
+
+// fillIfMissing populates message with common fields such as ID
+func fillIfMissing(msg service.DIDCommMsgMap) {
+	// if ID is empty we will create a new one
+	if msg.ID() == "" {
+		msg[jsonID] = uuid.New().String()
+	}
+}
+
+// getRecord returns message payload by msgID
+func (m *Messenger) getRecord(msgID string) (*record, error) {
+	src, err := m.store.Get(msgID)
+	if err != nil {
+		return nil, fmt.Errorf("store get: %w", err)
+	}
+
+	var r *record
+	if err = json.Unmarshal(src, &r); err != nil {
+		return nil, fmt.Errorf("unmarshal record: %w", err)
+	}
+
+	return r, nil
+}
+
+// saveRecord saves incoming message payload
+func (m *Messenger) saveRecord(msgID string, rec record) error {
+	src, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshal record: %w", err)
+	}
+
+	return m.store.Put(msgID, src)
 }

--- a/pkg/didcomm/messenger/messenger_test.go
+++ b/pkg/didcomm/messenger/messenger_test.go
@@ -7,9 +7,307 @@ SPDX-License-Identifier: Apache-2.0
 package messenger_test
 
 import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/messenger"
+	dispatcherMocks "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/didcomm/dispatcher"
+	messengerMocks "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/didcomm/messenger"
+	storageMocks "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/storage"
 )
 
 // makes sure it satisfies the interface
-var _ service.MessengerHandler = &messenger.Messenger{}
+var _ service.MessengerHandler = (*messenger.Messenger)(nil)
+
+func TestNewMessenger(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("success", func(t *testing.T) {
+		storageProvider := storageMocks.NewMockProvider(ctrl)
+		storageProvider.EXPECT().OpenStore(gomock.Any()).Return(nil, nil)
+
+		provider := messengerMocks.NewMockProvider(ctrl)
+		provider.EXPECT().StorageProvider().Return(storageProvider)
+		provider.EXPECT().OutboundDispatcher().Return(nil)
+
+		msgr, err := messenger.NewMessenger(provider)
+		require.NoError(t, err)
+		require.NotNil(t, msgr)
+	})
+
+	t.Run("open store error", func(t *testing.T) {
+		storageProvider := storageMocks.NewMockProvider(ctrl)
+		storageProvider.EXPECT().OpenStore(gomock.Any()).Return(nil, errors.New("test error"))
+
+		provider := messengerMocks.NewMockProvider(ctrl)
+		provider.EXPECT().StorageProvider().Return(storageProvider)
+
+		msgr, err := messenger.NewMessenger(provider)
+		require.Error(t, err)
+		require.Nil(t, msgr)
+	})
+}
+
+func TestMessenger_HandleInbound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("success", func(t *testing.T) {
+		const ID = "ID"
+
+		store := storageMocks.NewMockStore(ctrl)
+		store.EXPECT().Put(ID, gomock.Any()).Return(nil)
+
+		storageProvider := storageMocks.NewMockProvider(ctrl)
+		storageProvider.EXPECT().OpenStore(gomock.Any()).Return(store, nil)
+
+		provider := messengerMocks.NewMockProvider(ctrl)
+		provider.EXPECT().StorageProvider().Return(storageProvider)
+		provider.EXPECT().OutboundDispatcher().Return(nil)
+
+		msgr, err := messenger.NewMessenger(provider)
+		require.NoError(t, err)
+		require.NotNil(t, msgr)
+
+		require.NoError(t, msgr.HandleInbound(service.DIDCommMsgMap{"@id": ID}, "myDID", "theirDID"))
+	})
+
+	t.Run("absent ID", func(t *testing.T) {
+		storageProvider := storageMocks.NewMockProvider(ctrl)
+		storageProvider.EXPECT().OpenStore(gomock.Any()).Return(nil, nil)
+
+		provider := messengerMocks.NewMockProvider(ctrl)
+		provider.EXPECT().StorageProvider().Return(storageProvider)
+		provider.EXPECT().OutboundDispatcher().Return(nil)
+
+		msgr, err := messenger.NewMessenger(provider)
+		require.NoError(t, err)
+		require.NotNil(t, msgr)
+
+		err = msgr.HandleInbound(service.DIDCommMsgMap{}, "myDID", "theirDID")
+		require.Contains(t, fmt.Sprintf("%v", err), "message-id is absent")
+	})
+}
+
+func TestMessenger_Send(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const (
+		ID       = "ID"
+		myDID    = "myDID"
+		theirDID = "theirDID"
+	)
+
+	t.Run("success", func(t *testing.T) {
+		storageProvider := storageMocks.NewMockProvider(ctrl)
+		storageProvider.EXPECT().OpenStore(gomock.Any()).Return(nil, nil)
+
+		outbound := dispatcherMocks.NewMockOutbound(ctrl)
+		outbound.EXPECT().SendToDID(gomock.Any(), myDID, theirDID).Return(nil)
+
+		provider := messengerMocks.NewMockProvider(ctrl)
+		provider.EXPECT().StorageProvider().Return(storageProvider)
+		provider.EXPECT().OutboundDispatcher().Return(outbound)
+
+		msgr, err := messenger.NewMessenger(provider)
+		require.NoError(t, err)
+		require.NotNil(t, msgr)
+
+		require.NoError(t, msgr.Send(service.DIDCommMsgMap{"@id": ID}, myDID, theirDID))
+	})
+
+	t.Run("success msg without id", func(t *testing.T) {
+		storageProvider := storageMocks.NewMockProvider(ctrl)
+		storageProvider.EXPECT().OpenStore(gomock.Any()).Return(nil, nil)
+
+		outbound := dispatcherMocks.NewMockOutbound(ctrl)
+		outbound.EXPECT().
+			SendToDID(gomock.Any(), myDID, theirDID).
+			Do(func(msg interface{}, myDID, theirDID string) error {
+				didMsg, ok := msg.(service.DIDCommMsgMap)
+				require.True(t, ok)
+				// checks that @id was injected
+				require.NotNil(t, didMsg["@id"])
+				return nil
+			})
+
+		provider := messengerMocks.NewMockProvider(ctrl)
+		provider.EXPECT().StorageProvider().Return(storageProvider)
+		provider.EXPECT().OutboundDispatcher().Return(outbound)
+
+		msgr, err := messenger.NewMessenger(provider)
+		require.NoError(t, err)
+		require.NotNil(t, msgr)
+
+		// ~thread in the message causes a warning
+		require.NoError(t, msgr.Send(service.DIDCommMsgMap{"~thread": ""}, myDID, theirDID))
+	})
+}
+
+func TestMessenger_ReplyTo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const (
+		ID     = "ID"
+		errMsg = "test error"
+	)
+
+	t.Run("success", func(t *testing.T) {
+		store := storageMocks.NewMockStore(ctrl)
+		store.EXPECT().Get(ID).Return([]byte(`{}`), nil)
+
+		storageProvider := storageMocks.NewMockProvider(ctrl)
+		storageProvider.EXPECT().OpenStore(gomock.Any()).Return(store, nil)
+
+		outbound := dispatcherMocks.NewMockOutbound(ctrl)
+		outbound.EXPECT().
+			SendToDID(gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(msg interface{}, myDID, theirDID string) error {
+				didMsg, ok := msg.(service.DIDCommMsgMap)
+				require.True(t, ok)
+				// checks that ~thread was injected
+				require.NotNil(t, didMsg["~thread"])
+				// checks that ~thread->thid was injected
+				require.NotNil(t, didMsg["~thread"].(map[string]interface{})["thid"])
+				return nil
+			})
+
+		provider := messengerMocks.NewMockProvider(ctrl)
+		provider.EXPECT().StorageProvider().Return(storageProvider)
+		provider.EXPECT().OutboundDispatcher().Return(outbound)
+
+		msgr, err := messenger.NewMessenger(provider)
+		require.NoError(t, err)
+		require.NotNil(t, msgr)
+		require.NoError(t, msgr.ReplyTo(ID, service.DIDCommMsgMap{"@id": ID}))
+	})
+
+	t.Run("the message was not received", func(t *testing.T) {
+		store := storageMocks.NewMockStore(ctrl)
+		store.EXPECT().Get(ID).Return(nil, errors.New(errMsg))
+
+		storageProvider := storageMocks.NewMockProvider(ctrl)
+		storageProvider.EXPECT().OpenStore(gomock.Any()).Return(store, nil)
+
+		provider := messengerMocks.NewMockProvider(ctrl)
+		provider.EXPECT().StorageProvider().Return(storageProvider)
+		provider.EXPECT().OutboundDispatcher().Return(nil)
+
+		msgr, err := messenger.NewMessenger(provider)
+		require.NoError(t, err)
+		require.NotNil(t, msgr)
+
+		err = msgr.ReplyTo(ID, service.DIDCommMsgMap{})
+		require.Contains(t, fmt.Sprintf("%v", err), errMsg)
+	})
+
+	t.Run("success msg without id", func(t *testing.T) {
+		store := storageMocks.NewMockStore(ctrl)
+		store.EXPECT().Get(ID).Return([]byte(`{}`), nil)
+
+		storageProvider := storageMocks.NewMockProvider(ctrl)
+		storageProvider.EXPECT().OpenStore(gomock.Any()).Return(store, nil)
+
+		outbound := dispatcherMocks.NewMockOutbound(ctrl)
+		outbound.EXPECT().
+			SendToDID(gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(msg interface{}, myDID, theirDID string) error {
+				didMsg, ok := msg.(service.DIDCommMsgMap)
+				require.True(t, ok)
+				// checks that @id was injected
+				require.NotNil(t, didMsg["@id"])
+				// checks that ~thread was injected
+				require.NotNil(t, didMsg["~thread"])
+				// checks that ~thread->thid was injected
+				require.NotNil(t, didMsg["~thread"].(map[string]interface{})["thid"])
+				return nil
+			})
+
+		provider := messengerMocks.NewMockProvider(ctrl)
+		provider.EXPECT().StorageProvider().Return(storageProvider)
+		provider.EXPECT().OutboundDispatcher().Return(outbound)
+
+		msgr, err := messenger.NewMessenger(provider)
+		require.NoError(t, err)
+		require.NotNil(t, msgr)
+		// ~thread in the message causes a warning
+		require.NoError(t, msgr.ReplyTo(ID, service.DIDCommMsgMap{"~thread": ""}))
+	})
+}
+
+func TestMessenger_ReplyToNested(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const (
+		ID       = "ID"
+		thID     = "thID"
+		myDID    = "myDID"
+		theirDID = "theirDID"
+	)
+
+	t.Run("success", func(t *testing.T) {
+		storageProvider := storageMocks.NewMockProvider(ctrl)
+		storageProvider.EXPECT().OpenStore(gomock.Any()).Return(nil, nil)
+
+		outbound := dispatcherMocks.NewMockOutbound(ctrl)
+		outbound.EXPECT().
+			SendToDID(gomock.Any(), myDID, theirDID).
+			Do(func(msg interface{}, myDID, theirDID string) error {
+				didMsg, ok := msg.(service.DIDCommMsgMap)
+				require.True(t, ok)
+				// checks that ~thread was injected
+				require.NotNil(t, didMsg["~thread"])
+				// checks that ~thread->thid was injected
+				require.NotNil(t, didMsg["~thread"].(map[string]interface{})["pthid"])
+				return nil
+			})
+
+		provider := messengerMocks.NewMockProvider(ctrl)
+		provider.EXPECT().StorageProvider().Return(storageProvider)
+		provider.EXPECT().OutboundDispatcher().Return(outbound)
+
+		msgr, err := messenger.NewMessenger(provider)
+		require.NoError(t, err)
+		require.NotNil(t, msgr)
+		require.NoError(t, msgr.ReplyToNested(thID, service.DIDCommMsgMap{"@id": ID}, myDID, theirDID))
+	})
+
+	t.Run("success msg without id", func(t *testing.T) {
+		storageProvider := storageMocks.NewMockProvider(ctrl)
+		storageProvider.EXPECT().OpenStore(gomock.Any()).Return(nil, nil)
+
+		outbound := dispatcherMocks.NewMockOutbound(ctrl)
+		outbound.EXPECT().
+			SendToDID(gomock.Any(), myDID, theirDID).
+			Do(func(msg interface{}, myDID, theirDID string) error {
+				didMsg, ok := msg.(service.DIDCommMsgMap)
+				require.True(t, ok)
+				// checks that @id was injected
+				require.NotNil(t, didMsg["@id"])
+				// checks that ~thread was injected
+				require.NotNil(t, didMsg["~thread"])
+				// checks that ~thread->thid was injected
+				require.NotNil(t, didMsg["~thread"].(map[string]interface{})["pthid"])
+				return nil
+			})
+
+		provider := messengerMocks.NewMockProvider(ctrl)
+		provider.EXPECT().StorageProvider().Return(storageProvider)
+		provider.EXPECT().OutboundDispatcher().Return(outbound)
+
+		msgr, err := messenger.NewMessenger(provider)
+		require.NoError(t, err)
+		require.NotNil(t, msgr)
+		// ~thread in the message causes a warning
+		require.NoError(t, msgr.ReplyToNested(thID, service.DIDCommMsgMap{"~thread": ""}, myDID, theirDID))
+	})
+}

--- a/pkg/didcomm/protocol/introduce/service.go
+++ b/pkg/didcomm/protocol/introduce/service.go
@@ -283,21 +283,13 @@ func (s *Service) InvitationReceived(msg service.StateMsg) error {
 		return nil
 	}
 
-	payload, err := json.Marshal(&model.Ack{
+	// NOTE: the message is being used internally.
+	// Do not modify the payload such as ID and Thread.
+	_, err := s.HandleInbound(service.NewDIDCommMsgMap(&model.Ack{
 		Type:   AckMsgType,
 		ID:     uuid.New().String(),
 		Thread: &decorator.Thread{ID: h.Thread.PID},
-	})
-	if err != nil {
-		return fmt.Errorf("invitation received marshal: %w", err)
-	}
-
-	didMsg, err := service.ParseDIDCommMsgMap(payload)
-	if err != nil {
-		return fmt.Errorf("invitation received new DIDComm msg: %w", err)
-	}
-
-	_, err = s.HandleInbound(didMsg, "", "")
+	}), "", "")
 
 	return err
 }

--- a/pkg/didcomm/protocol/introduce/states_test.go
+++ b/pkg/didcomm/protocol/introduce/states_test.go
@@ -212,7 +212,9 @@ func TestAbandoning_ExecuteInbound(t *testing.T) {
 		defer ctrl.Finish()
 
 		messenger := serviceMocks.NewMockMessenger(ctrl)
-		messenger.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("test error"))
+		messenger.EXPECT().
+			ReplyToNested(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(errors.New("test error"))
 
 		didmsg, err := service.ParseDIDCommMsgMap(toBytes(t, &service.Header{Type: RequestMsgType}))
 		require.NoError(t, err)
@@ -253,9 +255,11 @@ func TestDeciding_ExecuteInbound(t *testing.T) {
 	defer ctrl.Finish()
 
 	messenger := serviceMocks.NewMockMessenger(ctrl)
-	messenger.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	messenger.EXPECT().ReplyTo(gomock.Any(), gomock.Any()).Return(nil)
 
-	followup, err := (&deciding{}).ExecuteInbound(messenger, &metaData{})
+	followup, err := (&deciding{}).ExecuteInbound(messenger, &metaData{
+		Msg: service.DIDCommMsgMap(map[string]interface{}{}),
+	})
 	require.NoError(t, err)
 	require.Equal(t, &waiting{}, followup)
 }

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -382,14 +382,15 @@ func createMessengerHandler(frameworkOpts *Aries) error {
 
 	ctx, err := context.New(
 		context.WithOutboundDispatcher(frameworkOpts.outboundDispatcher),
+		context.WithStorageProvider(frameworkOpts.storeProvider),
 	)
 	if err != nil {
 		return fmt.Errorf("context creation failed: %w", err)
 	}
 
-	frameworkOpts.messenger = messenger.NewMessenger(ctx)
+	frameworkOpts.messenger, err = messenger.NewMessenger(ctx)
 
-	return nil
+	return err
 }
 
 func createOutboundDispatcher(frameworkOpts *Aries) error {

--- a/pkg/internal/gomocks/didcomm/messenger/mocks.go
+++ b/pkg/internal/gomocks/didcomm/messenger/mocks.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	gomock "github.com/golang/mock/gomock"
 	dispatcher "github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	storage "github.com/hyperledger/aries-framework-go/pkg/storage"
 	reflect "reflect"
 )
 
@@ -45,4 +46,18 @@ func (m *MockProvider) OutboundDispatcher() dispatcher.Outbound {
 func (mr *MockProviderMockRecorder) OutboundDispatcher() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OutboundDispatcher", reflect.TypeOf((*MockProvider)(nil).OutboundDispatcher))
+}
+
+// StorageProvider mocks base method
+func (m *MockProvider) StorageProvider() storage.Provider {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StorageProvider")
+	ret0, _ := ret[0].(storage.Provider)
+	return ret0
+}
+
+// StorageProvider indicates an expected call of StorageProvider
+func (mr *MockProviderMockRecorder) StorageProvider() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageProvider", reflect.TypeOf((*MockProvider)(nil).StorageProvider))
 }


### PR DESCRIPTION
Following functions were implemented:
* Send
* ReplyTo
* ReplyToNested

NOTE: This implementation allows us to use messenger. The next changes related to the messenger would be done under the hood and should not affect usage.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>