### PR TITLE
feat: Present Proof - defines states for the protocol

### DIFF
--- a/pkg/didcomm/protocol/presentproof/states.go
+++ b/pkg/didcomm/protocol/presentproof/states.go
@@ -1,0 +1,255 @@
+package presentproof
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+)
+
+const (
+	// common states
+	stateNameStart      = "start"
+	stateNameAbandoning = "abandoning"
+	stateNameDone       = "done"
+	stateNameNoop       = "noop"
+
+	// states for Verifier
+	stateNameRequestSent                 = "request-sent"
+	stateNamePresentationReceived        = "presentation-received"
+	stateNameProposePresentationReceived = "propose-presentation-received"
+
+	// states for Prover
+	stateNameRequestReceived         = "request-received"
+	stateNamePresentationSent        = "presentation-sent"
+	stateNameProposePresentationSent = "propose-presentation-sent"
+)
+
+type metaData struct{}
+
+// state action for network call
+type stateAction func(messenger service.Messenger) error
+
+// the protocol's state.
+type state interface {
+	// Name of this state.
+	Name() string
+	// Whether this state allows transitioning into the next state.
+	CanTransitionTo(next state) bool
+	// Executes this state, returning a followup state to be immediately executed as well.
+	// The 'noOp' state should be returned if the state has no followup.
+	ExecuteInbound(msg *metaData) (state, stateAction, error)
+	ExecuteOutbound(msg *metaData) (state, stateAction, error)
+}
+
+// represents zero state's action
+func zeroAction(service.Messenger) error { return nil }
+
+// start state
+type start struct{}
+
+func (s *start) Name() string {
+	return stateNameStart
+}
+
+func (s *start) CanTransitionTo(st state) bool {
+	switch st.Name() {
+	// Verifier
+	case stateNameRequestSent, stateNameProposePresentationReceived:
+		return true
+	// Prover
+	case stateNameProposePresentationSent, stateNameRequestReceived:
+		return true
+	}
+
+	return false
+}
+
+func (s *start) ExecuteInbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteInbound is not implemented yet", s.Name())
+}
+
+func (s *start) ExecuteOutbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteOutbound is not implemented yet", s.Name())
+}
+
+// abandoning state
+type abandoning struct {
+	Code string
+}
+
+func (s *abandoning) Name() string {
+	return stateNameAbandoning
+}
+
+func (s *abandoning) CanTransitionTo(st state) bool {
+	return st.Name() == stateNameDone
+}
+
+func (s *abandoning) ExecuteInbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteInbound is not implemented yet", s.Name())
+}
+
+func (s *abandoning) ExecuteOutbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteOutbound is not implemented yet", s.Name())
+}
+
+// done state
+type done struct{}
+
+func (s *done) Name() string {
+	return stateNameDone
+}
+
+func (s *done) CanTransitionTo(_ state) bool {
+	return false
+}
+
+func (s *done) ExecuteInbound(_ *metaData) (state, stateAction, error) {
+	return &noOp{}, zeroAction, nil
+}
+
+func (s *done) ExecuteOutbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteOutbound is not implemented yet", s.Name())
+}
+
+// noOp state
+type noOp struct{}
+
+func (s *noOp) Name() string {
+	return stateNameNoop
+}
+
+func (s *noOp) CanTransitionTo(_ state) bool {
+	return false
+}
+
+func (s *noOp) ExecuteInbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, errors.New("cannot execute no-op")
+}
+
+func (s *noOp) ExecuteOutbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, errors.New("cannot execute no-op")
+}
+
+// requestReceived the Prover's state
+type requestReceived struct{}
+
+func (s *requestReceived) Name() string {
+	return stateNameRequestReceived
+}
+
+func (s *requestReceived) CanTransitionTo(st state) bool {
+	return st.Name() == stateNamePresentationSent ||
+		st.Name() == stateNameProposePresentationSent ||
+		st.Name() == stateNameAbandoning
+}
+
+func (s *requestReceived) ExecuteInbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteInbound is not implemented yet", s.Name())
+}
+
+func (s *requestReceived) ExecuteOutbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteOutbound is not implemented yet", s.Name())
+}
+
+// requestSent the Verifier's state
+type requestSent struct{}
+
+func (s *requestSent) Name() string {
+	return stateNameRequestSent
+}
+
+func (s *requestSent) CanTransitionTo(st state) bool {
+	return st.Name() == stateNamePresentationReceived ||
+		st.Name() == stateNameProposePresentationReceived ||
+		st.Name() == stateNameAbandoning
+}
+
+func (s *requestSent) ExecuteInbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteInbound is not implemented yet", s.Name())
+}
+
+func (s *requestSent) ExecuteOutbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteOutbound is not implemented yet", s.Name())
+}
+
+// presentationSent the Prover's state
+type presentationSent struct{}
+
+func (s *presentationSent) Name() string {
+	return stateNamePresentationSent
+}
+
+func (s *presentationSent) CanTransitionTo(st state) bool {
+	return st.Name() == stateNameAbandoning ||
+		st.Name() == stateNameDone
+}
+
+func (s *presentationSent) ExecuteInbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteInbound is not implemented yet", s.Name())
+}
+
+func (s *presentationSent) ExecuteOutbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteOutbound is not implemented yet", s.Name())
+}
+
+// presentationReceived the Verifier's state
+type presentationReceived struct{}
+
+func (s *presentationReceived) Name() string {
+	return stateNamePresentationReceived
+}
+
+func (s *presentationReceived) CanTransitionTo(st state) bool {
+	return st.Name() == stateNameAbandoning ||
+		st.Name() == stateNameDone
+}
+
+func (s *presentationReceived) ExecuteInbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteInbound is not implemented yet", s.Name())
+}
+
+func (s *presentationReceived) ExecuteOutbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteOutbound is not implemented yet", s.Name())
+}
+
+// proposePresentationSent the Prover's state
+type proposePresentationSent struct{}
+
+func (s *proposePresentationSent) Name() string {
+	return stateNameProposePresentationSent
+}
+
+func (s *proposePresentationSent) CanTransitionTo(st state) bool {
+	return st.Name() == stateNameRequestReceived ||
+		st.Name() == stateNameAbandoning
+}
+
+func (s *proposePresentationSent) ExecuteInbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteInbound is not implemented yet", s.Name())
+}
+
+func (s *proposePresentationSent) ExecuteOutbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteOutbound is not implemented yet", s.Name())
+}
+
+// proposePresentationReceived the Verifier's state
+type proposePresentationReceived struct{}
+
+func (s *proposePresentationReceived) Name() string {
+	return stateNameProposePresentationReceived
+}
+
+func (s *proposePresentationReceived) CanTransitionTo(st state) bool {
+	return st.Name() == stateNameRequestSent ||
+		st.Name() == stateNameAbandoning
+}
+
+func (s *proposePresentationReceived) ExecuteInbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteInbound is not implemented yet", s.Name())
+}
+
+func (s *proposePresentationReceived) ExecuteOutbound(_ *metaData) (state, stateAction, error) {
+	return nil, nil, fmt.Errorf("%s: ExecuteOutbound is not implemented yet", s.Name())
+}

