### PR TITLE
feat : Aries JS Worker Start/Stop and Notifier

### DIFF
--- a/cmd/aries-js-worker/index.html
+++ b/cmd/aries-js-worker/index.html
@@ -15,20 +15,83 @@ This is a test page for developers to test WASM integration.
     <script>
         // TODO fix the stutter in the API's exports ("Aries.Aries....")
         const aries = Aries.Aries({})
-        async function handleInput() {
-            document.querySelector("#output").value = "{}"
+        async function handleStart() {
+            const request = document.querySelector("#opts").value
+            const response = await aries.start(request)
+            document.querySelector("#output").value = response
+        }
+
+        async function handleStop() {
+            const response = await aries.stop("")
+            document.querySelector("#output").value = response
+        }
+
+        async function handleOperationInput() {
             const request = document.querySelector("#input").value
             const operation = document.querySelector("#operation").value
             const method = document.querySelector("#method").value
             const response = await aries[operation][method](request)
             document.querySelector("#output").value = response
         }
+
+        function startNotifier() {
+           const topic = document.querySelector("#notifier").value
+           async function* run() {
+                while (true)
+                    yield await aries.waitForNotification(topic)
+            }
+
+            const asyncIterator = run();
+
+            (async () => {
+                for await (const val of asyncIterator) {
+                    if (val) {
+                        // TODO display messages in this page
+                        alert(val)
+                    }
+                }
+            })();
+        }
+
     </script>
 </head>
 <body>
-<div>
+<div style="padding: 10px">
+
     <fieldset style="width: 100px">
-        <legend><b>Aries Agent Command Controller</b></legend>
+        <legend style="font-size: x-large;font-weight: bold">Aries Agent</legend>
+        <table>
+            <tr>
+                <td colspan="2">
+                    <div>Start Options :</div>
+                    <textarea id="opts" rows="5" cols="100">{"agent-default-label":"dem-js-agent","http-resolver-url":"","auto-accept":true,"outbound-transport":["ws","http"],"transport-return-route":"all","notifier-func-name":"sample-topic"}
+                    </textarea>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <button onClick="handleStart()">StartAgent</button>
+                    <button onClick="handleStop()">StopAgent</button>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <hr>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <input type="text" id="notifier" value="sample-topic" size="50"></input>
+                    <button onClick="startNotifier()">Start Notifier</button>
+                </td>
+            </tr>
+        </table>
+    </fieldset>
+
+    <br><br>
+
+    <fieldset style="width: 100px">
+        <legend style="font-size: x-large;font-weight: bold">Aries Agent Command Controller</legend>
         <table cellspacing="10px">
             <tr>
                 <td>
@@ -61,16 +124,24 @@ This is a test page for developers to test WASM integration.
                     &nbsp;
                 </td>
                 <td>
-                    <button onClick="handleInput()">Execute</button>
+                    <button onClick="handleOperationInput()">Execute</button>
                 </td>
             </tr>
         </table>
+
     </fieldset>
+
+    <br><br>
 </div>
 <hr/>
 <div>
-    <label for="output">Response: </label>
-    <output id="output"></output>
+    <label for="output" style="font-size: large;font-weight: bold">Response: </label>
+    <output id="output" style="color: green;"></output>
+</div>
+<br>
+<div id="error-div" style="visibility: hidden;color:red;font-size: x-large;">
+    <label for="error">Error: </label>
+    <output id="error" ></output>
 </div>
 </body>
 </html>

--- a/cmd/aries-js-worker/main.go
+++ b/cmd/aries-js-worker/main.go
@@ -12,12 +12,18 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"syscall/js"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/hyperledger/aries-framework-go/pkg/controller"
 	cmdctrl "github.com/hyperledger/aries-framework-go/pkg/controller/command"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/webhook"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/messaging/msghandler"
+	arieshttp "github.com/hyperledger/aries-framework-go/pkg/didcomm/transport/http"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport/ws"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
 )
 
@@ -40,29 +46,17 @@ type result struct {
 	IsErr   bool   `json:"isErr"`
 	ErrMsg  string `json:"errMsg"`
 	Payload string `json:"payload"`
+	Topic   string `json:"topic"`
 }
 
