### PR TITLE
feat: Route - Controller Command

### DIFF
--- a/pkg/controller/command/errors.go
+++ b/pkg/controller/command/errors.go
@@ -46,6 +46,9 @@ const (
 
 	// VDRI error group for VDRI command errors
 	VDRI Group = 4000
+
+	// ROUTE error group for Route command errors
+	ROUTE Group = 5000
 )
 
 // Error is the  interface for representing an command error condition, with the nil value representing no error.

--- a/pkg/controller/command/route/command.go
+++ b/pkg/controller/command/route/command.go
@@ -1,0 +1,86 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package route
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/hyperledger/aries-framework-go/pkg/client/route"
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
+)
+
+var logger = log.New("aries-framework/command/route")
+
+// Error codes
+const (
+	// InvalidRequestErrorCode for invalid requests
+	InvalidRequestErrorCode = command.Code(iota + command.ROUTE)
+
+	// ResponseWriteErrorCode for response write error
+	RegisterMissingConnIDCode
+
+	// RegisterRouterErrorCode for register router error
+	RegisterRouterErrorCode
+)
+
+// provider contains dependencies for the route protocol and is typically created by using aries.Context().
+type provider interface {
+	Service(id string) (interface{}, error)
+}
+
+// Command contains command operations provided by route controller.
+type Command struct {
+	routeClient *route.Client
+}
+
+// New returns new route controller command instance.
+func New(ctx provider) (*Command, error) {
+	routeClient, err := route.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create route client : %w", err)
+	}
+
+	return &Command{
+		routeClient: routeClient,
+	}, nil
+}
+
+// Register registers the agent with the router.
+func (o *Command) Register(rw io.Writer, req io.Reader) command.Error {
+	var request RegisterRouteReq
+
+	err := json.NewDecoder(req).Decode(&request)
+	if err != nil {
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf("request decode : %w", err))
+	}
+
+	if request.ConnectionID == "" {
+		return command.NewValidationError(RegisterMissingConnIDCode, errors.New("connectionID is mandatory"))
+	}
+
+	logger.Debugf("registering agent with router : connectionID=[%s]", request.ConnectionID)
+
+	err = o.routeClient.Register(request.ConnectionID)
+	if err != nil {
+		return command.NewExecuteError(RegisterRouterErrorCode, err)
+	}
+
+	writeResponse(rw, nil)
+
+	return nil
+}
+
+// writeResponse writes interface value to response
+func writeResponse(rw io.Writer, v interface{}) {
+	if err := json.NewEncoder(rw).Encode(v); err != nil {
+		logger.Errorf("Unable to send error response, %s", err)
+	}
+}

--- a/pkg/controller/command/route/command_test.go
+++ b/pkg/controller/command/route/command_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package route
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mockroute "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/route"
+	mockprovider "github.com/hyperledger/aries-framework-go/pkg/internal/mock/provider"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("test new command", func(t *testing.T) {
+		cmd, err := New(
+			&mockprovider.Provider{
+				ServiceValue: &mockroute.MockRouteSvc{},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+	})
+
+	t.Run("test new command - client creation fail", func(t *testing.T) {
+		cmd, err := New(
+			&mockprovider.Provider{},
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "create route client")
+		require.Nil(t, cmd)
+	})
+}
+
+func TestRegisterRoute(t *testing.T) {
+	t.Run("test register - success", func(t *testing.T) {
+		cmd, err := New(
+			&mockprovider.Provider{
+				ServiceValue: &mockroute.MockRouteSvc{},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		jsonReq := `{"connectionID":"123-abc"}`
+		var b bytes.Buffer
+		err = cmd.Register(&b, bytes.NewBufferString(jsonReq))
+		require.NoError(t, err)
+	})
+
+	t.Run("test register - empty connectionID", func(t *testing.T) {
+		cmd, err := New(
+			&mockprovider.Provider{
+				ServiceValue: &mockroute.MockRouteSvc{},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		jsonReq := `{"connectionID":""}`
+		var b bytes.Buffer
+		err = cmd.Register(&b, bytes.NewBufferString(jsonReq))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "connectionID is mandatory")
+	})
+
+	t.Run("test register - empty connectionID", func(t *testing.T) {
+		cmd, err := New(
+			&mockprovider.Provider{
+				ServiceValue: &mockroute.MockRouteSvc{},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		err = cmd.Register(&b, bytes.NewBufferString("--"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "request decode")
+	})
+
+	t.Run("test register - empty connectionID", func(t *testing.T) {
+		cmd, err := New(
+			&mockprovider.Provider{
+				ServiceValue: &mockroute.MockRouteSvc{
+					RegisterFunc: func(connectionID string) error {
+						return errors.New("register error")
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		jsonReq := `{"connectionID":"123-abc"}`
+		var b bytes.Buffer
+		err = cmd.Register(&b, bytes.NewBufferString(jsonReq))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "router registration")
+	})
+}

--- a/pkg/controller/command/route/models.go
+++ b/pkg/controller/command/route/models.go
@@ -1,0 +1,12 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package route
+
+// RegisterRouteReq contains parameters for registering router.
+type RegisterRouteReq struct {
+	ConnectionID string `json:"connectionID"`
+}


### PR DESCRIPTION
- Add command method for Route registration for different bindings
- The command uses route client

part of #989 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
