### PR TITLE
feat: Add (local) SecretLock implementation

### DIFF
--- a/pkg/framework/aries/api/protocol.go
+++ b/pkg/framework/aries/api/protocol.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
@@ -28,6 +29,7 @@ type Provider interface {
 	Service(id string) (interface{}, error)
 	StorageProvider() storage.Provider
 	LegacyKMS() legacykms.KeyManager
+	SecretLock() secretlock.Service
 	Crypto() crypto.Crypto
 	Packager() transport.Packager
 	ServiceEndpoint() string

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -122,6 +122,8 @@ func setAdditionalDefaultOpts(frameworkOpts *Aries) error {
 		frameworkOpts.msgSvcProvider = &noOpMessageServiceProvider{}
 	}
 
+	// TODO add SecretLock creation here.. #1150
+
 	return nil
 }
 

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/context"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/vdri"
 	"github.com/hyperledger/aries-framework-go/pkg/vdri/peer"
@@ -50,6 +51,7 @@ type Aries struct {
 	inboundTransports      []transport.InboundTransport
 	kmsCreator             api.KMSCreator
 	kms                    api.CloseableKMS
+	secretLock             secretlock.Service
 	crypto                 crypto.Crypto
 	packagerCreator        packager.Creator
 	packager               commontransport.Packager
@@ -211,6 +213,14 @@ func WithLegacyKMS(k api.KMSCreator) Option {
 	}
 }
 
