### PR TITLE
fix: Ignore Transport Return Route decorator for forward message

### DIFF
--- a/pkg/didcomm/dispatcher/outbound.go
+++ b/pkg/didcomm/dispatcher/outbound.go
@@ -93,7 +93,7 @@ func (o *OutboundDispatcher) Send(msg interface{}, senderVerKey string, des *ser
 		}
 
 		// update the outbound message with transport return route option [all or thread]
-		req, err = o.addTransportRouteOptions(req)
+		req, err = o.addTransportRouteOptions(req, des)
 		if err != nil {
 			return fmt.Errorf("add transport route options : %w", err)
 		}
@@ -191,7 +191,12 @@ func (o *OutboundDispatcher) createForwardMessage(msg []byte, des *service.Desti
 	return packedMsg, nil
 }
 
-func (o *OutboundDispatcher) addTransportRouteOptions(req []byte) ([]byte, error) {
+func (o *OutboundDispatcher) addTransportRouteOptions(req []byte, des *service.Destination) ([]byte, error) {
+	// dont add transport route options for forward messages
+	if len(des.RoutingKeys) != 0 {
+		return req, nil
+	}
+
 	if o.transportReturnRoute == decorator.TransportReturnRouteAll ||
 		o.transportReturnRoute == decorator.TransportReturnRouteThread {
 		// create the decorator with the option set in the framework

--- a/pkg/didcomm/dispatcher/outbound_test.go
+++ b/pkg/didcomm/dispatcher/outbound_test.go
@@ -234,6 +234,20 @@ func TestOutboundDispatcherTransportReturnRoute(t *testing.T) {
 
 		require.NoError(t, o.Send(req, "", &service.Destination{ServiceEndpoint: "url"}))
 	})
+
+	t.Run("transport route option - forward message", func(t *testing.T) {
+		transportReturnRoute := "thread"
+		o := NewOutbound(&mockProvider{
+			packagerValue:        &mockPackager{},
+			transportReturnRoute: transportReturnRoute,
+		})
+
+		testData := []byte("testData")
+
+		data, err := o.addTransportRouteOptions(testData, &service.Destination{RoutingKeys: []string{"abc"}})
+		require.NoError(t, err)
+		require.Equal(t, testData, data)
+	})
 }
 
 func TestOutboundDispatcher_Forward(t *testing.T) {


### PR DESCRIPTION
Closes #1218 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
