### PR TITLE
feat: Issue Credential - define models for the protocol

### DIFF
--- a/pkg/didcomm/protocol/decorator/decorator.go
+++ b/pkg/didcomm/protocol/decorator/decorator.go
@@ -42,3 +42,48 @@ type Transport struct {
 type ReturnRoute struct {
 	Value string `json:"~return_route,omitempty"`
 }
+
+// Attachment is intended to provide the possibility to include files, links or even JSON payload to the message.
+// To find out more please visit https://github.com/hyperledger/aries-rfcs/tree/master/concepts/0017-attachments
+type Attachment struct {
+	// ID is a JSON-LD construct that uniquely identifies attached content within the scope of a given message.
+	// Recommended on appended attachment descriptors. Possible but generally unused on embedded attachment descriptors.
+	// Never required if no references to the attachment exist; if omitted, then there is no way
+	// to refer to the attachment later in the thread, in error messages, and so forth.
+	// Because @id is used to compose URIs, it is recommended that this name be brief and avoid spaces
+	// and other characters that require URI escaping.
+	ID string `json:"@id,omitempty"`
+	// Description is an optional human-readable description of the content.
+	Description string `json:"description,omitempty"`
+	// FileName is a hint about the name that might be used if this attachment is persisted as a file.
+	// It is not required, and need not be unique. If this field is present and mime-type is not,
+	// the extension on the filename may be used to infer a MIME type.
+	FileName string `json:"filename,omitempty"`
+	// MimeType describes the MIME type of the attached content. Optional but recommended.
+	MimeType string `json:"mime-type,omitempty"`
+	// LastModTime is a hint about when the content in this attachment was last modified.
+	LastModTime time.Time `json:"lastmod_time,omitempty"`
+	// ByteCount is an optional, and mostly relevant when content is included by reference instead of by value.
+	// Lets the receiver guess how expensive it will be, in time, bandwidth, and storage, to fully fetch the attachment.
+	ByteCount int64 `json:"byte_count,omitempty"`
+	// Data is a JSON object that gives access to the actual content of the attachment.
+	Data AttachmentData `json:"data,omitempty"`
+}
+
+// AttachmentData contains attachment payload
+type AttachmentData struct {
+	// Sha256 is a hash of the content. Optional. Used as an integrity check if content is inlined.
+	// if content is only referenced, then including this field makes the content tamper-evident.
+	// This may be redundant, if the content is stored in an inherently immutable container like
+	// content-addressable storage. This may also be undesirable, if dynamic content at a specified
+	// link is beneficial. Including a hash without including a way to fetch the content via link
+	// is a form of proof of existence.
+	Sha256 string `json:"sha256,omitempty"`
+	// Links is a list of zero or more locations at which the content may be fetched.
+	Links []string `json:"links,omitempty"`
+	// Base64 encoded data, when representing arbitrary content inline instead of via links. Optional.
+	Base64 string `json:"base64,omitempty"`
+	// JSON is a directly embedded JSON data, when representing content inline instead of via links,
+	// and when the content is natively conveyable as JSON. Optional.
+	JSON interface{} `json:"json,omitempty"`
+}

--- a/pkg/didcomm/protocol/issuecredential/models.go
+++ b/pkg/didcomm/protocol/issuecredential/models.go
@@ -1,0 +1,98 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package issuecredential
+
+import "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+
+// ProposeCredential is an optional message sent by the potential Holder to the Issuer
+// to initiate the protocol or in response to a offer-credential message when the Holder
+// wants some adjustments made to the credential data offered by Issuer.
+type ProposeCredential struct {
+	Type string `json:"@type,omitempty"`
+	// Comment is an optional field that provides human readable information about this Credential Offer,
+	// so the offer can be evaluated by human judgment.
+	// TODO: Should follow DIDComm conventions for l10n. [Issue #1300]
+	Comment string `json:"comment,omitempty"`
+	// CredentialProposal is an optional JSON-LD object that represents
+	// the credential data that the Prover wants to receive.
+	CredentialProposal PreviewCredential `json:"credential_proposal,omitempty"`
+	// SchemaIssuerDid is an optional filter to request credential based on a particular Schema issuer DID.
+	SchemaIssuerDid string `json:"schema_issuer_did,omitempty"`
+	// SchemaID is an optional filter to request credential based on a particular Schema.
+	// This might be helpful when requesting a version 1 passport instead of a version 2 passport, for example.
+	SchemaID string `json:"schema_id,omitempty"`
+	// SchemaName is an optional filter to request credential based on a schema name.
+	// This is useful to allow a more user-friendly experience of requesting a credential by schema name.
+	SchemaName string `json:"schema_name,omitempty"`
+	// SchemaVersion is an optional filter to request credential based on a schema version.
+	// This is useful to allow a more user-friendly experience of requesting a credential by schema name and version.
+	SchemaVersion string `json:"schema_version,omitempty"`
+	// CredDefID is an optional filter to request credential based on a particular Credential Definition.
+	// This might be helpful when requesting a commercial driver's license instead of
+	// an ordinary driver's license, for example.
+	CredDefID string `json:"cred_def_id,omitempty"`
+	// IssuerDid is an optional filter to request a credential issued by the owner of a particular DID.
+	IssuerDid string `json:"issuer_did,omitempty"`
+}
+
+// OfferCredential is a message sent by the Issuer to the potential Holder,
+// describing the credential they intend to offer and possibly the price they expect to be paid.
+// TODO: Need to add ~payment_request and ~timing.expires_time decorators [Issue #1297]
+type OfferCredential struct {
+	Type string `json:"@type,omitempty"`
+	// Comment is an optional field that provides human readable information about this Credential Offer,
+	// so the offer can be evaluated by human judgment.
+	// TODO: Should follow DIDComm conventions for l10n. [Issue #1300]
+	Comment string `json:"comment,omitempty"`
+	// CredentialPreview is a JSON-LD object that represents the credential data that Issuer is willing to issue.
+	CredentialPreview PreviewCredential `json:"credential_preview,omitempty"`
+	// OffersAttach is a slice of attachments that further define the credential being offered.
+	// This might be used to clarify which formats or format versions will be issued.
+	OffersAttach []decorator.Attachment `json:"offers~attach,omitempty"`
+}
+
+// RequestCredential is a message sent by the potential Holder to the Issuer,
+// to request the issuance of a credential. Where circumstances do not require
+// a preceding Offer Credential message (e.g., there is no cost to issuance
+// that the Issuer needs to explain in advance, and there is no need for cryptographic negotiation),
+// this message initiates the protocol.
+// TODO: Need to add ~payment-receipt decorator [Issue #1298]
+type RequestCredential struct {
+	Type string `json:"@type,omitempty"`
+	// Comment is an optional field that provides human readable information about this Credential Offer,
+	// so the offer can be evaluated by human judgment.
+	// TODO: Should follow DIDComm conventions for l10n. [Issue #1300]
+	Comment string `json:"comment,omitempty"`
+	// RequestsAttach is a slice of attachments defining the requested formats for the credential
+	RequestsAttach []decorator.Attachment `json:"requests~attach,omitempty"`
+}
+
+// IssueCredential contains as attached payload the credentials being issued and is
+// sent in response to a valid Request Credential message.
+// TODO: Need to add ~please-ack decorator [Issue #1299]
+type IssueCredential struct {
+	Type string `json:"@type,omitempty"`
+	// Comment is an optional field that provides human readable information about this Credential Offer,
+	// so the offer can be evaluated by human judgment.
+	// TODO: Should follow DIDComm conventions for l10n. [Issue #1300]
+	Comment string `json:"comment,omitempty"`
+	// CredentialsAttach is a slice of attachments containing the issued credentials.
+	CredentialsAttach []decorator.Attachment `json:"credentials~attach,omitempty"`
+}
+
+// PreviewCredential is used to construct a preview of the data for the credential that is to be issued.
+type PreviewCredential struct {
+	Type       string      `json:"@type,omitempty"`
+	Attributes []Attribute `json:"attributes,omitempty"`
+}
+
+// Attribute describes an attribute for a Preview Credential
+type Attribute struct {
+	Name     string `json:"name,omitempty"`
+	MimeType string `json:"mime-type,omitempty"`
+	Value    string `json:"value,omitempty"`
+}


### PR DESCRIPTION
The following models were defined for the Issue Credential Protocol:
* ProposeCredential
* OfferCredential
* RequestCredential
* IssueCredential

Closes #1296 
Signed-off-by: Andrii Soluk <isoluchok@gmail.com>