### PR TITLE
refactor: Update context.InboundTransportEndpoint to context.ServiceEndpoint

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -35,7 +35,7 @@ var ErrConnectionNotFound = errors.New("connection not found")
 type provider interface {
 	Service(id string) (interface{}, error)
 	LegacyKMS() legacykms.KeyManager
-	InboundTransportEndpoint() string
+	ServiceEndpoint() string
 	StorageProvider() storage.Provider
 	TransientStorageProvider() storage.Provider
 }
@@ -43,11 +43,11 @@ type provider interface {
 // Client enable access to didexchange api
 type Client struct {
 	service.Event
-	didexchangeSvc           protocolService
-	routeSvc                 route.ProtocolService
-	legacyKMS                legacykms.KeyManager
-	inboundTransportEndpoint string
-	connectionStore          *connection.Recorder
+	didexchangeSvc  protocolService
+	routeSvc        route.ProtocolService
+	legacyKMS       legacykms.KeyManager
+	serviceEndpoint string
+	connectionStore *connection.Recorder
 }
 
 // protocolService defines DID Exchange service.
@@ -94,12 +94,12 @@ func New(ctx provider) (*Client, error) {
 	}
 
 	return &Client{
-		Event:                    didexchangeSvc,
-		didexchangeSvc:           didexchangeSvc,
-		routeSvc:                 routeSvc,
-		legacyKMS:                ctx.LegacyKMS(),
-		inboundTransportEndpoint: ctx.InboundTransportEndpoint(),
-		connectionStore:          connectionStore,
+		Event:           didexchangeSvc,
+		didexchangeSvc:  didexchangeSvc,
+		routeSvc:        routeSvc,
+		legacyKMS:       ctx.LegacyKMS(),
+		serviceEndpoint: ctx.ServiceEndpoint(),
+		connectionStore: connectionStore,
 	}, nil
 }
 
@@ -115,7 +115,7 @@ func (c *Client) CreateInvitation(label string) (*Invitation, error) {
 	}
 
 	// get the route configs
-	serviceEndpoint, routingKeys, err := route.GetRouterConfig(c.routeSvc, c.inboundTransportEndpoint)
+	serviceEndpoint, routingKeys, err := route.GetRouterConfig(c.routeSvc, c.serviceEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("create invitation - fetch router config : %w", err)
 	}

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -95,7 +95,7 @@ func TestNew(t *testing.T) {
 				didexchange.DIDExchange: svc,
 				route.Coordination:      &mockroute.MockRouteSvc{},
 			},
-			InboundEndpointValue: "endpoint"})
+			ServiceEndpointValue: "endpoint"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to open store")
 	})
@@ -117,7 +117,7 @@ func TestNew(t *testing.T) {
 				didexchange.DIDExchange: svc,
 				route.Coordination:      &mockroute.MockRouteSvc{},
 			},
-			InboundEndpointValue: "endpoint"})
+			ServiceEndpointValue: "endpoint"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to open transient store")
 	})
@@ -141,7 +141,7 @@ func TestClient_CreateInvitation(t *testing.T) {
 				route.Coordination:      &mockroute.MockRouteSvc{},
 			},
 			KMSValue:             &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-			InboundEndpointValue: "endpoint"})
+			ServiceEndpointValue: "endpoint"})
 
 		require.NoError(t, err)
 		inviteReq, err := c.CreateInvitation("agent")
@@ -225,7 +225,7 @@ func TestClient_CreateInvitation(t *testing.T) {
 				route.Coordination:      &mockroute.MockRouteSvc{RoutingKeys: routingKeys, RouterEndpoint: endpoint},
 			},
 			KMSValue:             &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-			InboundEndpointValue: "endpoint",
+			ServiceEndpointValue: "endpoint",
 		})
 		require.NoError(t, err)
 
@@ -255,7 +255,7 @@ func TestClient_CreateInvitation(t *testing.T) {
 				route.Coordination:      &mockroute.MockRouteSvc{ConfigErr: errors.New("router config error")},
 			},
 			KMSValue:             &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-			InboundEndpointValue: "endpoint",
