### PR TITLE
feat: 'db-path' start option for aries js worker WASM

### DIFF
--- a/cmd/aries-js-worker/README.md
+++ b/cmd/aries-js-worker/README.md
@@ -141,7 +141,8 @@ const aries = await new Framework({
     "auto-accept": true,
     "outbound-transport": ["ws", "http"],
     "transport-return-route": "all",
-    "log-level": "debug"
+    "log-level": "debug",
+    "db-path":"demoagent"
 })
 ```
 

--- a/cmd/aries-js-worker/index.html
+++ b/cmd/aries-js-worker/index.html
@@ -108,7 +108,7 @@ This is a test page for developers to test WASM integration.
             if (src == "rest"){
                 document.getElementById("opts").innerHTML = `{"assetsPath": "/dist/assets", "agent-rest-url": "http://localhost:8082", "agent-rest-wshook":"ws://localhost:8082/ws", "agent-rest-token":"arjswrkr001"}`
             } else {
-                document.getElementById("opts").innerHTML = `{"assetsPath": "/dist/assets", "agent-default-label":"dem-js-agent","http-resolver-url":[],"auto-accept":true,"outbound-transport":["ws","http"],"transport-return-route":"all","log-level":"debug"}`
+                document.getElementById("opts").innerHTML = `{"assetsPath": "/dist/assets", "agent-default-label":"dem-js-agent","http-resolver-url":[],"auto-accept":true,"outbound-transport":["ws","http"],"transport-return-route":"all","log-level":"debug", "db-path":"demoagent"}`
             }
         }
 
@@ -133,7 +133,7 @@ This is a test page for developers to test WASM integration.
                         <tr>
                             <td colspan="2">
                                 <div>Start Options :</div>
-                                <textarea id="opts" rows="5" cols="100">{"assetsPath": "/dist/assets", "agent-default-label":"dem-js-agent","http-resolver-url":[],"auto-accept":true,"outbound-transport":["ws","http"],"transport-return-route":"all","log-level":"debug"}
+                                <textarea id="opts" rows="5" cols="100">{"assetsPath": "/dist/assets", "agent-default-label":"dem-js-agent","http-resolver-url":[],"auto-accept":true,"outbound-transport":["ws","http"],"transport-return-route":"all","log-level":"debug", "db-path":"demoagent"}
                     </textarea>
                             </td>
                         </tr>

--- a/cmd/aries-js-worker/main.go
+++ b/cmd/aries-js-worker/main.go
@@ -28,6 +28,7 @@ import (
 	arieshttp "github.com/hyperledger/aries-framework-go/pkg/didcomm/transport/http"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport/ws"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/defaults"
 	"github.com/hyperledger/aries-framework-go/pkg/vdri/httpbinding"
 )
 
@@ -71,6 +72,7 @@ type ariesStartOpts struct {
 	OutboundTransport    []string `json:"outbound-transport"`
 	TransportReturnRoute string   `json:"transport-return-route"`
 	LogLevel             string   `json:"log-level"`
+	DBPath               string   `json:"db-path"`
 }
 
 // main registers the 'handleMsg' function in the JS context's global scope to receive commands.
@@ -348,6 +350,10 @@ func ariesOpts(opts *ariesStartOpts) ([]aries.Option, error) {
 
 	if opts.TransportReturnRoute != "" {
 		options = append(options, aries.WithTransportReturnRoute(opts.TransportReturnRoute))
+	}
+
+	if opts.DBPath != "" {
+		options = append(options, defaults.WithStorePath(opts.DBPath))
 	}
 
 	for _, transport := range opts.OutboundTransport {

--- a/pkg/framework/aries/default_js_wasm.go
+++ b/pkg/framework/aries/default_js_wasm.go
@@ -14,7 +14,7 @@ import (
 )
 
 func storeProvider() (storage.Provider, error) {
-	storeProv, err := jsindexeddb.NewProvider()
+	storeProv, err := jsindexeddb.NewProvider("")
 	if err != nil {
 		return nil, fmt.Errorf("js indexeddb provider initialization failed : %w", err)
 	}
@@ -23,7 +23,7 @@ func storeProvider() (storage.Provider, error) {
 }
 
 func transientStoreProvider() (storage.Provider, error) {
-	storeProv, err := jsindexeddb.NewProvider()
+	storeProv, err := jsindexeddb.NewProvider("")
 	if err != nil {
 		return nil, fmt.Errorf("js indexeddb  provider initialization failed : %w", err)
 	}

--- a/pkg/framework/aries/defaults/defaults_js_wasm.go
+++ b/pkg/framework/aries/defaults/defaults_js_wasm.go
@@ -14,7 +14,7 @@ import (
 // WithStorePath return new default store provider instantiate with db path
 func WithStorePath(storePath string) aries.Option {
 	return func(opts *aries.Aries) error {
-		store, err := jsindexeddb.NewProvider()
+		store, err := jsindexeddb.NewProvider(storePath)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/jsindexeddb/jsindexeddb.go
+++ b/pkg/storage/jsindexeddb/jsindexeddb.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	dbName    = "aries"
-	newdbName = "aries-%s"
+	dbName    = "aries-%s"
+	defDbName = "aries"
 )
 
 var dbVersion = 1 //nolint:gochecknoglobals
@@ -41,10 +41,15 @@ type Provider struct {
 
 // NewProvider instantiates Provider
 // TODO Add unit test for IndexedDB https://github.com/hyperledger/aries-framework-go/issues/834
-func NewProvider() (*Provider, error) {
+func NewProvider(dbName string) (*Provider, error) {
 	p := &Provider{stores: make(map[string]*js.Value)}
 
-	err := p.openDB(dbName, getStoreNames()...)
+	db := defDbName
+	if dbName != "" {
+		db = fmt.Sprintf(dbName, db)
+	}
+
+	err := p.openDB(db, getStoreNames()...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open IndexDB : %w", err)
 	}
@@ -71,7 +76,7 @@ func (p *Provider) OpenStore(name string) (storage.Store, error) {
 	defer p.Unlock()
 
 	// create new if not found in list of object stores (not the predefined ones)
-	err := p.openDB(fmt.Sprintf(newdbName, name), name)
+	err := p.openDB(fmt.Sprintf(dbName, name), name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/jsindexeddb/jsindexeddb_test.go
+++ b/pkg/storage/jsindexeddb/jsindexeddb_test.go
@@ -18,9 +18,24 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
+const sampleDBName = "testdb"
+
+func TestProvider(t *testing.T) {
+	t.Run("Test provider with empty db name", func(t *testing.T) {
+		prov, err := NewProvider("")
+		require.NoError(t, err)
+		require.NotNil(t, prov)
+	})
+	t.Run("Test provider with db name", func(t *testing.T) {
+		prov, err := NewProvider(sampleDBName)
+		require.NoError(t, err)
+		require.NotNil(t, prov)
+	})
+}
+
 func TestStore(t *testing.T) {
 	t.Run("Test store put and get", func(t *testing.T) {
-		prov, err := NewProvider()
+		prov, err := NewProvider(sampleDBName)
 		require.NoError(t, err)
 		store, err := prov.OpenStore("test")
 		require.NoError(t, err)
@@ -61,7 +76,7 @@ func TestStore(t *testing.T) {
 	})
 
 	t.Run("Test error from open db", func(t *testing.T) {
-		prov, err := NewProvider()
+		prov, err := NewProvider(sampleDBName)
 		require.NoError(t, err)
 
 		dbVersion = 3
@@ -78,7 +93,7 @@ func TestStore(t *testing.T) {
 	})
 
 	t.Run("Test store iterator", func(t *testing.T) {
-		prov, err := NewProvider()
+		prov, err := NewProvider(sampleDBName)
 		require.NoError(t, err)
 		store, err := prov.OpenStore("test-iterator")
 		require.NoError(t, err)
@@ -127,7 +142,7 @@ func verifyItr(t *testing.T, itr storage.StoreIterator, count int, prefix string
 }
 
 func TestIndexDBStoreDelete(t *testing.T) {
-	prov, err := NewProvider()
+	prov, err := NewProvider("sampledb")
 	require.NoError(t, err)
 
 	const commonKey = "did:example:1"


### PR DESCRIPTION
- added dbpath option in aries start opts to avoid collision between
multiple aries instance in same browser(context).
- closes #1388

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
