### PR TITLE
fix: Added HTTP Delete method to the CORS whitelist

### DIFF
--- a/cmd/aries-agent-rest/startcmd/start.go
+++ b/cmd/aries-agent-rest/startcmd/start.go
@@ -451,7 +451,11 @@ func startAgent(parameters *agentParameters) error {
 
 	logger.Infof("Starting aries agent rest on host [%s]", parameters.host)
 	// start server on given port and serve using given handlers
-	handler := cors.Default().Handler(router)
+	handler := cors.New(
+		cors.Options{
+			AllowedMethods: []string{http.MethodGet, http.MethodPost, http.MethodDelete, http.MethodHead},
+		},
+	).Handler(router)
 
 	err = parameters.server.ListenAndServe(parameters.host, handler)
 	if err != nil {


### PR DESCRIPTION
By default, CORS is enabled for HTTP HEAD, GET and POST Methods - https://github.com/rs/cors/blob/fdcf4f9773b8d459d3ec085a8c91b34fcd17803d/cors.go#L48-L50

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
