### PR TITLE
feat: compressed wasm for aries-js-worker

### DIFF
--- a/cmd/aries-js-worker/README.md
+++ b/cmd/aries-js-worker/README.md
@@ -22,3 +22,17 @@ View [`App.js`](./App.js) for examples.
 **Browser**
 
 View [`index.html`](./index.html) for examples.
+
+**Important:** Make sure the web server adds the appropriate headers when serving the compressed `aries-js-worker.wasm.gz` file:
+
+* `Content-Type: application/wasm`
+* `Content-Encoding: gzip`
+
+Consult your web server's documentation for instructions on how to do this (eg. for Apache: [Content-Type](https://httpd.apache.org/docs/2.4/mod/mod_mime.html#addtype), [Content-Encoding](https://httpd.apache.org/docs/2.4/mod/mod_deflate.html#precompressed)).
+
+Here is a hacky one-liner when using [`goexec`](https://github.com/shurcooL/goexec):
+
+```
+goexec -quiet 'http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { if strings.HasSuffix(r.RequestURI, ".gz") && !strings.Contains(r.RequestURI, "wasm=") { w.Header().Add("Content-Encoding", "gzip"); w.Header().Add("Content-Type", "application/wasm") }; http.FileServer(http.Dir(`.`)).ServeHTTP(w, r) }); http.ListenAndServe(`:8080`, nil)'
+```
+

--- a/cmd/aries-js-worker/package-lock.json
+++ b/cmd/aries-js-worker/package-lock.json
@@ -279,6 +279,16 @@
       "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
       "dev": true
     },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
     "ajv": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
@@ -828,6 +838,12 @@
         }
       }
     },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
+    },
     "clean-webpack-plugin": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
@@ -891,6 +907,146 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
+    },
+    "compression-webpack-plugin": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-3.1.0.tgz",
+      "integrity": "sha512-iqTHj3rADN4yHwXMBrQa/xrncex/uEQy8QHlaTKxGchT/hC0SdlJlmL/5eRqffmWq2ep0/Romw6Ld39JjTR/ug==",
+      "dev": true,
+      "requires": {
+        "cacache": "^13.0.1",
+        "find-cache-dir": "^3.0.0",
+        "neo-async": "^2.5.0",
+        "schema-utils": "^2.6.1",
+        "serialize-javascript": "^2.1.2",
+        "webpack-sources": "^1.0.1"
+      },
+      "dependencies": {
+        "cacache": {
+          "version": "13.0.1",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
+          "integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.2",
+            "figgy-pudding": "^3.5.1",
+            "fs-minipass": "^2.0.0",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.2.2",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^5.1.1",
+            "minipass": "^3.0.0",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.2",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "p-map": "^3.0.0",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.7.1",
+            "ssri": "^7.0.0",
+            "unique-filename": "^1.1.1"
+          }
+        },
+        "find-cache-dir": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
+          "integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^3.0.0",
+            "pkg-dir": "^4.1.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+          "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-map": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+          "dev": true,
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "schema-utils": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
+          "integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "ssri": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
+          "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+          "dev": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "minipass": "^3.1.1"
+          }
+        }
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1591,6 +1747,15 @@
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -2405,6 +2570,12 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
     "infer-owner": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
@@ -2856,6 +3027,50 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
+    },
+    "minipass": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+      "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-pipeline": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
+      "integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      }
     },
     "mississippi": {
       "version": "3.0.0",
@@ -4400,6 +4615,11 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha1-UBl+2yihxCymWcyLTmqd3W1ERVQ="
     }
   }
 }

--- a/cmd/aries-js-worker/package.json
+++ b/cmd/aries-js-worker/package.json
@@ -37,12 +37,13 @@
   },
   "homepage": "https://github.com/hyperledger/aries-framework-go#readme",
   "devDependencies": {
-    "clean-webpack-plugin": "=3.0.0",
-    "copy-webpack-plugin": "=5.1.1",
-    "file-loader": "=5.0.2",
-    "webpack": "=4.41.5",
-    "webpack-cli": "=3.3.10",
-    "webpack-merge": "=4.2.2",
-    "webpack-shell-plugin": "=0.5.0"
+    "clean-webpack-plugin": "3.0.0",
+    "compression-webpack-plugin": "3.1.0",
+    "copy-webpack-plugin": "5.1.1",
+    "file-loader": "5.0.2",
+    "webpack": "4.41.5",
+    "webpack-cli": "3.3.10",
+    "webpack-merge": "4.2.2",
+    "webpack-shell-plugin": "0.5.0"
   }
 }

--- a/cmd/aries-js-worker/src/worker-impl-node.js
+++ b/cmd/aries-js-worker/src/worker-impl-node.js
@@ -6,17 +6,17 @@ SPDX-License-Identifier: Apache-2.0
 
 const { workerData, parentPort } = require("worker_threads")
 const fs = require("fs")
