### PR TITLE
refactor: ed25519 signature verifier option

### DIFF
--- a/pkg/didcomm/protocol/didexchange/states.go
+++ b/pkg/didcomm/protocol/didexchange/states.go
@@ -591,10 +591,11 @@ func verifySignature(connSignature *ConnectionSignature, recipientKeys string) (
 	pubKey := base58.Decode(recipientKeys)
 
 	// TODO: Replace with signed attachments issue-626
-	signatureSuite := ed25519signature2018.New()
+	suiteVerifier := &ed25519signature2018.PublicKeyVerifier{}
+	signatureSuite := ed25519signature2018.New(ed25519signature2018.WithVerifier(suiteVerifier))
 
 	err = signatureSuite.Verify(&verifier.PublicKey{
-		Type:  kms.Ed25519Type,
+		Type:  kms.ED25519,
 		Value: pubKey},
 		sigData, signature)
 	if err != nil {

--- a/pkg/didcomm/protocol/didexchange/states_test.go
+++ b/pkg/didcomm/protocol/didexchange/states_test.go
@@ -596,7 +596,7 @@ func TestVerifySignature(t *testing.T) {
 
 		con, err := verifySignature(connectionSignature, "invalid-key")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "verify signature: ed25519: bad public key length")
+		require.Contains(t, err.Error(), "verify signature: ed25519: invalid key")
 		require.Nil(t, con)
 	})
 	t.Run("verify signature error", func(t *testing.T) {
@@ -607,7 +607,7 @@ func TestVerifySignature(t *testing.T) {
 		pubKey2, _ := generateKeyPair()
 		con, err := verifySignature(connectionSignature, pubKey2)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "signature doesn't match")
+		require.Contains(t, err.Error(), "ed25519: invalid signature")
 		require.Nil(t, con)
 	})
 	t.Run("connection unmarshal error", func(t *testing.T) {

--- a/pkg/doc/did/doc.go
+++ b/pkg/doc/did/doc.go
@@ -20,7 +20,6 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
 const (
@@ -781,7 +780,7 @@ func (r *didKeyResolver) Resolve(id string) (*verifier.PublicKey, error) {
 	for _, key := range r.PubKeys {
 		if key.ID == id {
 			return &verifier.PublicKey{
-				Type:  kms.KeyType(key.Type),
+				Type:  key.Type,
 				Value: key.Value,
 			}, nil
 		}

--- a/pkg/doc/did/doc_test.go
+++ b/pkg/doc/did/doc_test.go
@@ -836,7 +836,7 @@ func TestVerifyProof(t *testing.T) {
 
 		signedDoc := createSignedDidDocument(privKey, pubKey)
 
-		suite := ed25519signature2018.New()
+		suite := ed25519signature2018.New(ed25519signature2018.WithVerifier(&ed25519signature2018.PublicKeyVerifier{}))
 
 		// happy path - valid signed document
 		doc, err := ParseDocument(signedDoc)
@@ -849,7 +849,7 @@ func TestVerifyProof(t *testing.T) {
 		doc.Proof[0].ProofValue = []byte("invalid")
 		err = doc.VerifyProof(suite)
 		require.NotNil(t, err)
-		require.Contains(t, err.Error(), "signature doesn't match")
+		require.Contains(t, err.Error(), "ed25519: invalid signature")
 
 		// error - doc with no proof
 		doc, err = ParseDocument([]byte(d))
@@ -872,6 +872,7 @@ func TestDidKeyResolver_Resolve(t *testing.T) {
 	pubKeys := []PublicKey{{
 		ID:    "id",
 		Value: testKeyVal,
+		Type:  keyType,
 	}}
 
 	// happy path - key found

--- a/pkg/doc/jwt/verifier_test.go
+++ b/pkg/doc/jwt/verifier_test.go
@@ -45,7 +45,7 @@ func TestNewVerifier(t *testing.T) {
 
 		v := NewVerifier(getTestKeyResolver(
 			&verifier.PublicKey{
-				Type:  kms.Ed25519Type,
+				Type:  kms.ED25519,
 				Value: pubKey,
 			}, nil))
 		_, err = jose.ParseJWS(jws, v)
@@ -67,7 +67,7 @@ func TestNewVerifier(t *testing.T) {
 
 		v := NewVerifier(getTestKeyResolver(
 			&verifier.PublicKey{
-				Type:  "RSA",
+				Type:  kms.RSA,
 				Value: x509.MarshalPKCS1PublicKey(pubKey),
 			}, nil))
 		_, err = jose.ParseJWS(jws, v)
@@ -82,7 +82,7 @@ func TestBasicVerifier_Verify(t *testing.T) { // error corner cases
 	r.NoError(err)
 
 	v := NewVerifier(getTestKeyResolver(&verifier.PublicKey{
-		Type:  "RSA",
+		Type:  kms.RSA,
 		Value: pubKey,
 	}, nil))
 
@@ -128,13 +128,13 @@ func TestVerifyEdDSA(t *testing.T) {
 	signature := ed25519.Sign(privKey, []byte("test message"))
 
 	err = VerifyEdDSA(&verifier.PublicKey{
-		Type:  kms.Ed25519Type,
+		Type:  kms.ED25519,
 		Value: pubKey,
 	}, []byte("test message"), signature)
 	r.NoError(err)
 
 	err = VerifyEdDSA(&verifier.PublicKey{
-		Type:  kms.Ed25519Type,
+		Type:  kms.ED25519,
 		Value: []byte("invalid pub key"),
 	}, []byte("test message"), signature)
 	r.Error(err)
@@ -144,7 +144,7 @@ func TestVerifyEdDSA(t *testing.T) {
 	r.NoError(err)
 
 	err = VerifyEdDSA(&verifier.PublicKey{
-		Type:  kms.Ed25519Type,
+		Type:  kms.ED25519,
 		Value: anotherPubKey,
 	}, []byte("test message"), signature)
 	r.Error(err)
@@ -168,7 +168,7 @@ func TestVerifyRS256(t *testing.T) {
 	r.NoError(err)
 
 	err = VerifyRS256(&verifier.PublicKey{
-		Type:  "RSA",
+		Type:  kms.RSA,
 		Value: x509.MarshalPKCS1PublicKey(&privKey.PublicKey),
 	}, []byte("test message"), signature)
 	r.NoError(err)
@@ -177,7 +177,7 @@ func TestVerifyRS256(t *testing.T) {
 	r.NoError(err)
 
 	err = VerifyRS256(&verifier.PublicKey{
-		Type:  "RSA",
+		Type:  kms.RSA,
 		Value: x509.MarshalPKCS1PublicKey(&anotherPrivKey.PublicKey),
 	}, []byte("test message"), signature)
 	r.Error(err)

--- a/pkg/doc/signature/ed25519signature2018/public_key_verifier.go
+++ b/pkg/doc/signature/ed25519signature2018/public_key_verifier.go
@@ -1,0 +1,35 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ed25519signature2018
+
+import (
+	"crypto/ed25519"
+	"errors"
+
+	sigverifier "github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
+)
+
+// PublicKeyVerifier verifies a Ed25519 signature taking Ed25519 public key bytes as input.
+// NOTE: this verifier is present for backward compatibility reasons and can be removed soon.
+// Please use CryptoVerifier or your own verifier.
+type PublicKeyVerifier struct {
+}
+
+// Verify will verify a signature.
+func (v *PublicKeyVerifier) Verify(pubKey *sigverifier.PublicKey, doc, signature []byte) error {
+	// ed25519 panics if key size is wrong
+	if len(pubKey.Value) != ed25519.PublicKeySize {
+		return errors.New("ed25519: invalid key")
+	}
+
+	verified := ed25519.Verify(pubKey.Value, doc, signature)
+	if !verified {
+		return errors.New("ed25519: invalid signature")
+	}
+
+	return nil
+}

--- a/pkg/doc/signature/ed25519signature2018/public_key_verifier_test.go
+++ b/pkg/doc/signature/ed25519signature2018/public_key_verifier_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ed25519signature2018
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sigverifier "github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+)
+
+func TestPublicKeyVerifier_Verify(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	msg := []byte("test message")
+
+	msgSig := ed25519.Sign(privateKey, msg)
+
+	pubKey := &sigverifier.PublicKey{
+		Type:  kms.ED25519,
+		Value: publicKey,
+	}
+	v := &PublicKeyVerifier{}
+
+	err = v.Verify(pubKey, msg, msgSig)
+	require.NoError(t, err)
+
+	// invalid public key type
+	err = v.Verify(&sigverifier.PublicKey{
+		Type:  kms.ED25519,
+		Value: []byte("invalid-key"),
+	}, msg, msgSig)
+	require.Error(t, err)
+	require.EqualError(t, err, "ed25519: invalid key")
+
+	// invalid signature
+	err = v.Verify(pubKey, msg, []byte("invalid signature"))
+	require.Error(t, err)
+	require.EqualError(t, err, "ed25519: invalid signature")
+}

--- a/pkg/doc/signature/ed25519signature2018/suite_crypto.go
+++ b/pkg/doc/signature/ed25519signature2018/suite_crypto.go
@@ -1,0 +1,48 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ed25519signature2018
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/crypto"
+	sigverifier "github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
+)
+
+// CryptoSigner defines signer based on crypto.
+type CryptoSigner struct {
+	cr crypto.Crypto
+	kh interface{}
+}
+
+// NewCryptoSigner creates a new CryptoSigner.
+func NewCryptoSigner(cr crypto.Crypto, kh interface{}) *CryptoSigner {
+	return &CryptoSigner{
+		cr: cr,
+		kh: kh,
+	}
+}
+
+// Sign will sign document and return signature.
+func (s *CryptoSigner) Sign(msg []byte) ([]byte, error) {
+	return s.cr.Sign(msg, s.kh)
+}
+
+// CryptoVerifier defines signature verifier based on crypto.
+type CryptoVerifier struct {
+	cr crypto.Crypto
+}
+
+// NewCryptoVerifier creates a new CryptoVerifier.
+func NewCryptoVerifier(cr crypto.Crypto) *CryptoVerifier {
+	return &CryptoVerifier{
+		cr: cr,
+	}
+}
+
+// Verify will verify a signature.
+func (v *CryptoVerifier) Verify(kh *sigverifier.PublicKey, msg, signature []byte) error {
+	return v.cr.Verify(signature, msg, kh)
+}

--- a/pkg/doc/signature/ed25519signature2018/suite_crypto_test.go
+++ b/pkg/doc/signature/ed25519signature2018/suite_crypto_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ed25519signature2018
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/tink/go/keyset"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto"
+	sigverifier "github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
+	kmsapi "github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
+)
+
+func TestNewCryptoSignerAndVerifier(t *testing.T) {
+	lKMS := createKMS()
+
+	kid, kh := createKeyHandle(lKMS, kmsapi.ED25519Type)
+
+	tinkCrypto, err := tinkcrypto.New()
+	if err != nil {
+		panic("failed to create tinkcrypto")
+	}
+
+	doc := []byte("test doc")
+
+	suiteSigner := NewCryptoSigner(tinkCrypto, kh)
+	suiteVerifier := NewCryptoVerifier(&Crypto{
+		Crypto:   tinkCrypto,
+		localKMS: lKMS,
+	})
+
+	ss := New(WithSigner(suiteSigner), WithVerifier(suiteVerifier))
+
+	docSig, err := ss.Sign(doc)
+	if err != nil {
+		panic("failed to create a signature")
+	}
+
+	pubKeyBytes, err := lKMS.ExportPubKeyBytes(kid)
+	if err != nil {
+		panic("failed to export public key bytes")
+	}
+
+	pubKey := &sigverifier.PublicKey{
+		Type:  kmsapi.ED25519,
+		Value: pubKeyBytes,
+	}
+
+	err = ss.Verify(pubKey, doc, docSig)
+	if err != nil {
+		panic("failed to verify signature")
+	}
+}
+
+// LocalCrypto defines a verifier which is based on Local KMS and Crypto
+// which uses keyset.Handle as input for verification.
+type Crypto struct {
+	*tinkcrypto.Crypto
+	localKMS *localkms.LocalKMS
+}
+
+func (t *Crypto) Verify(sig, msg []byte, kh interface{}) error {
+	pubKey, ok := kh.(*sigverifier.PublicKey)
+	if !ok {
+		return errors.New("bad key handle format")
+	}
+
+	kmsKeyType, err := mapKeyTypeToKMS(pubKey.Type)
+	if err != nil {
+		return err
+	}
+
+	handle, err := t.localKMS.PubKeyBytesToHandle(pubKey.Value, kmsKeyType)
+	if err != nil {
+		return err
+	}
+
+	return t.Crypto.Verify(sig, msg, handle)
+}
+
+func createKeyHandle(kms *localkms.LocalKMS, keyType kmsapi.KeyType) (string, *keyset.Handle) {
+	kid, kh, err := kms.Create(keyType)
+	if err != nil {
+		panic(err)
+	}
+
+	return kid, kh.(*keyset.Handle)
+}
+
+func createKMS() *localkms.LocalKMS {
+	p := mockkms.NewProvider(storage.NewMockStoreProvider(), &noop.NoLock{})
+
+	k, err := localkms.New("local-lock://custom/master/key/", p)
+	if err != nil {
+		panic(err)
+	}
+
+	return k
+}
+
+func mapKeyTypeToKMS(t string) (kmsapi.KeyType, error) {
+	switch t {
+	case kmsapi.ED25519, "Ed25519VerificationKey2018":
+		return kmsapi.ED25519Type, nil
+	default:
+		return "", fmt.Errorf("unsupported key type: %s", t)
+	}
+}

--- a/pkg/doc/signature/verifier/verifier.go
+++ b/pkg/doc/signature/verifier/verifier.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/proof"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
 // signatureSuite encapsulates signature suite methods required for signature verification
@@ -23,7 +22,6 @@ type signatureSuite interface {
 	GetDigest(doc []byte) []byte
 
 	// Verify will verify signature against public key
-	// TODO change pubKey type to interface{} (https://github.com/hyperledger/aries-framework-go/issues/1458)
 	Verify(pubKey *PublicKey, doc []byte, signature []byte) error
 
 	// Accept registers this signature suite with the given signature type
@@ -32,7 +30,7 @@ type signatureSuite interface {
 
 // PublicKey contains a result of public key resolution.
 type PublicKey struct {
-	Type  kms.KeyType
+	Type  string
 	Value []byte
 }
 

--- a/pkg/doc/signature/verifier/verifier_test.go
+++ b/pkg/doc/signature/verifier/verifier_test.go
@@ -21,7 +21,7 @@ func TestVerify(t *testing.T) {
 	// happy path
 	okKeyResolver := &testKeyResolver{
 		publicKey: &PublicKey{
-			Type:  kms.Ed25519Type,
+			Type:  kms.ED25519,
 			Value: []byte("signature"),
 		},
 	}
@@ -120,7 +120,7 @@ type testKeyResolver struct {
 	err       error
 }
 
-func (r *testKeyResolver) Resolve(id string) (*PublicKey, error) {
+func (r *testKeyResolver) Resolve(string) (*PublicKey, error) {
 	return r.publicKey, r.err
 }
 
@@ -160,18 +160,18 @@ type testSignatureSuite struct {
 	accept bool
 }
 
-func (s *testSignatureSuite) GetCanonicalDocument(doc map[string]interface{}) ([]byte, error) {
+func (s *testSignatureSuite) GetCanonicalDocument(map[string]interface{}) ([]byte, error) {
 	return s.canonicalDocument, s.canonicalDocumentError
 }
 
-func (s *testSignatureSuite) GetDigest(doc []byte) []byte {
+func (s *testSignatureSuite) GetDigest([]byte) []byte {
 	return s.digest
 }
 
-func (s *testSignatureSuite) Verify(pubKey *PublicKey, doc, signature []byte) error {
+func (s *testSignatureSuite) Verify(*PublicKey, []byte, []byte) error {
 	return s.verifyError
 }
 
-func (s *testSignatureSuite) Accept(signatureType string) bool {
+func (s *testSignatureSuite) Accept(string) bool {
 	return s.accept
 }

--- a/pkg/doc/verifiable/common.go
+++ b/pkg/doc/verifiable/common.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
 // TODO https://github.com/square/go-jose/issues/263 support ES256K
@@ -57,7 +56,7 @@ func (ja JWSAlgorithm) name() (string, error) {
 type PublicKeyFetcher func(issuerID, keyID string) (*verifier.PublicKey, error)
 
 // SingleKey defines the case when only one verification key is used and we don't need to pick the one.
-func SingleKey(pubKey []byte, pubKeyType kms.KeyType) PublicKeyFetcher {
+func SingleKey(pubKey []byte, pubKeyType string) PublicKeyFetcher {
 	return func(issuerID, keyID string) (*verifier.PublicKey, error) {
 		return &verifier.PublicKey{
 			Type:  pubKeyType,
@@ -89,7 +88,7 @@ func (r *DIDKeyResolver) resolvePublicKey(issuerDID, keyID string) (*verifier.Pu
 		// sidetree now return #KEYID
 		if strings.Contains(key.ID, keyID) {
 			return &verifier.PublicKey{
-				Type:  kms.KeyType(key.Type),
+				Type:  key.Type,
 				Value: key.Value,
 			}, nil
 		}
@@ -101,7 +100,7 @@ func (r *DIDKeyResolver) resolvePublicKey(issuerDID, keyID string) (*verifier.Pu
 		// sidetree now return #KEYID
 		if strings.Contains(auth.PublicKey.ID, keyID) {
 			return &verifier.PublicKey{
-				Type:  kms.KeyType(auth.PublicKey.Type),
+				Type:  auth.PublicKey.Type,
 				Value: auth.PublicKey.Value,
 			}, nil
 		}

--- a/pkg/doc/verifiable/common_test.go
+++ b/pkg/doc/verifiable/common_test.go
@@ -253,12 +253,12 @@ func TestDIDKeyResolver_Resolve(t *testing.T) {
 	pubKey, err := resolver.PublicKeyFetcher()(didDoc.ID, publicKey.ID)
 	r.NoError(err)
 	r.Equal(publicKey.Value, pubKey.Value)
-	r.EqualValues(publicKey.Type, pubKey.Type)
+	r.Equal("Ed25519VerificationKey2018", pubKey.Type)
 
 	authPubKey, err := resolver.PublicKeyFetcher()(didDoc.ID, authentication.PublicKey.ID)
 	r.NoError(err)
 	r.Equal(authentication.PublicKey.Value, authPubKey.Value)
-	r.EqualValues(authentication.PublicKey.Type, authPubKey.Type)
+	r.Equal("Ed25519VerificationKey2018", authPubKey.Type)
 
 	pubKey, err = resolver.PublicKeyFetcher()(didDoc.ID, "invalid key")
 	r.Error(err)

--- a/pkg/doc/verifiable/credential_jws_test.go
+++ b/pkg/doc/verifiable/credential_jws_test.go
@@ -38,7 +38,7 @@ func TestJWTCredClaimsMarshalJWS(t *testing.T) {
 			require.NotNil(t, publicKey)
 
 			return &verifier.PublicKey{
-				Type:  kms.RSAType,
+				Type:  kms.RSA,
 				Value: publicKeyPemToBytes(publicKey),
 			}, nil
 		})
@@ -69,7 +69,7 @@ func TestCredJWSDecoderUnmarshal(t *testing.T) {
 		require.NotNil(t, publicKey)
 
 		return &verifier.PublicKey{
-			Type:  kms.RSAType,
+			Type:  kms.RSA,
 			Value: publicKeyPemToBytes(publicKey),
 		}, nil
 	}
@@ -124,7 +124,7 @@ func TestCredJWSDecoderUnmarshal(t *testing.T) {
 			require.NotNil(t, publicKey)
 
 			return &verifier.PublicKey{
-				Type:  kms.RSAType,
+				Type:  kms.RSA,
 				Value: publicKeyPemToBytes(publicKey),
 			}, nil
 		}

--- a/pkg/doc/verifiable/credential_jwt_proof_test.go
+++ b/pkg/doc/verifiable/credential_jwt_proof_test.go
@@ -91,7 +91,7 @@ func TestNewCredentialFromJWS(t *testing.T) {
 				require.NotNil(t, publicKey)
 
 				return &verifier.PublicKey{
-					Type:  kms.RSAType,
+					Type:  kms.RSA,
 					Value: publicKeyPemToBytes(publicKey),
 				}, nil
 			}))
@@ -139,7 +139,7 @@ func TestNewCredentialFromJWS_EdDSA(t *testing.T) {
 	// unmarshal credential from JWS
 	vcFromJWS, _, err := NewCredential(
 		vcJWSStr,
-		WithPublicKeyFetcher(SingleKey(pubKey, kms.Ed25519Type)))
+		WithPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)))
 	require.NoError(t, err)
 
 	// unmarshalled credential must be the same as original one
@@ -228,7 +228,7 @@ func createMockKeyFetcher(t *testing.T) PublicKeyFetcher {
 		require.NotNil(t, publicKey)
 
 		return &verifier.PublicKey{
-			Type:  kms.RSAType,
+			Type:  kms.RSA,
 			Value: publicKeyPemToBytes(publicKey),
 		}, nil
 	}

--- a/pkg/doc/verifiable/credential_ldp_test.go
+++ b/pkg/doc/verifiable/credential_ldp_test.go
@@ -23,7 +23,9 @@ func TestNewCredentialFromLinkedDataProof(t *testing.T) {
 	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
 	r.NoError(err)
 
-	suite := ed25519signature2018.New(ed25519signature2018.WithSigner(getEd25519TestSigner(privKey)))
+	suite := ed25519signature2018.New(
+		ed25519signature2018.WithSigner(getEd25519TestSigner(privKey)),
+		ed25519signature2018.WithVerifier(&ed25519signature2018.PublicKeyVerifier{}))
 
 	ldpContext := &LinkedDataProofContext{
 		SignatureType:           "Ed25519Signature2018",
@@ -43,7 +45,7 @@ func TestNewCredentialFromLinkedDataProof(t *testing.T) {
 
 	vcWithLdp, _, err := NewCredential(vcBytes,
 		WithEmbeddedSignatureSuites(suite),
-		WithPublicKeyFetcher(SingleKey(pubKey, kms.Ed25519Type)))
+		WithPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)))
 	r.NoError(err)
 	r.Equal(vc, vcWithLdp)
 }

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -681,7 +681,7 @@ func TestCredential_MarshalJSON(t *testing.T) {
 }
 
 func TestWithPublicKeyFetcher(t *testing.T) {
-	credentialOpt := WithPublicKeyFetcher(SingleKey([]byte("test pubKey"), kms.Ed25519Type))
+	credentialOpt := WithPublicKeyFetcher(SingleKey([]byte("test pubKey"), kms.ED25519))
 	require.NotNil(t, credentialOpt)
 
 	opts := &credentialOpts{}

--- a/pkg/doc/verifiable/example_credential_test.go
+++ b/pkg/doc/verifiable/example_credential_test.go
@@ -112,7 +112,7 @@ func ExampleCredential_embedding() {
 	// Decode JWS and make sure it's coincide with JSON.
 	_, vcBytesFromJWS, err := verifiable.NewCredential(
 		[]byte(jws),
-		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(issuerPubKey, kms.Ed25519Type)))
+		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(issuerPubKey, kms.ED25519)))
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to encode VC from JWS: %w", err))
 	}
@@ -181,7 +181,7 @@ func ExampleCredential_extraFields() {
 	// Decode JWS and make sure it's coincide with JSON.
 	_, vcBytesFromJWS, err := verifiable.NewCredential(
 		[]byte(jws),
-		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(issuerPubKey, kms.Ed25519Type)))
+		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(issuerPubKey, kms.ED25519)))
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to encode VC from JWS: %w", err))
 	}
@@ -240,7 +240,7 @@ func ExampleNewCredential() {
 	// The Holder receives JWS and decodes it.
 	_, vcDecodedBytes, err := verifiable.NewCredential(
 		[]byte(jws),
-		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(issuerPubKey, kms.Ed25519Type)))
+		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(issuerPubKey, kms.ED25519)))
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to decode VC JWS: %w", err))
 	}

--- a/pkg/doc/verifiable/example_presentation_test.go
+++ b/pkg/doc/verifiable/example_presentation_test.go
@@ -32,7 +32,7 @@ func ExampleNewPresentation() {
 	vp, err := verifiable.NewPresentation(
 		[]byte(vpJWS),
 
-		verifiable.WithPresPublicKeyFetcher(verifiable.SingleKey(holderPubKey, kms.Ed25519Type)))
+		verifiable.WithPresPublicKeyFetcher(verifiable.SingleKey(holderPubKey, kms.ED25519)))
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to decode VP JWS: %w", err))
 	}
@@ -401,12 +401,12 @@ func ExamplePresentation_MarshalledCredentials() {
 			switch issuerID {
 			case "did:example:76e12ec712ebc6f1c221ebfeb1f":
 				return &verifier.PublicKey{
-					Type:  kms.Ed25519Type,
+					Type:  kms.ED25519,
 					Value: issuerPubKey,
 				}, nil
 			case "did:example:ebfeb1f712ebc6f1c276e12ec21":
 				return &verifier.PublicKey{
-					Type:  kms.Ed25519Type,
+					Type:  kms.ED25519,
 					Value: holderPubKey,
 				}, nil
 			default:

--- a/pkg/doc/verifiable/linked_data_proof_test.go
+++ b/pkg/doc/verifiable/linked_data_proof_test.go
@@ -24,7 +24,7 @@ func Test_keyResolverAdapter_Resolve(t *testing.T) {
 	t.Run("successful public key resolving", func(t *testing.T) {
 		pubKey, _, err := ed25519.GenerateKey(rand.Reader)
 		require.NoError(t, err)
-		kra := &keyResolverAdapter{pubKeyFetcher: SingleKey(pubKey, kms.Ed25519Type)}
+		kra := &keyResolverAdapter{pubKeyFetcher: SingleKey(pubKey, kms.ED25519)}
 		resolvedPubKey, err := kra.Resolve("did1#key1")
 		require.NoError(t, err)
 		require.Equal(t, []byte(pubKey), resolvedPubKey.Value)
@@ -54,7 +54,7 @@ func Test_keyResolverAdapter_Resolve(t *testing.T) {
 type dummyKeyResolver []byte
 
 func (kr dummyKeyResolver) Resolve(string) (*verifier.PublicKey, error) {
-	return &verifier.PublicKey{Value: kr, Type: "type"}, nil
+	return &verifier.PublicKey{Value: kr, Type: kms.ED25519}, nil
 }
 
 // This example is generated using https://transmute-industries.github.io/vc-greeting-card
@@ -93,7 +93,8 @@ func TestLinkedDataProofVerifier(t *testing.T) {
 }
 `
 
-	documentVerifier := verifier.New(dummyKeyResolver(pubKey), ed25519signature2018.New())
+	documentVerifier := verifier.New(dummyKeyResolver(pubKey),
+		ed25519signature2018.New(ed25519signature2018.WithVerifier(&ed25519signature2018.PublicKeyVerifier{})))
 	err := documentVerifier.Verify([]byte(vcStr))
 	require.NoError(t, err)
 }

--- a/pkg/doc/verifiable/presentation_jws_test.go
+++ b/pkg/doc/verifiable/presentation_jws_test.go
@@ -92,7 +92,7 @@ func TestUnmarshalPresJWSClaims(t *testing.T) {
 			require.NotNil(t, publicKey)
 
 			return &verifier.PublicKey{
-				Type:  kms.RSAType,
+				Type:  kms.RSA,
 				Value: publicKeyPemToBytes(publicKey),
 			}, nil
 		})
@@ -123,7 +123,7 @@ func holderPublicKeyFetcher(t *testing.T) PublicKeyFetcher {
 		require.NotNil(t, publicKey)
 
 		return &verifier.PublicKey{
-			Type:  kms.RSAType,
+			Type:  kms.RSA,
 			Value: publicKeyPemToBytes(publicKey),
 		}, nil
 	}

--- a/pkg/doc/verifiable/presentation_jwt_proof_test.go
+++ b/pkg/doc/verifiable/presentation_jwt_proof_test.go
@@ -57,7 +57,7 @@ func TestNewPresentationFromJWS(t *testing.T) {
 				require.NotNil(t, publicKey)
 
 				return &verifier.PublicKey{
-					Type:  kms.RSAType,
+					Type:  kms.RSA,
 					Value: publicKeyPemToBytes(publicKey),
 				}, nil
 			}))
@@ -108,7 +108,7 @@ func TestNewPresentationFromJWS_EdDSA(t *testing.T) {
 	// unmarshal presentation from JWS
 	vpFromJWS, err := NewPresentation(
 		[]byte(vpJWSStr),
-		WithPresPublicKeyFetcher(SingleKey(pubKey, kms.Ed25519Type)))
+		WithPresPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)))
 	require.NoError(t, err)
 
 	// unmarshalled presentation must be the same as original one
@@ -211,12 +211,12 @@ func TestNewPresentationWithVCJWT(t *testing.T) {
 				switch keyID {
 				case "holder-key":
 					return &verifier.PublicKey{
-						Type:  kms.Ed25519Type,
+						Type:  kms.ED25519,
 						Value: holderPubKey,
 					}, nil
 				case "issuer-key":
 					return &verifier.PublicKey{
-						Type:  kms.RSAType,
+						Type:  kms.RSA,
 						Value: publicKeyPemToBytes(&issuerPrivKey.PublicKey),
 					}, nil
 				default:
@@ -257,7 +257,7 @@ func TestNewPresentationWithVCJWT(t *testing.T) {
 
 		// Decode VP
 		vpDecoded, err := NewPresentation([]byte(vpJWS), WithPresPublicKeyFetcher(
-			SingleKey(holderPubKey, kms.Ed25519Type)))
+			SingleKey(holderPubKey, kms.ED25519)))
 		r.NoError(err)
 		vpCreds, err := vpDecoded.MarshalledCredentials()
 		r.NoError(err)
@@ -296,7 +296,7 @@ func TestNewPresentationWithVCJWT(t *testing.T) {
 				switch keyID {
 				case "holder-key":
 					return &verifier.PublicKey{
-						Type:  kms.Ed25519Type,
+						Type:  kms.ED25519,
 						Value: holderPubKey,
 					}, nil
 				case "issuer-key":
@@ -305,7 +305,7 @@ func TestNewPresentationWithVCJWT(t *testing.T) {
 					r.NoError(gerr)
 
 					return &verifier.PublicKey{
-						Type:  kms.Ed25519Type,
+						Type:  kms.ED25519,
 						Value: anotherPubKey,
 					}, nil
 				default:
@@ -346,7 +346,7 @@ func createPresKeyFetcher(t *testing.T) func(issuerID string, keyID string) (*ve
 		require.NotNil(t, publicKey)
 
 		return &verifier.PublicKey{
-			Type:  kms.RSAType,
+			Type:  kms.RSA,
 			Value: publicKeyPemToBytes(publicKey),
 		}, nil
 	}

--- a/pkg/doc/verifiable/presentation_ldp_test.go
+++ b/pkg/doc/verifiable/presentation_ldp_test.go
@@ -42,7 +42,7 @@ func TestNewPresentationFromLinkedDataProof(t *testing.T) {
 
 	vcWithLdp, err := NewPresentation(vcBytes,
 		WithPresEmbeddedSignatureSuites(suite),
-		WithPresPublicKeyFetcher(SingleKey(pubKey, kms.Ed25519Type)))
+		WithPresPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)))
 	r.NoError(err)
 
 	r.NoError(err)

--- a/pkg/doc/verifiable/presentation_test.go
+++ b/pkg/doc/verifiable/presentation_test.go
@@ -369,7 +369,7 @@ func TestPresentation_decodeCredentials(t *testing.T) {
 
 	// single credential - JWS
 	opts := defaultPresentationOpts()
-	opts.publicKeyFetcher = SingleKey(pubKey, kms.Ed25519Type)
+	opts.publicKeyFetcher = SingleKey(pubKey, kms.ED25519)
 	dCreds, err := decodeCredentials(jws, opts)
 	r.NoError(err)
 	r.Len(dCreds, 1)
@@ -381,7 +381,7 @@ func TestPresentation_decodeCredentials(t *testing.T) {
 }
 
 func TestWithPresPublicKeyFetcher(t *testing.T) {
-	vpOpt := WithPresPublicKeyFetcher(SingleKey([]byte("test pubKey"), kms.Ed25519Type))
+	vpOpt := WithPresPublicKeyFetcher(SingleKey([]byte("test pubKey"), kms.ED25519))
 	require.NotNil(t, vpOpt)
 
 	opts := &presentationOpts{}

--- a/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
+++ b/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
 var logger = log.New("aries-framework/doc/verifiable/test-suite")
@@ -101,7 +102,7 @@ func encodeVPToJWS(vpBytes []byte, audience string, privateKey *rsa.PrivateKey, 
 		// do not test the cryptographic proofs (see https://github.com/w3c/vc-test-suite/issues/101)
 		verifiable.WithPresNoProofCheck(),
 		// the public key is used to decode verifiable credentials passed as JWS to the presentation
-		verifiable.WithPresPublicKeyFetcher(verifiable.SingleKey(publicKeyPemToBytes(publicKey), "RSA")))
+		verifiable.WithPresPublicKeyFetcher(verifiable.SingleKey(publicKeyPemToBytes(publicKey), kms.RSA)))
 	if err != nil {
 		abort("failed to decode presentation: %v", err)
 	}
@@ -141,7 +142,7 @@ func encodeVCToJWTUnsecured(vcBytes []byte) {
 func decodeVCJWTToJSON(vcBytes []byte, publicKey *rsa.PublicKey) {
 	// Asked to decode JWT
 	credential, _, err := verifiable.NewCredential(vcBytes,
-		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(publicKeyPemToBytes(publicKey), "RSA")),
+		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(publicKeyPemToBytes(publicKey), kms.RSA)),
 		// do not test the cryptographic proofs (see https://github.com/w3c/vc-test-suite/issues/101)
 		verifiable.WithNoProofCheck())
 	if err != nil {

--- a/pkg/kms/api.go
+++ b/pkg/kms/api.go
@@ -31,28 +31,51 @@ type Provider interface {
 // Creator method to create new key management service
 type Creator func(provider Provider) (KeyManager, error)
 
+const (
+	// AES128GCM key type value
+	AES128GCM = "AES128GCM"
+	// AES256GCMNoPrefix key type value
+	AES256GCMNoPrefix = "AES256GCMNoPrefix"
+	// AES256GCM key type value
+	AES256GCM = "AES256GCM"
+	// ChaCha20Poly1305 key type value
+	ChaCha20Poly1305 = "ChaCha20Poly1305"
+	// XChaCha20Poly1305 key type value
+	XChaCha20Poly1305 = "XChaCha20Poly1305"
+	// ECDSAP256 key type value
+	ECDSAP256 = "ECDSAP256"
+	// ECDSAP384 key type value
+	ECDSAP384 = "ECDSAP384"
+	// ECDSAP521 key type value
+	ECDSAP521 = "ECDSAP521"
+	// ED25519 key type value
+	ED25519 = "ED25519"
+	// RSA key type value
+	RSA = "RSA"
+)
+
 // KeyType represents a key type supported by the KMS
 type KeyType string
 
 const (
 	// AES128GCMType key type value
-	AES128GCMType = KeyType("AES128GCM")
+	AES128GCMType = KeyType(AES128GCM)
 	// AES256GCMNoPrefixType key type value
-	AES256GCMNoPrefixType = KeyType("AES256GCMNoPrefix")
+	AES256GCMNoPrefixType = KeyType(AES256GCMNoPrefix)
 	// AES256GCMType key type value
-	AES256GCMType = KeyType("AES256GCM")
+	AES256GCMType = KeyType(AES256GCM)
 	// ChaCha20Poly1305Type key type value
-	ChaCha20Poly1305Type = KeyType("ChaCha20Poly1305")
+	ChaCha20Poly1305Type = KeyType(ChaCha20Poly1305)
 	// XChaCha20Poly1305Type key type value
-	XChaCha20Poly1305Type = KeyType("XChaCha20Poly1305")
+	XChaCha20Poly1305Type = KeyType(XChaCha20Poly1305)
 	// ECDSAP256Type key type value
-	ECDSAP256Type = KeyType("ECDSAP256")
+	ECDSAP256Type = KeyType(ECDSAP256)
 	// ECDSAP384Type key type value
-	ECDSAP384Type = KeyType("ECDSAP384")
+	ECDSAP384Type = KeyType(ECDSAP384)
 	// ECDSAP521Type key type value
-	ECDSAP521Type = KeyType("ECDSAP521")
-	// Ed25519Type key type value
-	Ed25519Type = KeyType("ED25519")
+	ECDSAP521Type = KeyType(ECDSAP521)
+	// ED25519Type key type value
+	ED25519Type = KeyType(ED25519)
 	// RSAType key type value
-	RSAType = KeyType("RSA")
+	RSAType = KeyType(RSA)
 )

--- a/pkg/kms/legacykms/kms_test.go
+++ b/pkg/kms/legacykms/kms_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/ed25519signature2018"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/cryptoutil"
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
@@ -135,8 +134,9 @@ func TestBaseKMS_SignMessage(t *testing.T) {
 		require.NotEmpty(t, signature)
 
 		// verify signature
-		err = ed25519signature2018.New().Verify(
-			&verifier.PublicKey{Type: kms.Ed25519Type, Value: base58.Decode(fromVerKey)},
+		suiteVerifier := &ed25519signature2018.PublicKeyVerifier{}
+		err = ed25519signature2018.New(ed25519signature2018.WithVerifier(suiteVerifier)).Verify(
+			&verifier.PublicKey{Type: "ED25519", Value: base58.Decode(fromVerKey)},
 			testMsg, signature)
 		require.NoError(t, err)
 	})

--- a/pkg/kms/localkms/localkms.go
+++ b/pkg/kms/localkms/localkms.go
@@ -168,7 +168,7 @@ func getKeyTemplate(keyType kms.KeyType) (*tinkpb.KeyTemplate, error) {
 		keyTemplate.OutputPrefixType = tinkpb.OutputPrefixType_RAW
 
 		return keyTemplate, nil
-	case kms.Ed25519Type:
+	case kms.ED25519Type:
 		keyTemplate := signature.ED25519KeyTemplate()
 		keyTemplate.OutputPrefixType = tinkpb.OutputPrefixType_RAW
 

--- a/pkg/kms/localkms/localkms_test.go
+++ b/pkg/kms/localkms/localkms_test.go
@@ -202,7 +202,7 @@ func TestLocalKMS_Success(t *testing.T) {
 		kms.ECDSAP256Type,
 		kms.ECDSAP384Type,
 		kms.ECDSAP521Type,
-		kms.Ed25519Type,
+		kms.ED25519Type,
 	}
 
 	for _, v := range keyTemplates {
@@ -250,7 +250,7 @@ func TestLocalKMS_Success(t *testing.T) {
 		require.Equal(t, len(newKHPrimitives.Entries), len(rotatedKHPrimitives.Entries))
 		require.Equal(t, len(readKHPrimitives.Entries), len(rotatedKHPrimitives.Entries))
 
-		if strings.Contains(string(v), "ECDSA") || v == kms.Ed25519Type {
+		if strings.Contains(string(v), "ECDSA") || v == kms.ED25519Type {
 			pubKeyBytes, e := kmsService.ExportPubKeyBytes(keyID)
 			require.Errorf(t, e, "KeyID has been rotated. An error must be returned")
 			require.Empty(t, pubKeyBytes)

--- a/pkg/kms/localkms/pubkey_export_import_test.go
+++ b/pkg/kms/localkms/pubkey_export_import_test.go
@@ -63,7 +63,7 @@ func TestPubKeyExportAndRead(t *testing.T) {
 		},
 		{
 			tcName:      "export then read ED25519 public key",
-			keyType:     kms.Ed25519Type,
+			keyType:     kms.ED25519Type,
 			keyTemplate: ed25519KeyTemplate,
 			// TODO remove above line then uncomment below line when key template is available in Tink - issue #1489
 			// keyTemplate: signature.ED25519KeyWithoutPrefixTemplate()

--- a/pkg/kms/localkms/pubkey_reader.go
+++ b/pkg/kms/localkms/pubkey_reader.go
@@ -101,7 +101,7 @@ func getMarshalledProtoKeyAndKeyURL(pubKey []byte, kt kms.KeyType) ([]byte, stri
 		if err != nil {
 			return nil, "", err
 		}
-	case kms.Ed25519Type:
+	case kms.ED25519Type:
 		tURL = ed25519VerifierTypeURL
 		pubKeyProto := new(ed25519pb.Ed25519PublicKey)
 		pubKeyProto.Version = 0

--- a/pkg/mock/kms/mock_kms.go
+++ b/pkg/mock/kms/mock_kms.go
@@ -15,6 +15,8 @@ import (
 	tinkpb "github.com/google/tink/proto/tink_go_proto"
 
 	kmsservice "github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
 // KeyManager mocks a local Key Management Service
@@ -66,4 +68,28 @@ func CreateMockKeyHandle() (*keyset.Handle, error) {
 	}
 
 	return testkeyset.NewHandle(ks)
+}
+
+// Provider provides mock Provider implementation.
+type Provider struct {
+	storeProvider storage.Provider
+	secretLock    secretlock.Service
+}
+
+// StorageProvider return a storage provider.
+func (p *Provider) StorageProvider() storage.Provider {
+	return p.storeProvider
+}
+
+// SecretLock returns a secret lock service
+func (p *Provider) SecretLock() secretlock.Service {
+	return p.secretLock
+}
+
+// NewProvider creates a new mock Provider.
+func NewProvider(storeProvider storage.Provider, secretLock secretlock.Service) *Provider {
+	return &Provider{
+		storeProvider: storeProvider,
+		secretLock:    secretLock,
+	}
 }

--- a/test/bdd/pkg/verifiable/verifiable_steps.go
+++ b/test/bdd/pkg/verifiable/verifiable_steps.go
@@ -139,9 +139,11 @@ func (s *SDKSteps) verifyCredential(holder string) error {
 	vdriRegistry := s.bddContext.AgentCtx[holder].VDRIRegistry()
 	pKeyFetcher := verifiable.NewDIDKeyResolver(vdriRegistry).PublicKeyFetcher()
 
+	suite := ed25519signature2018.New(ed25519signature2018.WithVerifier(&ed25519signature2018.PublicKeyVerifier{}))
+
 	parsedVC, _, err := verifiable.NewCredential(s.issuedVCBytes,
 		verifiable.WithPublicKeyFetcher(pKeyFetcher),
-		verifiable.WithEmbeddedSignatureSuites(ed25519signature2018.New()))
+		verifiable.WithEmbeddedSignatureSuites(suite))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
closes #1458

Signed-off-by: Dima <dkinoshenko@gmail.com>

Follow-up issue to use Crypto for VC: https://github.com/hyperledger/aries-framework-go/issues/1416
Follow-up issue to use Crypto in JWS/JWT: https://github.com/hyperledger/aries-framework-go/issues/1267