### PR TITLE
feat: Get Router Connection API

### DIFF
--- a/cmd/aries-js-worker/src/aries.js
+++ b/cmd/aries-js-worker/src/aries.js
@@ -225,6 +225,9 @@ export const Aries = function(opts) {
             },
             unregister: async function () {
                 return invoke(aw, pending,  this.pkgname, "Unregister", "{}", "timeout while registering router")
+            },
+            getConnection: async function () {
+                return invoke(aw, pending,  this.pkgname, "GetConnection", "{}", "timeout while fetching router connection id")
             }
         }
     }

--- a/pkg/client/route/client.go
+++ b/pkg/client/route/client.go
@@ -34,6 +34,9 @@ type protocolService interface {
 
 	// Unregister unregisters the agent with the router
 	Unregister() error
+
+	// GetConnection returns the connectionID of the router.
+	GetConnection() (string, error)
 }
 
 // New return new instance of route client.
@@ -70,4 +73,15 @@ func (c *Client) Unregister() error {
 	}
 
 	return nil
+}
+
+// GetConnection returns the connectionID of the router.
+func (c *Client) GetConnection() (string, error) {
+	connectionID, err := c.routeSvc.GetConnection()
+
+	if err != nil {
+		return "", fmt.Errorf("get router connectionID : %w", err)
+	}
+
+	return connectionID, nil
 }

--- a/pkg/client/route/client_test.go
+++ b/pkg/client/route/client_test.go
@@ -88,3 +88,34 @@ func TestUnregister(t *testing.T) {
 		require.Contains(t, err.Error(), "router unregister")
 	})
 }
+
+func TestGetConnection(t *testing.T) {
+	t.Run("test get connection - success", func(t *testing.T) {
+		routerConnectionID := "conn-abc"
+
+		c, err := New(&mockprovider.Provider{
+			ServiceValue: &mockroute.MockRouteSvc{
+				ConnectionID: routerConnectionID,
+			},
+		})
+		require.NoError(t, err)
+
+		connID, err := c.GetConnection()
+		require.NoError(t, err)
+		require.Equal(t, routerConnectionID, connID)
+	})
+
+	t.Run("test get connection - error", func(t *testing.T) {
+		c, err := New(&mockprovider.Provider{
+			ServiceValue: &mockroute.MockRouteSvc{
+				GetConnectionIDErr: errors.New("get connection id error"),
+			},
+		})
+		require.NoError(t, err)
+
+		connID, err := c.GetConnection()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "get router connectionID")
+		require.Empty(t, connID)
+	})
+}

--- a/pkg/controller/command/route/models.go
+++ b/pkg/controller/command/route/models.go
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 package route
 
