### PR TITLE
feat: out-of-band protocol service skeleton

### DIFF
--- a/pkg/client/outofband/client.go
+++ b/pkg/client/outofband/client.go
@@ -10,20 +10,20 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/route"
-	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
-	"github.com/hyperledger/aries-framework-go/pkg/storage"
-	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
-
 	"github.com/google/uuid"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/outofband"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/route"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
 )
 
 const (
-	protocolURI    = "https://didcomm.org/oob-request/1.0"
-	requestMsgType = protocolURI + "/request"
+	// RequestMsgType is the request message's '@type'.
+	RequestMsgType = outofband.RequestMsgType
 )
 
 // RequestOptions allow you to customize the way request messages are built.
@@ -68,7 +68,7 @@ func New(p Provider) (*Client, error) {
 // Service entries can be optionally provided. If none are provided then a new one will be automatically created for
 // you.
 func (c *Client) CreateRequest(opts ...RequestOptions) (*Request, error) {
-	req := &Request{}
+	req := &Request{&outofband.Request{}}
 
 	for _, opt := range opts {
 		if err := opt(req); err != nil {
@@ -90,7 +90,7 @@ func (c *Client) CreateRequest(opts ...RequestOptions) (*Request, error) {
 	}
 
 	req.ID = uuid.New().String()
-	req.Type = requestMsgType
+	req.Type = RequestMsgType
 
 	err := c.connRecorder.SaveInvitation(req.ID, req)
 	if err != nil {

--- a/pkg/client/outofband/models.go
+++ b/pkg/client/outofband/models.go
@@ -6,15 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 
 package outofband
 
-import "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+import "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/outofband"
 
-// Request embeds the sender's request.
+// Request is the out-of-band protocol's 'request' message.
 type Request struct {
-	ID       string                  `json:"@id"`
-	Type     string                  `json:"@type"`
-	Label    string                  `json:"label,omitempty"`
-	Goal     string                  `json:"goal,omitempty"`
-	GoalCode string                  `json:"goal-code,omitempty"`
-	Requests []*decorator.Attachment `json:"request~attach"`
-	Service  []interface{}           `json:"service"` // Service is an array of either DIDs or 'service' block entries.
+	*outofband.Request
 }

--- a/pkg/didcomm/protocol/outofband/models.go
+++ b/pkg/didcomm/protocol/outofband/models.go
@@ -1,0 +1,20 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package outofband
+
+import "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+
+// Request embeds the sender's request.
+type Request struct {
+	ID       string                  `json:"@id"`
+	Type     string                  `json:"@type"`
+	Label    string                  `json:"label,omitempty"`
+	Goal     string                  `json:"goal,omitempty"`
+	GoalCode string                  `json:"goal-code,omitempty"`
+	Requests []*decorator.Attachment `json:"request~attach"`
+	Service  []interface{}           `json:"service"` // Service is an array of either DIDs or 'service' block entries.
+}

--- a/pkg/didcomm/protocol/outofband/service.go
+++ b/pkg/didcomm/protocol/outofband/service.go
@@ -1,0 +1,337 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package outofband
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/logutil"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
+)
+
+var logger = log.New("aries-framework/did-exchange/service")
+
+const (
+	// Name of this protocol service.
+	Name = "out-of-band"
+	// RequestMsgType is the '@type' for the request message.
+	RequestMsgType = "https://didcomm.org/oob-request/1.0/request"
+
+	// TODO channel size - https://github.com/hyperledger/aries-framework-go/issues/246
+	callbackChannelSize = 10
+)
+
+var errIgnoredDidEvent = errors.New("ignored")
+
+// Service implements the Out-Of-Band protocol.
+type Service struct {
+	service.Action
+	service.Message
+	callbackChannel            chan *callback
+	didSvc                     service.InboundHandler
+	didEvents                  chan service.StateMsg
+	store                      storage.Store
+	connections                *connection.Lookup
+	dispatch                   transport.InboundMessageHandler
+	getNextRequestFunc         func(*myState) (*decorator.Attachment, bool)
+	extractDIDCommMsgBytesFunc func(*decorator.Attachment) ([]byte, error)
+	listenerFunc               func()
+}
+
+type callback struct {
+	msg      service.DIDCommMsg
+	myDID    string
+	theirDID string
+}
+
+type myState struct {
+	ID           string
+	ConnectionID string
+	Request      *Request
+	Done         bool
+}
+
+// Provider provides this service's dependencies.
+type Provider interface {
+	Service(id string) (interface{}, error)
+	StorageProvider() storage.Provider
+	TransientStorageProvider() storage.Provider
+	InboundMessageHandler() transport.InboundMessageHandler
+}
+
+// New creates a new instance of the out-of-band service.
+func New(p Provider) (*Service, error) {
+	svc, err := p.Service(didexchange.DIDExchange)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize outofband service : %w", err)
+	}
+
+	didSvc, ok := svc.(service.InboundHandler)
+	if !ok {
+		return nil, errors.New("failed to cast the didexchange service to service.InboundHandler")
+	}
+
+	store, err := p.TransientStorageProvider().OpenStore(Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open the store : %w", err)
+	}
+
+	connectionLookup, err := connection.NewLookup(p)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open a connection.Lookup : %w", err)
+	}
+
+	s := &Service{
+		callbackChannel:            make(chan *callback, callbackChannelSize),
+		didSvc:                     didSvc,
+		didEvents:                  make(chan service.StateMsg, callbackChannelSize),
+		store:                      store,
+		connections:                connectionLookup,
+		dispatch:                   p.InboundMessageHandler(),
+		getNextRequestFunc:         getNextRequest,
+		extractDIDCommMsgBytesFunc: extractDIDCommMsgBytes,
+	}
+
+	s.listenerFunc = listener(s.callbackChannel, s.didEvents, s.handleRequestCallback, s.handleDIDEvent)
+
+	didEventsSvc, ok := didSvc.(service.Event)
+	if !ok {
+		return nil, errors.New("failed to cast didexchange service to service.Event")
+	}
+
+	if err = didEventsSvc.RegisterMsgEvent(s.didEvents); err != nil {
+		return nil, fmt.Errorf("failed to register for didexchange protocol msgs : %w", err)
+	}
+
+	go s.listenerFunc()
+
+	return s, nil
+}
+
+// Name is this service's name
+func (s *Service) Name() string {
+	return Name
+}
+
+// Accept determines whether this service can handle the given type of message
+func (s *Service) Accept(msgType string) bool {
+	// TODO add invitation msg type https://github.com/hyperledger/aries-rfcs/issues/451
+	return msgType == RequestMsgType
+}
+
+// HandleInbound handles inbound messages
+func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+	logger.Debugf("receive inbound message : %s", msg)
+
+	if !s.Accept(msg.Type()) {
+		return "", fmt.Errorf("unsupported message type %s", msg.Type())
+	}
+
+	// TODO should request messages with no attachments be rejected?
+	//  https://github.com/hyperledger/aries-rfcs/issues/451
+
+	go func() {
+		s.ActionEvent() <- service.DIDCommAction{
+			ProtocolName: Name,
+			Message:      msg,
+			Continue:     continueFunc(s.callbackChannel, msg, myDID, theirDID),
+			Stop: func(e error) {
+				// TODO noop - nothing to do here (not even cleanup)
+			},
+			Properties: nil,
+		}
+	}()
+
+	return "", nil
+}
+
+// HandleOutbound handles outbound messages
+func (s *Service) HandleOutbound(_ service.DIDCommMsg, _, _ string) error {
+	// TODO implement
+	return errors.New("not implemented")
+}
+
+func continueFunc(c chan *callback, msg service.DIDCommMsg, myDID, theirDID string) func(interface{}) {
+	return func(_ interface{}) {
+		c <- &callback{
+			msg:      msg,
+			myDID:    myDID,
+			theirDID: theirDID,
+		}
+	}
+}
+
+func listener(
+	callbacks chan *callback,
+	didEvents chan service.StateMsg,
+	handleReqFunc func(*callback) error,
+	handleDidEventFunc func(msg service.StateMsg) error) func() {
+	return func() {
+		for {
+			select {
+			case c := <-callbacks:
+				// TODO add support for handling the 'invitation' message
+				//  https://github.com/hyperledger/aries-framework-go/issues/1488
+				switch c.msg.Type() {
+				case RequestMsgType:
+					err := handleReqFunc(c)
+					if err != nil {
+						logutil.LogError(logger, Name, "handleRequestCallback", err.Error(),
+							logutil.CreateKeyValueString("msgType", c.msg.Type()),
+							logutil.CreateKeyValueString("msgID", c.msg.ID()))
+					}
+				default:
+					logutil.LogError(logger, Name, "callbackChannel", "unsupported msg type",
+						logutil.CreateKeyValueString("msgType", c.msg.Type()),
+						logutil.CreateKeyValueString("msgID", c.msg.ID()))
+				}
+			case e := <-didEvents:
+				err := handleDidEventFunc(e)
+				if err != nil {
+					logutil.LogError(logger, Name, "handleDIDEvent", err.Error())
+				}
+			}
+		}
+	}
+}
+
+func (s *Service) handleRequestCallback(c *callback) error {
+	// TODO either transform to a didexchange.invitation object or refactor didexchange.Service to accept this object
+	connID, err := s.didSvc.HandleInbound(c.msg, c.myDID, c.theirDID)
+	if err != nil {
+		return fmt.Errorf("didexchange service failed to handle inbound request : %w", err)
+	}
+
+	req := &Request{}
+
+	err = c.msg.Decode(req)
+	if err != nil {
+		return fmt.Errorf("failed to decode request message : %w", err)
+	}
+
+	// TODO if we want to implement retries then we should be saving state before invoking
+	//  the didexchange service
+	err = s.save(&myState{
+		ID:           c.msg.ID(),
+		ConnectionID: connID,
+		Request:      req,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to save my state : %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) handleDIDEvent(e service.StateMsg) error {
+	// TODO remove 'empty parent threadID check'?
+	if e.Type != service.PostState || e.Msg.Type() != didexchange.AckMsgType || e.Msg.ParentThreadID() == "" {
+		// we are only interested in a successfully completed didexchange.
+		// the out-of-band protocol thread should be the did-exchange's parent thread.
+		return errIgnoredDidEvent
+	}
+
+	state, err := s.fetchMyState(e.Msg.ParentThreadID())
+	if err != nil {
+		return fmt.Errorf("failed to load state data with id=%s : %w", e.Msg.ParentThreadID(), err)
+	}
+
+	req, found := s.getNextRequestFunc(state)
+	if !found {
+		return errIgnoredDidEvent
+	}
+
+	bytes, err := s.extractDIDCommMsgBytesFunc(req)
+	if err != nil {
+		return fmt.Errorf("failed to extract didcomm message from attachment : %w", err)
+	}
+
+	record, err := s.fetchConnectionRecord(state.ConnectionID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch connection record with id=%s : %w", state.ConnectionID, err)
+	}
+
+	err = s.dispatch(bytes, record.MyDID, record.TheirDID)
+	if err != nil {
+		return fmt.Errorf("failed to dispatch message : %w", err)
+	}
+
+	// TODO do we need the capability to register for events from whatever protocol service is handling that msg?
+
+	// TODO we're only processing a single message for now
+	state.Done = true
+
+	err = s.save(state)
+	if err != nil {
+		return fmt.Errorf("failed to update state : %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) save(state *myState) error {
+	bytes, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("failed to save state=%+v : %w", state, err)
+	}
+
+	err = s.store.Put(state.ID, bytes)
+	if err != nil {
+		return fmt.Errorf("failed to save state : %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) fetchMyState(id string) (*myState, error) {
+	bytes, err := s.store.Get(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch state data with id=%s : %w", id, err)
+	}
+
+	state := &myState{}
+
+	err = json.Unmarshal(bytes, state)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal state %+v : %w", state, err)
+	}
+
+	return state, nil
+}
+
+func (s *Service) fetchConnectionRecord(id string) (*connection.Record, error) {
+	r, err := s.connections.GetConnectionRecord(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch connection record for id=%s : %w", id, err)
+	}
+
+	return r, nil
+}
+
+// TODO a request message contains an array of attachments (each a request in of itself).
+//  Should we process in parallel? Would need a spec update.
+func getNextRequest(state *myState) (*decorator.Attachment, bool) {
+	if !state.Done {
+		return state.Request.Requests[0], true
+	}
+
+	return nil, false
+}
+
+func extractDIDCommMsgBytes(_ *decorator.Attachment) ([]byte, error) {
+	// TODO implement
+	return nil, nil
+}

--- a/pkg/didcomm/protocol/outofband/service_test.go
+++ b/pkg/didcomm/protocol/outofband/service_test.go
@@ -1,0 +1,587 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package outofband
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/model"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol"
+	mockdidexchange "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/protocol/didexchange"
+	mockstore "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("returns the service", func(t *testing.T) {
+		s, err := New(testProvider())
+		require.NoError(t, err)
+		require.NotNil(t, s)
+	})
+	t.Run("fails if no didexchange service is registered", func(t *testing.T) {
+		provider := testProvider()
+		provider.ServiceErr = api.ErrSvcNotFound
+		_, err := New(provider)
+		require.Error(t, err)
+	})
+	t.Run("fails if the didexchange service cannot be cast to an inboundhandler", func(t *testing.T) {
+		provider := testProvider()
+		provider.ServiceMap[didexchange.DIDExchange] = &struct{}{}
+		_, err := New(provider)
+		require.Error(t, err)
+	})
+	t.Run("wraps error thrown from transient store when it cannot be opened", func(t *testing.T) {
+		expected := errors.New("test")
+		provider := testProvider()
+		provider.TransientStoreProvider = &mockstore.MockStoreProvider{
+			ErrOpenStoreHandle: expected,
+		}
+		_, err := New(provider)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, expected))
+	})
+	t.Run("wraps error thrown from persistent store when it cannot be opened", func(t *testing.T) {
+		expected := errors.New("test")
+		provider := testProvider()
+		provider.StoreProvider = &mockstore.MockStoreProvider{
+			ErrOpenStoreHandle: expected,
+		}
+		_, err := New(provider)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, expected))
+	})
+	t.Run("fails if the didexchange service cannot be cast to service.Event", func(t *testing.T) {
+		provider := testProvider()
+		provider.ServiceMap[didexchange.DIDExchange] = &struct{ service.InboundHandler }{}
+		_, err := New(provider)
+		require.Error(t, err)
+	})
+	t.Run("wraps error thrown when attempting to register to listen for didexchange events", func(t *testing.T) {
+		expected := errors.New("test")
+		provider := testProvider()
+		provider.ServiceMap = map[string]interface{}{
+			didexchange.DIDExchange: &mockdidexchange.MockDIDExchangeSvc{
+				RegisterMsgEventErr: expected,
+			},
+		}
+		_, err := New(provider)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, expected))
+	})
+}
+
+func TestName(t *testing.T) {
+	s, err := New(testProvider())
+	require.NoError(t, err)
+	require.Equal(t, s.Name(), "out-of-band")
+}
+
+func TestAccept(t *testing.T) {
+	t.Run("accepts out-of-band request messages", func(t *testing.T) {
+		s, err := New(testProvider())
+		require.NoError(t, err)
+		require.True(t, s.Accept("https://didcomm.org/oob-request/1.0/request"))
+	})
+	t.Run("rejects unsupported messages", func(t *testing.T) {
+		s, err := New(testProvider())
+		require.NoError(t, err)
+		require.False(t, s.Accept("unsupported"))
+	})
+}
+
+func TestHandleInbound(t *testing.T) {
+	t.Run("accepts out-of-band request messages", func(t *testing.T) {
+		s, err := New(testProvider())
+		require.NoError(t, err)
+		_, err = s.HandleInbound(
+			service.NewDIDCommMsgMap(newRequest()),
+			"did:example:mine",
+			"did:example:theirs")
+		require.NoError(t, err)
+	})
+	t.Run("rejects unsupported message types", func(t *testing.T) {
+		s, err := New(testProvider())
+		require.NoError(t, err)
+		req := newRequest()
+		req.Type = "invalid"
+		_, err = s.HandleInbound(
+			service.NewDIDCommMsgMap(req),
+			"did:example:mine",
+			"did:example:theirs")
+		require.Error(t, err)
+	})
+	t.Run("fires off an action event", func(t *testing.T) {
+		expected := service.NewDIDCommMsgMap(newRequest())
+		s, err := New(testProvider())
+		require.NoError(t, err)
+		events := make(chan service.DIDCommAction)
+		err = s.RegisterActionEvent(events)
+		require.NoError(t, err)
+		_, err = s.HandleInbound(expected, "did:example:mine", "did:example:theirs")
+		require.NoError(t, err)
+		select {
+		case e := <-events:
+			require.Equal(t, Name, e.ProtocolName)
+			require.Equal(t, expected, e.Message)
+		case <-time.After(1 * time.Second):
+			t.Error("timeout waiting for action event")
+		}
+	})
+}
+
+func TestContinueFunc(t *testing.T) {
+	t.Run("enqueues callback", func(t *testing.T) {
+		callbacks := make(chan *callback, 2)
+		msg := service.NewDIDCommMsgMap(newRequest())
+		myDID := "did:example:mine"
+		theirDID := "did:example:theirs"
+		f := continueFunc(callbacks, msg, myDID, theirDID)
+		f(nil)
+		select {
+		case c := <-callbacks:
+			require.Equal(t, msg, c.msg)
+			require.Equal(t, myDID, c.myDID)
+			require.Equal(t, theirDID, c.theirDID)
+		case <-time.After(1 * time.Second):
+			t.Error("timeout")
+		}
+	})
+}
+
+func TestHandleRequestCallback(t *testing.T) {
+	t.Run("invokes the didexchange service", func(t *testing.T) {
+		invoked := make(chan struct{}, 2)
+		provider := testProvider()
+		provider.ServiceMap = map[string]interface{}{
+			didexchange.DIDExchange: &mockdidexchange.MockDIDExchangeSvc{
+				HandleFunc: func(msg service.DIDCommMsg) (string, error) {
+					invoked <- struct{}{}
+					return "", nil
+				},
+			},
+		}
+		s := newAutoService(t, provider)
+		err := s.handleRequestCallback(newReqCallback())
+		require.NoError(t, err)
+		select {
+		case <-invoked:
+		case <-time.After(1 * time.Second):
+			t.Error("timeout")
+		}
+	})
+	t.Run("wraps error returned by the didexchange service", func(t *testing.T) {
+		expected := errors.New("test")
+		provider := testProvider()
+		provider.ServiceMap = map[string]interface{}{
+			didexchange.DIDExchange: &mockdidexchange.MockDIDExchangeSvc{
+				HandleFunc: func(msg service.DIDCommMsg) (string, error) {
+					return "", expected
+				},
+			},
+		}
+		s := newAutoService(t, provider)
+		err := s.handleRequestCallback(newReqCallback())
+		require.Error(t, err)
+		require.True(t, errors.Is(err, expected))
+	})
+	t.Run("wraps error returned by the transient store", func(t *testing.T) {
+		expected := errors.New("test")
+		provider := testProvider()
+		provider.TransientStoreProvider = &mockstore.MockStoreProvider{
+			Store: &mockstore.MockStore{
+				ErrPut: expected,
+			},
+		}
+		s := newAutoService(t, provider)
+		err := s.handleRequestCallback(newReqCallback())
+		require.Error(t, err)
+		require.True(t, errors.Is(err, expected))
+	})
+}
+
+func TestHandleDIDEvent(t *testing.T) {
+	t.Run("invokes inbound msg handler", func(t *testing.T) {
+		invoked := make(chan struct{}, 2)
+		connID := uuid.New().String()
+		pthid := uuid.New().String()
+
+		provider := testProvider()
+		provider.InboundMsgHandler = func([]byte, string, string) error {
+			invoked <- struct{}{}
+			return nil
+		}
+
+		// setup connection state
+		r, err := connection.NewRecorder(provider)
+		require.NoError(t, err)
+		err = r.SaveConnectionRecord(&connection.Record{
+			ConnectionID: connID,
+			MyDID:        "did:example:mine",
+			TheirDID:     "did:example:theirs",
+		})
+		require.NoError(t, err)
+
+		s := newAutoService(t, provider,
+			withState(t, &myState{
+				ID:           pthid,
+				ConnectionID: connID,
+				Request:      newRequest(),
+				Done:         false,
+			},
+			))
+
+		err = s.handleDIDEvent(service.StateMsg{
+			ProtocolName: didexchange.DIDExchange,
+			Type:         service.PostState,
+			Msg:          service.NewDIDCommMsgMap(newAck(pthid)),
+		})
+		require.NoError(t, err)
+
+		select {
+		case <-invoked:
+		case <-time.After(1 * time.Second):
+			t.Error("timeout")
+		}
+	})
+	t.Run("wraps error returned by the transient store", func(t *testing.T) {
+		expected := errors.New("test")
+		provider := testProvider()
+		provider.TransientStoreProvider = &mockstore.MockStoreProvider{
+			Store: &mockstore.MockStore{
+				ErrGet: expected,
+			},
+		}
+		s := newAutoService(t, provider)
+		err := s.handleDIDEvent(service.StateMsg{
+			ProtocolName: didexchange.DIDExchange,
+			Type:         service.PostState,
+			Msg:          service.NewDIDCommMsgMap(newAck()),
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, expected))
+	})
+	t.Run("wraps error returned by the persistent store", func(t *testing.T) {
+		expected := errors.New("test")
+		pthid := uuid.New().String()
+
+		provider := testProvider()
+		provider.StoreProvider = &mockstore.MockStoreProvider{
+			Store: &mockstore.MockStore{
+				ErrGet: expected,
+			},
+		}
+		s := newAutoService(t, provider,
+			withState(t, &myState{
+				ID:           pthid,
+				ConnectionID: uuid.New().String(),
+				Request:      newRequest(),
+				Done:         false,
+			},
+			))
+		err := s.handleDIDEvent(service.StateMsg{
+			ProtocolName: didexchange.DIDExchange,
+			Type:         service.PostState,
+			Msg:          service.NewDIDCommMsgMap(newAck(pthid)),
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, expected))
+	})
+	t.Run("wraps error thrown by the dispatcher", func(t *testing.T) {
+		expected := errors.New("test")
+		pthid := uuid.New().String()
+		connID := uuid.New().String()
+
+		provider := testProvider()
+		provider.InboundMsgHandler = func([]byte, string, string) error {
+			return expected
+		}
+
+		// setup connection state
+		r, err := connection.NewRecorder(provider)
+		require.NoError(t, err)
+		err = r.SaveConnectionRecord(&connection.Record{
+			ConnectionID: connID,
+			MyDID:        "did:example:mine",
+			TheirDID:     "did:example:theirs",
+		})
+		require.NoError(t, err)
+
+		s := newAutoService(t, provider,
+			withState(t, &myState{
+				ID:           pthid,
+				ConnectionID: connID,
+				Request:      newRequest(),
+				Done:         false,
+			},
+			))
+		err = s.handleDIDEvent(service.StateMsg{
+			ProtocolName: didexchange.DIDExchange,
+			Type:         service.PostState,
+			Msg:          service.NewDIDCommMsgMap(newAck(pthid)),
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, expected))
+	})
+	t.Run("wraps error from store when saving state", func(t *testing.T) {
+		expected := errors.New("test")
+		pthid := uuid.New().String()
+		connID := uuid.New().String()
+
+		provider := testProvider()
+		provider.InboundMsgHandler = func([]byte, string, string) error {
+			return nil
+		}
+
+		// setup connection state
+		r, err := connection.NewRecorder(provider)
+		require.NoError(t, err)
+		err = r.SaveConnectionRecord(&connection.Record{
+			ConnectionID: connID,
+			MyDID:        "did:example:mine",
+			TheirDID:     "did:example:theirs",
+		})
+		require.NoError(t, err)
+
+		s := newAutoService(t, provider,
+			withState(t, &myState{
+				ID:           pthid,
+				ConnectionID: connID,
+				Request:      newRequest(),
+				Done:         false,
+			},
+			))
+
+		s.store = &mockstore.MockStore{
+			Store:  provider.TransientStoreProvider.Store.Store,
+			ErrPut: expected,
+		}
+
+		err = s.handleDIDEvent(service.StateMsg{
+			ProtocolName: didexchange.DIDExchange,
+			Type:         service.PostState,
+			Msg:          service.NewDIDCommMsgMap(newAck(pthid)),
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, expected))
+	})
+	t.Run("ignores non-poststate did events", func(t *testing.T) {
+		s := newAutoService(t, testProvider())
+		err := s.handleDIDEvent(service.StateMsg{
+			ProtocolName: didexchange.DIDExchange,
+			Type:         service.PreState,
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, errIgnoredDidEvent))
+	})
+	t.Run("ignores msgs that are not didexchange acks", func(t *testing.T) {
+		s := newAutoService(t, testProvider())
+		err := s.handleDIDEvent(service.StateMsg{
+			ProtocolName: didexchange.DIDExchange,
+			Type:         service.PostState,
+			Msg:          service.NewDIDCommMsgMap(&didexchange.Request{}),
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, errIgnoredDidEvent))
+	})
+	t.Run("ignores acks with no parent thread id", func(t *testing.T) {
+		s := newAutoService(t, testProvider())
+		err := s.handleDIDEvent(service.StateMsg{
+			ProtocolName: didexchange.DIDExchange,
+			Type:         service.PostState,
+			Msg: service.NewDIDCommMsgMap(&model.Ack{
+				Type:   didexchange.AckMsgType,
+				ID:     uuid.New().String(),
+				Status: "great",
+				Thread: &decorator.Thread{
+					ID: uuid.New().String(),
+				},
+			}),
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, errIgnoredDidEvent))
+	})
+	t.Run("ignores did event if no more requests are to be dispatched", func(t *testing.T) {
+		pthid := uuid.New().String()
+		connID := uuid.New().String()
+
+		s := newAutoService(t, testProvider(),
+			withState(t, &myState{
+				ID:           pthid,
+				ConnectionID: connID,
+				Request:      newRequest(),
+				Done:         false,
+			}),
+		)
+		s.getNextRequestFunc = func(*myState) (*decorator.Attachment, bool) {
+			return nil, false
+		}
+		err := s.handleDIDEvent(service.StateMsg{
+			ProtocolName: didexchange.DIDExchange,
+			Type:         service.PostState,
+			Msg:          service.NewDIDCommMsgMap(newAck(pthid)),
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, errIgnoredDidEvent))
+	})
+	t.Run("wraps error thrown while extracting didcomm msg bytes from request", func(t *testing.T) {
+		expected := errors.New("test")
+		pthid := uuid.New().String()
+		connID := uuid.New().String()
+
+		s := newAutoService(t, testProvider(),
+			withState(t, &myState{
+				ID:           pthid,
+				ConnectionID: connID,
+				Request:      newRequest(),
+				Done:         false,
+			}),
+		)
+		s.extractDIDCommMsgBytesFunc = func(*decorator.Attachment) ([]byte, error) {
+			return nil, expected
+		}
+		err := s.handleDIDEvent(service.StateMsg{
+			ProtocolName: didexchange.DIDExchange,
+			Type:         service.PostState,
+			Msg:          service.NewDIDCommMsgMap(newAck(pthid)),
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, expected))
+	})
+}
+
+func TestListener(t *testing.T) {
+	t.Run("invokes handleReqFunc", func(t *testing.T) {
+		invoked := make(chan struct{})
+		callbacks := make(chan *callback)
+		handleReqFunc := func(*callback) error {
+			invoked <- struct{}{}
+			return nil
+		}
+		go listener(callbacks, nil, handleReqFunc, nil)()
+
+		callbacks <- &callback{
+			msg: service.NewDIDCommMsgMap(newRequest()),
+		}
+
+		select {
+		case <-invoked:
+		case <-time.After(1 * time.Second):
+			t.Error("timeout")
+		}
+	})
+	t.Run("invokes handleDidEventFunc", func(t *testing.T) {
+		invoked := make(chan struct{})
+		didEvents := make(chan service.StateMsg)
+		handleDidEventFunc := func(msg service.StateMsg) error {
+			invoked <- struct{}{}
+			return nil
+		}
+		go listener(nil, didEvents, nil, handleDidEventFunc)()
+		didEvents <- service.StateMsg{}
+
+		select {
+		case <-invoked:
+		case <-time.After(1 * time.Second):
+			t.Error("timeout")
+		}
+	})
+}
+
+func testProvider() *protocol.MockProvider {
+	return &protocol.MockProvider{
+		StoreProvider:          mockstore.NewMockStoreProvider(),
+		TransientStoreProvider: mockstore.NewMockStoreProvider(),
+		ServiceMap: map[string]interface{}{
+			didexchange.DIDExchange: &mockdidexchange.MockDIDExchangeSvc{},
+		},
+	}
+}
+
+func newRequest() *Request {
+	return &Request{
+		ID:       uuid.New().String(),
+		Type:     RequestMsgType,
+		Label:    "test",
+		Goal:     "test",
+		GoalCode: "test",
+		Requests: []*decorator.Attachment{
+			{
+				ID:          uuid.New().String(),
+				Description: "test",
+				FileName:    "dont_open_this.exe",
+				MimeType:    "text/plain",
+				LastModTime: time.Now(),
+				Data: decorator.AttachmentData{
+					Base64: "test",
+				},
+			},
+		},
+		Service: []interface{}{"did:example:1235"},
+	}
+}
+
+func newReqCallback() *callback {
+	return &callback{
+		myDID:    fmt.Sprintf("did:example:%s", uuid.New().String()),
+		theirDID: fmt.Sprintf("did:example:%s", uuid.New().String()),
+		msg:      service.NewDIDCommMsgMap(newRequest()),
+	}
+}
+
+func withState(t *testing.T, states ...*myState) func(*Service) {
+	return func(s *Service) {
+		for i := range states {
+			err := s.save(states[i])
+			require.NoError(t, err)
+		}
+	}
+}
+
+func newAutoService(t *testing.T,
+	provider *protocol.MockProvider, opts ...func(*Service)) *Service { //nolint:interfacer
+	s, err := New(provider)
+	require.NoError(t, err)
+
+	for i := range opts {
+		opts[i](s)
+	}
+
+	events := make(chan service.DIDCommAction)
+	require.NoError(t, s.RegisterActionEvent(events))
+
+	go service.AutoExecuteActionEvent(events)
+
+	return s
+}
+
+func newAck(pthid ...string) *model.Ack {
+	a := &model.Ack{
+		Type:   didexchange.AckMsgType,
+		ID:     uuid.New().String(),
+		Status: "good",
+		Thread: &decorator.Thread{
+			ID:  uuid.New().String(),
+			PID: uuid.New().String(),
+		},
+	}
+
+	if len(pthid) > 0 {
+		a.Thread.PID = pthid[0]
+	}
+
+	return a
+}

