### PR TITLE
feat: notifiers support in  aries rest client js worker

### DIFF
--- a/cmd/aries-js-worker/README.md
+++ b/cmd/aries-js-worker/README.md
@@ -113,7 +113,8 @@ Then initialize your aries instance:
 ```js
 const aries = await new Aries.Framework({
     assetsPath: "/path/serving/the/assets", // still required for assets other than the wasm
-    "agent-rest-url": "http://controller.api.example.com"
+    "agent-rest-url": "http://controller.api.example.com", // REST controller URL of the agent
+    "agent-rest-wshook": "ws://controller.api.example.com" // Optional REST controller websocket URL from which you can listen to notifications
 })
 ```
 

--- a/cmd/aries-js-worker/index.html
+++ b/cmd/aries-js-worker/index.html
@@ -106,7 +106,7 @@ This is a test page for developers to test WASM integration.
             document.getElementById("mode-label").innerHTML = `Running in ${mode} mode`
 
             if (src == "rest"){
-                document.getElementById("opts").innerHTML = `{"assetsPath": "/dist/assets", "agent-rest-url": "http://localhost:8082"}`
+                document.getElementById("opts").innerHTML = `{"assetsPath": "/dist/assets", "agent-rest-url": "http://localhost:8082", "agent-rest-wshook":"ws://localhost:8881"}`
             } else {
                 document.getElementById("opts").innerHTML = `{"assetsPath": "/dist/assets", "agent-default-label":"dem-js-agent","http-resolver-url":[],"auto-accept":true,"outbound-transport":["ws","http"],"transport-return-route":"all","log-level":"debug"}`
             }

--- a/cmd/aries-js-worker/src/aries.js
+++ b/cmd/aries-js-worker/src/aries.js
@@ -91,7 +91,8 @@ function newMsg(pkg, fn, payload) {
  *      "outbound-transport": ["ws", "http"],
  *      "transport-return-route": "all",
  *      "log-level": "debug",
- *      "agent-rest-url": "http://controller.api.example.com"
+ *      "agent-rest-url": "http://controller.api.example.com",
+ *      "agent-rest-wshook": "ws://controller.api.example.com"
  * }
  *
  * @param opts framework initialization options.


### PR DESCRIPTION
- new constructor opts `agent-rest-wshook` in rest client based aries js
worker. If provided then `aries.startNotifier` can be used to listen to
incoming messages

- closes #1370

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
