### PR TITLE
feat: webnotfiers to send topic information

### DIFF
--- a/cmd/aries-js-worker/src/worker-impl-rest.js
+++ b/cmd/aries-js-worker/src/worker-impl-rest.js
@@ -82,9 +82,8 @@ const wsnotifier = class {
     constructor(url, postMsg) {
         this.socket = new WebSocket(url);
         this.socket.addEventListener('message', function (event) {
-            // TODO REST agents are not currently revealing topic information on incoming messages,
-            //  Once REST supports this feature, topic value will be dynamic. [Issue #1323]
-            postMsg(newResponse(Math.random().toString(36).slice(2),  JSON.parse(event.data), "", "all"));
+            const incoming = JSON.parse(event.data)
+            postMsg(newResponse(incoming.id,  incoming.message, "", incoming.topic));
         });
     }
     stop(){

--- a/pkg/controller/webnotifier/webhook.go
+++ b/pkg/controller/webnotifier/webhook.go
@@ -36,10 +36,15 @@ func (n *HTTPNotifier) Notify(topic string, message []byte) error {
 		return fmt.Errorf(emptyMessageErrMsg)
 	}
 
+	topicMsg, err := prepareTopicMessage(topic, message)
+	if err != nil {
+		return fmt.Errorf(failedToCreateErrMsg, err)
+	}
+
 	var allErrs error
 
 	for _, webhookURL := range n.urls {
-		err := notifyWH(fmt.Sprintf("%s/%s", webhookURL, topic), message)
+		err := notifyWH(webhookURL, topicMsg)
 		allErrs = appendError(allErrs, err)
 	}
 

--- a/pkg/controller/webnotifier/webnotifier.go
+++ b/pkg/controller/webnotifier/webnotifier.go
@@ -7,8 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package webnotifier
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
@@ -19,6 +22,7 @@ const (
 	notificationSendTimeout = 10 * time.Second
 	emptyTopicErrMsg        = "cannot notify with an empty topic"
 	emptyMessageErrMsg      = "cannot notify with an empty message"
+	failedToCreateErrMsg    = "failed to create topic message : %w"
 )
 
 var logger = log.New("aries-framework/webnotifier")
@@ -66,4 +70,18 @@ func appendError(errToAppendTo, err error) error {
 	}
 
 	return fmt.Errorf("%v;%v", errToAppendTo, err)
+}
+
+func prepareTopicMessage(topic string, message []byte) ([]byte, error) {
+	topicMsg := struct {
+		ID      string          `json:"id"`
+		Topic   string          `json:"topic"`
+		Message json.RawMessage `json:"message"`
+	}{
+		ID:      uuid.New().String(),
+		Topic:   topic,
+		Message: message,
+	}
+
+	return json.Marshal(topicMsg)
 }

--- a/test/bdd/pkg/messaging/messaging_controller_steps.go
+++ b/test/bdd/pkg/messaging/messaging_controller_steps.go
@@ -233,17 +233,21 @@ func (d *ControllerSteps) pullMsgFromWebhook(agentID string) (*service.DIDCommMs
 		return nil, fmt.Errorf("unable to find webhook URL for agent [%s]", agentID)
 	}
 
-	msg := service.DIDCommMsgMap{}
+	var incoming struct {
+		ID      string                `json:"id"`
+		Topic   string                `json:"topic"`
+		Message service.DIDCommMsgMap `json:"message"`
+	}
 
 	// try to pull recently pushed topics from webhook
 	for i := 0; i < pullTopicsAttemptsBeforeFail; i++ {
-		err := sendHTTP(http.MethodGet, webhookURL+checkForTopics, nil, &msg)
+		err := sendHTTP(http.MethodGet, webhookURL+checkForTopics, nil, &incoming)
 		if err != nil {
 			return nil, fmt.Errorf("failed pull topics from webhook, cause : %w", err)
 		}
 
-		if len(msg) > 0 {
-			return &msg, nil
+		if len(incoming.Message) > 0 {
+			return &incoming.Message, nil
 		}
 
 		time.Sleep(pullTopicsWaitInMilliSec * time.Millisecond)


### PR DESCRIPTION
- in previous version, web notifier topics are used for resolving/building
URLs which was forcing subscribers to support path matching topic names
(challenge: topic name are private and dynamic based on usecases)
- changes: web notifiers will send message containing uniquer ID, Topic
Name and Raw JSON message to given webnotfier endpoint.
- This fixed issue in JS worker where it wasn't able to find topic of
incoming messages.
- closes #1323

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>