### PR TITLE
refactor: Present Proof - states name were changed according to the RFC 0037

### DIFF
--- a/pkg/didcomm/protocol/presentproof/service.go
+++ b/pkg/didcomm/protocol/presentproof/service.go
@@ -279,14 +279,14 @@ func stateFromName(name string) state {
 		return &requestSent{}
 	case stateNamePresentationReceived:
 		return &presentationReceived{}
-	case stateNameProposePresentationReceived:
-		return &proposePresentationReceived{}
+	case stateNameProposalReceived:
+		return &proposalReceived{}
 	case stateNameRequestReceived:
 		return &requestReceived{}
 	case stateNamePresentationSent:
 		return &presentationSent{}
-	case stateNameProposePresentationSent:
-		return &proposePresentationSent{}
+	case stateNameProposalSent:
+		return &proposalSent{}
 	default:
 		return &noOp{}
 	}
@@ -303,10 +303,10 @@ func nextState(msg service.DIDCommMsg, outbound bool) (state, error) {
 		return &requestReceived{}, nil
 	case ProposePresentationMsgType:
 		if outbound {
-			return &proposePresentationSent{}, nil
+			return &proposalSent{}, nil
 		}
 
-		return &proposePresentationReceived{}, nil
+		return &proposalReceived{}, nil
 	case PresentationMsgType:
 		return &presentationReceived{}, nil
 	case ProblemReportMsgType:

--- a/pkg/didcomm/protocol/presentproof/service_test.go
+++ b/pkg/didcomm/protocol/presentproof/service_test.go
@@ -205,10 +205,10 @@ func Test_stateFromName(t *testing.T) {
 	require.Equal(t, stateFromName(stateNameDone), &done{})
 	require.Equal(t, stateFromName(stateNameRequestSent), &requestSent{})
 	require.Equal(t, stateFromName(stateNamePresentationReceived), &presentationReceived{})
-	require.Equal(t, stateFromName(stateNameProposePresentationReceived), &proposePresentationReceived{})
+	require.Equal(t, stateFromName(stateNameProposalReceived), &proposalReceived{})
 	require.Equal(t, stateFromName(stateNameRequestReceived), &requestReceived{})
 	require.Equal(t, stateFromName(stateNamePresentationSent), &presentationSent{})
-	require.Equal(t, stateFromName(stateNameProposePresentationSent), &proposePresentationSent{})
+	require.Equal(t, stateFromName(stateNameProposalSent), &proposalSent{})
 	require.Equal(t, stateFromName("unknown"), &noOp{})
 }
 
@@ -258,13 +258,13 @@ func Test_nextState(t *testing.T) {
 		Type: ProposePresentationMsgType,
 	}), true)
 	require.NoError(t, err)
-	require.Equal(t, next, &proposePresentationSent{})
+	require.Equal(t, next, &proposalSent{})
 
 	next, err = nextState(service.NewDIDCommMsgMap(ProposePresentation{
 		Type: ProposePresentationMsgType,
 	}), false)
 	require.NoError(t, err)
