### PR TITLE
feat: client pkg for out-of-band protocol

### DIFF
--- a/pkg/client/outofband/client.go
+++ b/pkg/client/outofband/client.go
@@ -1,0 +1,145 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package outofband
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+)
+
+const (
+	protocolURI    = "https://didcomm.org/oob-request/1.0"
+	requestMsgType = protocolURI + "/request"
+)
+
+// RequestOptions allow you to customize the way request messages are built.
+type RequestOptions func(*Request) error
+
+// ConnectionRecorder records connection records produced as byproducts of creation of messages.
+type ConnectionRecorder interface {
+	SaveInvitation(id string, i interface{}) error
+}
+
+// Provider provides the dependencies for the client.
+type Provider interface {
+	// DidDocServiceFunc returns a function that returns a DID doc `service` entry.
+	// Used when no service entries are specified when creating messages.
+	DidDocServiceFunc() func() (*did.Service, error)
+	ConnRecorder() ConnectionRecorder
+}
+
+// Client for the Out-Of-Band protocol:
+// https://github.com/hyperledger/aries-rfcs/blob/master/features/0434-outofband/README.md
+type Client struct {
+	didDocSvcFunc func() (*did.Service, error)
+	connRecorder  ConnectionRecorder
+}
+
+// New returns a new Client for the Out-Of-Band protocol.
+func New(p Provider) *Client {
+	return &Client{
+		didDocSvcFunc: p.DidDocServiceFunc(),
+		connRecorder:  p.ConnRecorder(),
+	}
+}
+
+// CreateRequest creates and saves an Out-Of-Band request message.
+// At least one attachment must be provided.
+// Service entries can be optionally provided. If none are provided then a new one will be automatically created for
+// you.
+func (c *Client) CreateRequest(opts ...RequestOptions) (*Request, error) {
+	req := &Request{}
+
+	for _, opt := range opts {
+		if err := opt(req); err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+	}
+
+	if len(req.Requests) == 0 {
+		return nil, errors.New("must provide at least one attachment to create an out-of-band request")
+	}
+
+	if len(req.Service) == 0 {
+		svc, err := c.didDocSvcFunc()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create a new inlined did doc service block : %w", err)
+		}
+
+		req.Service = []interface{}{svc}
+	}
+
+	req.ID = uuid.New().String()
+	req.Type = requestMsgType
+
+	err := c.connRecorder.SaveInvitation(req.ID, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to save request : %w", err)
+	}
+
+	return req, nil
+}
+
+// WithLabel allows you to specify the label on the message.
+func WithLabel(l string) RequestOptions {
+	return func(r *Request) error {
+		r.Label = l
+		return nil
+	}
+}
+
+// WithAttachments allows you to specify attachments to include in the `request~attach` property.
+func WithAttachments(a ...*decorator.Attachment) RequestOptions {
+	return func(r *Request) error {
+		r.Requests = a
+		return nil
+	}
+}
+
+// WithGoal allows you to specify the `goal` and `goalCode` for the message.
+func WithGoal(goal, goalCode string) RequestOptions {
+	return func(r *Request) error {
+		r.Goal = goal
+		r.GoalCode = goalCode
+
+		return nil
+	}
+}
+
+// WithServices allows you to specify service entries to include in the request message.
+// Each entry must be either a valid DID (string) or a `service` object.
+func WithServices(svcs ...interface{}) RequestOptions {
+	return func(r *Request) error {
+		all := make([]interface{}, len(svcs))
+
+		for i := range svcs {
+			switch svc := svcs[i].(type) {
+			case string:
+				_, err := did.Parse(svc)
+
+				if err != nil {
+					return fmt.Errorf("failed to parse did : %w", err)
+				}
+
+				all[i] = svc
+			case *did.Service:
+				all[i] = svc
+			default:
+				return fmt.Errorf("unsupported service data type : %+v", svc)
+			}
+		}
+
+		r.Service = all
+
+		return nil
+	}
+}

