### PR TITLE
feat: store Reader/Writer for default local KMS implementation

### DIFF
--- a/pkg/kms/localkms/localkms_reader.go
+++ b/pkg/kms/localkms/localkms_reader.go
@@ -1,0 +1,48 @@
+/*
+ Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package localkms
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+// newReader will create a new local storage storeReader of a keyset with ID value = keysetID
+// it is used internally by local kms
+func newReader(store storage.Store, keysetID string) *storeReader {
+	return &storeReader{
+		storage:  store,
+		keysetID: keysetID,
+	}
+}
+
+// storeReader struct to load a keyset from a local storage
+type storeReader struct {
+	buf      *bytes.Buffer
+	storage  storage.Store
+	keysetID string
+}
+
+// Read the keyset from local storage into p.
+func (l *storeReader) Read(p []byte) (int, error) {
+	if l.buf == nil {
+		if l.keysetID == "" {
+			return 0, fmt.Errorf("keysetID is not set")
+		}
+
+		data, err := l.storage.Get(l.keysetID)
+		if err != nil {
+			return 0, fmt.Errorf("cannot read data for keysetID %s: %w", l.keysetID, err)
+		}
+
+		l.buf = bytes.NewBuffer(data)
+	}
+
+	return l.buf.Read(p)
+}

--- a/pkg/kms/localkms/localkms_reader_test.go
+++ b/pkg/kms/localkms/localkms_reader_test.go
@@ -1,0 +1,108 @@
+/*
+ Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package localkms
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+func TestLocalKMSReader(t *testing.T) {
+	someKey := []byte("someKeyData")
+	someKeyID := "newKeyID"
+	storeData := map[string][]byte{
+		someKeyID: someKey,
+	}
+
+	t.Run("success case - create a valid storeReader with a non empty and stored keysetID", func(t *testing.T) {
+		localStore := &mockstorage.MockStore{Store: storeData}
+
+		l := newReader(localStore, someKeyID)
+		require.NotEmpty(t, l)
+		data := make([]byte, 512)
+		n, err := l.Read(data)
+		require.NoError(t, err)
+		require.Equal(t, len(someKey), n)
+
+		// try to read again - should return io.EOF
+		n, err = l.Read(data)
+		require.EqualError(t, err, io.EOF.Error())
+		require.Equal(t, n, 0)
+	})
+
+	t.Run("error case - create an invalid read with empty keysetID", func(t *testing.T) {
+		mockStore := &mockstorage.MockStore{Store: storeData}
+
+		l := newReader(mockStore, "")
+		require.NotEmpty(t, l)
+		data := make([]byte, 512)
+		n, err := l.Read(data)
+		require.EqualError(t, err, "keysetID is not set")
+		require.Equal(t, 0, n)
+	})
+
+	t.Run("error case - create an invalid read with non stored keyset", func(t *testing.T) {
+		mockStore := &mockstorage.MockStore{Store: map[string][]byte{}}
+
+		l := newReader(mockStore, someKeyID)
+		require.NotEmpty(t, l)
+		data := make([]byte, 512)
+		n, err := l.Read(data)
+		require.EqualError(t, err,
+			fmt.Errorf("cannot read data for keysetID %s: %w", someKeyID, storage.ErrDataNotFound).Error())
+		require.Equal(t, 0, n)
+	})
+
+	t.Run("success case - create a valid storeReader with very large keyset data", func(t *testing.T) {
+		var veryLargeData []byte
+		dataLen := 1000 * 1000
+		blockSize := 512
+		for i := 0; i < dataLen; i++ {
+			veryLargeData = append(veryLargeData, 'a')
+		}
+		largeStoreData := map[string][]byte{
+			someKeyID: veryLargeData,
+		}
+
+		mockStore := &mockstorage.MockStore{Store: largeStoreData}
+
+		l := newReader(mockStore, someKeyID)
+		require.NotEmpty(t, l)
+		data := make([]byte, blockSize)
+		bytesRead := 0
+		var readData []byte
+		for bytesRead < dataLen-blockSize {
+			n, err := l.Read(data)
+			require.NoError(t, err)
+			// data has capacity of 512 bytes (ie require multiple Read() calls to consume the whole keyset data)
+			require.Equal(t, blockSize, n)
+			bytesRead += n
+			readData = append(readData, data...)
+		}
+
+		// last read..
+		n, err := l.Read(data)
+		require.NoError(t, err)
+		// append remainder data read
+		readData = append(readData, data[:n]...)
+		// data has capacity of blockSize bytes, last read would be the remainder chunk of dataLen which is smaller
+		// than blockSize bytes
+		require.Equal(t, dataLen%blockSize, n)
+		require.Equal(t, len(readData), dataLen)
+
+		// try to read one more time, should return an error
+		n, err = l.Read(data)
+		require.EqualError(t, err, io.EOF.Error())
+		require.Equal(t, n, 0)
+	})
+}

--- a/pkg/kms/localkms/localkms_writer.go
+++ b/pkg/kms/localkms/localkms_writer.go
@@ -1,0 +1,74 @@
+/*
+ Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package localkms
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/google/tink/go/subtle/random"
+
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+// newWriter creates a new instance of local storage key storeWriter in the given store and for masterKeyURI
+func newWriter(kmsStore storage.Store, masterKeyURI string) *storeWriter {
+	mkURI := masterKeyURI
+	if strings.LastIndex(mkURI, "/") < len(mkURI)-1 {
+		mkURI += "/"
+	}
+
+	return &storeWriter{
+		storage:      kmsStore,
+		masterKeyURI: mkURI,
+	}
+}
+
+// storeWriter struct to store a keyset in a local store
+type storeWriter struct {
+	storage      storage.Store
+	masterKeyURI string
+	// KeysetID is set when Write() is called
+	KeysetID string
+}
+
+// Write a marshaled keyset p in localstore with masterKeyURI prefix + randomly generated KeysetID
+func (l *storeWriter) Write(p []byte) (int, error) {
+	if l.masterKeyURI == "" {
+		return 0, fmt.Errorf("master key is not set")
+	}
+
+	const keySetIDLength = 32
+
+	baseID := l.masterKeyURI
+	ksID := ""
+
+	for {
+		// generate random ID prefixed with masterKeyURI
+		ksID = baseID + base64.URLEncoding.EncodeToString(random.GetRandomBytes(keySetIDLength))
+
+		// ensure ksID is not already used
+		_, e := l.storage.Get(ksID)
+		if e != nil {
+			if e == storage.ErrDataNotFound {
+				break
+			}
+
+			return 0, e
+		}
+	}
+
+	err := l.storage.Put(ksID, p)
+	if err != nil {
+		return 0, err
+	}
+
+	l.KeysetID = ksID
+
+	return len(p), nil
+}

--- a/pkg/kms/localkms/localkms_writer_test.go
+++ b/pkg/kms/localkms/localkms_writer_test.go
@@ -1,0 +1,80 @@
+/*
+ Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+package localkms
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+)
+
+func TestLocalKMSWriter(t *testing.T) {
+	masterKeyURI := "/master/key/uri"
+
+	t.Run("success case - create a valid storeWriter and store a non empty key", func(t *testing.T) {
+		storeMap := map[string][]byte{}
+		mockStore := &mockstorage.MockStore{Store: storeMap}
+
+		l := newWriter(mockStore, masterKeyURI)
+		require.NotEmpty(t, l)
+		someKey := []byte("someKeyData")
+		n, err := l.Write(someKey)
+		require.NoError(t, err)
+		require.Equal(t, len(someKey), n)
+		require.NotEmpty(t, l.KeysetID)
+		retrievedKey, ok := storeMap[l.KeysetID]
+		require.True(t, ok)
+		require.Equal(t, retrievedKey, someKey)
+	})
+
+	t.Run("error case - create a storeWriter with missing mastKeyURI", func(t *testing.T) {
+		storeMap := map[string][]byte{}
+		mockStore := &mockstorage.MockStore{Store: storeMap}
+
+		l := newWriter(mockStore, "")
+		require.NotEmpty(t, l)
+		someKey := []byte("someKeyData")
+		n, err := l.Write(someKey)
+		require.EqualError(t, err, "master key is not set")
+		require.Equal(t, 0, n)
+	})
+
+	t.Run("error case - create a storeWriter using a bad storeWriter to storage", func(t *testing.T) {
+		storeMap := map[string][]byte{}
+		putError := fmt.Errorf("failed to put data")
+		mockStore := &mockstorage.MockStore{
+			Store:  storeMap,
+			ErrPut: putError,
+		}
+
+		l := newWriter(mockStore, masterKeyURI)
+		require.NotEmpty(t, l)
+		someKey := []byte("someKeyData")
+		n, err := l.Write(someKey)
+		require.EqualError(t, err, putError.Error())
+		require.Equal(t, 0, n)
+	})
+
+	t.Run("error case - create a storeWriter using a bad storeReader from storage", func(t *testing.T) {
+		storeMap := map[string][]byte{}
+		getError := fmt.Errorf("failed to get data")
+		mockStore := &mockstorage.MockStore{
+			Store:  storeMap,
+			ErrGet: getError,
+		}
+
+		l := newWriter(mockStore, masterKeyURI)
+		require.NotEmpty(t, l)
+		someKey := []byte("someKeyData")
+		n, err := l.Write(someKey)
+		require.EqualError(t, err, getError.Error())
+		require.Equal(t, 0, n)
+	})
+}


### PR DESCRIPTION
To prepare for the default local KMS implementation, a store
Reader and Writer need to be created to help persisting KMS
key sets in a local storage.

This is pre step for the next patch that includes the full
local KMS implementation.

part of #1149

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