+			ServiceEndpointValue: "endpoint",
 		})
 		require.NoError(t, err)
 
@@ -289,7 +289,7 @@ func TestClient_CreateInvitation(t *testing.T) {
 				},
 			},
 			KMSValue:             &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-			InboundEndpointValue: "endpoint",
+			ServiceEndpointValue: "endpoint",
 		})
 		require.NoError(t, err)
 
@@ -318,7 +318,7 @@ func TestClient_CreateInvitationWithDID(t *testing.T) {
 				route.Coordination:      &mockroute.MockRouteSvc{},
 			},
 			KMSValue:             &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-			InboundEndpointValue: "endpoint"})
+			ServiceEndpointValue: "endpoint"})
 		require.NoError(t, err)
 
 		const label = "agent"
@@ -385,7 +385,7 @@ func TestClient_QueryConnectionByID(t *testing.T) {
 				route.Coordination:      &mockroute.MockRouteSvc{},
 			},
 			KMSValue:             &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-			InboundEndpointValue: "endpoint"})
+			ServiceEndpointValue: "endpoint"})
 		require.NoError(t, err)
 
 		connRec := &connection.Record{ConnectionID: connID, ThreadID: threadID, State: "complete"}
@@ -421,7 +421,7 @@ func TestClient_QueryConnectionByID(t *testing.T) {
 				route.Coordination:      &mockroute.MockRouteSvc{},
 			},
 			KMSValue:             &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-			InboundEndpointValue: "endpoint"})
+			ServiceEndpointValue: "endpoint"})
 		require.NoError(t, err)
 
 		connRec := &connection.Record{ConnectionID: connID, ThreadID: threadID, State: "complete"}
@@ -450,7 +450,7 @@ func TestClient_QueryConnectionByID(t *testing.T) {
 				route.Coordination:      &mockroute.MockRouteSvc{},
 			},
 			KMSValue:             &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-			InboundEndpointValue: "endpoint"})
+			ServiceEndpointValue: "endpoint"})
 		require.NoError(t, err)
 
 		result, err := c.GetConnection(connID)
@@ -552,7 +552,7 @@ func TestClient_HandleInvitation(t *testing.T) {
 				route.Coordination:      &mockroute.MockRouteSvc{},
 			},
 			KMSValue:             &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-			InboundEndpointValue: "endpoint"})
+			ServiceEndpointValue: "endpoint"})
 
 		require.NoError(t, err)
 		inviteReq, err := c.CreateInvitation("agent")
@@ -574,7 +574,7 @@ func TestClient_HandleInvitation(t *testing.T) {
 				route.Coordination: &mockroute.MockRouteSvc{},
 			},
 
-			KMSValue: &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"}, InboundEndpointValue: "endpoint"})
+			KMSValue: &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"}, ServiceEndpointValue: "endpoint"})
 		require.NoError(t, err)
 		inviteReq, err := c.CreateInvitation("agent")
 		require.NoError(t, err)
@@ -595,7 +595,7 @@ func TestClient_CreateImplicitInvitation(t *testing.T) {
 				route.Coordination:      &mockroute.MockRouteSvc{},
 			},
 			KMSValue:             &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-			InboundEndpointValue: "endpoint"})
+			ServiceEndpointValue: "endpoint"})
 		require.NoError(t, err)
 
 		connectionID, err := c.CreateImplicitInvitation("alice", "did:example:123")
@@ -613,7 +613,7 @@ func TestClient_CreateImplicitInvitation(t *testing.T) {
 				route.Coordination: &mockroute.MockRouteSvc{},
 			},
 			KMSValue:             &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-			InboundEndpointValue: "endpoint"})
+			ServiceEndpointValue: "endpoint"})
 		require.NoError(t, err)
 
 		connectionID, err := c.CreateImplicitInvitation("Alice", "did:example:123")
