### PR TITLE
feat:  bddtests to use websocket notifiers

### DIFF
--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -145,6 +145,8 @@ func FeatureContext(s *godog.Suite) {
 		panic(fmt.Sprintf("Error returned from NewBDDContext: %s", err))
 	}
 
+	defer bddContext.Destroy()
+
 	// set dynamic args
 	bddContext.Args[SideTreeURL] = "http://localhost:48326/document"
 	bddContext.Args[DIDDocPath] = "fixtures/sidetree-mock/config/didDocument.json"

--- a/test/bdd/features/aries_e2e_route_option.feature
+++ b/test/bdd/features/aries_e2e_route_option.feature
@@ -30,8 +30,8 @@ Feature: DIDComm between Edge Agent(without Inbound) and Router/Mediator
       And   "Bob" retrieves connection record and validates that connection state is "completed"
 
   Scenario: Decentralized Identifier(DID) between Edge Agent and Router/Mediator using Transport Return Route option [REST Binding]
-    Given "Carl" agent is running with controller "http://localhost:10081" and webhook "http://localhost:10082" and "all" as the transport return route option
-    And   "Carl-Router" agent is running on "http://localhost:10091,ws://localhost:10092" with controller "http://localhost:10093" and webhook "http://localhost:10094"
+    Given "Carl" agent is running with controller "http://localhost:10081" and "all" as the transport return route option
+    And   "Carl-Router" agent is running on "http://localhost:10091,ws://localhost:10092" with controller "http://localhost:10093"
 
     When   "Carl-Router" creates invitation through controller with label "carl-router-agent"
       And   "Carl" receives invitation from "Carl-Router" through controller
@@ -39,8 +39,8 @@ Feature: DIDComm between Edge Agent(without Inbound) and Router/Mediator
     Then   "Carl" approves exchange invitation through controller
     And   "Carl-Router" approves exchange request through controller
 
-    Then   "Carl-Router" waits for post state event "completed" to webhook
-    And   "Carl" waits for post state event "completed" to webhook
+    Then   "Carl-Router" waits for post state event "completed" to web notifier
+    And   "Carl" waits for post state event "completed" to web notifier
 
     Then   "Carl-Router" retrieves connection record through controller and validates that connection state is "completed"
     And   "Carl" retrieves connection record through controller and validates that connection state is "completed"

