### PR TITLE
feat: Present Proof - state implementation for presentation/proposal-received

### DIFF
--- a/pkg/didcomm/protocol/presentproof/service.go
+++ b/pkg/didcomm/protocol/presentproof/service.go
@@ -61,6 +61,7 @@ type metaData struct {
 	inbound             bool
 	presentation        *Presentation
 	proposePresentation *ProposePresentation
+	request             *RequestPresentation
 	// err is used to determine whether callback was stopped
 	// e.g the user received an action event and executes Stop(err) function
 	// in that case `err` is equal to `err` which was passing to Stop function
@@ -83,6 +84,14 @@ func WithPresentation(msg *Presentation) Opt {
 func WithProposePresentation(msg *ProposePresentation) Opt {
 	return func(md *metaData) {
 		md.proposePresentation = msg
+	}
+}
+
+// WithRequestPresentation allows providing RequestPresentation message
+// USAGE: This message can be provided after receiving a propose message
+func WithRequestPresentation(msg *RequestPresentation) Opt {
+	return func(md *metaData) {
+		md.request = msg
 	}
 }
 

--- a/pkg/didcomm/protocol/presentproof/states_test.go
+++ b/pkg/didcomm/protocol/presentproof/states_test.go
@@ -262,10 +262,29 @@ func TestRequestSent_CanTransitionTo(t *testing.T) {
 }
 
 func TestRequestSent_ExecuteInbound(t *testing.T) {
-	followup, action, err := (&requestSent{}).ExecuteInbound(&metaData{})
-	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
-	require.Nil(t, followup)
-	require.Nil(t, action)
+	t.Run("Success", func(t *testing.T) {
+		followup, action, err := (&requestSent{}).ExecuteInbound(&metaData{
+			request: &RequestPresentation{},
+		})
+		require.NoError(t, err)
+		require.Equal(t, &noOp{}, followup)
+		require.NotNil(t, action)
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		messenger := serviceMocks.NewMockMessenger(ctrl)
+		messenger.EXPECT().ReplyTo(gomock.Any(), gomock.Any())
+
+		require.NoError(t, action(messenger))
+	})
+
+	t.Run("Request presentation is absent", func(t *testing.T) {
+		followup, action, err := (&requestSent{}).ExecuteInbound(&metaData{})
+		require.EqualError(t, err, "request was not provided")
+		require.Nil(t, followup)
+		require.Nil(t, action)
+	})
 }
 
 func TestRequestSent_ExecuteOutbound(t *testing.T) {
@@ -352,9 +371,17 @@ func TestPresentationReceived_CanTransitionTo(t *testing.T) {
 
 func TestPresentationReceived_ExecuteInbound(t *testing.T) {
 	followup, action, err := (&presentationReceived{}).ExecuteInbound(&metaData{})
-	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
-	require.Nil(t, followup)
-	require.Nil(t, action)
+	require.NoError(t, err)
+	require.Equal(t, &done{}, followup)
+	require.NotNil(t, action)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	messenger := serviceMocks.NewMockMessenger(ctrl)
+	messenger.EXPECT().ReplyTo(gomock.Any(), gomock.Any())
+
+	require.NoError(t, action(messenger))
 }
 
 func TestPresentationReceived_ExecuteOutbound(t *testing.T) {
@@ -410,9 +437,17 @@ func TestProposePresentationSent_ExecuteInbound(t *testing.T) {
 
 func TestProposePresentationSent_ExecuteOutbound(t *testing.T) {
 	followup, action, err := (&proposalSent{}).ExecuteOutbound(&metaData{})
-	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
-	require.Nil(t, followup)
-	require.Nil(t, action)
+	require.NoError(t, err)
+	require.Equal(t, &noOp{}, followup)
+	require.NotNil(t, action)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	messenger := serviceMocks.NewMockMessenger(ctrl)
+	messenger.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any())
+
+	require.NoError(t, action(messenger))
 }
 
 func TestProposePresentationReceived_CanTransitionTo(t *testing.T) {
@@ -435,9 +470,9 @@ func TestProposePresentationReceived_CanTransitionTo(t *testing.T) {
 
 func TestProposePresentationReceived_ExecuteInbound(t *testing.T) {
 	followup, action, err := (&proposalReceived{}).ExecuteInbound(&metaData{})
-	require.Contains(t, fmt.Sprintf("%v", err), "is not implemented yet")
-	require.Nil(t, followup)
-	require.Nil(t, action)
+	require.NoError(t, err)
+	require.Equal(t, &requestSent{}, followup)
+	require.NoError(t, action(nil))
 }
 
 func TestProposePresentationReceived_ExecuteOutbound(t *testing.T) {


### PR DESCRIPTION
The following states were implemented:
* request-sent  (inbound )
* presentation-received  (inbound)
* proposal-sent (outbound)
* proposal-received (inbound )

Closes #1511 
Signed-off-by: Andrii Soluk <isoluchok@gmail.com>