@@ -636,7 +636,7 @@ func TestClient_CreateImplicitInvitationWithDID(t *testing.T) {
 				route.Coordination:      &mockroute.MockRouteSvc{},
 			},
 			KMSValue:             &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-			InboundEndpointValue: "endpoint"})
+			ServiceEndpointValue: "endpoint"})
 		require.NoError(t, err)
 
 		connectionID, err := c.CreateImplicitInvitationWithDID(inviter, invitee)
@@ -654,7 +654,7 @@ func TestClient_CreateImplicitInvitationWithDID(t *testing.T) {
 				route.Coordination: &mockroute.MockRouteSvc{},
 			},
 			KMSValue:             &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-			InboundEndpointValue: "endpoint"})
+			ServiceEndpointValue: "endpoint"})
 		require.NoError(t, err)
 
 		connectionID, err := c.CreateImplicitInvitationWithDID(inviter, invitee)
@@ -672,7 +672,7 @@ func TestClient_CreateImplicitInvitationWithDID(t *testing.T) {
 				route.Coordination:      &mockroute.MockRouteSvc{},
 			},
 			KMSValue:             &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-			InboundEndpointValue: "endpoint"})
+			ServiceEndpointValue: "endpoint"})
 		require.NoError(t, err)
 
 		connectionID, err := c.CreateImplicitInvitationWithDID(inviter, nil)

