### PR TITLE
Secretlock API + mock

### DIFF
--- a/pkg/internal/mock/secretlock/mock_secretlock.go
+++ b/pkg/internal/mock/secretlock/mock_secretlock.go
@@ -1,0 +1,34 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package secretlock
+
+import "github.com/hyperledger/aries-framework-go/pkg/secretlock"
+
+// MockSecretLock mocking a Secret Lock service
+type MockSecretLock struct {
+	ValEncrypt string
+	ValDecrypt string
+	ErrEncrypt error
+	ErrDecrypt error
+}
+
+// Encrypt req for master key in keyURI
+func (m *MockSecretLock) Encrypt(keyURI string, req *secretlock.EncryptRequest) (*secretlock.EncryptResponse, error) {
+	if m.ErrEncrypt != nil {
+		return nil, m.ErrEncrypt
+	}
+
+	return &secretlock.EncryptResponse{Ciphertext: m.ValEncrypt}, nil
+}
+
+// Decrypt req for master key in keyURI
+func (m *MockSecretLock) Decrypt(keyURI string, req *secretlock.DecryptRequest) (*secretlock.DecryptResponse, error) {
+	if m.ErrDecrypt != nil {
+		return nil, m.ErrDecrypt
+	}
+
+	return &secretlock.DecryptResponse{Plaintext: m.ValDecrypt}, nil
+}

--- a/pkg/secretlock/api.go
+++ b/pkg/secretlock/api.go
@@ -1,0 +1,17 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package secretlock
+
+// package secretlock contains secret lock services to secure keys used by the Aries agent
+// and more specifically used by the KMS service.
+
+// Service provides crypto service used internally by the KMS
+type Service interface {
+	// Encrypt req for master key in keyURI
+	Encrypt(keyURI string, req *EncryptRequest) (*EncryptResponse, error)
+	// Decrypt req for master key in keyURI
+	Decrypt(keyURI string, req *DecryptRequest) (*DecryptResponse, error)
+}

--- a/pkg/secretlock/secretlock.go
+++ b/pkg/secretlock/secretlock.go
@@ -1,0 +1,28 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package secretlock
+
+// EncryptRequest for encrypting remote kms requests
+type EncryptRequest struct {
+	Plaintext                   string
+	AdditionalAuthenticatedData string
+}
+
+// DecryptRequest for decrypting remote kms requests
+type DecryptRequest struct {
+	Ciphertext                  string
+	AdditionalAuthenticatedData string
+}
+
+// EncryptResponse for receiving encryption response from remote kms requests
+type EncryptResponse struct {
+	Ciphertext string
+}
+
+// DecryptResponse for receiving decryption response from remote kms requests
+type DecryptResponse struct {
+	Plaintext string
+}


### PR DESCRIPTION
This API's main purpose is to encrypt (wrap) and decrypt (unwrap) keys written to/from the KMS