### PR TITLE
feat: Issue Credential - triggers an event after receiving IssueCredential

### DIFF
--- a/pkg/didcomm/protocol/issuecredential/service.go
+++ b/pkg/didcomm/protocol/issuecredential/service.go
@@ -401,6 +401,7 @@ func (s *Service) saveTransitionalPayload(id string, data transitionalPayload) e
 func canTriggerActionEvents(msg service.DIDCommMsg) bool {
 	return msg.Type() == ProposeCredentialMsgType ||
 		msg.Type() == OfferCredentialMsgType ||
+		msg.Type() == IssueCredentialMsgType ||
 		msg.Type() == RequestCredentialMsgType
 }
 


### PR DESCRIPTION
When the Holder sends a request message the Issuer may respond with an IssueCredential message. We need a possibility to reject this IssueCredential message (on the Holder side).

Part of #1173 
Signed-off-by: Andrii Soluk <isoluchok@gmail.com>