### PR TITLE
feat: #1277 canonicalize wasm filename extension to '.wasm'

### DIFF
--- a/cmd/aries-js-worker/README.md
+++ b/cmd/aries-js-worker/README.md
@@ -23,20 +23,97 @@ View [`App.js`](./App.js) for examples.
 
 Go to [`vue-framework-go`](./vue-aries-framework-go) for a sample agent built with Vue.js.
 
+Note: is the webpack devserver (`npm run serve`) not working for you? Note the points about
+[serving the assets](#important---serving-the-assets) below. See how `vue-aries-framework-go`
+[fixes this](vue-aries-framework-go/scripts/serve.sh).
+
 ### Browser
 
 View [`index.html`](./index.html) for examples.
 
-**Important:** Make sure the web server adds the appropriate headers when serving the compressed `aries-js-worker.wasm.gz` file:
+### Important - Serving the Assets
+
+`aries-js-worker` loads some assets at runtime: the web assembly binary and a couple of JS scripts. These assets are
+located in the `dist/assets` directory (if you `npm install` it, you'll find them in
+`./node_modules/@hyperledger/aries-framework-go/dist/assets`).
+
+Things that need to work if you are to use `aries-js-worker` on the client side.
+
+#### Headers
+
+Make sure the content server adds the appropriate headers when serving the compressed `aries-js-worker.wasm` file.
+`aries-js-worker` uses the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to fetch the wasm.
+
+Examples:
+
+**Serving gzipped wasm:**
+
+Headers:
 
 * `Content-Type: application/wasm`
 * `Content-Encoding: gzip`
 
-Consult your web server's documentation for instructions on how to do this (eg. for Apache: [Content-Type](https://httpd.apache.org/docs/2.4/mod/mod_mime.html#addtype), [Content-Encoding](https://httpd.apache.org/docs/2.4/mod/mod_deflate.html#precompressed)).
+**Serving wasm compressed with brotli:**
 
-Here is a hacky one-liner when using [`goexec`](https://github.com/shurcooL/goexec):
+If your browser supports it, then the headers are:
+
+* `Content-Type: application/wasm`
+* `Content-Encoding: br`
+
+Note, however, that your browser may not support this compression mode.
+ 
+Not all browsers include `br` in `Accept-Encoding` when using `fetch()` (Firefox doesn't) and it is impossible to
+override because `Accept-Encoding` is a [forbidden header name](https://fetch.spec.whatwg.org/#forbidden-header-name).
+
+**Serving uncompressed wasm (not recommended):**
+
+Headers:
+
+* `Content-Type: application/wasm`
+
+#### Path
+
+The URL used to fetch the WASM file is **always** `<assetsPath>/aries-js-worker.wasm`.
+This path needs to exist even if your content server is serving a compressed version.
+
+#### Configuring your content server
+
+Here are some examples:
+
+**Nginx**
+
+[Sending compressed files](https://docs.nginx.com/nginx/admin-guide/web-server/compression/#sending-compressed-files):
+enabling `gzip_static` on a location will automatically serve requests to `http://example.com/assets/aries-js-worker.wasm`
+with `aries-js-worker.wasm.gz` if it exists.
+
+Example: Nginx serving your assets under `/public/assets` with gzipped wasm:
 
 ```
-goexec -quiet 'http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { if strings.HasSuffix(r.RequestURI, ".gz") && !strings.Contains(r.RequestURI, "wasm=") { w.Header().Add("Content-Encoding", "gzip"); w.Header().Add("Content-Type", "application/wasm") }; http.FileServer(http.Dir(`.`)).ServeHTTP(w, r) }); http.ListenAndServe(`:8080`, nil)'
+location ~ aries-js-worker\.wasm$ {
+    gzip_static on;
+    types {
+        application/wasm  wasm;
+    }
+}
+```
+
+Files in `/public/assets`:
+
+```
+assets
+├── aries-js-worker.wasm.gz
+├── wasm_exec.js
+├── worker-impl-node.js
+└── worker-impl-web.js
+```
+
+Requests for `http://example.com/public/assets/aries-js-worker.wasm` will be served with the `.gz` file.
+
+**goexec**
+
+Here is a hacky one-liner when using [`goexec`](https://github.com/shurcooL/goexec) (for development purposes):
+
+```
+goexec -quiet 'http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {dir := http.Dir("."); if strings.HasSuffix(r.RequestURI, ".wasm") && !strings.Contains(r.RequestURI, "wasm=") {w.Header().Add("Content-Encoding", "gzip"); w.Header().Add("Content-Type", "application/wasm"); fmt.Sprintf(r.URL.Path); file, err := dir.Open(r.URL.Path + ".gz"); if err != nil {w.Header().Add("x-error", err.Error()); w.WriteHeader(http.StatusInternalServerError); return; }; buf := make([]byte, 2048); for err == nil { n := 0; n, err = file.Read(buf);if n > 0 {n, err = w.Write(buf[:n]);}}; if !errors.Is(err, io.EOF) {w.WriteHeader(http.StatusInternalServerError); return;}; }; http.FileServer(http.Dir(".")).ServeHTTP(w, r) }); http.ListenAndServe(":8080", nil)'
 ```
 

--- a/cmd/aries-js-worker/src/aries.js
+++ b/cmd/aries-js-worker/src/aries.js
@@ -97,7 +97,7 @@ export const Framework = class {
  * @param opts initialization options.
  * @constructor
  */
-export const Aries = function(opts) {
+const Aries = function(opts) {
     if (!opts) {
         throw new Error("aries: missing options")
     }
@@ -250,7 +250,7 @@ export const Aries = function(opts) {
         notifications,
         {
             dir: opts.assetsPath,
-            wasm: opts.assetsPath + "/aries-js-worker.wasm.gz",
+            wasm: opts.assetsPath + "/aries-js-worker.wasm",
             wasmJS: opts.assetsPath + "/wasm_exec.js"
         }
     )

--- a/cmd/aries-js-worker/src/worker-impl-node.js
+++ b/cmd/aries-js-worker/src/worker-impl-node.js
@@ -16,6 +16,7 @@ require(workerData.wasmJS)
 const go = new Go();
 go.env = Object.assign({ TMPDIR: require("os").tmpdir() }, process.env);
 go.exit = process.exit;
+// TODO we shouldn't always assume the wasm will be gzipped
 WebAssembly.instantiate(zlib.gunzipSync(fs.readFileSync(workerData.wasmPath)), go.importObject).then((result) => {
     return go.run(result.instance);
 }).catch((err) => {

--- a/cmd/aries-js-worker/vue-aries-framework-go/.gitignore
+++ b/cmd/aries-js-worker/vue-aries-framework-go/.gitignore
@@ -7,6 +7,7 @@
 .DS_Store
 node_modules
 /dist
+assets/
 
 # local env files
 .env.local

--- a/cmd/aries-js-worker/vue-aries-framework-go/README.md
+++ b/cmd/aries-js-worker/vue-aries-framework-go/README.md
@@ -14,10 +14,18 @@ npm run serve
 
 Browse to http://localhost:8080 to view it in action.
 
+**Note:**
+ 
+* This target requires `npm link` to run without `sudo`. Install `npm` via
+[nvm](https://github.com/nvm-sh/nvm) (recommended) or give it the proper permissions in the required paths.
+* Note how we serve the static assets [here](scripts/serve.sh).
+
 ### Compiles and minifies for production
 ```
 npm run build
 ```
+
+**Note:** [make sure you serve the assets correctly](../README.md#important---serving-the-assets).
 
 ### Lints and fixes files
 ```

--- a/cmd/aries-js-worker/vue-aries-framework-go/scripts/serve.sh
+++ b/cmd/aries-js-worker/vue-aries-framework-go/scripts/serve.sh
@@ -5,7 +5,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+cd ..
+npm link
+cd vue-aries-framework-go
+npm link @hyperledger/aries-framework-go
 rm -rf public/aries-framework-go
-cp -Rp node_modules/@hyperledger/aries-framework-go/ public
-gunzip public/aries-framework-go/dist/assets/aries-js-worker.wasm.gz
+mkdir -p public/aries-framework-go/assets
+cp -Rp node_modules/@hyperledger/aries-framework-go/dist/assets/* public/aries-framework-go/assets
+gunzip public/aries-framework-go/assets/aries-js-worker.wasm.gz
 vue-cli-service serve

--- a/cmd/aries-js-worker/vue-aries-framework-go/src/components/HelloFrameworkGo.vue
+++ b/cmd/aries-js-worker/vue-aries-framework-go/src/components/HelloFrameworkGo.vue
@@ -9,13 +9,11 @@ SPDX-License-Identifier: Apache-2.0
     <h1>{{ msg }}</h1>
 
     <div>
-      <label for="test-input">Input: </label>
-      <input type="text" id="test-input"/>
-      <button @click="handleInput()">echo</button>
+      <button @click="createInvitation()">Create Invitation</button>
     </div>
     <div>
-      <label for="test-output">Output: </label>
-      <output id="test-output"></output>
+      <label for="test-output">Invitation: </label>
+      <textarea id="test-output" rows="15" cols="70"></textarea>
     </div>
 
   </div>
@@ -28,10 +26,9 @@ SPDX-License-Identifier: Apache-2.0
       msg: String
     },
     methods: {
-      async handleInput () {
-        const invite = document.querySelector("#test-input").value
-        const connID = await this.$aries._test._echo(invite)
-        document.querySelector("#test-output").value = connID
+      async createInvitation () {
+        const invitation = await this.$aries.didexchange.createInvitation("{}")
+        document.querySelector("#test-output").value = JSON.stringify(invitation, undefined, 4)
       }
     }
   }

--- a/cmd/aries-js-worker/vue-aries-framework-go/src/main.js
+++ b/cmd/aries-js-worker/vue-aries-framework-go/src/main.js
@@ -7,8 +7,21 @@ SPDX-License-Identifier: Apache-2.0
 import Vue from 'vue'
 import App from './App.vue'
 
-import { Aries } from "@hyperledger/aries-framework-go"
-Object.defineProperty(Vue.prototype, "$aries", { value: new Aries({}) })
+import * as Aries from "@hyperledger/aries-framework-go"
+
+async function loadAries() {
+    Vue.prototype.$aries = await new Aries.Framework({
+        assetsPath: "/aries-framework-go/assets",
+        "agent-default-label":"dem-js-agent",
+        "http-resolver-url":[],
+        "auto-accept":true,
+        "outbound-transport":["ws","http"],
+        "transport-return-route":"all",
+        "log-level":"debug"
+    })
+}
+
+loadAries()
 
 Vue.config.productionTip = false
 

--- a/cmd/aries-js-worker/vue-aries-framework-go/vue.config.js
+++ b/cmd/aries-js-worker/vue-aries-framework-go/vue.config.js
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 const CopyPlugin = require("copy-webpack-plugin")
 
 module.exports = {
+    chainWebpack: config => config.resolve.symlinks(false),
     configureWebpack: {
         plugins: [
             new CopyPlugin([{


### PR DESCRIPTION
* Always fetching the wasm with the `.wasm` extension
* Provide some guidelines for users to configure their content servers correctly
* vue-aries-framework-go now `npm link`ed to aries-js-worker via `npm run server`

Signed-off-by: George Aristy <george.aristy@securekey.com>