-
+const zlib = require("zlib")
 // We expect two things in workerData:
 // - wasmJS: absolute path to the Go webassembly wrapper JS file
-// - wasm: absolute path to the wasm blob file
+// - wasm: absolute path to the gzipped wasm blob file
 
 require(workerData.wasmJS)
 
 const go = new Go();
 go.env = Object.assign({ TMPDIR: require("os").tmpdir() }, process.env);
 go.exit = process.exit;
-WebAssembly.instantiate(fs.readFileSync(workerData.wasmPath), go.importObject).then((result) => {
+WebAssembly.instantiate(zlib.gunzipSync(fs.readFileSync(workerData.wasmPath)), go.importObject).then((result) => {
     return go.run(result.instance);
 }).catch((err) => {
     console.error(err);

--- a/cmd/aries-js-worker/src/worker-impl-web.js
+++ b/cmd/aries-js-worker/src/worker-impl-web.js
@@ -28,10 +28,13 @@ if (!WebAssembly.instantiateStreaming) { // polyfill
 }
 
 const go = new Go();
+// Firefox is not including 'br' in fetch() for some reason.
+// Cannot override Accept-Encoding header for the fetch call (would've liked to use brotli).
+// Accept-Encoding is one of the forbidden headers of the Fetch API: https://fetch.spec.whatwg.org/#forbidden-header-name
 WebAssembly.instantiateStreaming(fetch(wasm), go.importObject).then(
-    result => { go.run(result.instance); },
-    err => { throw new Error("failed to fetch wasm blob: " + err.message) }
-);
+    result => {go.run(result.instance);},
+    err => {throw new Error("failed to fetch wasm blob: " + err.message)}
+)
 
 handleResult = function(r) {
     postMessage(JSON.parse(r))

--- a/cmd/aries-js-worker/src/worker-loader-node.js
+++ b/cmd/aries-js-worker/src/worker-loader-node.js
@@ -11,7 +11,7 @@ import wasm from "./aries-js-worker.wasm"
 import workerJS from "./worker-impl-node"
 
 export function _getWorker(pending) {
-    const worker = new Worker(workerJS, { workerData: {wasmJS: wasmJS, wasmPath: wasm} })
+    const worker = new Worker(workerJS, { workerData: {wasmJS: wasmJS, wasmPath: wasm + ".gz"} })
     worker.on("message", result => {
         const cb = pending.get(result.id)
         pending.delete(result.id)

--- a/cmd/aries-js-worker/src/worker-loader-web.js
+++ b/cmd/aries-js-worker/src/worker-loader-web.js
@@ -9,7 +9,7 @@ import wasm from "./aries-js-worker.wasm"
 import workerJS from "./worker-impl-web"
 
 export function _getWorker(pending) {
-    const worker = new Worker(workerJS + "?wasmJS=" + wasmJS + "&wasm=" + wasm)
+    const worker = new Worker(workerJS + "?wasmJS=" + wasmJS + "&wasm=" + wasm + ".gz")
     worker.onmessage = e => {
         const result = e.data
         const cb = pending.get(result.id)

--- a/cmd/aries-js-worker/webpack.config.node.js
+++ b/cmd/aries-js-worker/webpack.config.node.js
@@ -8,6 +8,7 @@ const path = require("path")
 
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const WebpackShellPlugin = require('webpack-shell-plugin')
+const CompressionPlugin = require("compression-webpack-plugin")
 
 const { PATHS } = require("./webpack.config.common.js")
 
@@ -29,6 +30,10 @@ module.exports = {
             onBuildStart: [
                 "mkdir -p " + OUTPUT
             ]
+        }),
+        new CompressionPlugin({
+            include: /\.wasm/,
+            deleteOriginalAssets: true
         })
     ],
     module: {

--- a/cmd/aries-js-worker/webpack.config.web.js
+++ b/cmd/aries-js-worker/webpack.config.web.js
@@ -8,6 +8,7 @@ const path = require("path")
 
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const WebpackShellPlugin = require('webpack-shell-plugin')
+const CompressionPlugin = require("compression-webpack-plugin")
 
 const { PATHS } = require("./webpack.config.common.js")
 
@@ -30,6 +31,10 @@ module.exports = {
             onBuildStart: [
                 "mkdir -p " + OUTPUT
             ]
+        }),
+        new CompressionPlugin({
+            include: /\.wasm/,
+            deleteOriginalAssets: true
         })
     ],
     module: {


### PR DESCRIPTION
Compressed the wasm.

Note: as mentioned in the README, for this to work the necessary headers need to be included in the response when fetching `aries-js-worker.wasm.gz`

Signed-off-by: George Aristy <goerge.aristy@securekey.com>