### PR TITLE
refactor: Removes redundant return value (HandleOutbound)

### DIFF
--- a/pkg/client/introduce/client.go
+++ b/pkg/client/introduce/client.go
@@ -58,12 +58,12 @@ func (c *Client) SendProposal(recipient1, recipient2 *introduce.Recipient) error
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 
-	_, err := c.service.HandleOutbound(proposal1, recipient1.MyDID, recipient1.TheirDID)
+	err := c.service.HandleOutbound(proposal1, recipient1.MyDID, recipient1.TheirDID)
 	if err != nil {
 		return fmt.Errorf("handle outbound: %w", err)
 	}
 
-	_, err = c.service.HandleOutbound(proposal2, recipient2.MyDID, recipient2.TheirDID)
+	err = c.service.HandleOutbound(proposal2, recipient2.MyDID, recipient2.TheirDID)
 
 	return err
 }
@@ -74,7 +74,7 @@ func (c *Client) SendProposalWithInvitation(inv *didexchange.Invitation, recipie
 
 	introduce.WrapWithMetadataPublicInvitation(proposal, inv.Invitation)
 
-	_, err := c.service.HandleOutbound(proposal, recipient.MyDID, recipient.TheirDID)
+	err := c.service.HandleOutbound(proposal, recipient.MyDID, recipient.TheirDID)
 
 	return err
 }
@@ -82,7 +82,7 @@ func (c *Client) SendProposalWithInvitation(inv *didexchange.Invitation, recipie
 // SendRequest sends a request.
 // Sending a request means that the introducee is willing to share its invitation.
 func (c *Client) SendRequest(to *introduce.PleaseIntroduceTo, myDID, theirDID string) error {
-	_, err := c.service.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
+	err := c.service.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
 		Type:              introduce.RequestMsgType,
 		PleaseIntroduceTo: to,
 	}), myDID, theirDID)

--- a/pkg/client/introduce/client_test.go
+++ b/pkg/client/introduce/client_test.go
@@ -88,7 +88,7 @@ func TestClient_SendProposal(t *testing.T) {
 		svc := introduceMocks.NewMockProtocolService(ctrl)
 		svc.EXPECT().
 			HandleOutbound(gomock.Any(), "firstMyDID", "firstTheirDID").
-			Return("", errors.New(errMsg))
+			Return(errors.New(errMsg))
 
 		provider.EXPECT().Service(gomock.Any()).Return(svc, nil)
 		client, err := New(provider)

--- a/pkg/didcomm/common/service/service.go
+++ b/pkg/didcomm/common/service/service.go
@@ -15,7 +15,7 @@ type InboundHandler interface {
 // OutboundHandler is handler for outbound messages
 type OutboundHandler interface {
 	// HandleOutbound handles outbound messages.
-	HandleOutbound(msg DIDCommMsg, myDID, theirDID string) (string, error)
+	HandleOutbound(msg DIDCommMsg, myDID, theirDID string) error
 }
 
 // Handler provides protocol service handle api.

--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -211,8 +211,8 @@ func (s *Service) Accept(msgType string) bool {
 }
 
 // HandleOutbound handles outbound didexchange messages.
-func (s *Service) HandleOutbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
-	return "", errors.New("not implemented")
+func (s *Service) HandleOutbound(msg service.DIDCommMsg, myDID, theirDID string) error {
+	return errors.New("not implemented")
 }
 
 func (s *Service) nextState(msgType, thID string) (state, error) {

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -938,7 +938,7 @@ func TestHandleOutbound(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = svc.HandleOutbound(service.DIDCommMsgMap{}, "", "")
+	err = svc.HandleOutbound(service.DIDCommMsgMap{}, "", "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not implemented")
 }

--- a/pkg/didcomm/protocol/introduce/service.go
+++ b/pkg/didcomm/protocol/introduce/service.go
@@ -293,17 +293,17 @@ func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) 
 }
 
 // HandleOutbound handles outbound message (introduce protocol)
-func (s *Service) HandleOutbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (s *Service) HandleOutbound(msg service.DIDCommMsg, myDID, theirDID string) error {
 	md, err := s.doHandle(msg, true)
 	if err != nil {
-		return "", fmt.Errorf("doHandle: %w", err)
+		return fmt.Errorf("doHandle: %w", err)
 	}
 
 	// sets outbound payload
 	md.MyDID = myDID
 	md.TheirDID = theirDID
 
-	return md.PIID, s.handle(md)
+	return s.handle(md)
 }
 
 // sendMsgEvents triggers the message events.

--- a/pkg/didcomm/protocol/introduce/service_test.go
+++ b/pkg/didcomm/protocol/introduce/service_test.go
@@ -249,7 +249,7 @@ func TestService_SkipProposal(t *testing.T) {
 		Type: didexchange.InvitationMsgType,
 	})
 
