### PR TITLE
fix: use connectionID instead of threadID

### DIFF
--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -487,7 +487,7 @@ func (s *Service) abandon(thID string, msg service.DIDCommMsg, processErr error)
 		Type:         service.PostState,
 		Msg:          msg,
 		StateID:      stateNameAbandoned,
-		Properties:   createErrorEventProperties(thID, "", processErr),
+		Properties:   createErrorEventProperties(connRec.ConnectionID, "", processErr),
 	})
 
 	return nil


### PR DESCRIPTION
Signed-off-by: pfeairheller <phil@scoir.com>

**Title:**
Fix a minor bug in didexchange service to allow for proper logging when connection is abandoned.

**Description:**
Closes: #1451 

Summary:
Updating the call to `createErrorEventProperties` to pass in the connectionID instead of the threadID.