+// WithSecretLock injects a SecretLock service to the Aries framework
+func WithSecretLock(s secretlock.Service) Option {
+	return func(opts *Aries) error {
+		opts.secretLock = s
+		return nil
+	}
+}
+
 // WithCrypto injects a crypto service to the Aries framework
 func WithCrypto(c crypto.Crypto) Option {
 	return func(opts *Aries) error {
@@ -257,6 +267,7 @@ func (a *Aries) Context() (*context.Provider, error) {
 		context.WithOutboundTransports(a.outboundTransports...),
 		context.WithProtocolServices(a.services...),
 		context.WithLegacyKMS(a.kms),
+		context.WithSecretLock(a.secretLock),
 		context.WithCrypto(a.crypto),
 		context.WithServiceEndpoint(serviceEndpoint(a)),
 		context.WithRouterEndpoint(routingEndpoint(a)),

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
@@ -28,6 +29,7 @@ type Provider struct {
 	storeProvider          storage.Provider
 	transientStoreProvider storage.Provider
 	kms                    legacykms.KMS
+	secretLock             secretlock.Service
 	crypto                 crypto.Crypto
 	packager               commontransport.Packager
 	primaryPacker          packer.Packer
@@ -80,6 +82,11 @@ func (p *Provider) Service(id string) (interface{}, error) {
 // LegacyKMS returns a kms service.
 func (p *Provider) LegacyKMS() legacykms.KeyManager {
 	return p.kms
+}
+
+// SecretLock returns a secret lock service
+func (p *Provider) SecretLock() secretlock.Service {
+	return p.secretLock
 }
 
 // Crypto returns the Crypto service
@@ -244,6 +251,14 @@ func WithProtocolServices(services ...dispatcher.ProtocolService) ProviderOption
 func WithLegacyKMS(w legacykms.KMS) ProviderOption {
 	return func(opts *Provider) error {
 		opts.kms = w
+		return nil
+	}
+}
+
+// WithSecretLock injects a secret lock service into the context
+func WithSecretLock(s secretlock.Service) ProviderOption {
+	return func(opts *Provider) error {
+		opts.secretLock = s
 		return nil
 	}
 }

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -25,6 +25,7 @@ import (
 	mockpackager "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/packager"
 	mockdidexchange "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/generic"
+	mocklock "github.com/hyperledger/aries-framework-go/pkg/internal/mock/secretlock"
 	mockcrypto "github.com/hyperledger/aries-framework-go/pkg/mock/crypto"
 	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms/legacykms"
 	"github.com/hyperledger/aries-framework-go/pkg/mock/storage"
@@ -257,6 +258,13 @@ func TestNewProvider(t *testing.T) {
 		prov, err := New(WithCrypto(mCrypto))
 		require.NoError(t, err)
 		require.Equal(t, mCrypto, prov.Crypto())
+	})
+
+	t.Run("test new with secret lock service", func(t *testing.T) {
+		mSecLck := &mocklock.MockSecretLock{}
+		prov, err := New(WithSecretLock(mSecLck))
+		require.NoError(t, err)
+		require.Equal(t, mSecLck, prov.SecretLock())
 	})
 
 	t.Run("test new with inbound transport endpoint", func(t *testing.T) {

--- a/pkg/internal/mock/secretlock/mock_secretlock.go
+++ b/pkg/internal/mock/secretlock/mock_secretlock.go
@@ -1,0 +1,35 @@
+/*
+ Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package secretlock
+
+import "github.com/hyperledger/aries-framework-go/pkg/secretlock"
+
+// MockSecretLock mocking a Secret Lock service
+type MockSecretLock struct {
+	ValEncrypt string
+	ValDecrypt string
+	ErrEncrypt error
+	ErrDecrypt error
+}
+
+// Encrypt req for master key in keyURI
+func (m *MockSecretLock) Encrypt(keyURI string, req *secretlock.EncryptRequest) (*secretlock.EncryptResponse, error) {
+	if m.ErrEncrypt != nil {
+		return nil, m.ErrEncrypt
+	}
+
+	return &secretlock.EncryptResponse{Ciphertext: m.ValEncrypt}, nil
+}
+
+// Decrypt req for master key in keyURI
+func (m *MockSecretLock) Decrypt(keyURI string, req *secretlock.DecryptRequest) (*secretlock.DecryptResponse, error) {
+	if m.ErrDecrypt != nil {
+		return nil, m.ErrDecrypt
+	}
+
+	return &secretlock.DecryptResponse{Plaintext: m.ValDecrypt}, nil
+}

--- a/pkg/secretlock/api.go
+++ b/pkg/secretlock/api.go
@@ -5,10 +5,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package secretlock
 
-// package secretlock contains secret lock services to secure keys used by the Aries agent
+// Package secretlock contains secret lock services to secure keys used by the Aries agent
 // and more specifically used by the KMS service.
 
 // Service provides crypto service used internally by the KMS
+// it is responsible for wrapping/unwrapping keys stored by the KMS using a master key
 type Service interface {
 	// Encrypt req for master key in keyURI
 	Encrypt(keyURI string, req *EncryptRequest) (*EncryptResponse, error)

--- a/pkg/secretlock/local/internal/cipher/util.go
+++ b/pkg/secretlock/local/internal/cipher/util.go
@@ -1,0 +1,22 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cipher
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+)
+
+// CreateAESCipher will create a new AES cipher for the given key.
+// This function is to be used by secretlock/local package only
+func CreateAESCipher(masterKey []byte) (cipher.AEAD, error) {
+	cipherBlock, err := aes.NewCipher(masterKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return cipher.NewGCM(cipherBlock)
+}

--- a/pkg/secretlock/local/internal/cipher/util_test.go
+++ b/pkg/secretlock/local/internal/cipher/util_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cipher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateAESCipherWithLongKey(t *testing.T) {
+	veryLongMK := make([]byte, 99)
+	for i := range veryLongMK {
+		veryLongMK[i] = 'a'
+	}
+
+	mk, err := CreateAESCipher(veryLongMK)
+	require.Error(t, err)
+	require.Empty(t, mk)
+}
+
+func TestCreateAESCipherWithValidKey(t *testing.T) {
+	mkWithValidSize := make([]byte, 32)
+	for i := range mkWithValidSize {
+		mkWithValidSize[i] = 'a'
+	}
+
+	mk, err := CreateAESCipher(mkWithValidSize)
+	require.NoError(t, err)
+	require.NotEmpty(t, mk)
+}

--- a/pkg/secretlock/local/local_secret_lock.go
+++ b/pkg/secretlock/local/local_secret_lock.go
@@ -1,0 +1,147 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package local
+
+import (
+	"crypto/cipher"
+	"encoding/base64"
+	"fmt"
+	"io"
+
+	"github.com/google/tink/go/subtle/random"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
+	cipherutil "github.com/hyperledger/aries-framework-go/pkg/secretlock/local/internal/cipher"
+)
+
+// package local provides a local secret lock service. The user must create a master key and store it
+// in a local file or an environment variable prior to using this service.
+//
+// The user has the option to encrypt the master key using hkdf.NewMasterLock(passphrase, hash func(), salt)
+// found in the sub package masterlock/hkdf.
+//
+// The master key must be stored (encrypted with a MasterLock or not encrypted) either in a file or in
+// an environment variable.
+//
+// The user can then call either:
+//		MasterKeyFromPath(path) or
+//		MasterKeyFromEnv(envPrefix, keyURI)
+// to get an io.Reader instance needed to read the master key and create a keys Lock service.
+//
+// It is recommended for the content of the reader to be base64URL encoded (by masterlock if protected or manually
+// if not). This is particularly true when setting a master key in an environment variable as some OSs may
+// reject setting env variables with binary data as value. The service will attempt to base64URL decode the content of
+// reader first and if it fails, will try to create the service with the raw (binary) content.
+//
+// To get the lock service, call:
+// 		NewService(reader, secLock)
+// where reader is the instance returned from one of the MasterKeyFrom..() functions mentioned above
+// and secLock which is the masterKey lock used to encrypt/decrypt the master key. If secLock is nil
+// then the masterKey content in reader will be used as-is without being decrypted. The keys however are always
+// encrypted using the read masterKey.
+
+var logger = log.New("aries-framework/lock")
+
+const masterKeyLen = 512
+
+// Lock is a secret lock service responsible for encrypting keys using a master key
+type Lock struct {
+	aead cipher.AEAD
+}
+
+// NewService creates a new instance of local secret lock service using a master key in masterKeyReader.
+// If the masterKey is not protected (secLock=nil) this function will attempt to base64 URL Decode the
+// content of masterKeyReader and if it fails, then will attempt to create a secret lock cipher with the raw key as is.
+func NewService(masterKeyReader io.Reader, secLock secretlock.Service) (secretlock.Service, error) {
+	masterKeyData := make([]byte, masterKeyLen)
+
+	if masterKeyReader == nil {
+		return nil, fmt.Errorf("masterKeyReader is nil")
+	}
+
+	n, err := masterKeyReader.Read(masterKeyData)
+	if err != nil {
+		if err != io.EOF && err != io.ErrUnexpectedEOF {
+			return nil, err
+		}
+	}
+
+	if n == 0 {
+		return nil, fmt.Errorf("masterKeyReader is empty")
+	}
+
+	var masterKey []byte
+
+	// if secLock not empty, then masterKeyData is encrypted (protected), let's decrypt it first.
+	if secLock != nil {
+		decResponse, e := secLock.Decrypt("", &secretlock.DecryptRequest{
+			Ciphertext: string(masterKeyData[:n])})
+		if e != nil {
+			return nil, e
+		}
+
+		masterKey = []byte(decResponse.Plaintext)
+	} else {
+		// masterKeyData is not encrypted, base64URL decode it
+		masterKey, err = base64.URLEncoding.DecodeString(string(masterKeyData[:n]))
+		if err != nil {
+			logger.Warnf("base64URL.Decode of unprotected master key failed. " +
+				"Will attempt to create a service using the key content from reader as is.")
+
+			masterKey = make([]byte, n)
+
+			// copy masterKey read from reader directly
+			copy(masterKey, masterKeyData)
+		}
+	}
+
+	// finally create the cipher to be used by the lock service
+	aead, err := cipherutil.CreateAESCipher(masterKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Lock{aead: aead}, nil
+}
+
+// Encrypt a key in req using master key in the local secret lock service
+// (keyURI is used for remote locks, it is ignored by this implementation)
+func (s *Lock) Encrypt(keyURI string, req *secretlock.EncryptRequest) (*secretlock.EncryptResponse, error) {
+	nonce := random.GetRandomBytes(uint32(s.aead.NonceSize()))
+	ct := s.aead.Seal(nil, nonce, []byte(req.Plaintext), []byte(req.AdditionalAuthenticatedData))
+	ct = append(nonce, ct...)
+
+	return &secretlock.EncryptResponse{
+		Ciphertext: base64.URLEncoding.EncodeToString(ct),
+	}, nil
+}
+
+// Decrypt a key in req using master key in the local secret lock service
+// (keyURI is used for remote locks, it is ignored by this implementation)
+func (s *Lock) Decrypt(keyURI string, req *secretlock.DecryptRequest) (*secretlock.DecryptResponse, error) {
+	ct, err := base64.URLEncoding.DecodeString(req.Ciphertext)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := uint32(s.aead.NonceSize())
+
+	// ensure ciphertext contains more than nonce+ciphertext (result from Encrypt())
+	if len(ct) <= int(nonceSize) {
+		return nil, fmt.Errorf("invalid request")
+	}
+
+	nonce := ct[0:nonceSize]
+	ct = ct[nonceSize:]
+
+	pt, err := s.aead.Open(nil, nonce, ct, []byte(req.AdditionalAuthenticatedData))
+	if err != nil {
+		return nil, err
+	}
+
+	return &secretlock.DecryptResponse{Plaintext: string(pt)}, nil
+}

--- a/pkg/secretlock/local/local_secret_lock_test.go
+++ b/pkg/secretlock/local/local_secret_lock_test.go
@@ -1,0 +1,384 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package local
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/tink/go/subtle/random"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/local/masterlock/hkdf"
+)
+
+const (
+	testKeyURI = "test://test/key/uri"
+	envPrefix  = "TESTLOCAL_"
+)
+
+func TestCreateServiceFromPathWithDifferentFileSizes(t *testing.T) {
+	tcs := []struct {
+		tcName       string
+		fileName     string
+		masterKeyLen int
+		readerError  bool
+		serviceError bool
+		base64Enc    bool
+	}{
+		{
+			tcName:       "large file",
+			fileName:     "masterKey_file_large.txt",
+			masterKeyLen: 9999,
+			readerError:  false,
+			serviceError: true,
+		},
+		{
+			tcName:       "empty file",
+			fileName:     "masterKey_file_empty.txt",
+			masterKeyLen: 0,
+			readerError:  true,
+			serviceError: true,
+		},
+		{
+			tcName:       "valid file with raw master key content",
+			fileName:     "masterKey_file_valid_raw.txt",
+			masterKeyLen: 32,
+			readerError:  false,
+			serviceError: false,
+		},
+		{
+			tcName:       "valid file with base64 URL Encoded master key",
+			fileName:     "masterKey_file_valid_enc.txt",
+			masterKeyLen: 32,
+			readerError:  false,
+			serviceError: false,
+			base64Enc:    true,
+		},
+	}
+
+	// nolint:scopelint
+	for _, tc := range tcs {
+		t.Run(tc.tcName, func(t *testing.T) {
+			masterKeyFilePath := tc.fileName
+			tmpfile, err := ioutil.TempFile("", masterKeyFilePath)
+			require.NoError(t, err)
+
+			defer func() {
+				// close file
+				require.NoError(t, tmpfile.Close())
+				// clean up file
+				require.NoError(t, os.Remove(tmpfile.Name()))
+			}()
+
+			masterKeyContent := []byte{}
+
+			if tc.masterKeyLen != 0 {
+				masterKeyContent = random.GetRandomBytes(uint32(tc.masterKeyLen))
+				require.NotEmpty(t, masterKeyContent)
+			}
+
+			if tc.base64Enc {
+				keyEncoded := base64.URLEncoding.EncodeToString(masterKeyContent)
+				masterKeyContent = []byte(keyEncoded)
+			}
+
+			n, err := tmpfile.Write(masterKeyContent)
+			require.NoError(t, err)
+			require.Equal(t, len(masterKeyContent), n)
+
+			// try to get a reader
+			r, err := MasterKeyFromPath(tmpfile.Name())
+			if tc.readerError {
+				require.Error(t, err)
+				require.Empty(t, r)
+
+				// set r to empty reader
+				r = bytes.NewReader([]byte{})
+			} else {
+				require.NoError(t, err)
+				require.NotEmpty(t, r)
+			}
+
+			// try to create lock service for this above reader with nil master lock (master key not encrypted)
+			s, err := NewService(r, nil)
+			if tc.serviceError {
+				require.Error(t, err)
+				require.Empty(t, s)
+			} else {
+				require.NoError(t, err)
+				require.NotEmpty(t, s)
+			}
+		})
+	}
+}
+
+func TestCreateServiceFromPathWithoutMasterLock(t *testing.T) {
+	masterKeyFilePath := "masterKey_file.txt"
+	tmpfile, err := ioutil.TempFile("", masterKeyFilePath)
+	require.NoError(t, err)
+
+	defer func() {
+		// close file
+		require.NoError(t, tmpfile.Close())
+		// clean up file
+		require.NoError(t, os.Remove(tmpfile.Name()))
+	}()
+
+	masterKeyContent := random.GetRandomBytes(uint32(32))
+	require.NotEmpty(t, masterKeyContent)
+
+	masterKeyToSave := make([]byte, base64.URLEncoding.EncodedLen(len(masterKeyContent)))
+	base64.URLEncoding.Encode(masterKeyToSave, masterKeyContent)
+
+	n, err := tmpfile.Write(masterKeyToSave)
+	require.NoError(t, err)
+	require.Equal(t, len(masterKeyToSave), n)
+
+	// try invalid path
+	r, err := MasterKeyFromPath("bad/mk/test/file/name")
+	require.Error(t, err)
+	require.Empty(t, r)
+
+	// try real file path
+	r, err = MasterKeyFromPath(tmpfile.Name())
+	require.NoError(t, err)
+	require.NotEmpty(t, r)
+
+	// create lock service with nil master lock (master key not encrypted)
+	s, err := NewService(r, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, s)
+
+	someKey := random.GetRandomBytes(uint32(32))
+	someKeyEnc, err := s.Encrypt("", &secretlock.EncryptRequest{
+		Plaintext: string(someKey)})
+	require.NoError(t, err)
+	require.NotEmpty(t, someKeyEnc)
+
+	someKeyDec, err := s.Decrypt("", &secretlock.DecryptRequest{
+		Ciphertext: someKeyEnc.Ciphertext})
+	require.NoError(t, err)
+	require.Equal(t, someKey, []byte(someKeyDec.Plaintext))
+
+	// try decrypting a non valid base64URL string
+	someKeyDec, err = s.Decrypt("", &secretlock.DecryptRequest{Ciphertext: "bad{}base64URLstring[]"})
+	require.Error(t, err)
+	require.Empty(t, someKeyDec)
+}
+
+func TestCreateServiceFromPathWithMasterLock(t *testing.T) {
+	masterKeyFilePath := "masterKey_file.txt"
+	tmpfile, err := ioutil.TempFile("", masterKeyFilePath)
+	require.NoError(t, err)
+
+	defer func() {
+		// close file
+		require.NoError(t, tmpfile.Close())
+		// clean up file
+		require.NoError(t, os.Remove(tmpfile.Name()))
+	}()
+
+	masterKeyContent := random.GetRandomBytes(uint32(32))
+	require.NotEmpty(t, masterKeyContent)
+
+	// first create a master lock to use in our secret lock and encrypt the master key
+	passphrase := "secretPassphrase"
+	keySize := sha256.New().Size()
+	// salt is optional, it can be nil
+	salt := make([]byte, keySize)
+	_, err = rand.Read(salt)
+	require.NoError(t, err)
+
+	masterLocker, err := hkdf.NewMasterLock(passphrase, sha256.New, salt)
+	require.NoError(t, err)
+	require.NotEmpty(t, masterLocker)
+
+	// now encrypt masterKeyContent
+	masterLockEnc, err := masterLocker.Encrypt("", &secretlock.EncryptRequest{
+		Plaintext: string(masterKeyContent)})
+	require.NoError(t, err)
+	require.NotEmpty(t, masterLockEnc)
+
+	// and write it to tmpfile
+	n, err := tmpfile.Write([]byte(masterLockEnc.Ciphertext))
+	require.NoError(t, err)
+	require.Equal(t, len(masterLockEnc.Ciphertext), n)
+
+	// now get a reader from path
+	r, err := MasterKeyFromPath(tmpfile.Name())
+	require.NoError(t, err)
+	require.NotEmpty(t, r)
+
+	// try a bad reader
+	badReader, err := MasterKeyFromPath("bad/mk/test/file/name")
+	require.Error(t, err)
+	require.Empty(t, badReader)
+
+	// finally create lock service with the master lock created earlier to encrypt decrypt keys using
+	// a protected (encrypted) master key
+	s, err := NewService(r, masterLocker)
+	require.NoError(t, err)
+	require.NotEmpty(t, s)
+
+	// now try to crate a lock service with a bad (nil) reader reference
+	badSerivce, err := NewService(badReader, masterLocker)
+	require.EqualError(t, err, "masterKeyReader is nil")
+	require.Empty(t, badSerivce)
+
+	// or a nil reader as argument
+	badSerivce, err = NewService(nil, masterLocker)
+	require.Error(t, err)
+	require.Empty(t, badSerivce)
+
+	// or a reader containing an invalid master key
+	badSerivce, err = NewService(bytes.NewReader([]byte("badMasterKey")), masterLocker)
+	require.Error(t, err)
+	require.Empty(t, badSerivce)
+
+	someKey := random.GetRandomBytes(uint32(32))
+	someKeyEnc, err := s.Encrypt("", &secretlock.EncryptRequest{
+		Plaintext: string(someKey)})
+	require.NoError(t, err)
+	require.NotEmpty(t, someKeyEnc)
+
+	someKeyDec, err := s.Decrypt("", &secretlock.DecryptRequest{
+		Ciphertext: someKeyEnc.Ciphertext})
+	require.NoError(t, err)
+	require.Equal(t, someKey, []byte(someKeyDec.Plaintext))
+
+	// finally try to decrypt a bad ciphertext
+	badCipher := base64.URLEncoding.EncodeToString([]byte("BadCipherTextInAction"))
+
+	someKeyDec, err = s.Decrypt("", &secretlock.DecryptRequest{Ciphertext: badCipher})
+	require.Error(t, err)
+	require.Empty(t, someKeyDec)
+
+	// try with a short cipher (shorter than nonce+ciphertext)
+	badCipher = base64.URLEncoding.EncodeToString([]byte("short"))
+
+	someKeyDec, err = s.Decrypt("", &secretlock.DecryptRequest{Ciphertext: badCipher})
+	require.Error(t, err)
+	require.Empty(t, someKeyDec)
+}
+
+func TestCreateServiceFromEnvWithoutMasterLock(t *testing.T) {
+	masterKeyContent := random.GetRandomBytes(uint32(32))
+	require.NotEmpty(t, masterKeyContent)
+
+	envKey := envPrefix + strings.ReplaceAll(testKeyURI, "/", "_")
+
+	// set the master key (unencrypted) in env
+	err := os.Setenv(envKey, base64.URLEncoding.EncodeToString(masterKeyContent))
+	require.NoError(t, err)
+
+	defer func() {
+		// clean up env variable
+		require.NoError(t, os.Unsetenv(envKey))
+	}()
+
+	r, err := MasterKeyFromEnv(envPrefix, "bad/mk/test/key")
+	require.Error(t, err)
+	require.Empty(t, r)
+
+	r, err = MasterKeyFromEnv(envPrefix, testKeyURI)
+	require.NoError(t, err)
+	require.NotEmpty(t, r)
+
+	// create lock service with nil master lock (master key not encrypted)
+	s, err := NewService(r, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, s)
+
+	someKey := random.GetRandomBytes(uint32(32))
+	someKeyEnc, err := s.Encrypt("", &secretlock.EncryptRequest{
+		Plaintext: string(someKey)})
+	require.NoError(t, err)
+	require.NotEmpty(t, someKeyEnc)
+
+	someKeyDec, err := s.Decrypt("", &secretlock.DecryptRequest{
+		Ciphertext: someKeyEnc.Ciphertext})
+	require.NoError(t, err)
+	require.Equal(t, someKey, []byte(someKeyDec.Plaintext))
+}
+
+func TestCreateServiceFromEnvWithMasterLock(t *testing.T) {
+	masterKeyContent := random.GetRandomBytes(uint32(32))
+	require.NotEmpty(t, masterKeyContent)
+
+	// first create a master lock to use in our secret lock and encrypt the master key
+	passphrase := "secretPassphrase"
+	keySize := sha256.New().Size()
+	// salt is optional, it can be nil
+	salt := make([]byte, keySize)
+	_, err := rand.Read(salt)
+	require.NoError(t, err)
+
+	masterLocker, err := hkdf.NewMasterLock(passphrase, sha256.New, salt)
+	require.NoError(t, err)
+	require.NotEmpty(t, masterLocker)
+
+	// now encrypt masterKeyContent
+	masterLockEnc, err := masterLocker.Encrypt("", &secretlock.EncryptRequest{
+		Plaintext: string(masterKeyContent)})
+	require.NoError(t, err)
+	require.NotEmpty(t, masterLockEnc)
+
+	envKey := envPrefix + strings.ReplaceAll(testKeyURI, "/", "_")
+
+	// now set the encrypted master key in env
+	err = os.Setenv(envKey, masterLockEnc.Ciphertext)
+	require.NoError(t, err)
+
+	defer func() {
+		// clean up env variable
+		require.NoError(t, os.Unsetenv(envKey))
+	}()
+
+	// get a reader from an invalid env variable
+	badReader, err := MasterKeyFromEnv(envPrefix, "bad/mk/test/key")
+	require.Error(t, err)
+	require.Empty(t, badReader)
+
+	// get a reader from a valid env variable
+	r, err := MasterKeyFromEnv(envPrefix, testKeyURI)
+	require.NoError(t, err)
+	require.NotEmpty(t, r)
+
+	// finally create lock service with the master lock created earlier to encrypt decrypt keys using
+	// a protected (encrypted) master key
+	s, err := NewService(r, masterLocker)
+	require.NoError(t, err)
+	require.NotEmpty(t, s)
+
+	// now try to crate a lock service with a bad reader
+	badSerivce, err := NewService(badReader, masterLocker)
+	require.Error(t, err)
+	require.Empty(t, badSerivce)
+
+	// or a nil reader
+	badSerivce, err = NewService(nil, masterLocker)
+	require.Error(t, err)
+	require.Empty(t, badSerivce)
+
+	someKey := random.GetRandomBytes(uint32(32))
+	someKeyEnc, err := s.Encrypt("", &secretlock.EncryptRequest{
+		Plaintext: string(someKey)})
+	require.NoError(t, err)
+	require.NotEmpty(t, someKeyEnc)
+
+	someKeyDec, err := s.Decrypt("", &secretlock.DecryptRequest{
+		Ciphertext: someKeyEnc.Ciphertext})
+	require.NoError(t, err)
+	require.Equal(t, someKey, []byte(someKeyDec.Plaintext))
+}

--- a/pkg/secretlock/local/local_secret_masterkey_reader.go
+++ b/pkg/secretlock/local/local_secret_masterkey_reader.go
@@ -1,0 +1,53 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package local
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// MasterKeyFromPath creates a new instance of a local secret lock Reader to read a master key stored in `path`.
+func MasterKeyFromPath(path string) (io.Reader, error) {
+	masterKeyFile, err := os.OpenFile(path, os.O_RDONLY, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		err = masterKeyFile.Close()
+		if err != nil {
+			logger.Warnf("failed to close file: %w", err)
+		}
+	}()
+
+	mkData := make([]byte, masterKeyLen)
+
+	n, err := io.ReadFull(masterKeyFile, mkData)
+	if err != nil {
+		if err != io.ErrUnexpectedEOF {
+			return nil, err
+		}
+	}
+
+	mkData = mkData[0:n]
+
+	return bytes.NewReader(mkData), nil
+}
+
+// MasterKeyFromEnv creates a new instance of a local secret lock Reader
+// to read a master key found in a env variable with key: `envPrefix` + `keyURI`.
+func MasterKeyFromEnv(envPrefix, keyURI string) (io.Reader, error) {
+	mk := os.Getenv(envPrefix + strings.ReplaceAll(keyURI, "/", "_"))
+	if mk == "" {
+		return nil, fmt.Errorf("masterKey not set")
+	}
+
+	return bytes.NewReader([]byte(mk)), nil
+}

--- a/pkg/secretlock/local/masterlock/hkdf/master_secret_lock.go
+++ b/pkg/secretlock/local/masterlock/hkdf/master_secret_lock.go
@@ -1,0 +1,112 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package hkdf
+
+import (
+	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"hash"
+	"io"
+
+	"github.com/google/tink/go/subtle/random"
+	"golang.org/x/crypto/hkdf"
+
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
+	cipherutil "github.com/hyperledger/aries-framework-go/pkg/secretlock/local/internal/cipher"
+)
+
+type masterLockHKDF struct {
+	h    func() hash.Hash
+	salt []byte
+	aead cipher.AEAD
+}
+
+// NewMasterLock is responsible for encrypting/decrypting a master key expanded from a passphrase using HKDF
+// using `passphrase`, hash function `h`, `salt`.
+// The size of a master key passed to Encrypt() must match `h()`.Size() since the key will be used for AEAD operations.
+// The salt is optional and can be set to nil.
+// This implementation must not be used directly in Aries framework. It should be passed in
+// as the second argument to local secret lock service constructor:
+// `local.NewService(masterKeyReader io.Reader, secLock secretlock.Service)`
+func NewMasterLock(passphrase string, h func() hash.Hash, salt []byte) (secretlock.Service, error) {
+	if passphrase == "" {
+		return nil, fmt.Errorf("passphrase is empty")
+	}
+
+	if h == nil {
+		return nil, fmt.Errorf("hash is nil")
+	}
+
+	size := h().Size()
+	if size > sha256.Size { // AEAD cipher requires at most sha256.Size
+		return nil, fmt.Errorf("hash size not supported")
+	}
+
+	// expand an encryption key from passphrase
+	expander := hkdf.New(h, []byte(passphrase), salt, nil)
+
+	masterKey := make([]byte, size)
+
+	_, err := io.ReadFull(expander, masterKey)
+	if err != nil {
+		return nil, err
+	}
+
+	aead, err := cipherutil.CreateAESCipher(masterKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &masterLockHKDF{
+		h:    h,
+		salt: salt,
+		aead: aead,
+	}, nil
+}
+
+// Encrypt a master key in req
+//  (keyURI is used for remote locks, it is ignored by this implementation)
+func (m *masterLockHKDF) Encrypt(keyURI string, req *secretlock.EncryptRequest) (*secretlock.EncryptResponse, error) {
+	if len(req.Plaintext) != m.h().Size() {
+		return nil, fmt.Errorf("invalid key size")
+	}
+
+	nonce := random.GetRandomBytes(uint32(m.aead.NonceSize()))
+	ct := m.aead.Seal(nil, nonce, []byte(req.Plaintext), []byte(req.AdditionalAuthenticatedData))
+	ct = append(nonce, ct...)
+
+	return &secretlock.EncryptResponse{
+		Ciphertext: base64.URLEncoding.EncodeToString(ct),
+	}, nil
+}
+
+// Decrypt a master key in req
+// (keyURI is used for remote locks, it is ignored by this implementation)
+func (m *masterLockHKDF) Decrypt(keyURI string, req *secretlock.DecryptRequest) (*secretlock.DecryptResponse, error) {
+	ct, err := base64.URLEncoding.DecodeString(req.Ciphertext)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := uint32(m.aead.NonceSize())
+
+	// ensure ciphertext contains more than nonce+ciphertext (result from Encrypt())
+	if len(ct) <= int(nonceSize) {
+		return nil, fmt.Errorf("invalid request")
+	}
+
+	nonce := ct[0:nonceSize]
+	ct = ct[nonceSize:]
+
+	pt, err := m.aead.Open(nil, nonce, ct, []byte(req.AdditionalAuthenticatedData))
+	if err != nil {
+		return nil, err
+	}
+
+	return &secretlock.DecryptResponse{Plaintext: string(pt)}, nil
+}

--- a/pkg/secretlock/local/masterlock/hkdf/master_secret_lock_test.go
+++ b/pkg/secretlock/local/masterlock/hkdf/master_secret_lock_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package hkdf
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/sha512"
+	"testing"
+
+	"github.com/google/tink/go/subtle/random"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
+)
+
+func TestMasterLock(t *testing.T) {
+	keySize := sha256.New().Size()
+	testKey := random.GetRandomBytes(uint32(keySize))
+	goodPassphrase := "somepassphrase"
+
+	salt := make([]byte, keySize)
+	_, err := rand.Read(salt)
+	require.NoError(t, err)
+
+	mkLock, err := NewMasterLock(goodPassphrase, sha256.New, salt)
+	require.NoError(t, err)
+
+	// try to create a bad master key lock (unsupported hash)
+	mkLockBad, err := NewMasterLock(goodPassphrase, sha512.New, salt)
+	require.Error(t, err)
+	require.Empty(t, mkLockBad)
+
+	encryptedMk, err := mkLock.Encrypt("", &secretlock.EncryptRequest{Plaintext: string(testKey)})
+	require.NoError(t, err)
+	require.NotEmpty(t, encryptedMk)
+
+	decryptedMk, err := mkLock.Decrypt("", &secretlock.DecryptRequest{Ciphertext: encryptedMk.Ciphertext})
+	require.NoError(t, err)
+	require.Equal(t, testKey, []byte(decryptedMk.Plaintext))
+
+	// try encrypting a key with a size different than keySize
+	badEncryptedMk, err := mkLock.Encrypt("", &secretlock.EncryptRequest{Plaintext: "BadKey"})
+	require.EqualError(t, err, "invalid key size")
+	require.Empty(t, badEncryptedMk)
+
+	// try decrypting a non valid base64URL string
+	decryptedMk, err = mkLock.Decrypt("", &secretlock.DecryptRequest{Ciphertext: "bad{}base64URLstring[]"})
+	require.Error(t, err)
+	require.Empty(t, decryptedMk)
+
+	// create a new lock instance with the same passphrase, hash, salt
+	mkLock2, err := NewMasterLock(goodPassphrase, sha256.New, salt)
+	require.NoError(t, err)
+
+	// ensure Decrypt() is successful and returns the same result as the original lock
+	decryptedMk2, err := mkLock2.Decrypt("", &secretlock.DecryptRequest{Ciphertext: encryptedMk.Ciphertext})
+	require.NoError(t, err)
+	require.Equal(t, testKey, []byte(decryptedMk2.Plaintext))
+
+	// recreate new lock with empty salt
+	mkLock2, err = NewMasterLock(goodPassphrase, sha256.New, nil)
+	require.NoError(t, err)
+
+	decryptedMk2, err = mkLock2.Decrypt("", &secretlock.DecryptRequest{Ciphertext: encryptedMk.Ciphertext})
+	require.Error(t, err)
+	require.Empty(t, decryptedMk2)
+
+	// recreate new lock with a different salt
+	salt2 := make([]byte, keySize)
+	_, err = rand.Read(salt2)
+	require.NoError(t, err)
+
+	mkLock2, err = NewMasterLock(goodPassphrase, sha256.New, salt2)
+	require.NoError(t, err)
+
+	decryptedMk2, err = mkLock2.Decrypt("", &secretlock.DecryptRequest{Ciphertext: encryptedMk.Ciphertext})
+	require.Error(t, err)
+	require.Empty(t, decryptedMk2)
+
+	// try with a bad passhrase
+	mkLock2, err = NewMasterLock("badPassphrase", sha256.New, salt)
+	require.NoError(t, err)
+
+	decryptedMk2, err = mkLock2.Decrypt("", &secretlock.DecryptRequest{Ciphertext: encryptedMk.Ciphertext})
+	require.Error(t, err)
+	require.Empty(t, decryptedMk2)
+
+	// try creating a lock with a nil hash
+	mkLock2, err = NewMasterLock(goodPassphrase, nil, salt)
+	require.Error(t, err)
+	require.Empty(t, mkLock2)
+
+	// try creating a lock with an empty passphrase
+	mkLock2, err = NewMasterLock("", sha256.New, salt)
+	require.Error(t, err)
+	require.Empty(t, mkLock2)
+}


### PR DESCRIPTION
This change includes reading a masterkey
            from 2 sources:
            1. masterKey loaded from env variable
            2. masterKey loaded from local path
    
    This change also includes password protection lock to encrypt
    the master key for additional protection of keys.
    
closes #1146