-	require.Equal(t, next, &proposePresentationReceived{})
+	require.Equal(t, next, &proposalReceived{})
 
 	next, err = nextState(service.NewDIDCommMsgMap(Presentation{
 		Type: PresentationMsgType,

--- a/pkg/didcomm/protocol/presentproof/states.go
+++ b/pkg/didcomm/protocol/presentproof/states.go
@@ -21,14 +21,14 @@ const (
 	stateNameNoop       = "noop"
 
 	// states for Verifier
-	stateNameRequestSent                 = "request-sent"
-	stateNamePresentationReceived        = "presentation-received"
-	stateNameProposePresentationReceived = "propose-presentation-received"
+	stateNameRequestSent          = "request-sent"
+	stateNamePresentationReceived = "presentation-received"
+	stateNameProposalReceived     = "proposal-received"
 
 	// states for Prover
-	stateNameRequestReceived         = "request-received"
-	stateNamePresentationSent        = "presentation-sent"
-	stateNameProposePresentationSent = "propose-presentation-sent"
+	stateNameRequestReceived  = "request-received"
+	stateNamePresentationSent = "presentation-sent"
+	stateNameProposalSent     = "proposal-sent"
 )
 
 const codeInternalError = "internal"
@@ -61,10 +61,10 @@ func (s *start) Name() string {
 func (s *start) CanTransitionTo(st state) bool {
 	switch st.Name() {
 	// Verifier
-	case stateNameRequestSent, stateNameProposePresentationReceived:
+	case stateNameRequestSent, stateNameProposalReceived:
 		return true
 	// Prover
-	case stateNameProposePresentationSent, stateNameRequestReceived:
+	case stateNameProposalSent, stateNameRequestReceived:
 		return true
 	}
 
@@ -147,7 +147,7 @@ func (s *requestReceived) Name() string {
 
 func (s *requestReceived) CanTransitionTo(st state) bool {
 	return st.Name() == stateNamePresentationSent ||
-		st.Name() == stateNameProposePresentationSent ||
+		st.Name() == stateNameProposalSent ||
 		st.Name() == stateNameAbandoning
 }
 
@@ -168,7 +168,7 @@ func (s *requestSent) Name() string {
 
 func (s *requestSent) CanTransitionTo(st state) bool {
 	return st.Name() == stateNamePresentationReceived ||
-		st.Name() == stateNameProposePresentationReceived ||
+		st.Name() == stateNameProposalReceived ||
 		st.Name() == stateNameAbandoning
 }
 
@@ -220,42 +220,42 @@ func (s *presentationReceived) ExecuteOutbound(_ *metaData) (state, stateAction,
 	return nil, nil, fmt.Errorf("%s: ExecuteOutbound is not implemented yet", s.Name())
 }
 
-// proposePresentationSent the Prover's state
-type proposePresentationSent struct{}
+// proposalSent the Prover's state
+type proposalSent struct{}
 
-func (s *proposePresentationSent) Name() string {
-	return stateNameProposePresentationSent
+func (s *proposalSent) Name() string {
+	return stateNameProposalSent
 }
 
-func (s *proposePresentationSent) CanTransitionTo(st state) bool {
+func (s *proposalSent) CanTransitionTo(st state) bool {
 	return st.Name() == stateNameRequestReceived ||
 		st.Name() == stateNameAbandoning
 }
 
-func (s *proposePresentationSent) ExecuteInbound(_ *metaData) (state, stateAction, error) {
+func (s *proposalSent) ExecuteInbound(_ *metaData) (state, stateAction, error) {
 	return nil, nil, fmt.Errorf("%s: ExecuteInbound is not implemented yet", s.Name())
 }
 
-func (s *proposePresentationSent) ExecuteOutbound(_ *metaData) (state, stateAction, error) {
+func (s *proposalSent) ExecuteOutbound(_ *metaData) (state, stateAction, error) {
 	return nil, nil, fmt.Errorf("%s: ExecuteOutbound is not implemented yet", s.Name())
 }
 
-// proposePresentationReceived the Verifier's state
-type proposePresentationReceived struct{}
+// proposalReceived the Verifier's state
+type proposalReceived struct{}
 
-func (s *proposePresentationReceived) Name() string {
-	return stateNameProposePresentationReceived
+func (s *proposalReceived) Name() string {
+	return stateNameProposalReceived
 }
 
-func (s *proposePresentationReceived) CanTransitionTo(st state) bool {
+func (s *proposalReceived) CanTransitionTo(st state) bool {
 	return st.Name() == stateNameRequestSent ||
 		st.Name() == stateNameAbandoning
 }
 
-func (s *proposePresentationReceived) ExecuteInbound(_ *metaData) (state, stateAction, error) {
+func (s *proposalReceived) ExecuteInbound(_ *metaData) (state, stateAction, error) {
 	return nil, nil, fmt.Errorf("%s: ExecuteInbound is not implemented yet", s.Name())
 }
 
-func (s *proposePresentationReceived) ExecuteOutbound(_ *metaData) (state, stateAction, error) {
+func (s *proposalReceived) ExecuteOutbound(_ *metaData) (state, stateAction, error) {
 	return nil, nil, fmt.Errorf("%s: ExecuteOutbound is not implemented yet", s.Name())
 }

--- a/pkg/didcomm/protocol/presentproof/states_test.go
+++ b/pkg/didcomm/protocol/presentproof/states_test.go
@@ -24,11 +24,11 @@ func TestStart_CanTransitionTo(t *testing.T) {
 	// states for Verifier
 	require.True(t, st.CanTransitionTo(&requestSent{}))
 	require.False(t, st.CanTransitionTo(&presentationReceived{}))
-	require.True(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	require.True(t, st.CanTransitionTo(&proposalReceived{}))
 	// states for Prover
 	require.True(t, st.CanTransitionTo(&requestReceived{}))
 	require.False(t, st.CanTransitionTo(&presentationSent{}))
-	require.True(t, st.CanTransitionTo(&proposePresentationSent{}))
+	require.True(t, st.CanTransitionTo(&proposalSent{}))
 }
 
 func TestStart_ExecuteInbound(t *testing.T) {
@@ -56,11 +56,11 @@ func TestAbandoning_CanTransitionTo(t *testing.T) {
 	// states for Verifier
 	require.False(t, st.CanTransitionTo(&requestSent{}))
 	require.False(t, st.CanTransitionTo(&presentationReceived{}))
-	require.False(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	require.False(t, st.CanTransitionTo(&proposalReceived{}))
 	// states for Prover
 	require.False(t, st.CanTransitionTo(&requestReceived{}))
 	require.False(t, st.CanTransitionTo(&presentationSent{}))
-	require.False(t, st.CanTransitionTo(&proposePresentationSent{}))
+	require.False(t, st.CanTransitionTo(&proposalSent{}))
 }
 
 func TestAbandoning_ExecuteInbound(t *testing.T) {
@@ -128,11 +128,11 @@ func TestRequestReceived_CanTransitionTo(t *testing.T) {
 	// states for Verifier
 	require.False(t, st.CanTransitionTo(&requestSent{}))
 	require.False(t, st.CanTransitionTo(&presentationReceived{}))
-	require.False(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	require.False(t, st.CanTransitionTo(&proposalReceived{}))
 	// states for Prover
 	require.False(t, st.CanTransitionTo(&requestReceived{}))
 	require.True(t, st.CanTransitionTo(&presentationSent{}))
-	require.True(t, st.CanTransitionTo(&proposePresentationSent{}))
+	require.True(t, st.CanTransitionTo(&proposalSent{}))
 }
 
 func TestRequestReceived_ExecuteInbound(t *testing.T) {
@@ -160,11 +160,11 @@ func TestRequestSent_CanTransitionTo(t *testing.T) {
 	// states for Verifier
 	require.False(t, st.CanTransitionTo(&requestSent{}))
 	require.True(t, st.CanTransitionTo(&presentationReceived{}))
-	require.True(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	require.True(t, st.CanTransitionTo(&proposalReceived{}))
 	// states for Prover
 	require.False(t, st.CanTransitionTo(&requestReceived{}))
 	require.False(t, st.CanTransitionTo(&presentationSent{}))
-	require.False(t, st.CanTransitionTo(&proposePresentationSent{}))
+	require.False(t, st.CanTransitionTo(&proposalSent{}))
 }
 
 func TestRequestSent_ExecuteInbound(t *testing.T) {
@@ -192,11 +192,11 @@ func TestPresentationSent_CanTransitionTo(t *testing.T) {
 	// states for Verifier
 	require.False(t, st.CanTransitionTo(&requestSent{}))
 	require.False(t, st.CanTransitionTo(&presentationReceived{}))
-	require.False(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	require.False(t, st.CanTransitionTo(&proposalReceived{}))
 	// states for Prover
 	require.False(t, st.CanTransitionTo(&requestReceived{}))
 	require.False(t, st.CanTransitionTo(&presentationSent{}))
-	require.False(t, st.CanTransitionTo(&proposePresentationSent{}))
+	require.False(t, st.CanTransitionTo(&proposalSent{}))
 }
 
 func TestPresentationSent_ExecuteInbound(t *testing.T) {
@@ -224,11 +224,11 @@ func TestPresentationReceived_CanTransitionTo(t *testing.T) {
 	// states for Verifier
 	require.False(t, st.CanTransitionTo(&requestSent{}))
 	require.False(t, st.CanTransitionTo(&presentationReceived{}))
-	require.False(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	require.False(t, st.CanTransitionTo(&proposalReceived{}))
 	// states for Prover
 	require.False(t, st.CanTransitionTo(&requestReceived{}))
 	require.False(t, st.CanTransitionTo(&presentationSent{}))
-	require.False(t, st.CanTransitionTo(&proposePresentationSent{}))
+	require.False(t, st.CanTransitionTo(&proposalSent{}))
 }
 
 func TestPresentationReceived_ExecuteInbound(t *testing.T) {
@@ -246,8 +246,8 @@ func TestPresentationReceived_ExecuteOutbound(t *testing.T) {
 }
 
 func TestProposePresentationSent_CanTransitionTo(t *testing.T) {
-	st := &proposePresentationSent{}
-	require.Equal(t, stateNameProposePresentationSent, st.Name())
+	st := &proposalSent{}
+	require.Equal(t, stateNameProposalSent, st.Name())
 	// common states
 	require.False(t, st.CanTransitionTo(&start{}))
 	require.True(t, st.CanTransitionTo(&abandoning{}))
@@ -256,30 +256,30 @@ func TestProposePresentationSent_CanTransitionTo(t *testing.T) {
 	// states for Verifier
 	require.False(t, st.CanTransitionTo(&requestSent{}))
 	require.False(t, st.CanTransitionTo(&presentationReceived{}))
-	require.False(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	require.False(t, st.CanTransitionTo(&proposalReceived{}))
 	// states for Prover
 	require.True(t, st.CanTransitionTo(&requestReceived{}))
 	require.False(t, st.CanTransitionTo(&presentationSent{}))
-	require.False(t, st.CanTransitionTo(&proposePresentationSent{}))
+	require.False(t, st.CanTransitionTo(&proposalSent{}))
 }
 
 func TestProposePresentationSent_ExecuteInbound(t *testing.T) {
-	followup, action, err := (&proposePresentationSent{}).ExecuteInbound(&metaData{})
+	followup, action, err := (&proposalSent{}).ExecuteInbound(&metaData{})
 	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
 	require.Nil(t, followup)
 	require.Nil(t, action)
 }
 
 func TestProposePresentationSent_ExecuteOutbound(t *testing.T) {
-	followup, action, err := (&proposePresentationSent{}).ExecuteOutbound(&metaData{})
+	followup, action, err := (&proposalSent{}).ExecuteOutbound(&metaData{})
 	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
 	require.Nil(t, followup)
 	require.Nil(t, action)
 }
 
 func TestProposePresentationReceived_CanTransitionTo(t *testing.T) {
-	st := &proposePresentationReceived{}
-	require.Equal(t, stateNameProposePresentationReceived, st.Name())
+	st := &proposalReceived{}
+	require.Equal(t, stateNameProposalReceived, st.Name())
 	// common states
 	require.False(t, st.CanTransitionTo(&start{}))
 	require.True(t, st.CanTransitionTo(&abandoning{}))
@@ -288,22 +288,22 @@ func TestProposePresentationReceived_CanTransitionTo(t *testing.T) {
 	// states for Verifier
 	require.True(t, st.CanTransitionTo(&requestSent{}))
 	require.False(t, st.CanTransitionTo(&presentationReceived{}))
-	require.False(t, st.CanTransitionTo(&proposePresentationReceived{}))
+	require.False(t, st.CanTransitionTo(&proposalReceived{}))
 	// states for Prover
 	require.False(t, st.CanTransitionTo(&requestReceived{}))
 	require.False(t, st.CanTransitionTo(&presentationSent{}))
-	require.False(t, st.CanTransitionTo(&proposePresentationSent{}))
+	require.False(t, st.CanTransitionTo(&proposalSent{}))
 }
 
 func TestProposePresentationReceived_ExecuteInbound(t *testing.T) {
-	followup, action, err := (&proposePresentationReceived{}).ExecuteInbound(&metaData{})
+	followup, action, err := (&proposalReceived{}).ExecuteInbound(&metaData{})
 	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
 	require.Nil(t, followup)
 	require.Nil(t, action)
 }
 
 func TestProposePresentationReceived_ExecuteOutbound(t *testing.T) {
-	followup, action, err := (&proposePresentationReceived{}).ExecuteOutbound(&metaData{})
+	followup, action, err := (&proposalReceived{}).ExecuteOutbound(&metaData{})
 	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
 	require.Nil(t, followup)
 	require.Nil(t, action)
@@ -316,9 +316,9 @@ func notTransition(t *testing.T, st state) {
 		// common states
 		&start{}, &abandoning{}, &done{}, &noOp{},
 		// states for Verifier
-		&requestSent{}, &presentationReceived{}, &proposePresentationReceived{},
+		&requestSent{}, &presentationReceived{}, &proposalReceived{},
 		// states for Prover
-		&requestReceived{}, &presentationSent{}, &proposePresentationSent{},
+		&requestReceived{}, &presentationSent{}, &proposalSent{},
 	}
 
 	for _, s := range allState {


### PR DESCRIPTION
The following states were renamed:
* proposal-sent
* proposal-received

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>