### PR TITLE
refactor: Removes deprecated Header structure

### DIFF
--- a/pkg/didcomm/common/service/did_comm_msg.go
+++ b/pkg/didcomm/common/service/did_comm_msg.go
@@ -14,8 +14,6 @@ import (
 	"time"
 
 	"github.com/mitchellh/mapstructure"
-
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 )
 
 const (
@@ -38,15 +36,6 @@ const (
 // 	}
 type Metadata struct {
 	Payload map[string]interface{} `json:"_internal_metadata,omitempty"`
-}
-
-// Header helper structure which keeps reusable fields
-// Deprecated: Use DIDCommMsg instead of Header
-// TODO: Remove deprecated Header structure https://github.com/hyperledger/aries-framework-go/issues/1075
-type Header struct {
-	ID     string           `json:"@id"`
-	Thread decorator.Thread `json:"~thread"`
-	Type   string           `json:"@type"`
 }
 
 // DIDCommMsgMap did comm msg

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -497,17 +497,15 @@ func TestService_Accept(t *testing.T) {
 
 func TestService_threadID(t *testing.T) {
 	t.Run("returns new thid for ", func(t *testing.T) {
-		didMsg, err := service.ParseDIDCommMsgMap(toBytes(t, &service.Header{Type: InvitationMsgType}))
-		require.NoError(t, err)
+		didMsg := service.NewDIDCommMsgMap(Invitation{Type: InvitationMsgType})
 		thid, err := threadID(didMsg)
 		require.NoError(t, err)
 		require.NotNil(t, thid)
 	})
 
 	t.Run("returns unmarshall error", func(t *testing.T) {
-		didMsg, err := service.ParseDIDCommMsgMap(toBytes(t, &service.Header{Type: RequestMsgType}))
-		require.NoError(t, err)
-		_, err = threadID(didMsg)
+		didMsg := service.NewDIDCommMsgMap(Request{Type: RequestMsgType})
+		_, err := threadID(didMsg)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "threadID not found")
 	})
@@ -810,7 +808,7 @@ func TestEventStoreError(t *testing.T) {
 	go func() {
 		for e := range actionCh {
 			e.Continue = func(args interface{}) {
-				svc.processCallback(&message{Msg: toDIDCommMsg(t, &service.Header{})})
+				svc.processCallback(&message{Msg: service.NewDIDCommMsgMap(struct{}{})})
 			}
 			e.Continue(&service.Empty{})
 		}
@@ -829,12 +827,9 @@ func TestEventProcessCallback(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	didMsg, err := service.ParseDIDCommMsgMap(toBytes(t, &service.Header{Type: AckMsgType}))
-	require.NoError(t, err)
-
 	msg := &message{
 		ThreadID: threadIDValue,
-		Msg:      didMsg,
+		Msg:      service.NewDIDCommMsgMap(model.Ack{Type: AckMsgType}),
 	}
 
 	err = svc.handleWithoutAction(msg)

--- a/pkg/didcomm/protocol/didexchange/states_test.go
+++ b/pkg/didcomm/protocol/didexchange/states_test.go
@@ -216,10 +216,14 @@ func TestNullState_Execute(t *testing.T) {
 
 func TestInvitedState_Execute(t *testing.T) {
 	t.Run("rejects msgs other than invitations", func(t *testing.T) {
-		others := []string{RequestMsgType, ResponseMsgType, AckMsgType}
-		for _, o := range others {
+		others := []service.DIDCommMsg{
+			service.NewDIDCommMsgMap(Request{Type: RequestMsgType}),
+			service.NewDIDCommMsgMap(Response{Type: ResponseMsgType}),
+			service.NewDIDCommMsgMap(model.Ack{Type: AckMsgType}),
+		}
+		for _, msg := range others {
 			_, _, _, err := (&invited{}).ExecuteInbound(&stateMachineMsg{
-				DIDCommMsg: toDIDCommMsg(t, &service.Header{Type: o}),
+				DIDCommMsg: msg,
 			}, "", &context{})
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "illegal msg type")
@@ -260,10 +264,13 @@ func TestRequestedState_Execute(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Run("rejects messages other than invitations or requests", func(t *testing.T) {
-		others := []string{ResponseMsgType, AckMsgType}
-		for _, o := range others {
+		others := []service.DIDCommMsg{
+			service.NewDIDCommMsgMap(Response{Type: ResponseMsgType}),
+			service.NewDIDCommMsgMap(model.Ack{Type: AckMsgType}),
+		}
+		for _, msg := range others {
 			_, _, _, e := (&requested{}).ExecuteInbound(&stateMachineMsg{
-				DIDCommMsg: toDIDCommMsg(t, &service.Header{Type: o}),
+				DIDCommMsg: msg,
 			}, "", &context{})
 			require.Error(t, e)
 			require.Contains(t, e.Error(), "illegal msg type")
@@ -340,10 +347,13 @@ func TestRespondedState_Execute(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("rejects messages other than requests and responses", func(t *testing.T) {
-		others := []string{InvitationMsgType, AckMsgType}
-		for _, o := range others {
+		others := []service.DIDCommMsg{
+			service.NewDIDCommMsgMap(Invitation{Type: InvitationMsgType}),
+			service.NewDIDCommMsgMap(model.Ack{Type: AckMsgType}),
+		}
+		for _, msg := range others {
 			_, _, _, e := (&responded{}).ExecuteInbound(&stateMachineMsg{
-				DIDCommMsg: toDIDCommMsg(t, &service.Header{Type: o}),
+				DIDCommMsg: msg,
 			}, "", &context{})
 			require.Error(t, e)
 			require.Contains(t, e.Error(), "illegal msg type")
@@ -407,7 +417,7 @@ func TestRespondedState_Execute(t *testing.T) {
 func TestAbandonedState_Execute(t *testing.T) {
 	t.Run("execute abandon state", func(t *testing.T) {
 		connRec, _, _, err := (&abandoned{}).ExecuteInbound(&stateMachineMsg{
-			DIDCommMsg: toDIDCommMsg(t, &service.Header{Type: ResponseMsgType}),
+			DIDCommMsg: service.NewDIDCommMsgMap(Response{Type: ResponseMsgType}),
 		}, "", &context{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not implemented")
@@ -495,10 +505,14 @@ func TestCompletedState_Execute(t *testing.T) {
 		require.IsType(t, &noOp{}, followup)
 	})
 	t.Run("rejects messages other than responses and acks", func(t *testing.T) {
-		others := []string{InvitationMsgType, RequestMsgType}
-		for _, o := range others {
+		others := []service.DIDCommMsg{
+			service.NewDIDCommMsgMap(Invitation{Type: InvitationMsgType}),
+			service.NewDIDCommMsgMap(Request{Type: RequestMsgType}),
+		}
+
+		for _, msg := range others {
 			_, _, _, err = (&completed{}).ExecuteInbound(&stateMachineMsg{
-				DIDCommMsg: toDIDCommMsg(t, &service.Header{Type: o})}, "", &context{})
+				DIDCommMsg: msg}, "", &context{})
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "illegal msg type")
 		}


### PR DESCRIPTION
* removed `Header` structure

Closes https://github.com/hyperledger/aries-framework-go/issues/1075
Signed-off-by: Andrii Soluk <isoluchok@gmail.com>