--- a/pkg/didcomm/protocol/route/service_test.go
+++ b/pkg/didcomm/protocol/route/service_test.go
@@ -137,7 +137,7 @@ func TestServiceRequestMsg(t *testing.T) {
 			StorageProviderValue:          mockstore.NewMockStoreProvider(),
 			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
 			KMSValue:                      &mockkms.CloseableKMS{},
-			InboundEndpointValue:          endpoint,
+			ServiceEndpointValue:          endpoint,
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSend: func(msg interface{}, senderVerKey string, des *service.Destination) error {
 					res, err := json.Marshal(msg)

--- a/pkg/framework/aries/api/protocol.go
+++ b/pkg/framework/aries/api/protocol.go
@@ -30,7 +30,7 @@ type Provider interface {
 	LegacyKMS() legacykms.KeyManager
 	Crypto() crypto.Crypto
 	Packager() transport.Packager
-	InboundTransportEndpoint() string
+	ServiceEndpoint() string
 	RouterEndpoint() string
 	VDRIRegistry() vdriapi.Registry
 	Signer() legacykms.Signer

--- a/pkg/framework/aries/example_test.go
+++ b/pkg/framework/aries/example_test.go
@@ -31,7 +31,7 @@ func Example() {
 	}
 
 	fmt.Println("context created successfully")
-	fmt.Println(ctx.InboundTransportEndpoint())
+	fmt.Println(ctx.ServiceEndpoint())
 
 	// Output:
 	// context created successfully

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -259,6 +259,7 @@ func (a *Aries) Context() (*context.Provider, error) {
 		context.WithLegacyKMS(a.kms),
 		context.WithCrypto(a.crypto),
 		context.WithServiceEndpoint(serviceEndpoint(a)),
+		context.WithRouterEndpoint(routingEndpoint(a)),
 		context.WithStorageProvider(a.storeProvider),
 		context.WithTransientStorageProvider(a.transientStoreProvider),
 		context.WithPacker(a.primaryPacker, a.packers...),
@@ -358,7 +359,7 @@ func createVDRI(frameworkOpts *Aries) error {
 	opts = append(opts,
 		vdri.WithVDRI(p),
 		vdri.WithDefaultServiceType(vdriapi.DIDCommServiceType),
-		vdri.WithDefaultServiceEndpoint(ctx.InboundTransportEndpoint()),
+		vdri.WithDefaultServiceEndpoint(ctx.ServiceEndpoint()),
 	)
 
 	frameworkOpts.vdriRegistry = vdri.New(ctx, opts...)

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -112,12 +112,16 @@ func (p *Provider) Signer() legacykms.Signer {
 	return p.kms
 }
 
-// InboundTransportEndpoint returns an inbound transport endpoint.
-func (p *Provider) InboundTransportEndpoint() string {
+// ServiceEndpoint returns an service endpoint. This endpoint is used in DID
+// Exchange Invitation or DID Document service to send messages to the agent.
+func (p *Provider) ServiceEndpoint() string {
 	return p.serviceEndpoint
 }
 
-// RouterEndpoint returns a router transport endpoint.
+// RouterEndpoint returns a router transport endpoint. The router gives this
+// endpoint to the requester agent during route registration. The requester
+// agent can use as it's service endpoint. The router checks the forward
+// message to routes the message based on the recipient keys(if registered).
 func (p *Provider) RouterEndpoint() string {
 	return p.routerEndpoint
 }

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -262,7 +262,7 @@ func TestNewProvider(t *testing.T) {
 	t.Run("test new with inbound transport endpoint", func(t *testing.T) {
 		prov, err := New(WithServiceEndpoint("endpoint"))
 		require.NoError(t, err)
-		require.Equal(t, "endpoint", prov.InboundTransportEndpoint())
+		require.Equal(t, "endpoint", prov.ServiceEndpoint())
 	})
 
 	t.Run("test new with router endpoint", func(t *testing.T) {

--- a/pkg/internal/mock/provider/mock_provider.go
+++ b/pkg/internal/mock/provider/mock_provider.go
@@ -19,7 +19,7 @@ type Provider struct {
 	ServiceErr                    error
 	ServiceMap                    map[string]interface{}
 	KMSValue                      legacykms.KeyManager
-	InboundEndpointValue          string
+	ServiceEndpointValue          string
 	StorageProviderValue          storage.Provider
 	TransientStorageProviderValue storage.Provider
 	PackerList                    []packer.Packer
@@ -46,14 +46,14 @@ func (p *Provider) LegacyKMS() legacykms.KeyManager {
 	return p.KMSValue
 }
 
-// InboundTransportEndpoint returns the inbound transport endpoint
-func (p *Provider) InboundTransportEndpoint() string {
-	return p.InboundEndpointValue
+// ServiceEndpoint returns the service endpoint
+func (p *Provider) ServiceEndpoint() string {
+	return p.ServiceEndpointValue
 }
 
 // RouterEndpoint returns the router transport endpoint
 func (p *Provider) RouterEndpoint() string {
-	return p.InboundEndpointValue
+	return p.ServiceEndpointValue
 }
 
 // StorageProvider returns the storage provider

--- a/pkg/restapi/operation/didexchange/didexchange.go
+++ b/pkg/restapi/operation/didexchange/didexchange.go
@@ -74,7 +74,7 @@ const (
 type provider interface {
 	Service(id string) (interface{}, error)
 	LegacyKMS() legacykms.KeyManager
-	InboundTransportEndpoint() string
+	ServiceEndpoint() string
 	StorageProvider() storage.Provider
 	TransientStorageProvider() storage.Provider
 }

--- a/pkg/restapi/operation/didexchange/didexchange_test.go
+++ b/pkg/restapi/operation/didexchange/didexchange_test.go
@@ -433,7 +433,7 @@ func getHandlerWithError(t *testing.T, lookup string, handleErr, acceptErr, impl
 			route.Coordination: &mockroute.MockRouteSvc{},
 		},
 		KMSValue:                      &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-		InboundEndpointValue:          "endpoint",
+		ServiceEndpointValue:          "endpoint",
 		TransientStorageProviderValue: &mockstore.MockStoreProvider{Store: &transientStore},
 		StorageProviderValue:          &mockstore.MockStoreProvider{Store: &store}},
 		webhook.NewHTTPNotifier(nil),


### PR DESCRIPTION
Support for multiple inbound transports was added as part of #1162. A new context method was added to provide Router Service endpoint.  This change updates the context method name which provides the service end point to be in sync with Router service endpoint.

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