-// RegisterRouteReq contains parameters for registering router.
-type RegisterRouteReq struct {
+// RegisterRoute contains parameters for registering router.
+type RegisterRoute struct {
 	ConnectionID string `json:"connectionID"`
 }

--- a/pkg/controller/rest/route/models.go
+++ b/pkg/controller/rest/route/models.go
@@ -19,11 +19,21 @@ type registerRouteReq struct { // nolint: unused,deadcode
 	// Params for registering the route
 	//
 	// in: body
-	Params route.RegisterRouteReq
+	Params route.RegisterRoute
 }
 
 // registerRouteRes model
 //
 // swagger:response registerRouteRes
 type registerRouteRes struct { // nolint: unused,deadcode
+}
+
+// ConnectionRes model
+//
+// response of get connection action
+//
+// swagger:response getConnectionResponse
+type ConnectionRes struct { // nolint: unused,deadcode
+	// in: body
+	Params route.RegisterRoute
 }

--- a/pkg/controller/rest/route/operation.go
+++ b/pkg/controller/rest/route/operation.go
@@ -16,9 +16,10 @@ import (
 )
 
 const (
-	routeOperationID = "/route"
-	registerPath     = routeOperationID + "/register"
-	unregisterPath   = routeOperationID + "/unregister"
+	routeOperationID  = "/route"
+	registerPath      = routeOperationID + "/register"
+	unregisterPath    = routeOperationID + "/unregister"
+	getConnectionPath = routeOperationID + "/connection"
 )
 
 // provider contains dependencies for the route protocol and is typically created by using aries.Context().
@@ -57,6 +58,7 @@ func (o *Operation) registerHandler() {
 	o.handlers = []rest.Handler{
 		cmdutil.NewHTTPHandler(registerPath, http.MethodPost, o.Register),
 		cmdutil.NewHTTPHandler(unregisterPath, http.MethodDelete, o.Unregister),
+		cmdutil.NewHTTPHandler(getConnectionPath, http.MethodGet, o.GetConnection),
 	}
 }
 
@@ -79,4 +81,15 @@ func (o *Operation) Register(rw http.ResponseWriter, req *http.Request) {
 //    default: genericError
 func (o *Operation) Unregister(rw http.ResponseWriter, req *http.Request) {
 	rest.Execute(o.command.Unregister, rw, req.Body)
+}
+
+// GetConnection swagger:route GET /route/connection route routerConnection
+//
+// Retrieves the router connection id.
+//
+// Responses:
+//    default: genericError
+//    200: getConnectionResponse
+func (o *Operation) GetConnection(rw http.ResponseWriter, req *http.Request) {
+	rest.Execute(o.command.GetConnection, rw, req.Body)
 }

--- a/pkg/didcomm/protocol/route/service.go
+++ b/pkg/didcomm/protocol/route/service.go
@@ -420,6 +420,18 @@ func (s *Service) Unregister() error {
 	return s.saveRouterConnectionID("")
 }
 
+// GetConnection returns the connectionID of the router.
+func (s *Service) GetConnection() (string, error) {
+	routerConnID, err := s.getRouterConnectionID()
+	if err != nil && !errors.Is(err, storage.ErrDataNotFound) {
+		return "", fmt.Errorf("fetch router connection id : %w", err)
+	} else if errors.Is(err, storage.ErrDataNotFound) || routerConnID == "" {
+		return "", ErrRouterNotRegistered
+	}
+
+	return routerConnID, nil
+}
+
 // AddKey adds a recKey of the agent to the registered router. This method blocks until a response is
 // received from the router or it times out.
 // TODO https://github.com/hyperledger/aries-framework-go/issues/1076 Support for multiple routers

--- a/pkg/internal/mock/didcomm/protocol/route/mock_route.go
+++ b/pkg/internal/mock/didcomm/protocol/route/mock_route.go
@@ -25,6 +25,8 @@ type MockRouteSvc struct {
 	ConfigErr          error
 	AddKeyErr          error
 	UnregisterErr      error
+	ConnectionID       string
+	GetConnectionIDErr error
 }
 
 // HandleInbound msg
@@ -94,4 +96,13 @@ func (m *MockRouteSvc) Config() (*route.Config, error) {
 	}
 
 	return route.NewConfig(m.RouterEndpoint, m.RoutingKeys), nil
+}
+
+// GetConnection returns the connectionID of the router.
+func (m *MockRouteSvc) GetConnection() (string, error) {
+	if m.GetConnectionIDErr != nil {
+		return "", m.GetConnectionIDErr
+	}
+
+	return m.ConnectionID, nil
 }

--- a/test/bdd/features/aries_router_e2e_controller.feature
+++ b/test/bdd/features/aries_router_e2e_controller.feature
@@ -25,7 +25,7 @@ Feature: DIDComm Transport between two Agents through DIDComm Routers [REST Bind
 
     Then   "Carl-Router" retrieves connection record through controller and validates that connection state is "completed"
     And   "Carl" retrieves connection record through controller and validates that connection state is "completed"
-    And   "Carl" saves the connectionID to variable "xyz"
+    And   "Carl" saves the connectionID to variable "carl-router-connID"
 
      # DID Exchange between Dave and his Router
     Given "Dave" agent is running with controller "http://localhost:10061" and webhook "http://localhost:10062" and "all" as the transport return route option
@@ -42,15 +42,17 @@ Feature: DIDComm Transport between two Agents through DIDComm Routers [REST Bind
 
     Then   "Dave-Router" retrieves connection record through controller and validates that connection state is "completed"
     And   "Dave" retrieves connection record through controller and validates that connection state is "completed"
-    And   "Dave" saves the connectionID to variable "abc"
+    And   "Dave" saves the connectionID to variable "dave-router-connID"
 
        # Carl registers her Router
     And   "Carl" unregisters the router
-    And   "Carl" sets connection "xyz" as the router
+    And   "Carl" sets connection "carl-router-connID" as the router
+    And   "Carl" verifies that the router connection is set to "carl-router-connID"
 
        # Dave registers his Router
     And   "Dave" unregisters the router
-    And   "Dave" sets connection "abc" as the router
+    And   "Dave" sets connection "dave-router-connID" as the router
+    And   "Dave" verifies that the router connection is set to "dave-router-connID"
 
      # DIDExchange between Alice and Bob through routers
     When   "Carl" creates invitation through controller with label "carl-agent"

--- a/test/bdd/features/aries_router_e2e_sdk.feature
+++ b/test/bdd/features/aries_router_e2e_sdk.feature
@@ -29,7 +29,7 @@ Feature: DIDComm Transport between two Agents through DIDComm Routers [SDK]
 
     Then   "Alice-Router" retrieves connection record and validates that connection state is "completed"
       And   "Alice" retrieves connection record and validates that connection state is "completed"
-      And   "Alice" saves connectionID to variable "xyz"
+      And   "Alice" saves connectionID to variable "alice-router-connID"
 
      # DID Exchange between Bob and his Router
     Given "Bob" edge agent is running with "websocket" as the outbound transport provider and "all" as the transport return route option
@@ -50,15 +50,17 @@ Feature: DIDComm Transport between two Agents through DIDComm Routers [SDK]
 
     Then   "Bob-Router" retrieves connection record and validates that connection state is "completed"
       And   "Bob" retrieves connection record and validates that connection state is "completed"
-      And   "Bob" saves connectionID to variable "abc"
+      And   "Bob" saves connectionID to variable "bob-router-connID"
 
        # Alice registers her Router
       And   "Alice" creates a route exchange client
-      And   "Alice" sets "xyz" as the router
+      And   "Alice" sets "alice-router-connID" as the router
+      And   "Alice" verifies that the router connection id is set to "alice-router-connID"
 
        # Bob registers his Router
       And   "Bob" creates a route exchange client
-      And   "Bob" sets "abc" as the router
+      And   "Bob" sets "bob-router-connID" as the router
+      And   "Bob" verifies that the router connection id is set to "bob-router-connID"
 
      # DIDExchange between Alice and Bob through routers
     When   "Alice" creates invitation
@@ -92,7 +94,7 @@ Feature: DIDComm Transport between two Agents through DIDComm Routers [SDK]
 
     Then   "Alice-Router" retrieves connection record and validates that connection state is "completed"
       And   "Alice" retrieves connection record and validates that connection state is "completed"
-      And   "Alice" saves connectionID to variable "xyz"
+      And   "Alice" saves connectionID to variable "alice-router-connID"
 
      # DID Exchange between Bob and his Router
     Given "Bob" agent is running on "localhost" port "random" with "http" as the transport provider
@@ -113,15 +115,17 @@ Feature: DIDComm Transport between two Agents through DIDComm Routers [SDK]
 
     Then   "Bob-Router" retrieves connection record and validates that connection state is "completed"
       And   "Bob" retrieves connection record and validates that connection state is "completed"
-      And   "Bob" saves connectionID to variable "abc"
+      And   "Bob" saves connectionID to variable "bob-router-connID"
 
        # Alice registers her Router
       And   "Alice" creates a route exchange client
-      And   "Alice" sets "xyz" as the router
+      And   "Alice" sets "alice-router-connID" as the router
+      And   "Alice" verifies that the router connection id is set to "alice-router-connID"
 
        # Bob registers his Router
       And   "Bob" creates a route exchange client
-      And   "Bob" sets "abc" as the router
+      And   "Bob" sets "bob-router-connID" as the router
+      And   "Bob" verifies that the router connection id is set to "bob-router-connID"
 
      # DIDExchange between Alice and Bob through routers
     When   "Alice" creates invitation
@@ -156,7 +160,7 @@ Feature: DIDComm Transport between two Agents through DIDComm Routers [SDK]
 
     Then   "Alice-Router" retrieves connection record and validates that connection state is "completed"
       And   "Alice" retrieves connection record and validates that connection state is "completed"
-      And   "Alice" saves connectionID to variable "xyz"
+      And   "Alice" saves connectionID to variable "alice-router-connID"
 
      # DID Exchange between Bob and his Router
     Given "Bob" edge agent is running with "http,websocket" as the outbound transport provider and "all" as the transport return route option
@@ -177,15 +181,17 @@ Feature: DIDComm Transport between two Agents through DIDComm Routers [SDK]
 
     Then   "Bob-Router" retrieves connection record and validates that connection state is "completed"
       And   "Bob" retrieves connection record and validates that connection state is "completed"
-      And   "Bob" saves connectionID to variable "abc"
+      And   "Bob" saves connectionID to variable "bob-router-connID"
 
        # Alice registers her Router
       And   "Alice" creates a route exchange client
-      And   "Alice" sets "xyz" as the router
+      And   "Alice" sets "alice-router-connID" as the router
+      And   "Alice" verifies that the router connection id is set to "alice-router-connID"
 
        # Bob registers his Router
       And   "Bob" creates a route exchange client
-      And   "Bob" sets "abc" as the router
+      And   "Bob" sets "bob-router-connID" as the router
+      And   "Bob" verifies that the router connection id is set to "bob-router-connID"
 
      # DIDExchange between Alice and Bob through routers
     When   "Alice" creates invitation

--- a/test/bdd/pkg/route/route_sdk_steps.go
+++ b/test/bdd/pkg/route/route_sdk_steps.go
@@ -44,7 +44,22 @@ func (d *SDKSteps) CreateRouteClient(agentID string) error {
 func (d *SDKSteps) RegisterRoute(agentID, varName string) error {
 	err := d.bddContext.RouteClients[agentID].Register(d.bddContext.Args[varName])
 	if err != nil {
-		return fmt.Errorf("failed to handle invitation: %w", err)
+		return fmt.Errorf("register route : %w", err)
+	}
+
+	return nil
+}
+
+// VerifyConnection verifies the router connection id has been set to the provided connection id.
+func (d *SDKSteps) VerifyConnection(agentID, varName string) error {
+	connectionID, err := d.bddContext.RouteClients[agentID].GetConnection()
+	if err != nil {
+		return fmt.Errorf("fetch router connection id : %w", err)
+	}
+
+	if connectionID != d.bddContext.Args[varName] {
+		return fmt.Errorf("router connection id does not match : routerConnID=%s newConnID=%s",
+			connectionID, d.bddContext.Args[varName])
 	}
 
 	return nil
@@ -54,4 +69,5 @@ func (d *SDKSteps) RegisterRoute(agentID, varName string) error {
 func (d *SDKSteps) RegisterSteps(s *godog.Suite) {
 	s.Step(`^"([^"]*)" creates a route exchange client$`, d.CreateRouteClient)
 	s.Step(`^"([^"]*)" sets "([^"]*)" as the router$`, d.RegisterRoute)
+	s.Step(`^"([^"]*)" verifies that the router connection id is set to "([^"]*)"$`, d.VerifyConnection)
 }


### PR DESCRIPTION
- New GetConnection API in route service, client and command (rest/wasm)
- SDK/REST BDD test update to include the new API

closes #1217 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>