### PR TITLE
feat: bearer authorization token support

### DIFF
--- a/cmd/aries-js-worker/src/agent-rest-client.js
+++ b/cmd/aries-js-worker/src/agent-rest-client.js
@@ -101,8 +101,9 @@ const pkgs = {
  * @class
  */
 export const Client = class {
-    constructor(url) {
+    constructor(url, token) {
         this.url = url
+        this.token = token
     }
 
     async handle(request) {
@@ -119,9 +120,17 @@ export const Client = class {
 
         console.debug(`[${r.method}] ${url}, request ${JSON.stringify(request.payload)}`)
 
+        let headers = {}
+        if (this.token) {
+            headers = {
+                "Authorization": `Bearer ${this.token}`
+            }
+        }
+
         const resp = await axios({
                 method: r.method,
                 url: url,
+                headers: headers,
                 data: request.payload
             });
 

--- a/cmd/aries-js-worker/src/worker-impl-rest.js
+++ b/cmd/aries-js-worker/src/worker-impl-rest.js
@@ -22,7 +22,7 @@ const ariesHandle = {
                 return newResponse(data.id, null, "'agent-rest-url' is required");
             }
 
-            controller = new RESTAgent.Client(data.payload["agent-rest-url"]);
+            controller = new RESTAgent.Client(data.payload["agent-rest-url"], data.payload["agent-rest-token"]);
             return newResponse(data.id, "aries is started");
         },
         Stop: (data) => {


### PR DESCRIPTION
- enable REST server to support authorization token validation
- add token support to JS client

Closes: #1203, #1324

Signed-off-by: Troy Ronda <troy@troyronda.com>