### PR TITLE
feat:stop notifier feature in aries-js-worker

### DIFF
--- a/cmd/aries-js-worker/index.html
+++ b/cmd/aries-js-worker/index.html
@@ -15,6 +15,7 @@ This is a test page for developers to test WASM integration.
     <script>
         // TODO fix the stutter in the API's exports ("Aries.Aries....")
         const aries = Aries.Aries({})
+        var stopNotifier
 
         async function handleStart() {
             const request = document.querySelector("#opts").value
@@ -35,7 +36,7 @@ This is a test page for developers to test WASM integration.
             document.querySelector("#output").value = JSON.stringify(response)
         }
 
-        function startNotifier() {
+        function startTopicNotifier() {
             var topics
             if (document.querySelector("#notifier").value) {
                 topics = document.querySelector("#notifier").value.split(",")
@@ -43,11 +44,11 @@ This is a test page for developers to test WASM integration.
                 topics = []
             }
 
-            aries.startNotifier(pushToMsgPanel, topics)
+            stopNotifier =  aries.startNotifier(pushToMsgPanel, topics)
         }
 
         function pushToMsgPanel(val) {
-            console.log("incomoing msg", val.id, val.topic, val.payload)
+            console.log("incoming msg :", val.id, val.topic, val.payload)
 
             var table = document.getElementById("msg-table");
             var row = table.insertRow(1);
@@ -59,6 +60,12 @@ This is a test page for developers to test WASM integration.
             cell1.innerHTML = val.id;
             cell2.innerHTML =  val.topic;
             cell3.innerHTML = JSON.stringify(val.payload);
+        }
+
+        function stopTopicNotifier() {
+            if (stopNotifier) {
+                stopNotifier()
+            }
         }
 
     </script>
@@ -95,7 +102,8 @@ This is a test page for developers to test WASM integration.
                                     subscribe to all topics.)
                                 </div>
                                 <input type="text" id="notifier" value="" size="50"></input>
-                                <button onClick="startNotifier()">Start Notifier</button>
+                                <button onClick="startTopicNotifier()">Start Notifier</button>
+                                <button onClick="stopTopicNotifier()">Stop Notifier</button>
                             </td>
                         </tr>
                     </table>


### PR DESCRIPTION
- `aries.startNotifier()` to return stop handle which can be used to
stop current notifier started.
- part of #1262

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
