### PR TITLE
feat: did-exchange controller commands

### DIFF
--- a/pkg/controller/command/didexchange/command.go
+++ b/pkg/controller/command/didexchange/command.go
@@ -1,0 +1,419 @@
+/*
+ *
+ * Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * /
+ *
+ */
+
+package didexchange
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/webhook"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+var logger = log.New("aries-framework/controller/did-exchange")
+
+const (
+	// webhook notifier topic
+	connectionsWebhookTopic = "connections"
+
+	// error messages
+	errEmptyInviterDID = "empty inviter DID"
+	errEmptyConnID     = "empty connection ID"
+)
+
+const (
+	// InvalidRequestErrorCode is typically a code for validation errors
+	// for invalid didexchange controller requests
+	InvalidRequestErrorCode = command.Code(iota + command.DIDExchange)
+
+	// CreateInvitationErrorCode is for failures in create invitation command
+	CreateInvitationErrorCode
+
+	// CreateImplicitInvitationErrorCode is for failures in create implicit invitation command
+	CreateImplicitInvitationErrorCode
+
+	// ReceiveInvitationErrorCode is for failures in receive invitation command
+	ReceiveInvitationErrorCode
+
+	// AcceptInvitationErrorCode is for failures in accept invitation command
+	AcceptInvitationErrorCode
+
+	// AcceptExchangeRequestErrorCode is for failures in accept exchange request command
+	AcceptExchangeRequestErrorCode
+
+	// QueryConnectionsErrorCode is for failures in query connection command
+	QueryConnectionsErrorCode
+
+	// RemoveConnectionErrorCode is for failures in remove connection command
+	RemoveConnectionErrorCode
+)
+
+// provider contains dependencies for the DID Exchange command and is typically created by using aries.Context()
+type provider interface {
+	Service(id string) (interface{}, error)
+	LegacyKMS() legacykms.KeyManager
+	ServiceEndpoint() string
+	StorageProvider() storage.Provider
+	TransientStorageProvider() storage.Provider
+}
+
+// New returns new DID Exchange controller command instance
+func New(ctx provider, notifier webhook.Notifier, defaultLabel string, autoAccept bool) (*Command, error) {
+	didExchange, err := didexchange.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if autoAccept {
+		actionCh := make(chan service.DIDCommAction)
+
+		err = didExchange.RegisterActionEvent(actionCh)
+		if err != nil {
+			return nil, fmt.Errorf("register action event failed: %w", err)
+		}
+
+		go service.AutoExecuteActionEvent(actionCh)
+	}
+
+	svc := &Command{
+		ctx:          ctx,
+		client:       didExchange,
+		msgCh:        make(chan service.StateMsg),
+		notifier:     notifier,
+		defaultLabel: defaultLabel,
+	}
+
+	err = svc.startClientEventListener()
+	if err != nil {
+		return nil, fmt.Errorf("event listener startup failed: %w", err)
+	}
+
+	return svc, nil
+}
+
+// Command is controller command for DID Exchange
+type Command struct {
+	ctx          provider
+	client       *didexchange.Client
+	msgCh        chan service.StateMsg
+	notifier     webhook.Notifier
+	defaultLabel string
+}
+
+// CreateInvitation Creates a new connection invitation.
+func (c *Command) CreateInvitation(rw io.Writer, req io.Reader) command.Error {
+	logger.Debugf("Creating connection invitation ")
+
+	var request CreateInvitationArgs
+
+	err := json.NewDecoder(req).Decode(&request)
+	if err != nil {
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	var invitation *didexchange.Invitation
+	// call didexchange client
+	if request.Public != "" {
+		invitation, err = c.client.CreateInvitationWithDID(c.defaultLabel, request.Public)
+	} else {
+		invitation, err = c.client.CreateInvitation(c.defaultLabel)
+	}
+
+	if err != nil {
+		return command.NewExecuteError(CreateInvitationErrorCode, err)
+	}
+
+	c.writeResponse(rw, &CreateInvitationResponse{
+		Invitation: invitation,
+		Alias:      request.Alias})
+
+	return nil
+}
+
+// ReceiveInvitation receives a new connection invitation.
+func (c *Command) ReceiveInvitation(rw io.Writer, req io.Reader) command.Error {
+	logger.Debugf("Receiving connection invitation ")
+
+	var request didexchange.Invitation
+
+	err := json.NewDecoder(req).Decode(&request.Invitation)
+	if err != nil {
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	connectionID, err := c.client.HandleInvitation(&request)
+	if err != nil {
+		return command.NewExecuteError(ReceiveInvitationErrorCode, err)
+	}
+
+	c.writeResponse(rw, ReceiveInvitationResponse{
+		ConnectionID: connectionID,
+	})
+
+	return nil
+}
+
+// AcceptInvitation accepts a stored connection invitation.
+func (c *Command) AcceptInvitation(rw io.Writer, req io.Reader) command.Error {
+	var request AcceptInvitationArgs
+
+	err := json.NewDecoder(req).Decode(&request)
+	if err != nil {
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if request.ID == "" {
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyConnID))
+	}
+
+	logger.Debugf("Accepting connection invitation for id[%s], label[%s], publicDID[%s]",
+		request.ID, c.defaultLabel, request.Public)
+
+	err = c.client.AcceptInvitation(request.ID, request.Public, c.defaultLabel)
+	if err != nil {
+		logger.Errorf("accept invitation api failed for id %s with error %s", request.ID, err)
+
+		return command.NewExecuteError(AcceptInvitationErrorCode, err)
+	}
+
+	c.writeResponse(rw, &AcceptInvitationResponse{
+		ConnectionID: request.ID,
+	})
+
+	return nil
+}
+
+// CreateImplicitInvitation creates implicit invitation using inviter DID.
+func (c *Command) CreateImplicitInvitation(rw io.Writer, req io.Reader) command.Error {
+	var request ImplicitInvitationArgs
+
+	err := json.NewDecoder(req).Decode(&request)
+	if err != nil {
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if request.InviterDID == "" {
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyInviterDID))
+	}
+
+	logger.Debugf("create implicit invitation: inviterDID[%s], inviterLabel[%s], inviteeDID[%s], inviteeLabel[%s]",
+		request.InviterDID, request.InviterLabel, request.InviteeDID, request.InviterLabel)
+
+	inviter := &didexchange.DIDInfo{DID: request.InviterDID, Label: request.InviterLabel}
+
+	var id string
+
+	if request.InviteeDID != "" {
+		invitee := &didexchange.DIDInfo{DID: request.InviteeDID, Label: request.InviteeLabel}
+		id, err = c.client.CreateImplicitInvitationWithDID(inviter, invitee)
+	} else {
+		id, err = c.client.CreateImplicitInvitation(inviter.Label, inviter.DID)
+	}
+
+	if err != nil {
+		logger.Errorf("create implicit invitation api failed for id %s with error %s", id, err)
+		return command.NewExecuteError(CreateImplicitInvitationErrorCode, err)
+	}
+
+	c.writeResponse(rw, &ImplicitInvitationResponse{
+		ConnectionID: id,
+	})
+
+	return nil
+}
+
+// AcceptExchangeRequest accepts a stored connection request.
+func (c *Command) AcceptExchangeRequest(rw io.Writer, req io.Reader) command.Error {
+	var request AcceptInvitationArgs
+
+	err := json.NewDecoder(req).Decode(&request)
+	if err != nil {
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if request.ID == "" {
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyConnID))
+	}
+
+	logger.Debugf("Accepting connection request for id [%s]", request.ID)
+
+	err = c.client.AcceptExchangeRequest(request.ID, request.Public, c.defaultLabel)
+	if err != nil {
+		logger.Errorf("accepting connection request failed for id %s with error %s", request.ID, err)
+		return command.NewExecuteError(AcceptExchangeRequestErrorCode, err)
+	}
+
+	c.writeResponse(rw, &ExchangeResponse{
+		ConnectionID: request.ID,
+	})
+
+	return nil
+}
+
+// QueryConnections queries agent to agent connections.
+func (c *Command) QueryConnections(rw io.Writer, req io.Reader) command.Error {
+	logger.Debugf("Querying connection invitations ")
+
+	var request QueryConnectionsArgs
+
+	err := json.NewDecoder(req).Decode(&request)
+	if err != nil {
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	results, err := c.client.QueryConnections(&request.QueryConnectionsParams)
+	if err != nil {
+		return command.NewExecuteError(QueryConnectionsErrorCode, err)
+	}
+
+	c.writeResponse(rw, &QueryConnectionsResponse{
+		Results: results,
+	})
+
+	return nil
+}
+
+// QueryConnectionByID fetches a single connection record by connection ID.
+func (c *Command) QueryConnectionByID(rw io.Writer, req io.Reader) command.Error {
+	var request QueryConnectionByIDArgs
+
+	err := json.NewDecoder(req).Decode(&request)
+	if err != nil {
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if request.ID == "" {
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyConnID))
+	}
+
+	logger.Debugf("Querying connection invitation for id [%s]", request.ID)
+
+	result, err := c.client.GetConnection(request.ID)
+	if err != nil {
+		return command.NewExecuteError(QueryConnectionsErrorCode, err)
+	}
+
+	c.writeResponse(rw, &QueryConnectionResponse{
+		Result: result,
+	})
+
+	return nil
+}
+
+// RemoveConnection removes given connection record.
+func (c *Command) RemoveConnection(rw io.Writer, req io.Reader) command.Error {
+	var request QueryConnectionByIDArgs
+
+	err := json.NewDecoder(req).Decode(&request)
+	if err != nil {
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if request.ID == "" {
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyConnID))
+	}
+
+	logger.Debugf("Removing connection record for id [%s]", request.ID)
+
+	err = c.client.RemoveConnection(request.ID)
+	if err != nil {
+		return command.NewExecuteError(RemoveConnectionErrorCode, err)
+	}
+
+	return nil
+}
+
+// writeResponse writes interface value to response
+func (c *Command) writeResponse(rw io.Writer, v interface{}) {
+	err := json.NewEncoder(rw).Encode(v)
+	// as of now, just log errors for writing response
+	if err != nil {
+		logger.Errorf("Unable to send error response, %s", err)
+	}
+}
+
+// startClientEventListener listens to action and message events from DID Exchange service.
+func (c *Command) startClientEventListener() error {
+	// register the message event channel
+	err := c.client.RegisterMsgEvent(c.msgCh)
+	if err != nil {
+		return fmt.Errorf("didexchange message event registration failed: %w", err)
+	}
+
+	// event listeners
+	go func() {
+		for e := range c.msgCh {
+			err := c.handleMessageEvents(e)
+			if err != nil {
+				logger.Errorf("handle message events failed : %s", err)
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (c *Command) handleMessageEvents(e service.StateMsg) error {
+	if e.Type == service.PostState {
+		switch v := e.Properties.(type) {
+		case didexchange.Event:
+			props := v
+
+			err := c.sendConnectionNotification(props.ConnectionID(), e.StateID)
+			if err != nil {
+				return fmt.Errorf("send connection notification failed : %w", err)
+			}
+		case error:
+			return fmt.Errorf("service processing failed : %w", v)
+		default:
+			return errors.New("event is not of DIDExchange event type")
+		}
+	}
+
+	return nil
+}
+
+func (c *Command) sendConnectionNotification(connectionID, stateID string) error {
+	conn, err := c.client.GetConnectionAtState(connectionID, stateID)
+	if err != nil {
+		logger.Errorf("Send notification failed, topic[%s], connectionID[%s]", connectionsWebhookTopic, connectionID)
+		return fmt.Errorf("connection notification webhook : %w", err)
+	}
+
+	connMsg := &ConnectionMsg{
+		ConnectionID: conn.ConnectionID,
+		State:        conn.State,
+		MyDid:        conn.MyDID,
+		TheirDid:     conn.TheirDID,
+		TheirLabel:   conn.TheirLabel,
+		TheirRole:    conn.TheirLabel,
+	}
+
+	jsonMessage, err := json.Marshal(connMsg)
+	if err != nil {
+		return fmt.Errorf("connection notification json marshal : %w", err)
+	}
+
+	logger.Debugf("Sending notification on topic '%s', message body : %s", connectionsWebhookTopic, jsonMessage)
+
+	err = c.notifier.Notify(connectionsWebhookTopic, jsonMessage)
+	if err != nil {
+		return fmt.Errorf("connection notification webhook : %w", err)
+	}
+
+	return nil
+}

--- a/pkg/controller/command/didexchange/command_test.go
+++ b/pkg/controller/command/didexchange/command_test.go
@@ -1,0 +1,1000 @@
+/*
+ *
+ * Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * /
+ *
+ */
+
+package didexchange
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcutil/base58"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
+	mockwebhook "github.com/hyperledger/aries-framework-go/pkg/controller/mocks/webhook"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/webhook"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	didexsvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/route"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
+	mockdidexchange "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/didexchange"
+	mockroute "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/route"
+	mockprovider "github.com/hyperledger/aries-framework-go/pkg/internal/mock/provider"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms/legacykms"
+	mockstore "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	mockvdri "github.com/hyperledger/aries-framework-go/pkg/mock/vdri"
+	"github.com/hyperledger/aries-framework-go/pkg/restapi/operation/didexchange/models"
+	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
+)
+
+const (
+	mockSvcEndpoint = "endpoint"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("Successfully create new DID exchange command", func(t *testing.T) {
+		cmd, err := New(mockProvider(), webhook.NewHTTPNotifier(nil), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+	})
+
+	t.Run("Successfully create new DID exchange command with auto accept", func(t *testing.T) {
+		cmd, err := New(mockProvider(), webhook.NewHTTPNotifier(nil), "", true)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+	})
+
+	t.Run("Test create new DID exchange command failure", func(t *testing.T) {
+		cmd, err := New(&mockprovider.Provider{ServiceErr: errors.New("test-error")},
+			webhook.NewHTTPNotifier(nil), "", false)
+		require.Error(t, err)
+		require.Nil(t, cmd)
+	})
+}
+
+func TestCommand_CreateInvitation(t *testing.T) {
+	t.Run("Successful CreateInvitation with label", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		jsonReq := `{"alias":"myalias"}`
+		var b bytes.Buffer
+		cmdErr := cmd.CreateInvitation(&b, bytes.NewBufferString(jsonReq))
+		require.NoError(t, cmdErr)
+
+		response := CreateInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response.Invitation)
+		require.Equal(t, mockSvcEndpoint, response.Invitation.ServiceEndpoint)
+		require.Empty(t, response.Invitation.Label)
+		require.Equal(t, "myalias", response.Alias)
+		require.NotEmpty(t, response.Invitation.ID)
+		require.Equal(t, "https://didcomm.org/didexchange/1.0/invitation", response.Invitation.Type)
+	})
+
+	t.Run("Successful CreateInvitation with label and public DID", func(t *testing.T) {
+		const publicDID = "sample-public-did"
+
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		jsonReq := fmt.Sprintf(`{"alias":"myalias", "public":"%s"}`, publicDID)
+
+		var b bytes.Buffer
+		cmdErr := cmd.CreateInvitation(&b, bytes.NewBufferString(jsonReq))
+		require.NoError(t, cmdErr)
+
+		response := CreateInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response.Invitation)
+		require.Empty(t, response.Invitation.ServiceEndpoint)
+		require.Empty(t, response.Invitation.Label)
+		require.NotEmpty(t, response.Alias)
+		require.NotEmpty(t, response.Invitation.DID)
+		require.Equal(t, publicDID, response.Invitation.DID)
+	})
+
+	t.Run("Successful CreateInvitation with default params", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.CreateInvitation(&b, bytes.NewBufferString("{}"))
+		require.NoError(t, cmdErr)
+
+		response := CreateInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response.Invitation)
+		require.Equal(t, mockSvcEndpoint, response.Invitation.ServiceEndpoint)
+		require.Empty(t, response.Invitation.Label)
+		require.Empty(t, response.Alias)
+		require.NotEmpty(t, response.Invitation.ID)
+		require.Equal(t, "https://didcomm.org/didexchange/1.0/invitation", response.Invitation.Type)
+	})
+
+	t.Run("CreateInvitation failure", func(t *testing.T) {
+		const errMsg = "sample-err-01"
+		provider := mockProvider()
+		provider.StorageProviderValue = mockstore.NewCustomMockStoreProvider(
+			&mockstore.MockStore{
+				ErrPut: fmt.Errorf(errMsg),
+			},
+		)
+
+		cmd, err := New(provider, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.CreateInvitation(&b, bytes.NewBufferString("--"))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+
+		b.Reset()
+		cmdErr = cmd.CreateInvitation(&b, bytes.NewBufferString("{}"))
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errMsg)
+		require.Equal(t, CreateInvitationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+}
+
+func TestCommand_ReceiveInvitation(t *testing.T) {
+	t.Run("Successful ReceiveInvitation", func(t *testing.T) {
+		var jsonStr = `{
+		"serviceEndpoint":"http://alice.agent.example.com:8081",
+		"recipientKeys":["FDmegH8upiNquathbHZiGBZKwcudNfNWPeGQFBt8eNNi"],
+		"@id":"a35c0ac6-4fc3-46af-a072-c1036d036057",
+		"label":"agent",
+		"@type":"https://didcomm.org/didexchange/1.0/invitation"}`
+
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.ReceiveInvitation(&b, bytes.NewBufferString(jsonStr))
+		require.NoError(t, cmdErr)
+
+		response := models.ReceiveInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.ConnectionID)
+	})
+
+	t.Run("ReceiveInvitation failure", func(t *testing.T) {
+		var jsonStr = `{
+    	"@type": "https://didcomm.org/connections/1.0/invitation",
+    	"@id": "4e8650d9-6cc9-491e-b00e-7bf6cb5858fc",
+    	"serviceEndpoint": "http://ip10-0-46-4-blikjbs9psqg8vrg4p10-8020.direct.play-with-von.vonx.io",
+    	"label": "Faber Agent",
+    	"recipientKeys": [
+      		"6LE8yhZB8Xffc5vFgFntE3YLrxq5JVUsoAvUQgUyktGt"
+    		]
+  	}`
+		const errMsg = "sample-err-01"
+
+		prov := mockProvider()
+		prov.ServiceMap[didexsvc.DIDExchange] = &mockdidexchange.MockDIDExchangeSvc{
+			ProtocolName: "mockProtocolSvc",
+			HandleFunc: func(msg service.DIDCommMsg) (string, error) {
+				return uuid.New().String(), fmt.Errorf(errMsg)
+			},
+		}
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.ReceiveInvitation(&b, bytes.NewBufferString(jsonStr))
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errMsg)
+		require.Equal(t, ReceiveInvitationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+
+	t.Run("ReceiveInvitation validation error", func(t *testing.T) {
+		var jsonStr = `--`
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.ReceiveInvitation(&b, bytes.NewBufferString(jsonStr))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+}
+
+func TestCommand_QueryConnectionByID(t *testing.T) {
+	t.Run("QueryConnectionByID success", func(t *testing.T) {
+		// prepare data
+		const connID = "1234"
+		prov := mockProvider()
+		store := mockstore.MockStore{Store: make(map[string][]byte)}
+		connRec := &connection.Record{State: "complete", ConnectionID: "1234", ThreadID: "th1234"}
+
+		connBytes, err := json.Marshal(connRec)
+		require.NoError(t, err)
+		require.NoError(t, store.Put("conn_"+connID, connBytes))
+		prov.StorageProviderValue = &mockstore.MockStoreProvider{Store: &store}
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		jsoStr := fmt.Sprintf(`{"id":"%s"}`, connID)
+
+		var b bytes.Buffer
+		cmdErr := cmd.QueryConnectionByID(&b, bytes.NewBufferString(jsoStr))
+		require.NoError(t, cmdErr)
+
+		response := models.QueryConnectionResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.Result.ConnectionID)
+		require.Equal(t, connID, response.Result.ConnectionID)
+	})
+
+	t.Run("QueryConnectionByID validation error", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.QueryConnectionByID(&b, bytes.NewBufferString("--"))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("QueryConnectionByID validation error", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.QueryConnectionByID(&b, bytes.NewBufferString("{}"))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+		require.Contains(t, cmdErr.Error(), errEmptyConnID)
+	})
+
+	t.Run("QueryConnectionByID store failure", func(t *testing.T) {
+		// prepare data
+		const errMsg = "sample-err-01"
+		prov := mockProvider()
+		store := mockstore.MockStore{ErrGet: fmt.Errorf(errMsg)}
+		prov.StorageProviderValue = &mockstore.MockStoreProvider{Store: &store}
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.QueryConnectionByID(&b, bytes.NewBufferString(`{"id":"xyz"}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, QueryConnectionsErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+		require.Contains(t, cmdErr.Error(), errMsg)
+	})
+}
+
+func TestCommand_QueryConnections(t *testing.T) {
+	t.Run("test query connections with state filter", func(t *testing.T) {
+		// prepare data
+		const connID = "1234"
+		const state = "requested"
+
+		prov := mockProvider()
+		store := mockstore.MockStore{Store: make(map[string][]byte)}
+		connRec := &connection.Record{State: state, ConnectionID: connID, ThreadID: "th1234"}
+
+		connBytes, err := json.Marshal(connRec)
+		require.NoError(t, err)
+		require.NoError(t, store.Put("conn_"+connID, connBytes))
+		prov.StorageProviderValue = &mockstore.MockStoreProvider{Store: &store}
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		jsoStr := fmt.Sprintf(`{"state":"%s"}`, state)
+
+		var b bytes.Buffer
+		cmdErr := cmd.QueryConnections(&b, bytes.NewBufferString(jsoStr))
+		require.NoError(t, cmdErr)
+
+		response := models.QueryConnectionsResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.Results)
+		require.Len(t, response.Results, 1)
+		require.NotEmpty(t, connID, response.Results[0].ConnectionID)
+		require.NotEmpty(t, state, response.Results[0].State)
+
+		// test for record not found
+		b.Reset()
+		cmdErr = cmd.QueryConnections(&b, bytes.NewBufferString(`{"state":"completed"}`))
+		require.NoError(t, cmdErr)
+
+		response = models.QueryConnectionsResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.Empty(t, response)
+	})
+
+	t.Run("test query connections without state filter", func(t *testing.T) {
+		// prepare data
+		const connID = "1234"
+
+		prov := mockProvider()
+		store := mockstore.MockStore{Store: make(map[string][]byte)}
+		connRec := &connection.Record{State: "completed", ConnectionID: connID, ThreadID: "th1234"}
+
+		connBytes, err := json.Marshal(connRec)
+		require.NoError(t, err)
+		require.NoError(t, store.Put("conn_"+connID, connBytes))
+		prov.StorageProviderValue = &mockstore.MockStoreProvider{Store: &store}
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.QueryConnections(&b, bytes.NewBufferString("{}"))
+		require.NoError(t, cmdErr)
+
+		response := QueryConnectionsResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.Results)
+		require.Len(t, response.Results, 1)
+		require.NotEmpty(t, connID, response.Results[0].ConnectionID)
+	})
+
+	t.Run("test query connections validation error", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.QueryConnections(&b, bytes.NewBufferString("--"))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+}
+
+func TestCommand_AcceptInvitation(t *testing.T) {
+	t.Run("test accept invitation success", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptInvitation(&b, bytes.NewBufferString(`{"id":"1234"}`))
+		require.NoError(t, cmdErr)
+
+		response := AcceptInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+		require.Equal(t, "1234", response.ConnectionID)
+	})
+
+	t.Run("test accept invitation validation error", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptInvitation(&b, bytes.NewBufferString(`{"id":""}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+		require.Contains(t, cmdErr.Error(), errEmptyConnID)
+
+		b.Reset()
+		cmdErr = cmd.AcceptInvitation(&b, bytes.NewBufferString(`--`))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("test accept invitation failures", func(t *testing.T) {
+		const errMsg = "sample-err-01"
+		prov := mockProvider()
+		prov.ServiceMap[didexsvc.DIDExchange] = &mockdidexchange.MockDIDExchangeSvc{
+			ProtocolName: "mockProtocolSvc",
+			HandleFunc: func(msg service.DIDCommMsg) (string, error) {
+				return uuid.New().String(), nil
+			},
+			AcceptError: fmt.Errorf(errMsg),
+		}
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptInvitation(&b, bytes.NewBufferString(`{"id":"1234"}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, AcceptInvitationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+		require.Contains(t, cmdErr.Error(), errMsg)
+	})
+
+	t.Run("test accept invitation complete flow", func(t *testing.T) {
+		store := mockstore.NewMockStoreProvider()
+		didExSvc, err := didexsvc.New(&protocol.MockProvider{
+			TransientStoreProvider: store,
+			ServiceMap: map[string]interface{}{
+				route.Coordination: &mockroute.MockRouteSvc{},
+			},
+		})
+
+		require.NoError(t, err)
+
+		done := make(chan struct{})
+		connID := make(chan string)
+
+		// create the client
+		cmd, err := New(&mockprovider.Provider{
+			TransientStorageProviderValue: store,
+			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				didexsvc.DIDExchange: didExSvc,
+				route.Coordination:   &mockroute.MockRouteSvc{},
+			}},
+			&mockwebhook.Notifier{
+				NotifyFunc: func(topic string, message []byte) error {
+					require.Equal(t, connectionsWebhookTopic, topic)
+					conn := ConnectionMsg{}
+					jsonErr := json.Unmarshal(message, &conn)
+					require.NoError(t, jsonErr)
+
+					if conn.State == "invited" {
+						connID <- conn.ConnectionID
+					}
+
+					if conn.State == "requested" {
+						close(done)
+					}
+
+					return nil
+				},
+			},
+			"", false,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		pubKey, _ := generateKeyPair()
+		// send connection invitation message
+		invitation, err := json.Marshal(
+			&didexsvc.Invitation{
+				Type:          didexsvc.InvitationMsgType,
+				ID:            "abc",
+				Label:         "test",
+				RecipientKeys: []string{pubKey},
+			},
+		)
+		require.NoError(t, err)
+
+		msg, err := service.ParseDIDCommMsgMap(invitation)
+		require.NoError(t, err)
+
+		_, err = didExSvc.HandleInbound(msg, "", "")
+		require.NoError(t, err)
+
+		var cid string
+		select {
+		case cid = <-connID:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "tests are not validated")
+		}
+
+		jsonStr := fmt.Sprintf(`{"id":"%s"}`, cid)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptInvitation(&b, bytes.NewBufferString(jsonStr))
+		require.NoError(t, cmdErr)
+
+		response := AcceptInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		select {
+		case <-done:
+		case <-time.After(1 * time.Second):
+			require.Fail(t, "tests are not validated")
+		}
+	})
+}
+
+func TestCommand_CreateImplicitInvitation(t *testing.T) {
+	t.Run("test create implicit invitation success", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.CreateImplicitInvitation(&b, bytes.NewBufferString(`{"their_did":"samle-public-did"}`))
+		require.NoError(t, cmdErr)
+
+		response := ImplicitInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+		require.NotEmpty(t, response)
+		require.Equal(t, "connection-id", response.ConnectionID)
+	})
+
+	t.Run("test create implicit invitation with DID success", func(t *testing.T) {
+		const jsonStr = `{"their_did":"samle-public-did","my_did":"my-public-did"}`
+
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.CreateImplicitInvitation(&b, bytes.NewBufferString(jsonStr))
+		require.NoError(t, cmdErr)
+
+		response := ImplicitInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+		require.NotEmpty(t, response)
+		require.Equal(t, "connection-id", response.ConnectionID)
+	})
+
+	t.Run("test create implicit invitation validation error", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.CreateImplicitInvitation(&b, bytes.NewBufferString(`{}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("test handler failure", func(t *testing.T) {
+		const errMsg = "sample-err-01"
+		prov := mockProvider()
+		prov.ServiceMap[didexsvc.DIDExchange] = &mockdidexchange.MockDIDExchangeSvc{
+			ProtocolName: "mockProtocolSvc",
+			HandleFunc: func(msg service.DIDCommMsg) (string, error) {
+				return uuid.New().String(), nil
+			},
+			ImplicitInvitationErr: fmt.Errorf(errMsg),
+		}
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.CreateImplicitInvitation(&b, bytes.NewBufferString(`{"their_did":"samle-public-did"}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, CreateImplicitInvitationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+}
+
+func TestCommand_AcceptExchangeRequest(t *testing.T) {
+	t.Run("test accept exchange request success", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptExchangeRequest(&b, bytes.NewBufferString(`{"id":"1234"}`))
+		require.NoError(t, cmdErr)
+
+		response := ExchangeResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+		require.Equal(t, "1234", response.ConnectionID)
+	})
+
+	t.Run("test accept exchange request validation error", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptExchangeRequest(&b, bytes.NewBufferString(`{"id":""}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+		require.Contains(t, cmdErr.Error(), errEmptyConnID)
+
+		b.Reset()
+		cmdErr = cmd.AcceptExchangeRequest(&b, bytes.NewBufferString(`--`))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("test accept exchange request failures", func(t *testing.T) {
+		const errMsg = "sample-err-01"
+		prov := mockProvider()
+		prov.ServiceMap[didexsvc.DIDExchange] = &mockdidexchange.MockDIDExchangeSvc{
+			ProtocolName: "mockProtocolSvc",
+			HandleFunc: func(msg service.DIDCommMsg) (string, error) {
+				return uuid.New().String(), nil
+			},
+			AcceptError: fmt.Errorf(errMsg),
+		}
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptExchangeRequest(&b, bytes.NewBufferString(`{"id":"1234"}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, AcceptExchangeRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+		require.Contains(t, cmdErr.Error(), errMsg)
+	})
+
+	t.Run("test accept exchange request complete flow", func(t *testing.T) {
+		transientStore := mockstore.NewMockStoreProvider()
+		store := mockstore.NewMockStoreProvider()
+		didExSvc, err := didexsvc.New(
+			&protocol.MockProvider{
+				TransientStoreProvider: transientStore, StoreProvider: store,
+				ServiceMap: map[string]interface{}{
+					route.Coordination: &mockroute.MockRouteSvc{},
+				},
+			},
+		)
+
+		require.NoError(t, err)
+
+		done := make(chan struct{})
+		connID := make(chan string)
+
+		// create the client
+		cmd, err := New(&mockprovider.Provider{
+			TransientStorageProviderValue: transientStore,
+			StorageProviderValue:          store,
+			ServiceMap: map[string]interface{}{
+				didexsvc.DIDExchange: didExSvc,
+				route.Coordination:   &mockroute.MockRouteSvc{},
+			},
+			KMSValue: &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"}},
+			&mockwebhook.Notifier{
+				NotifyFunc: func(topic string, message []byte) error {
+					require.Equal(t, connectionsWebhookTopic, topic)
+
+					conn := ConnectionMsg{}
+					jsonErr := json.Unmarshal(message, &conn)
+					require.NoError(t, jsonErr)
+
+					if conn.State == "requested" {
+						connID <- conn.ConnectionID
+					}
+
+					if conn.State == "responded" {
+						close(done)
+					}
+
+					return nil
+				},
+			},
+			"", false,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		// send connection request message
+		id := "valid-thread-id"
+		newDidDoc, err := (&mockvdri.MockVDRIRegistry{}).Create("peer")
+		require.NoError(t, err)
+
+		invitation, err := cmd.client.CreateInvitation("test")
+		require.NoError(t, err)
+
+		request, err := json.Marshal(
+			&didexsvc.Request{
+				Type:  didexsvc.RequestMsgType,
+				ID:    id,
+				Label: "test",
+				Thread: &decorator.Thread{
+					PID: invitation.ID,
+				},
+				Connection: &didexsvc.Connection{
+					DID:    newDidDoc.ID,
+					DIDDoc: newDidDoc,
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		msg, err := service.ParseDIDCommMsgMap(request)
+		require.NoError(t, err)
+
+		_, err = didExSvc.HandleInbound(msg, "", "")
+		require.NoError(t, err)
+
+		cid := <-connID
+
+		jsonStr := fmt.Sprintf(`{"id":"%s"}`, cid)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptExchangeRequest(&b, bytes.NewBufferString(jsonStr))
+		require.NoError(t, cmdErr)
+
+		response := models.AcceptExchangeResult{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "tests are not validated")
+		}
+	})
+}
+
+func TestCommand_RemoveConnection(t *testing.T) {
+	t.Run("test remove connection", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+
+		cmdErr := cmd.RemoveConnection(&b, bytes.NewBufferString(`{"id":"1234"}`))
+		require.NoError(t, cmdErr)
+	})
+
+	t.Run("test remove connection validation error", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.RemoveConnection(&b, bytes.NewBufferString(`{"id":""}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+		require.Contains(t, cmdErr.Error(), errEmptyConnID)
+
+		b.Reset()
+		cmdErr = cmd.RemoveConnection(&b, bytes.NewBufferString(`--`))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+}
+
+func TestCommand_WriteResponse(t *testing.T) {
+	cmd, err := New(mockProvider(), nil, "", false)
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	cmd.writeResponse(&mockWriter{}, CreateInvitationResponse{})
+}
+
+func TestOperationEventError(t *testing.T) {
+	const errMsg = "channel is already registered for the action event"
+
+	t.Run("message event registration failed", func(t *testing.T) {
+		client, err := didexchange.New(&mockprovider.Provider{
+			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				didexsvc.DIDExchange: &mockdidexchange.MockDIDExchangeSvc{
+					RegisterMsgEventErr: errors.New(errMsg),
+				},
+				route.Coordination: &mockroute.MockRouteSvc{},
+			}})
+
+		require.NoError(t, err)
+		cmd := &Command{client: client, msgCh: make(chan service.StateMsg)}
+		err = cmd.startClientEventListener()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "didexchange message event registration failed: "+errMsg)
+	})
+}
+
+func TestHandleMessageEvent(t *testing.T) {
+	storeProv := &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: make(map[string][]byte)}}
+	op, err := New(&mockprovider.Provider{
+		TransientStorageProviderValue: storeProv,
+		StorageProviderValue: &mockstore.MockStoreProvider{
+			Store: &mockstore.MockStore{Store: make(map[string][]byte)}},
+		ServiceMap: map[string]interface{}{
+			didexsvc.DIDExchange: &mockdidexchange.MockDIDExchangeSvc{},
+			route.Coordination:   &mockroute.MockRouteSvc{},
+		}},
+		webhook.NewHTTPNotifier(nil), "", false)
+	require.NoError(t, err)
+	require.NotNil(t, op)
+
+	e := didExEvent{}
+	connRec := connection.Record{ConnectionID: e.ConnectionID(), ThreadID: "xyz", State: "completed"}
+	connBytes, err := json.Marshal(connRec)
+	require.NoError(t, err)
+	require.NoError(t, storeProv.Store.Put("conn_"+e.ConnectionID(), connBytes))
+
+	err = op.handleMessageEvents(service.StateMsg{Type: service.PostState, Properties: "invalid didex prop type"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "event is not of DIDExchange event type")
+
+	err = op.handleMessageEvents(service.StateMsg{Type: service.PostState, Properties: errors.New("err type")})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "service processing failed : err type")
+
+	err = op.handleMessageEvents(service.StateMsg{Type: service.PostState, Properties: &didExEvent{}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "send connection notification failed : "+
+		"connection notification webhook :")
+}
+
+func TestSendConnectionNotification(t *testing.T) {
+	const (
+		connID   = "id1"
+		threadID = "xyz"
+	)
+
+	storeProv := &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: make(map[string][]byte)}}
+	connRec := connection.Record{ConnectionID: connID, ThreadID: threadID, State: "completed"}
+	connBytes, err := json.Marshal(connRec)
+	require.NoError(t, err)
+	require.NoError(t, storeProv.Store.Put("conn_id1", connBytes))
+	require.NoError(t, storeProv.Store.Put("connstate_id1"+"completed", connBytes))
+
+	t.Run("send notification success", func(t *testing.T) {
+		const testState = "completed"
+		store := &mockstore.MockStore{Store: make(map[string][]byte)}
+		connRec := &connection.Record{State: testState, ConnectionID: connID, ThreadID: "th1234"}
+		connBytes, err := json.Marshal(connRec)
+		require.NoError(t, err)
+		require.NoError(t, store.Put(stateKey(connID, testState), connBytes))
+
+		op, err := New(&mockprovider.Provider{
+			TransientStorageProviderValue: &mockstore.MockStoreProvider{Store: store},
+			StorageProviderValue:          &mockstore.MockStoreProvider{Store: store},
+			ServiceMap: map[string]interface{}{
+				didexsvc.DIDExchange: &mockdidexchange.MockDIDExchangeSvc{},
+				route.Coordination:   &mockroute.MockRouteSvc{},
+			}},
+			webhook.NewHTTPNotifier(nil), "", false)
+		require.NoError(t, err)
+		err = op.sendConnectionNotification(connID, "completed")
+		require.NoError(t, err)
+	})
+	t.Run("send notification connection not found error", func(t *testing.T) {
+		op, err := New(&mockprovider.Provider{
+			TransientStorageProviderValue: storeProv,
+			StorageProviderValue: &mockstore.MockStoreProvider{
+				Store: &mockstore.MockStore{Store: make(map[string][]byte)}},
+			ServiceMap: map[string]interface{}{
+				didexsvc.DIDExchange: &mockdidexchange.MockDIDExchangeSvc{},
+				route.Coordination:   &mockroute.MockRouteSvc{},
+			}},
+			webhook.NewHTTPNotifier(nil), "", false)
+		require.NoError(t, err)
+		err = op.sendConnectionNotification("id2", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "connection notification webhook : cannot fetch state from store:")
+	})
+	t.Run("send notification webhook error", func(t *testing.T) {
+		const testState = "completed"
+		store := &mockstore.MockStore{Store: make(map[string][]byte)}
+		connRec := &connection.Record{State: testState, ConnectionID: connID, ThreadID: "th1234"}
+		connBytes, err := json.Marshal(connRec)
+		require.NoError(t, err)
+		require.NoError(t, store.Put(stateKey(connID, testState), connBytes))
+
+		op, err := New(&mockprovider.Provider{
+			TransientStorageProviderValue: &mockstore.MockStoreProvider{Store: store},
+			StorageProviderValue:          &mockstore.MockStoreProvider{Store: store},
+			ServiceMap: map[string]interface{}{
+				didexsvc.DIDExchange: &mockdidexchange.MockDIDExchangeSvc{},
+				route.Coordination:   &mockroute.MockRouteSvc{},
+			}},
+			&mockwebhook.Notifier{NotifyFunc: func(topic string, message []byte) error {
+				return errors.New("webhook error")
+			}},
+			"", false)
+		require.NoError(t, err)
+		require.NotNil(t, op)
+		err = op.sendConnectionNotification(connID, testState)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "connection notification webhook : webhook error")
+	})
+}
+
+type mockWriter struct {
+}
+
+func (m *mockWriter) Write(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("sample-error")
+}
+
+func mockProvider() *mockprovider.Provider {
+	return &mockprovider.Provider{
+		TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+		StorageProviderValue:          mockstore.NewMockStoreProvider(),
+		ServiceMap: map[string]interface{}{
+			didexsvc.DIDExchange: &mockdidexchange.MockDIDExchangeSvc{},
+			route.Coordination:   &mockroute.MockRouteSvc{},
+		},
+		KMSValue:             &mockkms.CloseableKMS{},
+		ServiceEndpointValue: mockSvcEndpoint,
+	}
+}
+
+func stateKey(connID, state string) string {
+	return fmt.Sprintf("connstate_%s_%s", connID, state)
+}
+
+type didExEvent struct {
+}
+
+func (e *didExEvent) ConnectionID() string {
+	return "abc"
+}
+
+func (e *didExEvent) InvitationID() string {
+	return "xyz"
+}
+
+func generateKeyPair() (string, []byte) {
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+
+	return base58.Encode(pubKey[:]), privKey
+}

--- a/pkg/controller/command/didexchange/models.go
+++ b/pkg/controller/command/didexchange/models.go
@@ -1,0 +1,322 @@
+/*
+ *
+ * Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * /
+ *
+ */
+
+package didexchange
+
+import (
+	"time"
+
+	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
+)
+
+// CreateInvitationArgs model
+//
+// This is used for creating invitation
+//
+type CreateInvitationArgs struct {
+
+	// The Alias to be used in invitation to be created
+	Alias string `json:"alias"`
+
+	// Optional public DID to be used in invitation
+	Public string `json:"public,omitempty"`
+}
+
+// CreateInvitationResponse model
+//
+// This is used for returning a create invitation response with a single connection invitation as body
+//
+type CreateInvitationResponse struct {
+	Invitation *didexchange.Invitation `json:"invitation"`
+
+	Alias string `json:"alias"`
+
+	InvitationURL string `json:"invitation_url"`
+}
+
+// ReceiveInvitationResponse model
+//
+// This is used for returning a receive invitation response with a single receive invitation response as body
+//
+type ReceiveInvitationResponse struct {
+	// State of the connection invitation
+	State string `json:"state"`
+
+	// Created time
+	CreateTime time.Time `json:"created_at,omitempty"`
+
+	// Updated time
+	UpdateTime time.Time `json:"updated_at,omitempty"`
+
+	// the connection ID of the connection invitation
+	ConnectionID string `json:"connection_id"`
+
+	// Routing state of connection invitation
+	RoutingState string `json:"routing_state,omitempty"`
+
+	// Connection invitation initiator
+	Initiator string `json:"initiator,omitempty"`
+
+	// Connection invitation accept mode
+	Accept string `json:"accept,omitempty"`
+
+	// Invitation mode
+	Mode string `json:"invitation_mode,omitempty"`
+
+	// Request ID of invitation response
+	RequestID string `json:"request_id"`
+
+	// My DID
+	DID string `json:"my_did"`
+
+	// Invitation key
+	InvitationKey string `json:"invitation_key,omitempty"`
+
+	// Other party's label
+	InviterLabel string `json:"their_label,omitempty"`
+}
+
+// AcceptInvitationArgs model
+//
+// This is used for operation to accept connection invitation
+//
+type AcceptInvitationArgs struct {
+	// Connection ID
+	ID string `json:"id"`
+
+	// Optional Public DID to be used for this request
+	Public string `json:"public"`
+}
+
+// AcceptInvitationResponse model
+//
+// This is used for returning a accept invitation response for single invitation
+//
+type AcceptInvitationResponse struct {
+
+	// State of the connection invitation
+	State string `json:"state,omitempty"`
+
+	// Other party's DID
+	InviterDID string `json:"their_did,omitempty"`
+
+	// Created time
+	CreateTime time.Time `json:"created_at,omitempty"`
+
+	// Connection invitation accept mode
+	Accept string `json:"accept,omitempty"`
+
+	// My DID
+	DID string `json:"my_did,omitempty"`
+
+	// Request ID of invitation response
+	RequestID string `json:"request_id,omitempty"`
+
+	// Other party's label
+	InviterLabel string `json:"their_label,omitempty"`
+
+	// Alias
+	Alias string `json:"alias,omitempty"`
+
+	// Other party's role
+	InviterRole string `json:"their_role,omitempty"`
+
+	// Connection invitation initiator
+	Initiator string `json:"initiator,omitempty"`
+
+	// Updated time
+	UpdateTime time.Time `json:"updated_at,omitempty"`
+
+	// Invitation key
+	InvitationKey string `json:"invitation_key,omitempty"`
+
+	// Routing state of connection invitation
+	RoutingState string `json:"routing_state,omitempty"`
+
+	// Inbound Connection ID  of the connection invitation
+	InboundConnectionID string `json:"inbound_connection_id,omitempty"`
+
+	// the connection ID of the connection invitation
+	ConnectionID string `json:"connection_id,omitempty"`
+
+	// Error message
+	Error string `json:"error_msg,omitempty"`
+
+	// Invitation mode
+	Mode string `json:"invitation_mode,omitempty"`
+}
+
+// ImplicitInvitationArgs model
+//
+// This is used by invitee to create implicit invitation
+//
+type ImplicitInvitationArgs struct {
+	// InviterDID
+	InviterDID string `json:"their_did"`
+
+	// Optional inviter label
+	InviterLabel string `json:"their_label"`
+
+	// Optional invitee did
+	InviteeDID string `json:"my_did"`
+
+	// Optional invitee label
+	InviteeLabel string `json:"my_label"`
+}
+
+// ImplicitInvitationResponse model
+//
+// This is used for returning create implicit invitation response
+//
+type ImplicitInvitationResponse struct {
+	// the connection ID of the connection for implicit invitation
+	ConnectionID string `json:"connection_id,omitempty"`
+}
+
+// GetConnectionRequest model
+//
+// This is used for getting specific connection record
+//
+type GetConnectionRequest struct {
+	// The ID of the connection to get
+	ID string `json:"id"`
+}
+
+// QueryConnectionsArgs model
+//
+// This is used for querying connections
+//
+type QueryConnectionsArgs struct {
+	// Params for querying connections
+	didexchange.QueryConnectionsParams
+}
+
+// QueryConnectionResponse model
+//
+// This is used for returning query connection result for single record search
+//
+type QueryConnectionResponse struct {
+	Result *didexchange.Connection `json:"result,omitempty"`
+}
+
+// QueryConnectionsResponse model
+//
+// This is used for returning query connections results
+//
+type QueryConnectionsResponse struct {
+	Results []*didexchange.Connection `json:"results,omitempty"`
+}
+
+// AcceptExchangeRequestArgs model
+//
+// This is used for accepting connection request
+//
+type AcceptExchangeRequestArgs struct {
+	// Connection ID
+	ID string `json:"id"`
+
+	// Optional Public DID to be used for this invitation
+	// request
+	Public string `json:"public"`
+}
+
+// ExchangeResponse model
+//
+// response of accept exchange request
+//
+type ExchangeResponse struct {
+
+	// Routing state of connection invitation
+	RoutingState string `json:"routing_state,omitempty"`
+
+	// the connection ID of the connection invitation
+	InboundConnectionID string `json:"inbound_connection_id,omitempty"`
+
+	// Invitation key
+	InvitationKey string `json:"invitation_key,omitempty"`
+
+	// TheirDID is other party's DID
+	TheirDID string `json:"their_did"`
+
+	// Request ID of the connection request
+	RequestID string `json:"request_id"`
+
+	// Invitation mode
+	Mode string `json:"invitation_mode,omitempty"`
+
+	// TheirRole is other party's role
+	TheirRole string `json:"their_role,omitempty"`
+
+	// TheirRole is other party's role
+	TheirLabel string `json:"their_label,omitempty"`
+
+	// the connection ID of the connection invitation
+	ConnectionID string `json:"connection_id,omitempty"`
+
+	// Initiator is Connection invitation initiator
+	Initiator string `json:"initiator,omitempty"`
+
+	// MyDID is DID of the agent
+	MyDID string `json:"my_did,omitempty"`
+
+	// Updated time
+	UpdatedTime time.Time `json:"updated_at,omitempty"`
+
+	// Created time
+	CreatedTime time.Time `json:"created_at,omitempty"`
+
+	// Error message
+	Error string `json:"error_msg,omitempty"`
+
+	// Alias of connection invitation
+	Alias string `json:"alias,omitempty"`
+
+	// State of the connection invitation
+	State string `json:"state"`
+
+	// Connection invitation accept mode
+	Accept string `json:"accept,omitempty"`
+}
+
+// RemoveConnectionRequest model
+//
+// This is used for removing connection request
+//
+type RemoveConnectionRequest struct {
+	// The ID of the connection record to remove
+	ID string `json:"id"`
+}
+
+// QueryConnectionByIDArgs model
+//
+// This is used for querying connection by ID
+//
+type QueryConnectionByIDArgs struct {
+	// Connection ID
+	ID string `json:"id"`
+}
+
+// ConnectionMsg is sent when a pairwise connection record is updated.
+type ConnectionMsg struct {
+	ConnectionID        string `json:"connection_id"`
+	State               string `json:"state"`
+	MyDid               string `json:"myDid"`
+	TheirDid            string `json:"theirDid"`
+	TheirLabel          string `json:"theirLabel"`
+	TheirRole           string `json:"theirRole"`
+	InboundConnectionID string `json:"inbound_connection_id"`
+	Initiator           string `json:"initiator"`
+	InvitationKey       string `json:"invitation_key"`
+	RequestID           string `json:"request_id"`
+	RoutingState        string `json:"routing_state"`
+	Accept              string `json:"accept"`
+	ErrorMsg            string `json:"error_msg"`
+	InvitationMode      string `json:"invitation_mode"`
+	Alias               string `json:"alias"`
+}

--- a/pkg/didcomm/protocol/didexchange/states_test.go
+++ b/pkg/didcomm/protocol/didexchange/states_test.go
@@ -271,7 +271,7 @@ func TestRequestedState_Execute(t *testing.T) {
 		}
 	})
 	t.Run("handle inbound invitations", func(t *testing.T) {
-		ctx := getContext(t, prov)
+		ctx := getContext(t, &prov)
 		msg, err := service.ParseDIDCommMsgMap(invitationPayloadBytes)
 		require.NoError(t, err)
 		// nolint: govet
@@ -330,7 +330,7 @@ func TestRequestedState_Execute(t *testing.T) {
 }
 func TestRespondedState_Execute(t *testing.T) {
 	prov := getProvider()
-	ctx := getContext(t, prov)
+	ctx := getContext(t, &prov)
 	request, err := createRequest(ctx)
 	require.NoError(t, err)
 	requestPayloadBytes, err := json.Marshal(request)
@@ -644,7 +644,7 @@ func TestVerifySignature(t *testing.T) {
 
 func TestPrepareConnectionSignature(t *testing.T) {
 	prov := getProvider()
-	ctx := getContext(t, prov)
+	ctx := getContext(t, &prov)
 	pubKey, privKey := generateKeyPair()
 	invitation, err := createMockInvitation(pubKey, ctx)
 	require.NoError(t, err)
@@ -752,7 +752,7 @@ func TestNewRequestFromInvitation(t *testing.T) {
 
 	t.Run("successful new request from invitation", func(t *testing.T) {
 		prov := getProvider()
-		ctx := getContext(t, prov)
+		ctx := getContext(t, &prov)
 		invitationBytes, err := json.Marshal(invitation)
 		require.NoError(t, err)
 		thid, err := threadID(bytesToDIDCommMsg(t, invitationBytes))
@@ -798,7 +798,7 @@ func TestNewResponseFromRequest(t *testing.T) {
 	prov := getProvider()
 
 	t.Run("successful new response from request", func(t *testing.T) {
-		ctx := getContext(t, prov)
+		ctx := getContext(t, &prov)
 		request, err := createRequest(ctx)
 		require.NoError(t, err)
 		_, connRec, err := ctx.handleInboundRequest(request, &options{}, &connection.Record{})
@@ -850,7 +850,7 @@ func TestNewResponseFromRequest(t *testing.T) {
 func TestHandleInboundResponse(t *testing.T) {
 	pubKey, _ := generateKeyPair()
 	prov := getProvider()
-	ctx := getContext(t, prov)
+	ctx := getContext(t, &prov)
 	_, err := createMockInvitation(pubKey, ctx)
 	require.NoError(t, err)
 	request, err := createRequest(ctx)
@@ -882,7 +882,7 @@ func TestHandleInboundResponse(t *testing.T) {
 }
 func TestGetInvitationRecipientKey(t *testing.T) {
 	prov := getProvider()
-	ctx := getContext(t, prov)
+	ctx := getContext(t, &prov)
 
 	t.Run("successfully getting invitation recipient key", func(t *testing.T) {
 		invitation := &Invitation{
@@ -923,7 +923,7 @@ func TestGetInvitationRecipientKey(t *testing.T) {
 func TestGetPublicKey(t *testing.T) {
 	t.Run("successfully getting public key by id", func(t *testing.T) {
 		prov := protocol.MockProvider{}
-		ctx := getContext(t, prov)
+		ctx := getContext(t, &prov)
 		newDidDoc, err := ctx.vdriRegistry.Create(testMethod)
 		require.NoError(t, err)
 		pubkey, ok := diddoc.LookupPublicKey(newDidDoc.PublicKey[0].ID, newDidDoc)
@@ -932,7 +932,7 @@ func TestGetPublicKey(t *testing.T) {
 	})
 	t.Run("failed to get public key", func(t *testing.T) {
 		prov := protocol.MockProvider{}
-		ctx := getContext(t, prov)
+		ctx := getContext(t, &prov)
 		newDidDoc, err := ctx.vdriRegistry.Create(testMethod)
 		require.NoError(t, err)
 		pubkey, ok := diddoc.LookupPublicKey("invalid-key", newDidDoc)
@@ -1131,9 +1131,9 @@ func getProvider() protocol.MockProvider {
 	}
 }
 
-func getContext(t *testing.T, prov protocol.MockProvider) *context {
+func getContext(t *testing.T, prov *protocol.MockProvider) *context {
 	pubKey, privKey := generateKeyPair()
-	connStore, err := newConnectionStore(&prov)
+	connStore, err := newConnectionStore(prov)
 	require.NoError(t, err)
 
 	return &context{outboundDispatcher: prov.OutboundDispatcher(),


### PR DESCRIPTION
- added DIDExchange controller command
- part of #1176

TODO:
- migrate DID Exchange REST operation to use controller command
- move `pkg/restapi` to `controller/restapi`

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
