### PR TITLE
feat: Create a new Storage type with Delete() function

### DIFF
--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -609,8 +609,9 @@ func TestService_Update(t *testing.T) {
 }
 
 type mockStore struct {
-	put func(string, []byte) error
-	get func(string) ([]byte, error)
+	put    func(string, []byte) error
+	get    func(string) ([]byte, error)
+	delete func(string) error
 }
 
 // Put stores the key and the record
@@ -621,6 +622,11 @@ func (m *mockStore) Put(k string, v []byte) error {
 // Get fetches the record based on key
 func (m *mockStore) Get(k string) ([]byte, error) {
 	return m.get(k)
+}
+
+// Delete the record based on key
+func (m *mockStore) Delete(k string) error {
+	return m.delete(k)
 }
 
 // Search returns storage iterator

--- a/pkg/framework/aries/example_test.go
+++ b/pkg/framework/aries/example_test.go
@@ -72,6 +72,7 @@ func (c *mockDBProvider) OpenStore(name string) (storage.Store, error) {
 func (c *mockDBProvider) CloseStore(name string) error {
 	return nil
 }
+
 func (c *mockDBProvider) Close() error {
 	return nil
 }

--- a/pkg/internal/gomocks/storage/mocks.go
+++ b/pkg/internal/gomocks/storage/mocks.go
@@ -99,6 +99,20 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
+// Delete mocks base method
+func (m *MockStore) Delete(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete
+func (mr *MockStoreMockRecorder) Delete(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), arg0)
+}
+
 // Get mocks base method
 func (m *MockStore) Get(arg0 string) ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/pkg/mock/storage/mock_store.go
+++ b/pkg/mock/storage/mock_store.go
@@ -67,6 +67,11 @@ type MockStore struct {
 	ErrItr error
 }
 
+// MockStoreWithDelete mock store with delete capability
+type MockStoreWithDelete struct {
+	MockStore
+}
+
 // Put stores the key and the record
 func (s *MockStore) Put(k string, v []byte) error {
 	if k == "" {
@@ -119,6 +124,15 @@ func (s *MockStore) Iterator(start, limit string) storage.StoreIterator {
 	}
 
 	return NewMockIterator(batch)
+}
+
+// Delete will delete record with k key
+func (s *MockStore) Delete(k string) error {
+	s.lock.Lock()
+	delete(s.Store, k)
+	s.lock.Unlock()
+
+	return nil
 }
 
 // NewMockIterator returns new mock iterator for given batch

--- a/pkg/storage/jsindexeddb/jsindexeddb.go
+++ b/pkg/storage/jsindexeddb/jsindexeddb.go
@@ -127,6 +127,22 @@ func (s *store) Iterator(start, limit string) storage.StoreIterator {
 	return newIterator(batch, err)
 }
 
+// Delete will delete record with k key
+func (s *store) Delete(k string) error {
+	if k == "" {
+		return errors.New("key is mandatory")
+	}
+
+	req := s.db.Call("transaction", s.name, "readwrite").Call("objectStore", s.name).Call("delete", k)
+
+	_, err := getResult(req)
+	if err != nil {
+		return fmt.Errorf("failed to delete data with key: %s - error: %w", k, err)
+	}
+
+	return nil
+}
+
 type iterator struct {
 	batch *js.Value
 	err   error

--- a/pkg/storage/jsindexeddb/jsindexeddb_test.go
+++ b/pkg/storage/jsindexeddb/jsindexeddb_test.go
@@ -121,3 +121,38 @@ func verifyItr(t *testing.T, itr storage.StoreIterator, count int, prefix string
 	require.Empty(t, itr.Key())
 	require.Empty(t, itr.Value())
 }
+
+func TestIndexDBStoreDelete(t *testing.T) {
+	prov, err := NewProvider()
+	require.NoError(t, err)
+
+	const commonKey = "did:example:1"
+
+	data := []byte("value1")
+
+	// create store 1 & store 2
+	store1, err := prov.OpenStore("store1")
+	require.NoError(t, err)
+
+	// put in store 1
+	err = store1.Put(commonKey, data)
+	require.NoError(t, err)
+
+	// get in store 1 - found
+	doc, err := store1.Get(commonKey)
+	require.NoError(t, err)
+	require.NotEmpty(t, doc)
+	require.Equal(t, data, doc)
+
+	// now try Delete with an empty key - should fail
+	err = store1.Delete("")
+	require.EqualError(t, err, "key is mandatory")
+
+	// finally test Delete an existing key
+	err = store1.Delete(commonKey)
+	require.NoError(t, err)
+
+	doc, err = store1.Get(commonKey)
+	require.EqualError(t, err, storage.ErrDataNotFound.Error())
+	require.Empty(t, doc)
+}

--- a/pkg/storage/leveldb/leveldb_store.go
+++ b/pkg/storage/leveldb/leveldb_store.go
@@ -149,3 +149,12 @@ func (s *leveldbStore) Iterator(start, limit string) storage.StoreIterator {
 
 	return s.db.NewIterator(&util.Range{Start: []byte(start), Limit: []byte(limit)}, nil)
 }
+
+// Delete will delete record with k key
+func (s *leveldbStore) Delete(k string) error {
+	if k == "" {
+		return errors.New("key is mandatory")
+	}
+
+	return s.db.Delete([]byte(k), nil)
+}

--- a/pkg/storage/leveldb/leveldb_store_test.go
+++ b/pkg/storage/leveldb/leveldb_store_test.go
@@ -255,3 +255,39 @@ func cleanupFile(t *testing.T, file *os.File) {
 		t.Fatalf("Failed to cleanup file: %s", file.Name())
 	}
 }
+
+func TestLevelDBStoreDelete(t *testing.T) {
+	path, cleanup := setupLevelDB(t)
+	defer cleanup()
+
+	const commonKey = "did:example:1"
+
+	prov := NewProvider(path)
+	data := []byte("value1")
+
+	// create store 1 & store 2
+	store1, err := prov.OpenStore("store1")
+	require.NoError(t, err)
+
+	// put in store 1
+	err = store1.Put(commonKey, data)
+	require.NoError(t, err)
+
+	// get in store 1 - found
+	doc, err := store1.Get(commonKey)
+	require.NoError(t, err)
+	require.NotEmpty(t, doc)
+	require.Equal(t, data, doc)
+
+	// now try Delete with an empty key - should fail
+	err = store1.Delete("")
+	require.EqualError(t, err, "key is mandatory")
+
+	// finally test Delete an existing key
+	err = store1.Delete(commonKey)
+	require.NoError(t, err)
+
+	doc, err = store1.Get(commonKey)
+	require.EqualError(t, err, storage.ErrDataNotFound.Error())
+	require.Empty(t, doc)
+}

--- a/pkg/storage/mem/mem_store.go
+++ b/pkg/storage/mem/mem_store.go
@@ -143,6 +143,19 @@ func (s *memStore) Iterator(start, limit string) storage.StoreIterator {
 	return newMemIterator(batch)
 }
 
+// Delete will delete record with k key
+func (s *memStore) Delete(k string) error {
+	if k == "" {
+		return errors.New("key is mandatory")
+	}
+
+	s.Lock()
+	delete(s.db, k)
+	s.Unlock()
+
+	return nil
+}
+
 type memIterator struct {
 	currentIndex int
 	currentItem  []string

--- a/pkg/storage/mem/mem_store_test.go
+++ b/pkg/storage/mem/mem_store_test.go
@@ -213,3 +213,35 @@ func TestMemStoreIterator(t *testing.T) {
 		require.NoError(t, itr.Error())
 	})
 }
+
+func TestMemStoreDelete(t *testing.T) {
+	const commonKey = "did:example:1"
+
+	prov := NewProvider()
+	data := []byte("value1")
+	// create store 1 & store 2
+	store1, err := prov.OpenStore("store1")
+	require.NoError(t, err)
+
+	// put in store 1
+	err = store1.Put(commonKey, data)
+	require.NoError(t, err)
+
+	// get in store 1 - found
+	doc, err := store1.Get(commonKey)
+	require.NoError(t, err)
+	require.NotEmpty(t, doc)
+	require.Equal(t, data, doc)
+
+	// now try Delete with an empty key - should fail
+	err = store1.Delete("")
+	require.EqualError(t, err, "key is mandatory")
+
+	// finally test Delete an existing key
+	err = store1.Delete(commonKey)
+	require.NoError(t, err)
+
+	doc, err = store1.Get(commonKey)
+	require.EqualError(t, err, storage.ErrDataNotFound.Error())
+	require.Empty(t, doc)
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -43,6 +43,9 @@ type Store interface {
 	//
 	// StoreIterator: iterator for result range
 	Iterator(start, limit string) StoreIterator
+
+	// Delete will delete a record with k key
+	Delete(k string) error
 }
 
 // StoreIterator is the iterator for the latest snapshot of the underlying store.


### PR DESCRIPTION
In order to support rotating keys from the storage (or deleting data in general),
there should be a storage service with Delete() function available

closes #1147

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>