### PR TITLE
feat: 'db-namespace' start option for aries js worker WASM

### DIFF
--- a/cmd/aries-js-worker/README.md
+++ b/cmd/aries-js-worker/README.md
@@ -142,7 +142,7 @@ const aries = await new Framework({
     "outbound-transport": ["ws", "http"],
     "transport-return-route": "all",
     "log-level": "debug",
-    "db-path":"demoagent"
+    "db-namespace":"demoagent"
 })
 ```
 

--- a/cmd/aries-js-worker/index.html
+++ b/cmd/aries-js-worker/index.html
@@ -108,7 +108,7 @@ This is a test page for developers to test WASM integration.
             if (src == "rest"){
                 document.getElementById("opts").innerHTML = `{"assetsPath": "/dist/assets", "agent-rest-url": "http://localhost:8082", "agent-rest-wshook":"ws://localhost:8082/ws", "agent-rest-token":"arjswrkr001"}`
             } else {
-                document.getElementById("opts").innerHTML = `{"assetsPath": "/dist/assets", "agent-default-label":"dem-js-agent","http-resolver-url":[],"auto-accept":true,"outbound-transport":["ws","http"],"transport-return-route":"all","log-level":"debug", "db-path":"demoagent"}`
+                document.getElementById("opts").innerHTML = `{"assetsPath": "/dist/assets", "agent-default-label":"dem-js-agent","http-resolver-url":[],"auto-accept":true,"outbound-transport":["ws","http"],"transport-return-route":"all","log-level":"debug", "db-namespace":"demoagent"}`
             }
         }
 
@@ -133,7 +133,7 @@ This is a test page for developers to test WASM integration.
                         <tr>
                             <td colspan="2">
                                 <div>Start Options :</div>
-                                <textarea id="opts" rows="5" cols="100">{"assetsPath": "/dist/assets", "agent-default-label":"dem-js-agent","http-resolver-url":[],"auto-accept":true,"outbound-transport":["ws","http"],"transport-return-route":"all","log-level":"debug", "db-path":"demoagent"}
+                                <textarea id="opts" rows="5" cols="100">{"assetsPath": "/dist/assets", "agent-default-label":"dem-js-agent","http-resolver-url":[],"auto-accept":true,"outbound-transport":["ws","http"],"transport-return-route":"all","log-level":"debug", "db-namespace":"demoagent"}
                     </textarea>
                             </td>
                         </tr>

--- a/cmd/aries-js-worker/main.go
+++ b/cmd/aries-js-worker/main.go
@@ -72,7 +72,7 @@ type ariesStartOpts struct {
 	OutboundTransport    []string `json:"outbound-transport"`
 	TransportReturnRoute string   `json:"transport-return-route"`
 	LogLevel             string   `json:"log-level"`
-	DBPath               string   `json:"db-path"`
+	DBNamespace          string   `json:"db-namespace"`
 }
 
 // main registers the 'handleMsg' function in the JS context's global scope to receive commands.
@@ -352,8 +352,8 @@ func ariesOpts(opts *ariesStartOpts) ([]aries.Option, error) {
 		options = append(options, aries.WithTransportReturnRoute(opts.TransportReturnRoute))
 	}
 
-	if opts.DBPath != "" {
-		options = append(options, defaults.WithStorePath(opts.DBPath))
+	if opts.DBNamespace != "" {
+		options = append(options, defaults.WithStorePath(opts.DBNamespace))
 	}
 
 	for _, transport := range opts.OutboundTransport {

--- a/pkg/framework/aries/default_js_wasm.go
+++ b/pkg/framework/aries/default_js_wasm.go
@@ -23,7 +23,7 @@ func storeProvider() (storage.Provider, error) {
 }
 
 func transientStoreProvider() (storage.Provider, error) {
-	storeProv, err := jsindexeddb.NewProvider("")
+	storeProv, err := jsindexeddb.NewProvider("temp")
 	if err != nil {
 		return nil, fmt.Errorf("js indexeddb  provider initialization failed : %w", err)
 	}

--- a/pkg/storage/jsindexeddb/jsindexeddb.go
+++ b/pkg/storage/jsindexeddb/jsindexeddb.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
 	"github.com/hyperledger/aries-framework-go/pkg/store/did"
+	"github.com/hyperledger/aries-framework-go/pkg/store/verifiable"
 	"github.com/hyperledger/aries-framework-go/pkg/vdri/peer"
 )
 
@@ -41,12 +42,12 @@ type Provider struct {
 
 // NewProvider instantiates Provider
 // TODO Add unit test for IndexedDB https://github.com/hyperledger/aries-framework-go/issues/834
-func NewProvider(dbName string) (*Provider, error) {
+func NewProvider(name string) (*Provider, error) {
 	p := &Provider{stores: make(map[string]*js.Value)}
 
 	db := defDbName
-	if dbName != "" {
-		db = fmt.Sprintf(dbName, db)
+	if name != "" {
+		db = fmt.Sprintf(dbName, name)
 	}
 
 	err := p.openDB(db, getStoreNames()...)
@@ -276,5 +277,6 @@ func getStoreNames() []string {
 		peer.StoreNamespace,
 		did.StoreName,
 		localkms.Namespace,
+		verifiable.NameSpace,
 	}
 }

--- a/pkg/store/verifiable/store.go
+++ b/pkg/store/verifiable/store.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	nameSpace = "verifiable"
+	// NameSpace for vc store
+	NameSpace = "verifiable"
 )
 
 // ErrNotFound signals that the entry for the given DID and key is not present in the store.
@@ -32,7 +33,7 @@ type provider interface {
 
 // New returns a new vc store
 func New(ctx provider) (*Store, error) {
-	store, err := ctx.StorageProvider().OpenStore(nameSpace)
+	store, err := ctx.StorageProvider().OpenStore(NameSpace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open vc store: %w", err)
 	}


### PR DESCRIPTION
- added db namespace option in aries start opts to avoid collision between
multiple aries instance in same browser(context).
- closes #1388

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