-	_, err := alice.HandleOutbound(proposal, Alice, Bob)
+	err := alice.HandleOutbound(proposal, Alice, Bob)
 	require.NoError(t, err)
 }
 
@@ -308,10 +308,10 @@ func TestService_Proposal(t *testing.T) {
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 
-	_, err := alice.HandleOutbound(proposal1, Alice, Bob)
+	err := alice.HandleOutbound(proposal1, Alice, Bob)
 	require.NoError(t, err)
 
-	_, err = alice.HandleOutbound(proposal2, Alice, Carol)
+	err = alice.HandleOutbound(proposal2, Alice, Carol)
 	require.NoError(t, err)
 }
 
@@ -374,10 +374,10 @@ func TestService_ProposalContinue(t *testing.T) {
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 
-	_, err := alice.HandleOutbound(proposal1, Alice, Bob)
+	err := alice.HandleOutbound(proposal1, Alice, Bob)
 	require.NoError(t, err)
 
-	_, err = alice.HandleOutbound(proposal2, Alice, Carol)
+	err = alice.HandleOutbound(proposal2, Alice, Carol)
 	require.NoError(t, err)
 }
 
@@ -436,10 +436,10 @@ func TestService_ProposalSecond(t *testing.T) {
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 
-	_, err := alice.HandleOutbound(proposal1, Alice, Bob)
+	err := alice.HandleOutbound(proposal1, Alice, Bob)
 	require.NoError(t, err)
 
-	_, err = alice.HandleOutbound(proposal2, Alice, Carol)
+	err = alice.HandleOutbound(proposal2, Alice, Carol)
 	require.NoError(t, err)
 }
 
@@ -502,10 +502,10 @@ func TestService_ProposalSecondContinue(t *testing.T) {
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 
-	_, err := alice.HandleOutbound(proposal1, Alice, Bob)
+	err := alice.HandleOutbound(proposal1, Alice, Bob)
 	require.NoError(t, err)
 
-	_, err = alice.HandleOutbound(proposal2, Alice, Carol)
+	err = alice.HandleOutbound(proposal2, Alice, Carol)
 	require.NoError(t, err)
 }
 
@@ -559,10 +559,10 @@ func TestService_ProposalNoInvitation(t *testing.T) {
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 
-	_, err := alice.HandleOutbound(proposal1, Alice, Bob)
+	err := alice.HandleOutbound(proposal1, Alice, Bob)
 	require.NoError(t, err)
 
-	_, err = alice.HandleOutbound(proposal2, Alice, Carol)
+	err = alice.HandleOutbound(proposal2, Alice, Carol)
 	require.NoError(t, err)
 }
 
@@ -603,7 +603,7 @@ func TestService_SkipProposalStopIntroducee(t *testing.T) {
 		Type: didexchange.InvitationMsgType,
 	})
 
-	_, err := alice.HandleOutbound(proposal, Alice, Bob)
+	err := alice.HandleOutbound(proposal, Alice, Bob)
 	require.NoError(t, err)
 }
 
@@ -657,10 +657,10 @@ func TestService_ProposalStopIntroduceeFirst(t *testing.T) {
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 
-	_, err := alice.HandleOutbound(proposal1, Alice, Bob)
+	err := alice.HandleOutbound(proposal1, Alice, Bob)
 	require.NoError(t, err)
 
-	_, err = alice.HandleOutbound(proposal2, Alice, Carol)
+	err = alice.HandleOutbound(proposal2, Alice, Carol)
 	require.NoError(t, err)
 }
 
@@ -714,10 +714,10 @@ func TestService_ProposalStopIntroduceeSecond(t *testing.T) {
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 
-	_, err := alice.HandleOutbound(proposal1, Alice, Bob)
+	err := alice.HandleOutbound(proposal1, Alice, Bob)
 	require.NoError(t, err)
 
-	_, err = alice.HandleOutbound(proposal2, Alice, Carol)
+	err = alice.HandleOutbound(proposal2, Alice, Carol)
 	require.NoError(t, err)
 }
 
