### PR TITLE
refactor: Save VC - Skip signing validation

### DIFF
--- a/pkg/controller/command/verifiable/command.go
+++ b/pkg/controller/command/verifiable/command.go
@@ -147,7 +147,7 @@ func (o *Command) SaveCredential(rw io.Writer, req io.Reader) command.Error {
 		return command.NewValidationError(SaveCredentialErrorCode, fmt.Errorf(errEmptyCredentialName))
 	}
 
-	vc, _, err := verifiable.NewCredential([]byte(request.VerifiableCredential))
+	vc, err := verifiable.NewUnverifiedCredential([]byte(request.VerifiableCredential))
 	if err != nil {
 		logutil.LogError(logger, commandName, saveCredentialCommandMethod, "parse vc : "+err.Error())
 

--- a/pkg/controller/rest/verifiable/operation_test.go
+++ b/pkg/controller/rest/verifiable/operation_test.go
@@ -161,7 +161,7 @@ func TestSaveVC(t *testing.T) {
 		require.NotEmpty(t, buf)
 
 		require.Equal(t, http.StatusBadRequest, code)
-		verifyError(t, verifiable.SaveCredentialErrorCode, "parse vc : decode new credential", buf.Bytes())
+		verifyError(t, verifiable.SaveCredentialErrorCode, "parse vc : unmarshal new credential", buf.Bytes())
 	})
 }
 


### PR DESCRIPTION
While saving, the system should just do basic valition without checking for signing to avoid passing signing details. The signing will be validated during presentation generation.

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>
