### PR TITLE
fix: loading raw pub key to Tink keyset.Handle fails verification

### DIFF
--- a/pkg/kms/localkms/localkms.go
+++ b/pkg/kms/localkms/localkms.go
@@ -142,14 +142,37 @@ func getKeyTemplate(keyType kms.KeyType) (*tinkpb.KeyTemplate, error) {
 		return aead.ChaCha20Poly1305KeyTemplate(), nil
 	case kms.XChaCha20Poly1305Type:
 		return aead.XChaCha20Poly1305KeyTemplate(), nil
+
+	// TODO: Uncomment below when key template functions are available in Tink
+	//       and remove temporary cases below  - issue #1489
+	// case kms.ECDSAP256Type:
+	//	return signature.ECDSAP256KeyWithoutPrefixTemplate(), nil
+	// case kms.ECDSAP384Type:
+	//	return signature.ECDSAP384KeyWithoutPrefixTemplate(), nil
+	// case kms.ECDSAP521Type:
+	//	return signature.ECDSAP521KeyWithoutPrefixTemplate(), nil
+	// case kms.Ed25519Type:
+	//	return signature.ED25519KeyWithoutPrefixTemplate(), nil
 	case kms.ECDSAP256Type:
-		return signature.ECDSAP256KeyTemplate(), nil
+		keyTemplate := signature.ECDSAP256KeyTemplate()
+		keyTemplate.OutputPrefixType = tinkpb.OutputPrefixType_RAW
+
+		return keyTemplate, nil
 	case kms.ECDSAP384Type:
-		return signature.ECDSAP384KeyTemplate(), nil
+		keyTemplate := signature.ECDSAP384KeyTemplate()
+		keyTemplate.OutputPrefixType = tinkpb.OutputPrefixType_RAW
+
+		return keyTemplate, nil
 	case kms.ECDSAP521Type:
-		return signature.ECDSAP521KeyTemplate(), nil
+		keyTemplate := signature.ECDSAP521KeyTemplate()
+		keyTemplate.OutputPrefixType = tinkpb.OutputPrefixType_RAW
+
+		return keyTemplate, nil
 	case kms.Ed25519Type:
-		return signature.ED25519KeyTemplate(), nil
+		keyTemplate := signature.ED25519KeyTemplate()
+		keyTemplate.OutputPrefixType = tinkpb.OutputPrefixType_RAW
+
+		return keyTemplate, nil
 	default:
 		return nil, fmt.Errorf("key type unrecognized")
 	}

--- a/pkg/kms/localkms/pubkey_export_import_test.go
+++ b/pkg/kms/localkms/pubkey_export_import_test.go
@@ -21,6 +21,16 @@ import (
 )
 
 func TestPubKeyExportAndRead(t *testing.T) {
+	// TODO remove below variables when corresponding key templates `WithoutPrefix` are available in Tink - issue #1489
+	ecdsaP256KeyTemplate := signature.ECDSAP256KeyTemplate()
+	ecdsaP256KeyTemplate.OutputPrefixType = tinkpb.OutputPrefixType_RAW
+	ecdsaP384KeyTemplate := signature.ECDSAP384KeyTemplate()
+	ecdsaP384KeyTemplate.OutputPrefixType = tinkpb.OutputPrefixType_RAW
+	ecdsaP521KeyTemplate := signature.ECDSAP521KeyTemplate()
+	ecdsaP521KeyTemplate.OutputPrefixType = tinkpb.OutputPrefixType_RAW
+	ed25519KeyTemplate := signature.ED25519KeyTemplate()
+	ed25519KeyTemplate.OutputPrefixType = tinkpb.OutputPrefixType_RAW
+
 	var flagTests = []struct {
 		tcName      string
 		keyType     kms.KeyType
@@ -30,26 +40,34 @@ func TestPubKeyExportAndRead(t *testing.T) {
 		{
 			tcName:      "export then read ECDSAP256 public key",
 			keyType:     kms.ECDSAP256Type,
-			keyTemplate: signature.ECDSAP256KeyTemplate(),
-			doSign:      true,
+			keyTemplate: ecdsaP256KeyTemplate,
+			// TODO remove above line then uncomment below line when key template is available in Tink - issue #1489
+			// keyTemplate: signature.ECDSAP256KeyWithoutPrefixTemplate()
+			doSign: true,
 		},
 		{
 			tcName:      "export then read ECDSAP384 public key",
 			keyType:     kms.ECDSAP384Type,
-			keyTemplate: signature.ECDSAP384KeyTemplate(),
-			doSign:      true,
+			keyTemplate: ecdsaP384KeyTemplate,
+			// TODO remove above line then uncomment below line when key template is available in Tink - issue #1489
+			// keyTemplate: signature.ECDSAP384KeyWithoutPrefixTemplate()
+			doSign: true,
 		},
 		{
 			tcName:      "export then read ECDSAP521 public key",
 			keyType:     kms.ECDSAP521Type,
-			keyTemplate: signature.ECDSAP521KeyTemplate(),
-			doSign:      true,
+			keyTemplate: ecdsaP521KeyTemplate,
+			// TODO remove above line then uncomment below line when key template is available in Tink - issue #1489
+			// keyTemplate: signature.ECDSAP521KeyWithoutPrefixTemplate()
+			doSign: true,
 		},
 		{
 			tcName:      "export then read ED25519 public key",
 			keyType:     kms.Ed25519Type,
-			keyTemplate: signature.ED25519KeyTemplate(),
-			doSign:      true,
+			keyTemplate: ed25519KeyTemplate,
+			// TODO remove above line then uncomment below line when key template is available in Tink - issue #1489
+			// keyTemplate: signature.ED25519KeyWithoutPrefixTemplate()
+			doSign: true,
 		},
 	}
 
@@ -78,7 +96,7 @@ func TestPubKeyExportAndRead(t *testing.T) {
 				require.NotEmpty(t, verifier)
 
 				err = verifier.Verify(s, msg)
-				require.NotEmpty(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/kms/localkms/pubkey_reader.go
+++ b/pkg/kms/localkms/pubkey_reader.go
@@ -44,8 +44,8 @@ func publicKeyBytesToHandle(pubKey []byte, kt kms.KeyType) (*keyset.Handle, erro
 				KeyData: keyData,
 				Status:  tinkpb.KeyStatusType_ENABLED,
 				KeyId:   1,
-				// for now, assumption is raw bytes always come from keys created by TINK
-				OutputPrefixType: tinkpb.OutputPrefixType_TINK,
+				// since we're building the key from raw key bytes, then must use raw key prefix type
+				OutputPrefixType: tinkpb.OutputPrefixType_RAW,
 			}},
 		PrimaryKeyId: 1,
 	}


### PR DESCRIPTION
Since default signing key templates have Tink specific prefix,
need to use RAW type to avoid adding a prefix. This will fix
verification with a keyset.Handle created from raw public key []byte

To unblock dev, the temporary fix is to manually change the key templates
in aries-framework-go code. A followup issue is created to use Tink
created key templates without a prefix when the templates are
available in Tink (#1489).

closes #1483

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>