### PR TITLE
feat: Issue Credential - client implementation (part 2)

### DIFF
--- a/pkg/client/issuecredential/client.go
+++ b/pkg/client/issuecredential/client.go
@@ -93,3 +93,74 @@ func (c *Client) SendRequest(request *issuecredential.RequestCredential, myDID, 
 
 	return c.service.HandleOutbound(service.NewDIDCommMsgMap(request), myDID, theirDID)
 }
+
+// AcceptProposal is used when the Issuer is willing to accept the proposal.
+// NOTE: For async usage.
+func (c *Client) AcceptProposal(piID string, msg *issuecredential.OfferCredential) error {
+	return c.service.ActionContinue(piID, WithOfferCredential(msg))
+}
+
+// DeclineProposal is used when the Issuer does not want to accept the proposal.
+// NOTE: For async usage.
+func (c *Client) DeclineProposal(piID, reason string) error {
+	return c.service.ActionStop(piID, errors.New(reason))
+}
+
+// AcceptOffer is used when the Holder is willing to accept the offer.
+func (c *Client) AcceptOffer(piID string) error {
+	return c.service.ActionContinue(piID, nil)
+}
+
+// DeclineOffer is used when the Holder does not want to accept the offer.
+// NOTE: For async usage.
+func (c *Client) DeclineOffer(piID, reason string) error {
+	return c.service.ActionStop(piID, errors.New(reason))
+}
+
+// NegotiateProposal is used when the Holder wants to negotiate about an offer he received.
+// NOTE: For async usage. This function can be used only after receiving OfferCredential
+func (c *Client) NegotiateProposal(piID string, msg *issuecredential.ProposeCredential) error {
+	return c.service.ActionContinue(piID, WithProposeCredential(msg))
+}
+
+// AcceptRequest is used when the Issuer is willing to accept the request.
+// NOTE: For async usage.
+func (c *Client) AcceptRequest(piID string, msg *issuecredential.IssueCredential) error {
+	return c.service.ActionContinue(piID, WithIssueCredential(msg))
+}
+
+// DeclineRequest is used when the Issuer does not want to accept the request.
+// NOTE: For async usage.
+func (c *Client) DeclineRequest(piID, reason string) error {
+	return c.service.ActionStop(piID, errors.New(reason))
+}
+
+// AcceptCredential is used when the Holder is willing to accept the IssueCredential.
+// NOTE: For async usage.
+func (c *Client) AcceptCredential(piID string) error {
+	return c.service.ActionContinue(piID, nil)
+}
+
+// DeclineCredential is used when the Holder does not want to accept the IssueCredential.
+// NOTE: For async usage.
+func (c *Client) DeclineCredential(piID, reason string) error {
+	return c.service.ActionStop(piID, errors.New(reason))
+}
+
+// WithProposeCredential allows providing ProposeCredential message
+// USAGE: This message should be provided after receiving an OfferCredential message
+func WithProposeCredential(msg *issuecredential.ProposeCredential) issuecredential.Opt {
+	return issuecredential.WithProposeCredential(msg)
+}
+
+// WithOfferCredential allows providing OfferCredential message
+// USAGE: This message should be provided after receiving a ProposeCredential message
+func WithOfferCredential(msg *issuecredential.OfferCredential) issuecredential.Opt {
+	return issuecredential.WithOfferCredential(msg)
+}
+
+// WithIssueCredential allows providing IssueCredential message
+// USAGE: This message should be provided after receiving a RequestCredential message
+func WithIssueCredential(msg *issuecredential.IssueCredential) issuecredential.Opt {
+	return issuecredential.WithIssueCredential(msg)
+}

--- a/pkg/client/issuecredential/client_test.go
+++ b/pkg/client/issuecredential/client_test.go
@@ -142,3 +142,147 @@ func TestClient_SendRequest(t *testing.T) {
 		require.EqualError(t, client.SendRequest(nil, Alice, Bob), errEmptyRequest.Error())
 	})
 }