--- a/pkg/client/outofband/client_test.go
+++ b/pkg/client/outofband/client_test.go
@@ -1,0 +1,339 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package outofband
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("returns client", func(t *testing.T) {
+		c := New(
+			&mockProvider{
+				didDocSvcFunc: func() (*did.Service, error) {
+					return &did.Service{}, nil
+				},
+				connRecorder: connRecorder(),
+			},
+		)
+		require.NotNil(t, c)
+	})
+}
+
+func TestCreateRequest(t *testing.T) {
+	t.Run("fails with no attachment", func(t *testing.T) {
+		c := New(
+			&mockProvider{
+				didDocSvcFunc: func() (*did.Service, error) {
+					return &did.Service{}, nil
+				},
+				connRecorder: connRecorder(),
+			},
+		)
+		_, err := c.CreateRequest()
+		require.Error(t, err)
+	})
+	t.Run("sets an id", func(t *testing.T) {
+		c := New(
+			&mockProvider{
+				didDocSvcFunc: func() (*did.Service, error) {
+					return &did.Service{}, nil
+				},
+				connRecorder: connRecorder(),
+			},
+		)
+		req, err := c.CreateRequest(WithAttachments(dummyAttachment(t)))
+		require.NoError(t, err)
+		require.NotEmpty(t, req.ID)
+	})
+	t.Run("sets correct type", func(t *testing.T) {
+		c := New(
+			&mockProvider{
+				didDocSvcFunc: func() (*did.Service, error) {
+					return &did.Service{}, nil
+				},
+				connRecorder: connRecorder(),
+			},
+		)
+		req, err := c.CreateRequest(WithAttachments(dummyAttachment(t)))
+		require.NoError(t, err)
+		require.Equal(t, "https://didcomm.org/oob-request/1.0/request", req.Type)
+	})
+	t.Run("WithAttachments", func(t *testing.T) {
+		c := New(
+			&mockProvider{
+				didDocSvcFunc: func() (*did.Service, error) {
+					return &did.Service{}, nil
+				},
+				connRecorder: connRecorder(),
+			},
+		)
+		first := dummyAttachment(t)
+		second := dummyAttachment(t)
+		req, err := c.CreateRequest(WithAttachments(first, second))
+		require.NoError(t, err)
+		require.Len(t, req.Requests, 2)
+		require.Contains(t, req.Requests, first)
+		require.Contains(t, req.Requests, second)
+	})
+	t.Run("includes the diddoc Service block returned by provider", func(t *testing.T) {
+		expected := &did.Service{
+			ID:              uuid.New().String(),
+			Type:            uuid.New().String(),
+			Priority:        0,
+			RecipientKeys:   []string{uuid.New().String()},
+			RoutingKeys:     []string{uuid.New().String()},
+			ServiceEndpoint: uuid.New().String(),
+			Properties:      nil,
+		}
+		c := New(
+			&mockProvider{
+				didDocSvcFunc: func() (*did.Service, error) {
+					return expected, nil
+				},
+				connRecorder: connRecorder(),
+			},
+		)
+		req, err := c.CreateRequest(WithAttachments(dummyAttachment(t)))
+		require.NoError(t, err)
+		require.Len(t, req.Service, 1)
+		require.Equal(t, expected, req.Service[0])
+	})
+	t.Run("WithLabel", func(t *testing.T) {
+		c := New(
+			&mockProvider{
+				didDocSvcFunc: func() (*did.Service, error) {
+					return &did.Service{}, nil
+				},
+				connRecorder: connRecorder(),
+			},
+		)
+		expected := uuid.New().String()
+		req, err := c.CreateRequest(
+			WithAttachments(dummyAttachment(t)),
+			WithLabel(expected))
+		require.NoError(t, err)
+		require.Equal(t, expected, req.Label)
+	})
+	t.Run("WithGoal", func(t *testing.T) {
+		c := New(
+			&mockProvider{
+				didDocSvcFunc: func() (*did.Service, error) {
+					return &did.Service{}, nil
+				},
+				connRecorder: connRecorder(),
+			},
+		)
+		expectedGoal := uuid.New().String()
+		expectedGoalCode := uuid.New().String()
+		req, err := c.CreateRequest(
+			WithAttachments(dummyAttachment(t)),
+			WithGoal(expectedGoal, expectedGoalCode))
+		require.NoError(t, err)
+		require.Equal(t, expectedGoal, req.Goal)
+		require.Equal(t, expectedGoalCode, req.GoalCode)
+	})
+	t.Run("WithServices diddoc service blocks", func(t *testing.T) {
+		c := New(
+			&mockProvider{
+				didDocSvcFunc: func() (*did.Service, error) {
+					return &did.Service{}, nil
+				},
+				connRecorder: connRecorder(),
+			},
+		)
+		expected := &did.Service{
+			ID:              uuid.New().String(),
+			Type:            uuid.New().String(),
+			Priority:        0,
+			RecipientKeys:   []string{uuid.New().String()},
+			RoutingKeys:     []string{uuid.New().String()},
+			ServiceEndpoint: uuid.New().String(),
+			Properties:      nil,
+		}
+		req, err := c.CreateRequest(
+			WithAttachments(dummyAttachment(t)),
+			WithServices(expected))
+		require.NoError(t, err)
+		require.Len(t, req.Service, 1)
+		require.Equal(t, expected, req.Service[0])
+	})
+	t.Run("WithServices dids", func(t *testing.T) {
+		c := New(
+			&mockProvider{
+				didDocSvcFunc: func() (*did.Service, error) {
+					return &did.Service{}, nil
+				},
+				connRecorder: connRecorder(),
+			},
+		)
+		expected := "did:example:123"
+		req, err := c.CreateRequest(
+			WithAttachments(dummyAttachment(t)),
+			WithServices(expected))
+		require.NoError(t, err)
+		require.Len(t, req.Service, 1)
+		require.Equal(t, expected, req.Service[0])
+	})
+	t.Run("WithServices dids and diddoc service blocks", func(t *testing.T) {
+		c := New(
+			&mockProvider{
+				didDocSvcFunc: func() (*did.Service, error) {
+					return &did.Service{}, nil
+				},
+				connRecorder: connRecorder(),
+			},
+		)
+		didRef := "did:example:123"
+		svc := &did.Service{
+			ID:              uuid.New().String(),
+			Type:            uuid.New().String(),
+			Priority:        0,
+			RecipientKeys:   []string{uuid.New().String()},
+			RoutingKeys:     []string{uuid.New().String()},
+			ServiceEndpoint: uuid.New().String(),
+			Properties:      nil,
+		}
+		req, err := c.CreateRequest(
+			WithAttachments(dummyAttachment(t)),
+			WithServices(svc, didRef))
+		require.NoError(t, err)
+		require.Len(t, req.Service, 2)
+		require.Contains(t, req.Service, didRef)
+		require.Contains(t, req.Service, svc)
+	})
+	t.Run("WithServices rejects invalid dids", func(t *testing.T) {
+		c := New(
+			&mockProvider{
+				didDocSvcFunc: func() (*did.Service, error) {
+					return &did.Service{}, nil
+				},
+				connRecorder: connRecorder(),
+			},
+		)
+		didRef := "123"
+		_, err := c.CreateRequest(
+			WithAttachments(dummyAttachment(t)),
+			WithServices(didRef))
+		require.Error(t, err)
+	})
+	t.Run("WithServices rejects unsupported service data types", func(t *testing.T) {
+		c := New(
+			&mockProvider{
+				didDocSvcFunc: func() (*did.Service, error) {
+					return &did.Service{}, nil
+				},
+				connRecorder: connRecorder(),
+			},
+		)
+		unsupported := &struct{ foo string }{foo: "bar"}
+		_, err := c.CreateRequest(
+			WithAttachments(dummyAttachment(t)),
+			WithServices(unsupported))
+		require.Error(t, err)
+	})
+	t.Run("wraps error from diddoc service func", func(t *testing.T) {
+		expected := errors.New("test")
+		c := New(
+			&mockProvider{
+				didDocSvcFunc: func() (*did.Service, error) {
+					return nil, expected
+				},
+				connRecorder: connRecorder(),
+			},
+		)
+		_, err := c.CreateRequest(WithAttachments(dummyAttachment(t)))
+		require.Error(t, err)
+		require.True(t, errors.Is(err, expected))
+	})
+	t.Run("wraps error from the connection recorder", func(t *testing.T) {
+		expected := errors.New("test")
+		c := New(
+			&mockProvider{
+				didDocSvcFunc: func() (*did.Service, error) {
+					return &did.Service{}, nil
+				},
+				connRecorder: &mockConnRecorder{
+					saveInvFunc: func(string, interface{}) error {
+						return expected
+					},
+				},
+			},
+		)
+		_, err := c.CreateRequest(WithAttachments(dummyAttachment(t)))
+		require.Error(t, err)
+		require.True(t, errors.Is(err, expected))
+	})
+}
+
+type mockProvider struct {
+	didDocSvcFunc func() (*did.Service, error)
+	connRecorder  ConnectionRecorder
+}
+
+func (m *mockProvider) DidDocServiceFunc() func() (*did.Service, error) {
+	return m.didDocSvcFunc
+}
+
+func (m *mockProvider) ConnRecorder() ConnectionRecorder {
+	return m.connRecorder
+}
+
+func connRecorder() ConnectionRecorder {
+	return &mockConnRecorder{
+		saveInvFunc: func(string, interface{}) error {
+			return nil
+		},
+	}
+}
+
+type mockConnRecorder struct {
+	saveInvFunc func(id string, i interface{}) error
+}
+
+func (m *mockConnRecorder) SaveInvitation(id string, i interface{}) error {
+	return m.saveInvFunc(id, i)
+}
+
+func dummyAttachment(t *testing.T) *decorator.Attachment {
+	return base64Attachment(t, &didcommMsg{
+		ID:   uuid.New().String(),
+		Type: uuid.New().String(),
+	})
+}
+
+func base64Attachment(t *testing.T, data interface{}) *decorator.Attachment {
+	bytes, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	return &decorator.Attachment{
+		ID:          uuid.New().String(),
+		Description: uuid.New().String(),
+		FileName:    uuid.New().String(),
+		MimeType:    uuid.New().String(),
+		LastModTime: time.Now(),
+		ByteCount:   0,
+		Data: decorator.AttachmentData{
+			Base64: base64.StdEncoding.EncodeToString(bytes),
+		},
+	}
+}
+
+type didcommMsg struct {
+	ID   string
+	Type string
+}

--- a/pkg/client/outofband/models.go
+++ b/pkg/client/outofband/models.go
@@ -1,0 +1,20 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package outofband
+
+import "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+
+// Request embeds the sender's request.
+type Request struct {
+	ID       string                  `json:"@id"`
+	Type     string                  `json:"@type"`
+	Label    string                  `json:"label,omitempty"`
+	Goal     string                  `json:"goal,omitempty"`
+	GoalCode string                  `json:"goal-code,omitempty"`
+	Requests []*decorator.Attachment `json:"request~attach"`
+	Service  []interface{}           `json:"service"` // Service is an array of either DIDs or 'service' block entries.
+}


### PR DESCRIPTION
closes #1456

* client package for the [Out-Of-Band protocol](https://github.com/hyperledger/aries-rfcs/blob/master/features/0434-outofband/README.md) 
* `did.Parse(string)` helper function (see #20)

TODO: add support for the creation of Out-Of-Band [`invitation`](https://github.com/hyperledger/aries-rfcs/blob/master/features/0434-outofband/README.md#message-type-httpsdidcommorgoob-invitationverinvitation)

Signed-off-by: George Aristy <george.aristy@securekey.com>
