### PR TITLE
fix: Revert Creator for JSONLD signature

### DIFF
--- a/pkg/doc/verifiable/linked_data_proof.go
+++ b/pkg/doc/verifiable/linked_data_proof.go
@@ -90,6 +90,7 @@ type LinkedDataProofContext struct {
 	Suite                   signerSignatureSuite    // required
 	SignatureRepresentation SignatureRepresentation // required
 	Created                 *time.Time              // optional
+	Creator                 string                  // optional
 }
 
 func checkLinkedDataProof(jsonldBytes []byte, suite verifierSignatureSuite, pubKeyFetcher PublicKeyFetcher) error {
@@ -140,5 +141,6 @@ func mapContext(context *LinkedDataProofContext) *signer.Context {
 		SignatureType:           context.SignatureType,
 		SignatureRepresentation: proof.SignatureRepresentation(context.SignatureRepresentation),
 		Created:                 context.Created,
+		Creator:                 context.Creator,
 	}
 }


### PR DESCRIPTION
Currently there's no way to determine who created proof for JSON LD signature since creator field has been removed. Restoring Creator field back.

Closes #1338

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>