--- a/pkg/didcomm/protocol/presentproof/states_test.go
+++ b/pkg/didcomm/protocol/presentproof/states_test.go
@@ -1,0 +1,321 @@
+package presentproof
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStart_CanTransitionTo(t *testing.T) {
+	st := &start{}
+	require.Equal(t, stateNameStart, st.Name())
+	// common states
+	require.False(t, st.CanTransitionTo(&start{}))
+	require.False(t, st.CanTransitionTo(&abandoning{}))
+	require.False(t, st.CanTransitionTo(&done{}))
+	require.False(t, st.CanTransitionTo(&noOp{}))
+	// states for Verifier
+	require.True(t, st.CanTransitionTo(&requestSent{}))
+	require.False(t, st.CanTransitionTo(&presentationReceived{}))
+	require.True(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	// states for Prover
+	require.True(t, st.CanTransitionTo(&requestReceived{}))
+	require.False(t, st.CanTransitionTo(&presentationSent{}))
+	require.True(t, st.CanTransitionTo(&proposePresentationSent{}))
+}
+
+func TestStart_ExecuteInbound(t *testing.T) {
+	followup, action, err := (&start{}).ExecuteInbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestStart_ExecuteOutbound(t *testing.T) {
+	followup, action, err := (&start{}).ExecuteOutbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestAbandoning_CanTransitionTo(t *testing.T) {
+	st := &abandoning{}
+	require.Equal(t, stateNameAbandoning, st.Name())
+	// common states
+	require.False(t, st.CanTransitionTo(&start{}))
+	require.False(t, st.CanTransitionTo(&abandoning{}))
+	require.True(t, st.CanTransitionTo(&done{}))
+	require.False(t, st.CanTransitionTo(&noOp{}))
+	// states for Verifier
+	require.False(t, st.CanTransitionTo(&requestSent{}))
+	require.False(t, st.CanTransitionTo(&presentationReceived{}))
+	require.False(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	// states for Prover
+	require.False(t, st.CanTransitionTo(&requestReceived{}))
+	require.False(t, st.CanTransitionTo(&presentationSent{}))
+	require.False(t, st.CanTransitionTo(&proposePresentationSent{}))
+}
+
+func TestAbandoning_ExecuteInbound(t *testing.T) {
+	followup, action, err := (&abandoning{}).ExecuteInbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestAbandoning_ExecuteOutbound(t *testing.T) {
+	followup, action, err := (&abandoning{}).ExecuteOutbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestDone_CanTransitionTo(t *testing.T) {
+	st := &done{}
+	require.Equal(t, stateNameDone, st.Name())
+	notTransition(t, st)
+}
+
+func TestDone_ExecuteInbound(t *testing.T) {
+	followup, action, err := (&done{}).ExecuteInbound(&metaData{})
+	require.NoError(t, err)
+	require.Equal(t, &noOp{}, followup)
+	require.NoError(t, action(nil))
+}
+
+func TestDone_ExecuteOutbound(t *testing.T) {
+	followup, action, err := (&done{}).ExecuteOutbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestNoOp_CanTransitionTo(t *testing.T) {
+	st := &noOp{}
+	require.Equal(t, stateNameNoop, st.Name())
+	notTransition(t, st)
+}
+
+func TestNoOp_ExecuteInbound(t *testing.T) {
+	followup, action, err := (&noOp{}).ExecuteInbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "cannot execute no-op")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestNoOp_ExecuteOutbound(t *testing.T) {
+	followup, action, err := (&noOp{}).ExecuteOutbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "cannot execute no-op")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestRequestReceived_CanTransitionTo(t *testing.T) {
+	st := &requestReceived{}
+	require.Equal(t, stateNameRequestReceived, st.Name())
+	// common states
+	require.False(t, st.CanTransitionTo(&start{}))
+	require.True(t, st.CanTransitionTo(&abandoning{}))
+	require.False(t, st.CanTransitionTo(&done{}))
+	require.False(t, st.CanTransitionTo(&noOp{}))
+	// states for Verifier
+	require.False(t, st.CanTransitionTo(&requestSent{}))
+	require.False(t, st.CanTransitionTo(&presentationReceived{}))
+	require.False(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	// states for Prover
+	require.False(t, st.CanTransitionTo(&requestReceived{}))
+	require.True(t, st.CanTransitionTo(&presentationSent{}))
+	require.True(t, st.CanTransitionTo(&proposePresentationSent{}))
+}
+
+func TestRequestReceived_ExecuteInbound(t *testing.T) {
+	followup, action, err := (&requestReceived{}).ExecuteInbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestRequestReceived_ExecuteOutbound(t *testing.T) {
+	followup, action, err := (&requestReceived{}).ExecuteOutbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestRequestSent_CanTransitionTo(t *testing.T) {
+	st := &requestSent{}
+	require.Equal(t, stateNameRequestSent, st.Name())
+	// common states
+	require.False(t, st.CanTransitionTo(&start{}))
+	require.True(t, st.CanTransitionTo(&abandoning{}))
+	require.False(t, st.CanTransitionTo(&done{}))
+	require.False(t, st.CanTransitionTo(&noOp{}))
+	// states for Verifier
+	require.False(t, st.CanTransitionTo(&requestSent{}))
+	require.True(t, st.CanTransitionTo(&presentationReceived{}))
+	require.True(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	// states for Prover
+	require.False(t, st.CanTransitionTo(&requestReceived{}))
+	require.False(t, st.CanTransitionTo(&presentationSent{}))
+	require.False(t, st.CanTransitionTo(&proposePresentationSent{}))
+}
+
+func TestRequestSent_ExecuteInbound(t *testing.T) {
+	followup, action, err := (&requestSent{}).ExecuteInbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestRequestSent_ExecuteOutbound(t *testing.T) {
+	followup, action, err := (&requestSent{}).ExecuteOutbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestPresentationSent_CanTransitionTo(t *testing.T) {
+	st := &presentationSent{}
+	require.Equal(t, stateNamePresentationSent, st.Name())
+	// common states
+	require.False(t, st.CanTransitionTo(&start{}))
+	require.True(t, st.CanTransitionTo(&abandoning{}))
+	require.True(t, st.CanTransitionTo(&done{}))
+	require.False(t, st.CanTransitionTo(&noOp{}))
+	// states for Verifier
+	require.False(t, st.CanTransitionTo(&requestSent{}))
+	require.False(t, st.CanTransitionTo(&presentationReceived{}))
+	require.False(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	// states for Prover
+	require.False(t, st.CanTransitionTo(&requestReceived{}))
+	require.False(t, st.CanTransitionTo(&presentationSent{}))
+	require.False(t, st.CanTransitionTo(&proposePresentationSent{}))
+}
+
+func TestPresentationSent_ExecuteInbound(t *testing.T) {
+	followup, action, err := (&presentationSent{}).ExecuteInbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestPresentationSent_ExecuteOutbound(t *testing.T) {
+	followup, action, err := (&presentationSent{}).ExecuteOutbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestPresentationReceived_CanTransitionTo(t *testing.T) {
+	st := &presentationReceived{}
+	require.Equal(t, stateNamePresentationReceived, st.Name())
+	// common states
+	require.False(t, st.CanTransitionTo(&start{}))
+	require.True(t, st.CanTransitionTo(&abandoning{}))
+	require.True(t, st.CanTransitionTo(&done{}))
+	require.False(t, st.CanTransitionTo(&noOp{}))
+	// states for Verifier
+	require.False(t, st.CanTransitionTo(&requestSent{}))
+	require.False(t, st.CanTransitionTo(&presentationReceived{}))
+	require.False(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	// states for Prover
+	require.False(t, st.CanTransitionTo(&requestReceived{}))
+	require.False(t, st.CanTransitionTo(&presentationSent{}))
+	require.False(t, st.CanTransitionTo(&proposePresentationSent{}))
+}
+
+func TestPresentationReceived_ExecuteInbound(t *testing.T) {
+	followup, action, err := (&presentationReceived{}).ExecuteInbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestPresentationReceived_ExecuteOutbound(t *testing.T) {
+	followup, action, err := (&presentationReceived{}).ExecuteOutbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestProposePresentationSent_CanTransitionTo(t *testing.T) {
+	st := &proposePresentationSent{}
+	require.Equal(t, stateNameProposePresentationSent, st.Name())
+	// common states
+	require.False(t, st.CanTransitionTo(&start{}))
+	require.True(t, st.CanTransitionTo(&abandoning{}))
+	require.False(t, st.CanTransitionTo(&done{}))
+	require.False(t, st.CanTransitionTo(&noOp{}))
+	// states for Verifier
+	require.False(t, st.CanTransitionTo(&requestSent{}))
+	require.False(t, st.CanTransitionTo(&presentationReceived{}))
+	require.False(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	// states for Prover
+	require.True(t, st.CanTransitionTo(&requestReceived{}))
+	require.False(t, st.CanTransitionTo(&presentationSent{}))
+	require.False(t, st.CanTransitionTo(&proposePresentationSent{}))
+}
+
+func TestProposePresentationSent_ExecuteInbound(t *testing.T) {
+	followup, action, err := (&proposePresentationSent{}).ExecuteInbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestProposePresentationSent_ExecuteOutbound(t *testing.T) {
+	followup, action, err := (&proposePresentationSent{}).ExecuteOutbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestProposePresentationReceived_CanTransitionTo(t *testing.T) {
+	st := &proposePresentationReceived{}
+	require.Equal(t, stateNameProposePresentationReceived, st.Name())
+	// common states
+	require.False(t, st.CanTransitionTo(&start{}))
+	require.True(t, st.CanTransitionTo(&abandoning{}))
+	require.False(t, st.CanTransitionTo(&done{}))
+	require.False(t, st.CanTransitionTo(&noOp{}))
+	// states for Verifier
+	require.True(t, st.CanTransitionTo(&requestSent{}))
+	require.False(t, st.CanTransitionTo(&presentationReceived{}))
+	require.False(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	// states for Prover
+	require.False(t, st.CanTransitionTo(&requestReceived{}))
+	require.False(t, st.CanTransitionTo(&presentationSent{}))
+	require.False(t, st.CanTransitionTo(&proposePresentationSent{}))
+}
+
+func TestProposePresentationReceived_ExecuteInbound(t *testing.T) {
+	followup, action, err := (&proposePresentationReceived{}).ExecuteInbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func TestProposePresentationReceived_ExecuteOutbound(t *testing.T) {
+	followup, action, err := (&proposePresentationReceived{}).ExecuteOutbound(&metaData{})
+	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
+	require.Nil(t, followup)
+	require.Nil(t, action)
+}
+
+func notTransition(t *testing.T, st state) {
+	t.Helper()
+
+	var allState = [...]state{
+		// common states
+		&start{}, &abandoning{}, &done{}, &noOp{},
+		// states for Verifier
+		&requestSent{}, &presentationReceived{}, &proposePresentationReceived{},
+		// states for Prover
+		&requestReceived{}, &presentationSent{}, &proposePresentationSent{},
+	}
+
+	for _, s := range allState {
+		require.False(t, st.CanTransitionTo(s))
+	}
+}


### PR DESCRIPTION
The following states were defined:
* request-sent (Verifier)
* presentation-received (Verifier)
* propose-presentation-received (Verifier)
* request-received (Prover)
* presentation-sent (Prover)
* propose-presentation-sent (Prover)

Closes #1486 
Signed-off-by: Andrii Soluk <isoluchok@gmail.com>