+
+func TestClient_AcceptProposal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	provider := mocks.NewMockProvider(ctrl)
+
+	svc := mocks.NewMockProtocolService(ctrl)
+	svc.EXPECT().ActionContinue("PIID", gomock.Any()).Return(nil)
+
+	provider.EXPECT().Service(gomock.Any()).Return(svc, nil)
+	client, err := New(provider)
+	require.NoError(t, err)
+
+	require.NoError(t, client.AcceptProposal("PIID", &issuecredential.OfferCredential{}))
+}
+
+func TestClient_DeclineProposal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	provider := mocks.NewMockProvider(ctrl)
+
+	svc := mocks.NewMockProtocolService(ctrl)
+	svc.EXPECT().ActionStop("PIID", errors.New("the reason")).Return(nil)
+
+	provider.EXPECT().Service(gomock.Any()).Return(svc, nil)
+	client, err := New(provider)
+	require.NoError(t, err)
+
+	require.NoError(t, client.DeclineProposal("PIID", "the reason"))
+}
+
+func TestClient_AcceptOffer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	provider := mocks.NewMockProvider(ctrl)
+
+	svc := mocks.NewMockProtocolService(ctrl)
+	svc.EXPECT().ActionContinue("PIID", gomock.Any()).Return(nil)
+
+	provider.EXPECT().Service(gomock.Any()).Return(svc, nil)
+	client, err := New(provider)
+	require.NoError(t, err)
+
+	require.NoError(t, client.AcceptOffer("PIID"))
+}
+
+func TestClient_DeclineOffer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	provider := mocks.NewMockProvider(ctrl)
+
+	svc := mocks.NewMockProtocolService(ctrl)
+	svc.EXPECT().ActionStop("PIID", errors.New("the reason")).Return(nil)
+
+	provider.EXPECT().Service(gomock.Any()).Return(svc, nil)
+	client, err := New(provider)
+	require.NoError(t, err)
+
+	require.NoError(t, client.DeclineOffer("PIID", "the reason"))
+}
+
+func TestClient_AcceptRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	provider := mocks.NewMockProvider(ctrl)
+
+	svc := mocks.NewMockProtocolService(ctrl)
+	svc.EXPECT().ActionContinue("PIID", gomock.Any()).Return(nil)
+
+	provider.EXPECT().Service(gomock.Any()).Return(svc, nil)
+	client, err := New(provider)
+	require.NoError(t, err)
+
+	require.NoError(t, client.AcceptRequest("PIID", &issuecredential.IssueCredential{}))
+}
+
+func TestClient_DeclineRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	provider := mocks.NewMockProvider(ctrl)
+
+	svc := mocks.NewMockProtocolService(ctrl)
+	svc.EXPECT().ActionStop("PIID", errors.New("the reason")).Return(nil)
+
+	provider.EXPECT().Service(gomock.Any()).Return(svc, nil)
+	client, err := New(provider)
+	require.NoError(t, err)
+
+	require.NoError(t, client.DeclineRequest("PIID", "the reason"))
+}
+
+func TestClient_NegotiateProposal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	provider := mocks.NewMockProvider(ctrl)
+
+	svc := mocks.NewMockProtocolService(ctrl)
+	svc.EXPECT().ActionContinue("PIID", gomock.Any()).Return(nil)
+
+	provider.EXPECT().Service(gomock.Any()).Return(svc, nil)
+	client, err := New(provider)
+	require.NoError(t, err)
+
+	require.NoError(t, client.NegotiateProposal("PIID", &issuecredential.ProposeCredential{}))
+}
+
+func TestClient_AcceptCredential(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	provider := mocks.NewMockProvider(ctrl)
+
+	svc := mocks.NewMockProtocolService(ctrl)
+	svc.EXPECT().ActionContinue("PIID", gomock.Any()).Return(nil)
+
+	provider.EXPECT().Service(gomock.Any()).Return(svc, nil)
+	client, err := New(provider)
+	require.NoError(t, err)
+
+	require.NoError(t, client.AcceptCredential("PIID"))
+}
+
+func TestClient_DeclineCredential(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	provider := mocks.NewMockProvider(ctrl)
+
+	svc := mocks.NewMockProtocolService(ctrl)
+	svc.EXPECT().ActionStop("PIID", errors.New("the reason")).Return(nil)
+
+	provider.EXPECT().Service(gomock.Any()).Return(svc, nil)
+	client, err := New(provider)
+	require.NoError(t, err)
+
+	require.NoError(t, client.DeclineCredential("PIID", "the reason"))
+}


### PR DESCRIPTION
Implements  Issue Credential Client. Includes all possible methods.

Closes #1438 
Signed-off-by: Andrii Soluk <isoluchok@gmail.com>