--- a/pkg/internal/mock/didcomm/protocol/mock_protocol.go
+++ b/pkg/internal/mock/didcomm/protocol/mock_protocol.go
@@ -9,6 +9,7 @@ package protocol
 import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
 	mockservice "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/service"
@@ -29,6 +30,7 @@ type MockProvider struct {
 	CustomKMS              *mockkms.CloseableKMS
 	ServiceErr             error
 	ServiceMap             map[string]interface{}
+	InboundMsgHandler      transport.InboundMessageHandler
 }
 
 // OutboundDispatcher is mock outbound dispatcher for DID exchange service
@@ -97,4 +99,9 @@ func (p *MockProvider) Messenger() service.Messenger {
 	}
 
 	return &mockservice.MockMessenger{}
+}
+
+// InboundMessageHandler handles an unpacked inbound message.
+func (p *MockProvider) InboundMessageHandler() transport.InboundMessageHandler {
+	return p.InboundMsgHandler
 }


### PR DESCRIPTION
closes #1478 

Skeleton for the Out-Of-Band protocol service.

* A single out-of-band `request` contains one or more (didcomm?) messages embedded in attachments
* the service needs to first run didexchange (which *may* reuse an existing connection)
* the service then needs to dispatch the embedded requests (assuming didcomm for now...) to their respective handlers
