### PR TITLE
chore: Changed godoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Release](https://img.shields.io/github/release/hyperledger/aries-framework-go.svg?style=flat-square)](https://github.com/hyperledger/aries-framework-go/releases/latest)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://raw.githubusercontent.com/hyperledger/aries-framework-go/master/LICENSE)
-[![Godocs](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/hyperledger/aries-framework-go)
+[![Godocs](https://img.shields.io/badge/godoc-reference-blue.svg)](https://pkg.go.dev/github.com/hyperledger/aries-framework-go)
 
 [![Build Status](https://github.com/hyperledger/aries-framework-go/workflows/build/badge.svg)](https://github.com/hyperledger/aries-framework-go/actions)
 [![codecov](https://codecov.io/gh/hyperledger/aries-framework-go/branch/master/graph/badge.svg)](https://codecov.io/gh/hyperledger/aries-framework-go)


### PR DESCRIPTION
See https://blog.golang.org/pkg.go.dev-2020

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>