### PR TITLE
fix: aries-js-worker notifier to follow REST notifier behavior

### DIFF
--- a/cmd/aries-js-worker/index.html
+++ b/cmd/aries-js-worker/index.html
@@ -35,10 +35,18 @@ This is a test page for developers to test WASM integration.
         }
 
         function startNotifier() {
-           const topic = document.querySelector("#notifier").value
+            var topics
+            if (document.querySelector("#notifier").value) {
+                topics = document.querySelector("#notifier").value.split(",")
+            } else {
+                topics = []
+            }
+
+            // pass array of topics to notifier or pass ["all"] to subscribe for all
+            // TODO whole generator logic below to be moved inside js package (aries.js)
            async function* run() {
                 while (true)
-                    yield await aries.waitForNotification(topic)
+                    yield await aries.waitForNotification(topics)
             }
 
             const asyncIterator = run();
@@ -64,7 +72,7 @@ This is a test page for developers to test WASM integration.
             <tr>
                 <td colspan="2">
                     <div>Start Options :</div>
-                    <textarea id="opts" rows="5" cols="100">{"agent-default-label":"dem-js-agent","http-resolver-url":"","auto-accept":true,"outbound-transport":["ws","http"],"transport-return-route":"all","notifier-func-name":"sample-topic","log-level":"debug"}
+                    <textarea id="opts" rows="5" cols="100">{"agent-default-label":"dem-js-agent","http-resolver-url":"","auto-accept":true,"outbound-transport":["ws","http"],"transport-return-route":"all","log-level":"debug"}
                     </textarea>
                 </td>
             </tr>
@@ -81,7 +89,8 @@ This is a test page for developers to test WASM integration.
             </tr>
             <tr>
                 <td>
-                    <input type="text" id="notifier" value="sample-topic" size="50"></input>
+                    <div style="font-size: small;">(Enter comma separated topics below, leave it empty to subscribe to all topics.)</div>
+                    <input type="text" id="notifier" value="" size="50"></input>
                     <button onClick="startNotifier()">Start Notifier</button>
                 </td>
             </tr>
@@ -134,10 +143,11 @@ This is a test page for developers to test WASM integration.
     <br><br>
 </div>
 <hr/>
-<div>
+<div style="height: 10%">
     <label for="output" style="font-size: large;font-weight: bold">Response: </label>
     <output id="output" style="color: green;"></output>
 </div>
+<hr/>
 <br>
 <div id="error-div" style="visibility: hidden;color:red;font-size: x-large;">
     <label for="error">Error: </label>

--- a/cmd/aries-js-worker/src/aries.js
+++ b/cmd/aries-js-worker/src/aries.js
@@ -107,15 +107,21 @@ export const Aries = function(opts) {
             return invoke("aries", "Stop", "{}", "timeout while stopping aries")
         },
 
-        waitForNotification : async function waitForNotification(topic) {
+        waitForNotification : async function waitForNotification(topics) {
             return new Promise((resolve, reject) => {
                 const timer = setTimeout(_ => resolve(), 10000)
-                NOTIFICATIONS.set(topic, result => {
-                    if (result.isErr) {
-                        reject(new Error(result.errMsg))
-                    }
-                    resolve(result.payload)
-                })
+                // subscribe for all by default if topics not provided
+                if (topics.length == 0){
+                    topics = ["all"]
+                }
+                topics.forEach(function (topic, index) {
+                    NOTIFICATIONS.set(topic, result => {
+                        if (result.isErr) {
+                            reject(new Error(result.errMsg))
+                        }
+                        resolve(result.payload)
+                    })
+                });
             });
         },
 
@@ -181,8 +187,8 @@ export const Aries = function(opts) {
             register: async function (text) {
                 return invoke(this.pkgname, "Register", text, "timeout while registering router")
             },
-            unregister: async function (text) {
-                return invoke(this.pkgname, "Unregister", text, "timeout while registering router")
+            unregister: async function () {
+                return invoke(this.pkgname, "Unregister", "{}", "timeout while registering router")
             }
         }
     }

--- a/cmd/aries-js-worker/src/worker-loader-node.js
+++ b/cmd/aries-js-worker/src/worker-loader-node.js
@@ -13,6 +13,16 @@ import workerJS from "./worker-impl-node"
 export function _getWorker(pending, notifications) {
     const worker = new Worker(workerJS, { workerData: {wasmJS: wasmJS, wasmPath: wasm} })
     worker.on("message", result => {
+        if (result.topic ){
+            if (notifications.get(result.topic)) {
+                notifications.get(result.topic)(result)
+            }  else if (notifications.get("all")){
+                notifications.get("all")(result)
+            } else {
+                console.log("no subscribers found for this topic", result.topic)
+            }
+            return
+        }
         const cb = pending.get(result.id)
         pending.delete(result.id)
         cb(result)

--- a/cmd/aries-js-worker/src/worker-loader-web.js
+++ b/cmd/aries-js-worker/src/worker-loader-web.js
@@ -13,10 +13,10 @@ export function _getWorker(pending, notifications) {
     worker.onmessage = e => {
         const result = e.data
         if (result.topic ){
-            const notify = notifications.get(result.topic)
-            if (notify) {
-                console.log("sending incoming message on topic", result.topic, result)
-                notify(result)
+            if (notifications.get(result.topic)) {
+                notifications.get(result.topic)(result)
+            }  else if (notifications.get("all")){
+                notifications.get("all")(result)
             } else {
                 console.log("no subscribers found for this topic", result.topic)
             }


### PR DESCRIPTION
- use `aries.waitForNotification()` to subscribe for all the topics
- use `aries.waitForNotification(topics)` to subscribe by topics.
- removed "notifier-func-name" from aries start opts.
- closes #1259

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
