### PR TITLE
refactor: do not pass private key to Sign() in linked data proofs

### DIFF
--- a/pkg/doc/signature/signer/signer.go
+++ b/pkg/doc/signature/signer/signer.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/ed25519signature2018"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/proof"
 )
 
@@ -26,9 +25,7 @@ type signatureSuite interface {
 
 	// Accept registers this signature suite with the given signature type
 	Accept(signatureType string) bool
-}
 
-type signer interface {
 	// Sign will sign document and return signature
 	Sign(doc []byte) ([]byte, error)
 }
@@ -42,17 +39,13 @@ type DocumentSigner struct {
 type Context struct {
 	SignatureType string     // required
 	Creator       string     // required
-	Signer        signer     // required
 	Created       *time.Time // optional
 	Domain        string     // optional
 	Nonce         []byte     // optional
 }
 
 // New returns new instance of document verifier
-func New() *DocumentSigner {
-	var signatureSuites []signatureSuite
-	signatureSuites = append(signatureSuites, &ed25519signature2018.SignatureSuite{})
-
+func New(signatureSuites ...signatureSuite) *DocumentSigner {
 	return &DocumentSigner{signatureSuites: signatureSuites}
 }
 
@@ -108,7 +101,7 @@ func (signer *DocumentSigner) signObject(context *Context, jsonLdObject map[stri
 		return err
 	}
 
-	s, err := context.Signer.Sign(message)
+	s, err := suite.Sign(message)
 	if err != nil {
 		return err
 	}
@@ -138,10 +131,6 @@ func isValidContext(context *Context) error {
 
 	if context.SignatureType == "" {
 		return errors.New("signature type is missing")
-	}
-
-	if context.Signer == nil {
-		return errors.New("signer is missing")
 	}
 
 	return nil

--- a/pkg/doc/signature/verifier/verifier.go
+++ b/pkg/doc/signature/verifier/verifier.go
@@ -43,9 +43,10 @@ type DocumentVerifier struct {
 }
 
 // New returns new instance of document verifier
-func New(resolver keyResolver) *DocumentVerifier {
-	var signatureSuites []signatureSuite
-	signatureSuites = append(signatureSuites, &ed25519signature2018.SignatureSuite{})
+func New(resolver keyResolver, signatureSuites ...signatureSuite) *DocumentVerifier {
+	if len(signatureSuites) == 0 {
+		signatureSuites = []signatureSuite{ed25519signature2018.New()}
+	}
 
 	return &DocumentVerifier{signatureSuites: signatureSuites, pkResolver: resolver}
 }

--- a/pkg/doc/verifiable/credential.go
+++ b/pkg/doc/verifiable/credential.go
@@ -482,7 +482,7 @@ type credentialOpts struct {
 	disabledProofCheck    bool
 	jsonldDocumentLoader  ld.DocumentLoader
 	strictValidation      bool
-	ldpSuites             []verifierSignatureSuite
+	ldpSuite              verifierSignatureSuite
 }
 
 // CredentialOpt is the Verifiable Credential decoding option
@@ -570,10 +570,10 @@ func WithStrictValidation() CredentialOpt {
 	}
 }
 
-// WithEmbeddedSignatureSuites defines the suites which are used to check embedded linked data proof of VC.
-func WithEmbeddedSignatureSuites(suites ...verifierSignatureSuite) CredentialOpt {
+// WithEmbeddedSignatureSuites defines the suite which is used to check embedded linked data proof of VC.
+func WithEmbeddedSignatureSuites(suite verifierSignatureSuite) CredentialOpt {
 	return func(opts *credentialOpts) {
-		opts.ldpSuites = suites
+		opts.ldpSuite = suite
 	}
 }
 

--- a/pkg/doc/verifiable/credential_ldp_test.go
+++ b/pkg/doc/verifiable/credential_ldp_test.go
@@ -22,11 +22,12 @@ func TestNewCredentialFromLinkedDataProof(t *testing.T) {
 	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
 	r.NoError(err)
 
+	suite := ed25519signature2018.New(ed25519signature2018.WithSigner(getSigner(privKey)))
+
 	ldpContext := &LinkedDataProofContext{
 		Creator:       "John",
 		SignatureType: "Ed25519Signature2018",
-		Suite:         ed25519signature2018.New(),
-		PrivateKey:    privKey,
+		Suite:         suite,
 	}
 
 	vc, _, err := NewCredential([]byte(validCredential))
@@ -39,7 +40,7 @@ func TestNewCredentialFromLinkedDataProof(t *testing.T) {
 	r.NoError(err)
 
 	vcWithLdp, _, err := NewCredential(vcBytes,
-		WithEmbeddedSignatureSuites(ed25519signature2018.New()),
+		WithEmbeddedSignatureSuites(suite),
 		WithPublicKeyFetcher(SingleKey([]byte(pubKey))))
 	r.NoError(err)
 
@@ -47,7 +48,6 @@ func TestNewCredentialFromLinkedDataProof(t *testing.T) {
 	r.Equal(vc, vcWithLdp)
 }
 
-// TODO add a scenario when a new proof is appended to already existent one.
 func TestCredential_AddLinkedDataProof(t *testing.T) {
 	r := require.New(t)
 
@@ -57,8 +57,7 @@ func TestCredential_AddLinkedDataProof(t *testing.T) {
 	ldpContext := &LinkedDataProofContext{
 		Creator:       "John",
 		SignatureType: "Ed25519Signature2018",
-		Suite:         ed25519signature2018.New(),
-		PrivateKey:    privKey,
+		Suite:         ed25519signature2018.New(ed25519signature2018.WithSigner(getSigner(privKey))),
 	}
 
 	t.Run("Add a valid Linked Data proof to VC", func(t *testing.T) {
@@ -103,9 +102,8 @@ func TestCredential_AddLinkedDataProof(t *testing.T) {
 
 		vc.CustomFields = nil
 		ldpContextWithMissingSignatureType := &LinkedDataProofContext{
-			Creator:    "John",
-			Suite:      ed25519signature2018.New(),
-			PrivateKey: privKey,
+			Creator: "John",
+			Suite:   ed25519signature2018.New(ed25519signature2018.WithSigner(getSigner(privKey))),
 		}
 
 		err = vc.AddLinkedDataProof(ldpContextWithMissingSignatureType)

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -800,8 +800,7 @@ func TestWithEmbeddedSignatureSuites(t *testing.T) {
 
 	opts := &credentialOpts{}
 	credentialOpt(opts)
-	require.Len(t, opts.ldpSuites, 1)
-	require.Equal(t, suite, opts.ldpSuites[0])
+	require.Equal(t, suite, opts.ldpSuite)
 }
 
 func TestCustomCredentialJsonSchemaValidator2018(t *testing.T) {

--- a/pkg/doc/verifiable/embedded_proof.go
+++ b/pkg/doc/verifiable/embedded_proof.go
@@ -66,7 +66,7 @@ func checkEmbeddedProof(docBytes []byte, vcOpts *credentialOpts) ([]byte, error)
 
 	switch proofType {
 	case linkedDataProof:
-		err = checkLinkedDataProof(docBytes, vcOpts.ldpSuites, vcOpts.publicKeyFetcher)
+		err = checkLinkedDataProof(docBytes, vcOpts.ldpSuite, vcOpts.publicKeyFetcher)
 	default:
 		err = fmt.Errorf("unsupported proof type: %v", proofType)
 	}

--- a/pkg/doc/verifiable/presentation.go
+++ b/pkg/doc/verifiable/presentation.go
@@ -263,7 +263,7 @@ type rawPresentation struct {
 type presentationOpts struct {
 	publicKeyFetcher   PublicKeyFetcher
 	disabledProofCheck bool
-	ldpSuites          []verifierSignatureSuite
+	ldpSuite           verifierSignatureSuite
 }
 
 // PresentationOpt is the Verifiable Presentation decoding option
@@ -277,10 +277,10 @@ func WithPresPublicKeyFetcher(fetcher PublicKeyFetcher) PresentationOpt {
 	}
 }
 
-// WithPresEmbeddedSignatureSuites defines the suites which are used to check embedded linked data proof of VP.
-func WithPresEmbeddedSignatureSuites(suites ...verifierSignatureSuite) PresentationOpt {
+// WithPresEmbeddedSignatureSuites defines the suite which is used to check embedded linked data proof of VP.
+func WithPresEmbeddedSignatureSuites(suite verifierSignatureSuite) PresentationOpt {
 	return func(opts *presentationOpts) {
-		opts.ldpSuites = suites
+		opts.ldpSuite = suite
 	}
 }
 
@@ -390,11 +390,10 @@ func decodeCredentials(rawCred interface{}, opts *presentationOpts) ([]interface
 }
 
 func mapOpts(vpOpts *presentationOpts) *credentialOpts {
-	// !opts.disabledProofCheck, opts.publicKeyFetcher, opts.suite
 	return &credentialOpts{
 		publicKeyFetcher:   vpOpts.publicKeyFetcher,
 		disabledProofCheck: vpOpts.disabledProofCheck,
-		ldpSuites:          vpOpts.ldpSuites,
+		ldpSuite:           vpOpts.ldpSuite,
 	}
 }
 

--- a/pkg/doc/verifiable/presentation_ldp_test.go
+++ b/pkg/doc/verifiable/presentation_ldp_test.go
@@ -22,11 +22,12 @@ func TestNewPresentationFromLinkedDataProof(t *testing.T) {
 	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
 	r.NoError(err)
 
+	suite := ed25519signature2018.New(ed25519signature2018.WithSigner(getSigner(privKey)))
+
 	ldpContext := &LinkedDataProofContext{
 		Creator:       "John",
 		SignatureType: "Ed25519Signature2018",
-		Suite:         ed25519signature2018.New(),
-		PrivateKey:    privKey,
+		Suite:         suite,
 	}
 
 	vc, err := NewPresentation([]byte(validPresentation))
@@ -39,7 +40,7 @@ func TestNewPresentationFromLinkedDataProof(t *testing.T) {
 	r.NoError(err)
 
 	vcWithLdp, err := NewPresentation(vcBytes,
-		WithPresEmbeddedSignatureSuites(ed25519signature2018.New()),
+		WithPresEmbeddedSignatureSuites(suite),
 		WithPresPublicKeyFetcher(SingleKey([]byte(pubKey))))
 	r.NoError(err)
 
@@ -56,8 +57,7 @@ func TestPresentation_AddLinkedDataProof(t *testing.T) {
 	ldpContext := &LinkedDataProofContext{
 		Creator:       "Bill",
 		SignatureType: "Ed25519Signature2018",
-		Suite:         ed25519signature2018.New(),
-		PrivateKey:    privKey,
+		Suite:         ed25519signature2018.New(ed25519signature2018.WithSigner(getSigner(privKey))),
 	}
 
 	t.Run("Add a valid Linked Data proof to VC", func(t *testing.T) {
@@ -100,9 +100,8 @@ func TestPresentation_AddLinkedDataProof(t *testing.T) {
 
 		vp.RefreshService = nil
 		ldpContextWithMissingSignatureType := &LinkedDataProofContext{
-			Creator:    "Bill",
-			Suite:      ed25519signature2018.New(),
-			PrivateKey: privKey,
+			Creator: "Bill",
+			Suite:   ed25519signature2018.New(ed25519signature2018.WithSigner(getSigner(privKey))),
 		}
 
 		err = vp.AddLinkedDataProof(ldpContextWithMissingSignatureType)

--- a/pkg/doc/verifiable/presentation_test.go
+++ b/pkg/doc/verifiable/presentation_test.go
@@ -396,6 +396,5 @@ func TestWithPresEmbeddedSignatureSuites(t *testing.T) {
 
 	opts := &presentationOpts{}
 	vpOpt(opts)
-	require.Len(t, opts.ldpSuites, 1)
-	require.Equal(t, suite, opts.ldpSuites[0])
+	require.Equal(t, suite, opts.ldpSuite)
 }

--- a/pkg/doc/verifiable/support_test.go
+++ b/pkg/doc/verifiable/support_test.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package verifiable
 
 import (
+	"crypto/ed25519"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/json"
@@ -161,4 +162,20 @@ func (vp *Presentation) stringJSON(t *testing.T) string {
 	require.NoError(t, err)
 
 	return string(bytes)
+}
+
+func getSigner(privKey []byte) *testSigner {
+	return &testSigner{privateKey: privKey}
+}
+
+type testSigner struct {
+	privateKey []byte
+}
+
+func (s *testSigner) Sign(doc []byte) ([]byte, error) {
+	if l := len(s.privateKey); l != ed25519.PrivateKeySize {
+		return nil, errors.New("ed25519: bad private key length")
+	}
+
+	return ed25519.Sign(s.privateKey, doc), nil
 }

--- a/pkg/kms/legacykms/kms.go
+++ b/pkg/kms/legacykms/kms.go
@@ -166,7 +166,9 @@ func (w *BaseKMS) SignMessage(message []byte, fromVerKey string) ([]byte, error)
 		return nil, fmt.Errorf("failed to get key: %w", err)
 	}
 
-	return ed25519signature2018.New().Sign(kpc.SigKeyPair.Priv, message)
+	signer := &ed25519Signer{kpc: kpc}
+
+	return ed25519signature2018.New(ed25519signature2018.WithSigner(signer)).Sign(message)
 }
 
 // Close the LegacyKMS
@@ -264,4 +266,12 @@ func (w *BaseKMS) GetEncryptionKey(verKey []byte) ([]byte, error) {
 	}
 
 	return kpCombo.EncKeyPair.Pub, nil
+}
+
+type ed25519Signer struct {
+	kpc *cryptoutil.MessagingKeys
+}
+
+func (s *ed25519Signer) Sign(data []byte) ([]byte, error) {
+	return ed25519.Sign(s.kpc.SigKeyPair.Priv, data), nil
 }

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/hyperledger/aries-framework-go v0.0.0
 	github.com/trustbloc/sidetree-core-go v0.1.0
+	nhooyr.io/websocket v1.7.4
 
 )
 


### PR DESCRIPTION
Signed-off-by: Dima <dkinoshenko@gmail.com>

#339

There will be additional PR to refactor the usage of private keys to build JWS from verifiable credential / presentation.