--- a/test/bdd/features/aries_router_e2e_controller.feature
+++ b/test/bdd/features/aries_router_e2e_controller.feature
@@ -11,8 +11,8 @@ Feature: DIDComm Transport between two Agents through DIDComm Routers [REST Bind
   # https://wiki.hyperledger.org/display/ARIES/DIDComm+MediatorRouter
   Scenario: Decentralized Identifier(DID) Exchange between two Edge Agents(without Inbound) through Routers
     # DID Exchange between Carl and his Router
-    Given "Carl" agent is running with controller "http://localhost:10081" and webhook "http://localhost:10082" and "all" as the transport return route option
-    And   "Carl-Router" agent is running on "http://localhost:10091,ws://localhost:10092" with controller "http://localhost:10093" and webhook "http://localhost:10094"
+    Given "Carl" agent is running with controller "http://localhost:10081" and "all" as the transport return route option
+    And   "Carl-Router" agent is running on "http://localhost:10091,ws://localhost:10092" with controller "http://localhost:10093"
 
     When   "Carl-Router" creates invitation through controller with label "carl-router-agent"
     And   "Carl" receives invitation from "Carl-Router" through controller
@@ -20,16 +20,16 @@ Feature: DIDComm Transport between two Agents through DIDComm Routers [REST Bind
     Then   "Carl" approves exchange invitation through controller
     And   "Carl-Router" approves exchange request through controller
 
-    Then   "Carl-Router" waits for post state event "completed" to webhook
-    And   "Carl" waits for post state event "completed" to webhook
+    Then   "Carl-Router" waits for post state event "completed" to web notifier
+    And   "Carl" waits for post state event "completed" to web notifier
 
     Then   "Carl-Router" retrieves connection record through controller and validates that connection state is "completed"
     And   "Carl" retrieves connection record through controller and validates that connection state is "completed"
     And   "Carl" saves the connectionID to variable "carl-router-connID"
 
      # DID Exchange between Dave and his Router
-    Given "Dave" agent is running with controller "http://localhost:10061" and webhook "http://localhost:10062" and "all" as the transport return route option
-    And   "Dave-Router" agent is running on "http://localhost:10071,ws://localhost:10092" with controller "http://localhost:10073" and webhook "http://localhost:10074"
+    Given "Dave" agent is running with controller "http://localhost:10061" and "all" as the transport return route option
+    And   "Dave-Router" agent is running on "http://localhost:10071,ws://localhost:10092" with controller "http://localhost:10073"
 
     When   "Dave-Router" creates invitation through controller with label "Dave-router-agent"
     And   "Dave" receives invitation from "Dave-Router" through controller
@@ -37,8 +37,8 @@ Feature: DIDComm Transport between two Agents through DIDComm Routers [REST Bind
     Then   "Dave" approves exchange invitation through controller
     And   "Dave-Router" approves exchange request through controller
 
-    Then   "Dave-Router" waits for post state event "completed" to webhook
-    And   "Dave" waits for post state event "completed" to webhook
+    Then   "Dave-Router" waits for post state event "completed" to web notifier
+    And   "Dave" waits for post state event "completed" to web notifier
 
     Then   "Dave-Router" retrieves connection record through controller and validates that connection state is "completed"
     And   "Dave" retrieves connection record through controller and validates that connection state is "completed"
@@ -61,8 +61,8 @@ Feature: DIDComm Transport between two Agents through DIDComm Routers [REST Bind
     Then   "Dave" approves exchange invitation through controller
     And   "Carl" approves exchange request through controller
 
-    Then   "Carl" waits for post state event "completed" to webhook
-    And   "Dave" waits for post state event "completed" to webhook
+    Then   "Carl" waits for post state event "completed" to web notifier
+    And   "Dave" waits for post state event "completed" to web notifier
 
     Then   "Carl" retrieves connection record through controller and validates that connection state is "completed"
     And   "Dave" retrieves connection record through controller and validates that connection state is "completed"

--- a/test/bdd/features/didexchange_e2e_controller.feature
+++ b/test/bdd/features/didexchange_e2e_controller.feature
@@ -10,15 +10,15 @@
 Feature: Decentralized Identifier(DID) exchange between the agents using controller API
 
   Scenario: did exchange e2e flow using controller api
-    Given "Alice" agent is running on "localhost" port "8081" with controller "http://localhost:8082" and webhook "http://localhost:8083"
-      And   "Bob" agent is running on "localhost" port "9081" with controller "http://localhost:9082" and webhook "http://localhost:9083"
+    Given "Alice" agent is running on "localhost" port "8081" with controller "http://localhost:8082"
+      And   "Bob" agent is running on "localhost" port "9081" with controller "http://localhost:9082"
 
     When   "Alice" creates invitation through controller with label "alice-agent"
       And   "Bob" receives invitation from "Alice" through controller
       And   "Bob" approves exchange invitation through controller
       And   "Alice" approves exchange request through controller
-      And   "Alice" waits for post state event "completed" to webhook
-      And   "Bob" waits for post state event "completed" to webhook
+      And   "Alice" waits for post state event "completed" to web notifier
+      And   "Bob" waits for post state event "completed" to web notifier
 
     Then   "Alice" retrieves connection record through controller and validates that connection state is "completed"
       And   "Bob" retrieves connection record through controller and validates that connection state is "completed"

--- a/test/bdd/features/didexchange_public_did.feature
+++ b/test/bdd/features/didexchange_public_did.feature
@@ -101,8 +101,8 @@ Feature: Decentralized Identifier(DID) exchange between the agents using public 
 
   @didexchange_controller_public_dids_invitation
   Scenario: did exchange e2e flow using public DID in invitation
-    Given "Filip" agent is running on "localhost" port "8081" with controller "http://localhost:8082" and webhook "http://localhost:8083" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
-      And  "Derek" agent is running on "localhost" port "9081" with controller "http://localhost:9082" and webhook "http://localhost:9083" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+    Given "Filip" agent is running on "localhost" port "8081" with controller "http://localhost:8082" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+      And  "Derek" agent is running on "localhost" port "9081" with controller "http://localhost:9082" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
 
     Then "Filip" creates "sidetree" public DID through controller
       And  "Derek" creates "sidetree" public DID through controller
@@ -112,16 +112,16 @@ Feature: Decentralized Identifier(DID) exchange between the agents using public 
 
     Then "Filip" creates "sidetree" public DID through controller
       And  "Filip" approves exchange request with public DID through controller
-      And  "Filip" waits for post state event "completed" to webhook
-      And  "Derek" waits for post state event "completed" to webhook
+      And  "Filip" waits for post state event "completed" to web notifier
+      And  "Derek" waits for post state event "completed" to web notifier
 
     Then  "Filip" retrieves connection record through controller and validates that connection state is "completed"
     And  "Derek" retrieves connection record through controller and validates that connection state is "completed"
 
   @didexchange_controller_mixed_public_and_peer_dids
   Scenario: did exchange e2e flow using public DID in invitation
-    Given "Filip" agent is running on "localhost" port "8081" with controller "http://localhost:8082" and webhook "http://localhost:8083" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
-      And  "Derek" agent is running on "localhost" port "9081" with controller "http://localhost:9082" and webhook "http://localhost:9083" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+    Given "Filip" agent is running on "localhost" port "8081" with controller "http://localhost:8082" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+      And  "Derek" agent is running on "localhost" port "9081" with controller "http://localhost:9082" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
 
     Then "Filip" creates "sidetree" public DID through controller
       And  "Derek" creates "sidetree" public DID through controller
@@ -129,38 +129,38 @@ Feature: Decentralized Identifier(DID) exchange between the agents using public 
       And  "Derek" receives invitation from "Filip" through controller
       And  "Derek" approves exchange invitation with public DID through controller
       And  "Filip" approves exchange request through controller
-      And  "Filip" waits for post state event "completed" to webhook
-      And  "Derek" waits for post state event "completed" to webhook
+      And  "Filip" waits for post state event "completed" to web notifier
+      And  "Derek" waits for post state event "completed" to web notifier
 
     Then  "Filip" retrieves connection record through controller and validates that connection state is "completed"
       And  "Derek" retrieves connection record through controller and validates that connection state is "completed"
 
   @didexchange_controller_implicit_invitation_peer_did
   Scenario: did exchange e2e flow using public DID in invitation
-    Given "Filip" agent is running on "localhost" port "8081" with controller "http://localhost:8082" and webhook "http://localhost:8083" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
-      And  "Derek" agent is running on "localhost" port "9081" with controller "http://localhost:9082" and webhook "http://localhost:9083" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+    Given "Filip" agent is running on "localhost" port "8081" with controller "http://localhost:8082" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+      And  "Derek" agent is running on "localhost" port "9081" with controller "http://localhost:9082" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
 
     Then "Filip" creates "sidetree" public DID through controller
       And  "Derek" creates "sidetree" public DID through controller
       And  "Derek" initiates connection through controller with "Filip" using peer DID
       And  "Filip" approves exchange request with public DID through controller
-      And  "Filip" waits for post state event "completed" to webhook
-      And  "Derek" waits for post state event "completed" to webhook
+      And  "Filip" waits for post state event "completed" to web notifier
+      And  "Derek" waits for post state event "completed" to web notifier
 
     Then  "Filip" retrieves connection record through controller and validates that connection state is "completed"
       And  "Derek" retrieves connection record through controller and validates that connection state is "completed"
 
   @didexchange_controller_implicit_invitation_public_did
   Scenario: did exchange e2e flow using public DID in invitation
-    Given "Filip" agent is running on "localhost" port "8081" with controller "http://localhost:8082" and webhook "http://localhost:8083" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
-    And  "Derek" agent is running on "localhost" port "9081" with controller "http://localhost:9082" and webhook "http://localhost:9083" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+    Given "Filip" agent is running on "localhost" port "8081" with controller "http://localhost:8082" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+    And  "Derek" agent is running on "localhost" port "9081" with controller "http://localhost:9082" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
 
     Then "Filip" creates "sidetree" public DID through controller
       And  "Derek" creates "sidetree" public DID through controller
       And  "Derek" initiates connection through controller with "Filip" using public DID
       And  "Filip" approves exchange request with public DID through controller
-      And  "Filip" waits for post state event "completed" to webhook
-      And  "Derek" waits for post state event "completed" to webhook
+      And  "Filip" waits for post state event "completed" to web notifier
+      And  "Derek" waits for post state event "completed" to web notifier
 
     Then  "Filip" retrieves connection record through controller and validates that connection state is "completed"
       And  "Derek" retrieves connection record through controller and validates that connection state is "completed"

--- a/test/bdd/features/messaging_e2e_controller.feature
+++ b/test/bdd/features/messaging_e2e_controller.feature
@@ -10,23 +10,23 @@ Feature: Messaging between the agents using REST/controller binding
 
   # Reference : https://github.com/hyperledger/aries-rfcs/blob/master/features/0351-purpose-decorator/README.md
   Scenario: sending message from one agent to another using message service
-    Given "Baha" agent is running on "localhost" port "8081" with controller "http://localhost:8082" and webhook "http://localhost:8083"
+    Given "Baha" agent is running on "localhost" port "8081" with webhook "http://localhost:8083" and controller "http://localhost:8082"
     And   "Baha" registers a message service through controller with name "generic-invite" for type "https://didcomm.org/generic/1.0/message" and purpose "meeting,appointment,event"
 
-    Given "Tal" agent is running on "localhost" port "9081" with controller "http://localhost:9082" and webhook "http://localhost:9083"
+    Given "Tal" agent is running on "localhost" port "9081" with webhook "http://localhost:9083" and controller "http://localhost:9082"
     And   "Baha" has established connection with "Tal" through did exchange using controller
 
     When  "Tal" sends meeting invite message "Hey, meet me today at 4PM" through controller with type "https://didcomm.org/generic/1.0/message" and purpose "meeting" to "Baha"
-    Then   "Baha" message service receives meeting invite message to webhook "Hey, meet me today at 4PM" with type "https://didcomm.org/generic/1.0/message" from "Tal"
+    Then   "Baha" receives invite message "Hey, meet me today at 4PM" with type "https://didcomm.org/generic/1.0/message" to webhook for topic "generic-invite" from "Tal"
 
   @basic_message_e2e_controller
     # Reference : https://github.com/hyperledger/aries-rfcs/tree/master/features/0095-basic-message
   Scenario: sending message from one agent to another using message service controller through "Basic Message Protocol 1.0"
-    Given "Baha" agent is running on "localhost" port "8081" with controller "http://localhost:8082" and webhook "http://localhost:8083"
+    Given "Baha" agent is running on "localhost" port "8081" with controller "http://localhost:8082"
     And   "Baha" registers a message service through controller with name "basic-message" for basic message type
 
-    Given "Tal" agent is running on "localhost" port "9081" with controller "http://localhost:9082" and webhook "http://localhost:9083"
+    Given "Tal" agent is running on "localhost" port "9081" with controller "http://localhost:9082"
     And   "Baha" has established connection with "Tal" through did exchange using controller
 
     When  "Tal" sends basic message "Your hovercraft is full of eels." through controller to "Baha"
-    Then   "Baha" receives basic message to webhook "Your hovercraft is full of eels." from "Tal"
+    Then   "Baha" receives basic message "Your hovercraft is full of eels." for topic "basic-message" from "Tal"

--- a/test/bdd/webhook/main.go
+++ b/test/bdd/webhook/main.go
@@ -23,7 +23,7 @@ var logger = log.New("aries-framework/webhook")
 const (
 	addressPattern  = ":%s"
 	checkTopicsPath = "/checktopics"
-	topicsSize      = 50
+	topicsSize      = 5000
 	topicTimeout    = 100 * time.Millisecond
 )
 


### PR DESCRIPTION
- migrated all controller tests to websocket notification to pull
events. This change is going to  improve test performance.
- one of the scenario in  generic messaging test will still use webhook URL to
keep webhook URL notification mechanism covered.
- closes #1402

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
