### PR TITLE
fix: aries-js-worker startOpts parsing

### DIFF
--- a/cmd/aries-js-worker/main.go
+++ b/cmd/aries-js-worker/main.go
@@ -313,7 +313,15 @@ func newErrResult(id, msg string) *result {
 func startOpts(payload map[string]interface{}) (*ariesStartOpts, error) {
 	opts := &ariesStartOpts{}
 
-	err := mapstructure.Decode(payload, opts)
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "json",
+		Result:  opts,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = decoder.Decode(payload)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix parse of start options in aries-js-worker.

Signed-off-by: George Aristy <george.aristy@securekey.com>