### PR TITLE
fix: Invoke websocket.Ping() function to keep the connection alive

### DIFF
--- a/pkg/didcomm/transport/ws/inbound.go
+++ b/pkg/didcomm/transport/ws/inbound.go
@@ -82,7 +82,7 @@ func (i *Inbound) processRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	i.pool.listener(c)
+	i.pool.listener(c, false)
 }
 
 func upgradeConnection(w http.ResponseWriter, r *http.Request) (*websocket.Conn, error) {

--- a/pkg/didcomm/transport/ws/outbound.go
+++ b/pkg/didcomm/transport/ws/outbound.go
@@ -99,7 +99,7 @@ func (cs *OutboundClient) getConnection(destination *service.Destination) (*webs
 				cs.pool.add(v, conn)
 			}
 
-			go cs.pool.listener(conn)
+			go cs.pool.listener(conn, true)
 		} else {
 			cleanup = func() {
 				err = conn.Close(websocket.StatusNormalClosure, "closing the connection")

--- a/pkg/didcomm/transport/ws/upgrade_js_wasm.go
+++ b/pkg/didcomm/transport/ws/upgrade_js_wasm.go
@@ -9,6 +9,7 @@ package ws
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	"nhooyr.io/websocket"
 )
@@ -29,4 +30,8 @@ func acceptRecipient(pool *connPool, keys []string) bool {
 	}
 
 	return false
+}
+
+func keepConnAlive(conn *websocket.Conn, outbound bool, frequency time.Duration) {
+	// TODO make sure connection is alive (conn.Ping() doesn't work with JS/WASM build)
 }


### PR DESCRIPTION
The web server, load balancer, network routers between the client and server closes the TCP keepalives connection. Added a new function to invoke Ping requests frequently to keep the connection alive

closes #1214 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
