### PR TITLE
feat: Support for RemoveConnection in DIDExchange clients

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -272,7 +272,11 @@ func (c *Client) GetConnectionAtState(connectionID, stateID string) (*Connection
 }
 
 // RemoveConnection removes connection record for given id
-func (c *Client) RemoveConnection(id string) error {
-	// TODO https://github.com/hyperledger/aries-framework-go/issues/553 RemoveConnection from did exchange service
+func (c *Client) RemoveConnection(connectionID string) error {
+	err := c.connectionStore.RemoveConnection(connectionID)
+	if err != nil {
+		return fmt.Errorf("cannot remove connection from the store: err=%w", err)
+	}
+
 	return nil
 }

--- a/pkg/controller/rest/didexchange/operation_test.go
+++ b/pkg/controller/rest/didexchange/operation_test.go
@@ -361,7 +361,7 @@ func TestOperation_RemoveConnection(t *testing.T) {
 	t.Run("test remove connection success", func(t *testing.T) {
 		handler := getHandler(t, removeConnection)
 		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer([]byte("test-id")),
-			operationID+"/5555/remove")
+			operationID+"/1234/remove")
 		require.NoError(t, err)
 		require.Empty(t, buf.Bytes())
 	})


### PR DESCRIPTION
**Title:**
Implementation of removing the connection records from the stores

**Description:**
Closes #553 
Removes connection and it's mapping records across store and transient store.

Remove connection sequence in _pkg/store/connection/connection_recorder.go_ mirrors the save connection one. It removes all records for any state of the connection from the transient store, as well as did mappings records and namespace, threadID and connectionID mappings if there are some.