-// All supported command handlers.
-func handlers() map[string]map[string]func(*command) *result {
-	pkgMap := defaultHandlers()
-
-	if isTest {
-		return pkgMap
-	}
-
-	commands := getAllCommands()
-
-	for _, cmd := range commands {
-		fnMap, ok := pkgMap[cmd.Name()]
-		if !ok {
-			fnMap = make(map[string]func(*command) *result)
-		}
-
-		fnMap[cmd.Method()] = cmdExecToFn(cmd.Handle())
-		pkgMap[cmd.Name()] = fnMap
-	}
-
-	return pkgMap
+// ariesStartOpts contains opts for starting aries
+type ariesStartOpts struct {
+	Label                string   `json:"agent-default-label"`
+	HTTPResolver         string   `json:"http-resolver-url"`
+	AutoAccept           bool     `json:"auto-accept"`
+	OutboundTransport    []string `json:"outbound-transport"`
+	TransportReturnRoute string   `json:"transport-return-route"`
+	Notifier             string   `json:"notifier-func-name"`
 }
 
 // main registers the 'handleMsg' function in the JS context's global scope to receive commands.
@@ -84,41 +78,6 @@ func main() {
 	select {}
 }
 
-// initAries creates aries agent instance
-// TODO currently running on default opts, should be able pass custom framework opts
-func getAllCommands() []cmdctrl.Handler {
-	msgHandler := msghandler.NewRegistrar()
-
-	a, err := aries.New(aries.WithMessageServiceProvider(msgHandler))
-	if err != nil {
-		js.Global().Get("console").Call("error",
-			fmt.Sprintf("aries wasm: failed to aries framework : %s", err),
-		)
-
-		return nil
-	}
-
-	ctx, err := a.Context()
-	if err != nil {
-		js.Global().Get("console").Call("error",
-			fmt.Sprintf("aries wasm: failed to get aries framework context: %s", err),
-		)
-
-		return nil
-	}
-
-	commands, err := controller.GetCommandHandlers(ctx, controller.WithMessageHandler(msgHandler))
-	if err != nil {
-		js.Global().Get("console").Call("error",
-			fmt.Sprintf("aries wasm: failed to get command list: %s", err),
-		)
-
-		return nil
-	}
-
-	return commands
-}
-
 func takeFrom(in chan *command) func(js.Value, []js.Value) interface{} {
 	return func(_ js.Value, args []js.Value) interface{} {
 		cmd := &command{}
@@ -135,7 +94,13 @@ func takeFrom(in chan *command) func(js.Value, []js.Value) interface{} {
 }
 
 func pipe(input chan *command, output chan *result) {
-	handlers := handlers()
+	handlers := defaultHandlers()
+
+	var started bool
+
+	if isTest {
+		started = true
+	}
 
 	for c := range input {
 		if c.ID == "" {
@@ -145,22 +110,26 @@ func pipe(input chan *command, output chan *result) {
 			)
 		}
 
+		if !started {
+			var rs *result
+			rs, started = startAries(c, handlers)
+			output <- rs
+
+			continue
+		}
+
 		if pkg, found := handlers[c.Pkg]; found {
 			if fn, found := pkg[c.Fn]; found {
 				output <- fn(c)
-			} else {
-				output <- &result{
-					ID:     c.ID,
-					IsErr:  true,
-					ErrMsg: "invalid fn: " + c.Fn,
+				// support restart by resetting flag
+				if c.Pkg == "aries" && c.Fn == "Stop" {
+					started = false
 				}
+			} else {
+				output <- newErrResult(c.ID, "invalid fn: "+c.Pkg)
 			}
 		} else {
-			output <- &result{
-				ID:     c.ID,
-				IsErr:  true,
-				ErrMsg: "invalid pkg: " + c.Pkg,
-			}
+			output <- newErrResult(c.ID, "invalid pkg: "+c.Pkg)
 		}
 	}
 }
@@ -187,11 +156,7 @@ func cmdExecToFn(exec cmdctrl.Exec) func(*command) *result {
 
 		err := exec(&buf, req)
 		if err != nil {
-			return &result{
-				ID:     c.ID,
-				IsErr:  true,
-				ErrMsg: fmt.Sprintf("code: %+v, message: %s", err.Code(), err.Error()),
-			}
+			return newErrResult(c.ID, fmt.Sprintf("code: %+v, message: %s", err.Code(), err.Error()))
 		}
 
 		return &result{
@@ -211,11 +176,7 @@ func defaultHandlers() map[string]map[string]func(*command) *result {
 				}
 			},
 			"throwError": func(c *command) *result {
-				return &result{
-					ID:     c.ID,
-					IsErr:  true,
-					ErrMsg: "an error!",
-				}
+				return newErrResult(c.ID, "an error !!")
 			},
 			"timeout": func(c *command) *result {
 				const echoTimeout = 10 * time.Second
@@ -229,4 +190,160 @@ func defaultHandlers() map[string]map[string]func(*command) *result {
 			},
 		},
 	}
+}
+
+func startAries(c *command, pkgMap map[string]map[string]func(*command) *result) (*result, bool) {
+	if c.Pkg != "aries" && c.Fn != "Start" {
+		return newErrResult(c.ID, "start aries before running any command"), false
+	} else if c.Fn == "Stop" {
+		return newErrResult(c.ID, "stop already called, start again to run any command"), false
+	}
+
+	cOpts, err := startOpts(c.Payload)
+	if err != nil {
+		return newErrResult(c.ID, err.Error()), false
+	}
+
+	options, err := ariesOpts(cOpts)
+	if err != nil {
+		return newErrResult(c.ID, err.Error()), false
+	}
+
+	msgHandler := msghandler.NewRegistrar()
+	options = append(options, aries.WithMessageServiceProvider(msgHandler))
+
+	a, err := aries.New(options...)
+	if err != nil {
+		return newErrResult(c.ID, err.Error()), false
+	}
+
+	ctx, err := a.Context()
+	if err != nil {
+		return newErrResult(c.ID, err.Error()), false
+	}
+
+	var notifier webhook.Notifier
+	if cOpts.Notifier != "" {
+		notifier = &jsNotifier{topic: cOpts.Notifier}
+	}
+
+	commands, err := controller.GetCommandHandlers(ctx, controller.WithMessageHandler(msgHandler),
+		controller.WithDefaultLabel(cOpts.Label), controller.WithNotifier(notifier))
+	if err != nil {
+		return newErrResult(c.ID, err.Error()), false
+	}
+
+	// add command handlers
+	addCommandHandlers(commands, pkgMap)
+
+	// add stop aries handler
+	addStopAriesHandler(a, pkgMap)
+
+	return &result{
+		ID:      c.ID,
+		Payload: "aries started",
+	}, true
+}
+
+func addCommandHandlers(commands []cmdctrl.Handler, pkgMap map[string]map[string]func(*command) *result) {
+	for _, cmd := range commands {
+		fnMap, ok := pkgMap[cmd.Name()]
+		if !ok {
+			fnMap = make(map[string]func(*command) *result)
+		}
+
+		fnMap[cmd.Method()] = cmdExecToFn(cmd.Handle())
+		pkgMap[cmd.Name()] = fnMap
+	}
+}
+
+func addStopAriesHandler(a *aries.Aries, pkgMap map[string]map[string]func(*command) *result) {
+	fnMap := make(map[string]func(*command) *result)
+	fnMap["Stop"] = func(c *command) *result {
+		err := a.Close()
+		if err != nil {
+			return newErrResult(c.ID, err.Error())
+		}
+
+		// reset handlers when stopped
+		for k := range pkgMap {
+			delete(pkgMap, k)
+		}
+
+		return &result{
+			ID:      c.ID,
+			Payload: "aries stoppped",
+		}
+	}
+	pkgMap["aries"] = fnMap
+}
+
+func newErrResult(id, msg string) *result {
+	return &result{
+		ID:     id,
+		IsErr:  true,
+		ErrMsg: msg,
+	}
+}
+
+func startOpts(str string) (*ariesStartOpts, error) {
+	opts := ariesStartOpts{}
+
+	err := json.Unmarshal([]byte(str), &opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &opts, nil
+}
+
+func ariesOpts(opts *ariesStartOpts) ([]aries.Option, error) {
+	msgHandler := msghandler.NewRegistrar()
+
+	var options []aries.Option
+	options = append(options, aries.WithMessageServiceProvider(msgHandler))
+
+	if opts.TransportReturnRoute != "" {
+		options = append(options, aries.WithTransportReturnRoute(opts.TransportReturnRoute))
+	}
+
+	for _, transport := range opts.OutboundTransport {
+		switch transport {
+		case "http":
+			outbound, err := arieshttp.NewOutbound(arieshttp.WithOutboundHTTPClient(&http.Client{}))
+			if err != nil {
+				return nil, err
+			}
+
+			options = append(options, aries.WithOutboundTransports(outbound))
+		case "ws":
+			options = append(options, aries.WithOutboundTransports(ws.NewOutbound()))
+		default:
+			return nil, fmt.Errorf("unsupported transport : %s", transport)
+		}
+	}
+
+	return options, nil
+}
+
+// jsNotifier notifies incoming events once registered
+type jsNotifier struct {
+	topic string
+}
+
+// Notify is mock implementation of webhook notifier Notify()
+func (n *jsNotifier) Notify(topic string, message []byte) error {
+	out, err := json.Marshal(&result{
+		ID:      uuid.New().String(),
+		Topic:   n.topic,
+		Payload: string(message),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	js.Global().Call("handleResult", string(out))
+
+	return nil
 }

--- a/cmd/aries-js-worker/src/aries.js
+++ b/cmd/aries-js-worker/src/aries.js
@@ -27,7 +27,8 @@ const { _getWorker } = require("worker_loader")
 
 // TODO synchronize access on this map?
 const PENDING = new Map()
-const WORKER = _getWorker(PENDING)
+const NOTIFICATIONS = new Map()
+const WORKER = _getWorker(PENDING, NOTIFICATIONS)
 
 // Singleton
 let INSTANCE = null
@@ -92,6 +93,27 @@ export const Aries = function(opts) {
             _echo: async function (text) {
                 return invoke("test", "echo", text, "timeout while accepting invitation")
             }
+
+        },
+
+        start: async function(opts) {
+            return invoke("aries", "Start", opts, "timeout while starting aries")
+        },
+
+        stop: async function(opts) {
+            return invoke("aries", "Stop", opts, "timeout while stopping aries")
+        },
+
+        waitForNotification : async function waitForNotification(topic) {
+            return new Promise((resolve, reject) => {
+                const timer = setTimeout(_ => resolve(), 10000)
+                NOTIFICATIONS.set(topic, result => {
+                    if (result.isErr) {
+                        reject(new Error(result.errMsg))
+                    }
+                    resolve(result.payload)
+                })
+            });
         },
 
         didexchange: {
@@ -163,4 +185,5 @@ export const Aries = function(opts) {
     }
 
     return INSTANCE
+
 }

--- a/cmd/aries-js-worker/src/worker-loader-node.js
+++ b/cmd/aries-js-worker/src/worker-loader-node.js
@@ -10,7 +10,7 @@ import wasmJS from "./wasm_exec.js"
 import wasm from "./aries-js-worker.wasm.gz"
 import workerJS from "./worker-impl-node"
 
-export function _getWorker(pending) {
+export function _getWorker(pending, notifications) {
     const worker = new Worker(workerJS, { workerData: {wasmJS: wasmJS, wasmPath: wasm} })
     worker.on("message", result => {
         const cb = pending.get(result.id)

--- a/cmd/aries-js-worker/src/worker-loader-web.js
+++ b/cmd/aries-js-worker/src/worker-loader-web.js
@@ -8,10 +8,20 @@ import wasmJS from "./wasm_exec.js"
 import wasm from "./aries-js-worker.wasm.gz"
 import workerJS from "./worker-impl-web"
 
-export function _getWorker(pending) {
+export function _getWorker(pending, notifications) {
     const worker = new Worker(workerJS + "?wasmJS=" + wasmJS + "&wasm=" + wasm)
     worker.onmessage = e => {
         const result = e.data
+        if (result.topic ){
+            const notify = notifications.get(result.topic)
+            if (notify) {
+                console.log("sending incoming message on topic", result.topic, result)
+                notify(result)
+            } else {
+                console.log("no subscribers found for this topic", result.topic)
+            }
+          return
+        }
         const cb = pending.get(result.id)
         pending.delete(result.id)
         cb(result)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/controller/internal/mocks/webhook"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/defaults"
@@ -60,7 +61,7 @@ func TestGetCommandHandlers_Success(t *testing.T) {
 	// test with options
 	handlers, err = GetCommandHandlers(ctx, WithMessageHandler(msghandler.NewMockMsgServiceProvider()),
 		WithAutoAccept(true), WithDefaultLabel("sample-label"),
-		WithWebhookURLs("sample-wh-url"))
+		WithWebhookURLs("sample-wh-url"), WithNotifier(webhook.NewMockWebhookNotifier()))
 	require.NoError(t, err)
 	require.NotEmpty(t, handlers)
 }


### PR DESCRIPTION
- Aries.Start(opts) can be used to start aries in JS worker
sample :
`{"agent-default-label":"dem-js-agent","http-resolver-url":"","auto-accept":true,"outbound-transport":["ws","http"],"transport-return-route":"all","notifier-func-name":"sample-topic"}`
- Aries.Stop() can be used to stop aries
- Command controller can only be called between start and stop
- Register notifier using `Aries.waitForNotification("<topic-name>")`, make sure you use same `notifier-func-name` in aries opts.

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