@@ -785,7 +785,7 @@ func TestService_ProposalWithRequest(t *testing.T) {
 		"done", "done",
 	), checkDIDCommAction(t, Carol, action{Expected: introduce.ProposalMsgType}))
 
-	_, err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
+	err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
 		Type: introduce.RequestMsgType,
 		PleaseIntroduceTo: &introduce.PleaseIntroduceTo{To: introduce.To{
 			Name: Carol,
@@ -865,7 +865,7 @@ func TestService_ProposalWithRequestContinue(t *testing.T) {
 		"done", "done",
 	), checkDIDCommAction(t, Carol, action{Expected: introduce.ProposalMsgType}))
 
-	_, err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
+	err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
 		Type: introduce.RequestMsgType,
 		PleaseIntroduceTo: &introduce.PleaseIntroduceTo{To: introduce.To{
 			Name: Carol,
@@ -938,7 +938,7 @@ func TestService_ProposalWithRequestSecond(t *testing.T) {
 		},
 	))
 
-	_, err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
+	err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
 		Type: introduce.RequestMsgType,
 		PleaseIntroduceTo: &introduce.PleaseIntroduceTo{To: introduce.To{
 			Name: Carol,
@@ -1006,7 +1006,7 @@ func TestService_ProposalWithRequestStopIntroduceeFirst(t *testing.T) {
 		"done", "done",
 	), checkDIDCommAction(t, Carol, action{Expected: introduce.ProposalMsgType}))
 
-	_, err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
+	err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
 		Type: introduce.RequestMsgType,
 		PleaseIntroduceTo: &introduce.PleaseIntroduceTo{To: introduce.To{
 			Name: Carol,
@@ -1074,7 +1074,7 @@ func TestService_ProposalWithRequestStopIntroduceeSecond(t *testing.T) {
 		runtime.Goexit()
 	})
 
-	_, err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
+	err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
 		Type: introduce.RequestMsgType,
 		PleaseIntroduceTo: &introduce.PleaseIntroduceTo{To: introduce.To{
 			Name: Carol,
@@ -1113,7 +1113,7 @@ func TestService_ProposalWithRequestIntroducerStop(t *testing.T) {
 		"done", "done",
 	), nil)
 
-	_, err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
+	err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
 		Type: introduce.RequestMsgType,
 		PleaseIntroduceTo: &introduce.PleaseIntroduceTo{To: introduce.To{
 			Name: Carol,
@@ -1163,7 +1163,7 @@ func TestService_SkipProposalWithRequest(t *testing.T) {
 		"done", "done",
 	), checkDIDCommAction(t, Bob, action{Expected: introduce.ProposalMsgType}))
 
-	_, err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
+	err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
 		Type: introduce.RequestMsgType,
 		PleaseIntroduceTo: &introduce.PleaseIntroduceTo{To: introduce.To{
 			Name: Carol,
@@ -1215,7 +1215,7 @@ func TestService_SkipProposalWithRequestStopIntroducee(t *testing.T) {
 		runtime.Goexit()
 	})
 
-	_, err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
+	err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
 		Type: introduce.RequestMsgType,
 		PleaseIntroduceTo: &introduce.PleaseIntroduceTo{To: introduce.To{
 			Name: Carol,
@@ -1253,7 +1253,7 @@ func TestService_ProposalWithRequestNoRecipients(t *testing.T) {
 		"done", "done",
 	), nil)
 
-	_, err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
+	err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
 		Type: introduce.RequestMsgType,
 		PleaseIntroduceTo: &introduce.PleaseIntroduceTo{To: introduce.To{
 			Name: Carol,
@@ -1351,7 +1351,7 @@ func TestService_HandleOutbound(t *testing.T) {
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
 		const errMsg = "doHandle: invalid state transition: noop -> arranging"
-		_, err = svc.HandleOutbound(msg, "", "")
+		err = svc.HandleOutbound(msg, "", "")
 		require.EqualError(t, err, errMsg)
 	})
 }

--- a/pkg/didcomm/protocol/route/service.go
+++ b/pkg/didcomm/protocol/route/service.go
@@ -175,8 +175,8 @@ func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) 
 }
 
 // HandleOutbound handles outbound route coordination messages.
-func (s *Service) HandleOutbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
-	return "", errors.New("not implemented")
+func (s *Service) HandleOutbound(msg service.DIDCommMsg, myDID, theirDID string) error {
+	return errors.New("not implemented")
 }
 
 // Accept checks whether the service can handle the message type.

--- a/pkg/didcomm/protocol/route/service_test.go
+++ b/pkg/didcomm/protocol/route/service_test.go
@@ -94,7 +94,7 @@ func TestServiceHandleOutbound(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = svc.HandleOutbound(nil, "", "")
+		err = svc.HandleOutbound(nil, "", "")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not implemented")
 	})

--- a/pkg/internal/gomocks/client/introduce/mocks.go
+++ b/pkg/internal/gomocks/client/introduce/mocks.go
@@ -117,12 +117,11 @@ func (mr *MockProtocolServiceMockRecorder) HandleInbound(arg0, arg1, arg2 interf
 }
 
 // HandleOutbound mocks base method
-func (m *MockProtocolService) HandleOutbound(arg0 service.DIDCommMsg, arg1, arg2 string) (string, error) {
+func (m *MockProtocolService) HandleOutbound(arg0 service.DIDCommMsg, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleOutbound", arg0, arg1, arg2)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // HandleOutbound indicates an expected call of HandleOutbound

--- a/pkg/internal/gomocks/didcomm/common/service/mocks.go
+++ b/pkg/internal/gomocks/didcomm/common/service/mocks.go
@@ -49,12 +49,11 @@ func (mr *MockDIDCommMockRecorder) HandleInbound(arg0, arg1, arg2 interface{}) *
 }
 
 // HandleOutbound mocks base method
-func (m *MockDIDComm) HandleOutbound(arg0 service.DIDCommMsg, arg1, arg2 string) (string, error) {
+func (m *MockDIDComm) HandleOutbound(arg0 service.DIDCommMsg, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleOutbound", arg0, arg1, arg2)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // HandleOutbound indicates an expected call of HandleOutbound

--- a/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
@@ -27,7 +27,7 @@ import (
 type MockDIDExchangeSvc struct {
 	ProtocolName             string
 	HandleFunc               func(service.DIDCommMsg) (string, error)
-	HandleOutboundFunc       func(msg service.DIDCommMsg, myDID, theirDID string) (string, error)
+	HandleOutboundFunc       func(msg service.DIDCommMsg, myDID, theirDID string) error
 	AcceptFunc               func(string) bool
 	RegisterActionEventErr   error
 	UnregisterActionEventErr error
@@ -47,12 +47,12 @@ func (m *MockDIDExchangeSvc) HandleInbound(msg service.DIDCommMsg, myDID, theirD
 }
 
 // HandleOutbound msg
-func (m *MockDIDExchangeSvc) HandleOutbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (m *MockDIDExchangeSvc) HandleOutbound(msg service.DIDCommMsg, myDID, theirDID string) error {
 	if m.HandleOutboundFunc != nil {
 		return m.HandleOutboundFunc(msg, myDID, theirDID)
 	}
 
-	return "", nil
+	return nil
 }
 
 // Accept msg checks the msg type

--- a/pkg/internal/mock/didcomm/protocol/route/mock_route.go
+++ b/pkg/internal/mock/didcomm/protocol/route/mock_route.go
@@ -17,7 +17,7 @@ import (
 type MockRouteSvc struct {
 	ProtocolName       string
 	HandleFunc         func(service.DIDCommMsg) (string, error)
-	HandleOutboundFunc func(msg service.DIDCommMsg, myDID, theirDID string) (string, error)
+	HandleOutboundFunc func(msg service.DIDCommMsg, myDID, theirDID string) error
 	AcceptFunc         func(string) bool
 	RegisterFunc       func(connectionID string) error
 	RouterEndpoint     string
@@ -39,12 +39,12 @@ func (m *MockRouteSvc) HandleInbound(msg service.DIDCommMsg, myDID, theirDID str
 }
 
 // HandleOutbound msg
-func (m *MockRouteSvc) HandleOutbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (m *MockRouteSvc) HandleOutbound(msg service.DIDCommMsg, myDID, theirDID string) error {
 	if m.HandleOutboundFunc != nil {
 		return m.HandleOutboundFunc(msg, myDID, theirDID)
 	}
 
-	return "", nil
+	return nil
 }
 
 // Accept msg checks the msg type


### PR DESCRIPTION
`HandleOutbound` function returns useless value. This PR fixes it.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>