### PR TITLE
feat: mimetype for REST controller response

### DIFF
--- a/pkg/controller/rest/rest.go
+++ b/pkg/controller/rest/rest.go
@@ -31,6 +31,8 @@ func Execute(exec command.Exec, rw http.ResponseWriter, req io.Reader) {
 	if err != nil {
 		SendError(rw, err)
 	}
+
+	rw.Header().Set("Content-Type", "application/json")
 }
 
 // genericError is aries rest api error response
@@ -59,7 +61,6 @@ func SendError(rw http.ResponseWriter, err command.Error) {
 // SendHTTPStatusError sends given http status code to response with error body
 func SendHTTPStatusError(rw http.ResponseWriter, httpStatus int, code command.Code, err error) {
 	rw.WriteHeader(httpStatus)
-	rw.Header().Set("Content-Type", "application/json")
 
 	e := json.NewEncoder(rw).Encode(genericError{
 		Code:    code,

--- a/pkg/controller/rest/route/operation.go
+++ b/pkg/controller/rest/route/operation.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/command/route"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/internal/cmdutil"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/rest"
@@ -69,7 +68,7 @@ func (o *Operation) registerHandler() {
 //    default: genericError
 //    200: registerRouteRes
 func (o *Operation) Register(rw http.ResponseWriter, req *http.Request) {
-	executeCommand(o.command.Register, rw, req)
+	rest.Execute(o.command.Register, rw, req.Body)
 }
 
 // Unregister swagger:route DELETE /route/unregister route unregisterRouter
@@ -79,13 +78,5 @@ func (o *Operation) Register(rw http.ResponseWriter, req *http.Request) {
 // Responses:
 //    default: genericError
 func (o *Operation) Unregister(rw http.ResponseWriter, req *http.Request) {
-	executeCommand(o.command.Unregister, rw, req)
-}
-
-// executeCommand executes given command with args provided.
-func executeCommand(exec command.Exec, rw http.ResponseWriter, req *http.Request) {
-	err := exec(rw, req.Body)
-	if err != nil {
-		rest.SendError(rw, err)
-	}
+	rest.Execute(o.command.Unregister, rw, req.Body)
 }


### PR DESCRIPTION
- added `application/json` mimetype for REST controller response
- closes #1272

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
