### PR TITLE
fix: multiple objectstores under same indexdb database

### DIFF
--- a/pkg/didcomm/messenger/messenger.go
+++ b/pkg/didcomm/messenger/messenger.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	messengerStore = "messenger_store"
+	// MessengerStore is messenger store name
+	MessengerStore = "messenger_store"
 
 	metadataKey = "metadata_%s"
 
@@ -53,7 +54,7 @@ type Messenger struct {
 
 // NewMessenger returns a new instance of the Messenger
 func NewMessenger(ctx Provider) (*Messenger, error) {
-	store, err := ctx.StorageProvider().OpenStore(messengerStore)
+	store, err := ctx.StorageProvider().OpenStore(MessengerStore)
 	if err != nil {
 		return nil, fmt.Errorf("open store: %w", err)
 	}

--- a/pkg/kms/legacykms/kms.go
+++ b/pkg/kms/legacykms/kms.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	keyStoreNamespace = "keystore"
+	// KeyStoreNamespace is keystore namespace
+	KeyStoreNamespace = "keystore"
 )
 
 // provider contains dependencies for the base LegacyKMS and is typically created by using aries.Context()
@@ -37,9 +38,9 @@ type BaseKMS struct {
 
 // New return new instance of LegacyKMS implementation
 func New(ctx provider) (*BaseKMS, error) {
-	ks, err := ctx.StorageProvider().OpenStore(keyStoreNamespace)
+	ks, err := ctx.StorageProvider().OpenStore(KeyStoreNamespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to OpenStore for '%s', cause: %w", keyStoreNamespace, err)
+		return nil, fmt.Errorf("failed to OpenStore for '%s', cause: %w", KeyStoreNamespace, err)
 	}
 
 	return &BaseKMS{keystore: ks}, nil

--- a/pkg/storage/jsindexeddb/jsindexeddb_test.go
+++ b/pkg/storage/jsindexeddb/jsindexeddb_test.go
@@ -61,13 +61,17 @@ func TestStore(t *testing.T) {
 	})
 
 	t.Run("Test error from open db", func(t *testing.T) {
-		dbVersion = 3
-		defer func() { dbVersion = 1 }()
 		prov, err := NewProvider()
 		require.NoError(t, err)
+
+		dbVersion = 3
+		defer func() { dbVersion = 1 }()
 		_, err = prov.OpenStore("test1")
 		require.NoError(t, err)
+
 		dbVersion = 2
+		delete(prov.stores, "test1")
+
 		_, err = prov.OpenStore("test1")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to open indexedDB: VersionError")

--- a/pkg/store/connection/connection_lookup.go
+++ b/pkg/store/connection/connection_lookup.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	nameSpace           = "didexchange"
+	// Namespace is namespace of connection store name
+	Namespace           = "didexchange"
 	keyPattern          = "%s_%s"
 	connIDKeyPrefix     = "conn"
 	connStateKeyPrefix  = "connstate"
@@ -59,12 +60,12 @@ type Record struct {
 // NewLookup returns new connection lookup instance.
 // Lookup is read only connection store. It provides connection record related query features.
 func NewLookup(p provider) (*Lookup, error) {
-	store, err := p.StorageProvider().OpenStore(nameSpace)
+	store, err := p.StorageProvider().OpenStore(Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open permanent store to create new connection recorder: %w", err)
 	}
 
-	transientStore, err := p.TransientStorageProvider().OpenStore(nameSpace)
+	transientStore, err := p.TransientStorageProvider().OpenStore(Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open transient store to create new connection recorder: %w", err)
 	}

--- a/pkg/store/connection/connection_lookup_test.go
+++ b/pkg/store/connection/connection_lookup_test.go
@@ -294,7 +294,7 @@ func TestConnectionRecorder_QueryConnectionRecord(t *testing.T) {
 	t.Run("test query connection record", func(t *testing.T) {
 		store := &mockstorage.MockStore{Store: make(map[string][]byte)}
 
-		transientStore, err := mem.NewProvider().OpenStore(nameSpace)
+		transientStore, err := mem.NewProvider().OpenStore(Namespace)
 		require.NoError(t, err)
 
 		const (

--- a/pkg/store/did/didconnection.go
+++ b/pkg/store/did/didconnection.go
@@ -18,6 +18,9 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
+// StoreName DID connection store name
+const StoreName = "didconnection"
+
 // ErrNotFound signals that the entry for the given DID and key is not present in the store.
 var ErrNotFound = errors.New("did not found under given key")
 
@@ -38,7 +41,7 @@ type provider interface {
 
 // New returns a new did lookup Store
 func New(ctx provider) (*Store, error) {
-	store, err := ctx.StorageProvider().OpenStore("didconnection")
+	store, err := ctx.StorageProvider().OpenStore(StoreName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- due to complications in dynamically adding objectstores under already
opened indexdb database, jsindexdb provider will have predefined list of
objectstores. `onupgradeevent` during very first creation of database
will create those object stores in advance.
- attempt to create store not defined in object store will not return
any error, instead it will create new database for that object store.
- closes #1309

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
