### PR TITLE
feat: Support compact proof option in signature suites

### DIFF
--- a/pkg/doc/did/doc.go
+++ b/pkg/doc/did/doc.go
@@ -794,6 +794,9 @@ type signatureSuite interface {
 
 	// Accept registers this signature suite with the given signature type
 	Accept(signatureType string) bool
+
+	// CompactProof indicates weather to compact the proof doc before canonization
+	CompactProof() bool
 }
 
 // VerifyProof verifies document proofs

--- a/pkg/doc/signature/ed25519signature2018/suite.go
+++ b/pkg/doc/signature/ed25519signature2018/suite.go
@@ -22,8 +22,9 @@ import (
 
 // SignatureSuite implements ed25519 signature suite
 type SignatureSuite struct {
-	signer   signer
-	verifier verifier
+	signer       signer
+	verifier     verifier
+	compactProof bool
 }
 
 const (
@@ -55,6 +56,13 @@ func WithSigner(s signer) SuiteOpt {
 func WithVerifier(v verifier) SuiteOpt {
 	return func(opts *SignatureSuite) {
 		opts.verifier = v
+	}
+}
+
+// WithCompactProof indicates that proof compaction is needed, by default it is not done.
+func WithCompactProof() SuiteOpt {
+	return func(opts *SignatureSuite) {
+		opts.compactProof = true
 	}
 }
 
@@ -113,6 +121,11 @@ func (s *SignatureSuite) Sign(data []byte) ([]byte, error) {
 // Accept will accept only ed25519 signature type
 func (s *SignatureSuite) Accept(t string) bool {
 	return t == signatureType
+}
+
+// CompactProof indicates weather to compact the proof doc before canonization
+func (s *SignatureSuite) CompactProof() bool {
+	return s.compactProof
 }
 
 // ErrSignerNotDefined is returned when Sign() is called but signer option is not defined.

--- a/pkg/doc/signature/ed25519signature2018/suite_test.go
+++ b/pkg/doc/signature/ed25519signature2018/suite_test.go
@@ -44,7 +44,7 @@ func TestSignatureSuite_Verify(t *testing.T) {
 		Type:  signatureType,
 		Value: []byte("any key"),
 	}
-	ss := New(WithVerifier(&mockVerifier{}))
+	ss := New(WithVerifier(&mockVerifier{}), WithCompactProof())
 
 	// happy path
 	err := ss.Verify(pubKey, []byte("any doc"), []byte("any signature"))
@@ -61,6 +61,11 @@ func TestSignatureSuite_Verify(t *testing.T) {
 	err = ss.Verify(pubKey, []byte("any doc"), []byte("any signature"))
 	require.Error(t, err)
 	require.EqualError(t, err, "verify error")
+}
+
+func TestWithCompactProof(t *testing.T) {
+	suite := New(WithCompactProof())
+	require.True(t, suite.CompactProof())
 }
 
 func TestSignatureSuite_GetCanonicalDocument(t *testing.T) {

--- a/pkg/doc/signature/proof/data.go
+++ b/pkg/doc/signature/proof/data.go
@@ -20,6 +20,9 @@ type signatureSuite interface {
 
 	// GetDigest returns document digest
 	GetDigest(doc []byte) []byte
+
+	// CompactProof indicates weather to compact the proof doc before canonization
+	CompactProof() bool
 }
 
 // SignatureRepresentation defines a representation of signature value.

--- a/pkg/doc/signature/proof/data_test.go
+++ b/pkg/doc/signature/proof/data_test.go
@@ -106,6 +106,7 @@ func TestCreateVerifyData(t *testing.T) {
 }
 
 type mockSignatureSuite struct {
+	compactProof bool
 }
 
 // GetCanonicalDocument will return normalized/canonical version of the document
@@ -128,6 +129,10 @@ func (s *mockSignatureSuite) GetCanonicalDocument(doc map[string]interface{}) ([
 func (s *mockSignatureSuite) GetDigest(doc []byte) []byte {
 	digest := sha512.Sum512(doc)
 	return digest[:]
+}
+
+func (s *mockSignatureSuite) CompactProof() bool {
+	return s.compactProof
 }
 
 //nolint:lll

--- a/pkg/doc/signature/proof/jws.go
+++ b/pkg/doc/signature/proof/jws.go
@@ -101,21 +101,26 @@ func prepareJWSProof(suite signatureSuite, proofOptions map[string]interface{}) 
 
 	delete(proofOptionsCopy, jsonldJWS)
 	delete(proofOptionsCopy, jsonldProofValue)
+	delete(proofOptionsCopy, jsonldType)
 
 	return suite.GetCanonicalDocument(proofOptionsCopy)
 }
 
 func prepareDocumentForJWS(suite signatureSuite, jsonldObject map[string]interface{}) ([]byte, error) {
 	// copy document object without proof
-	docCopy := GetCopyWithoutProof(jsonldObject)
+	doc := GetCopyWithoutProof(jsonldObject)
 
-	docCompacted, err := getCompactedWithSecuritySchema(docCopy)
-	if err != nil {
-		return nil, err
+	if suite.CompactProof() {
+		docCompacted, err := getCompactedWithSecuritySchema(doc)
+		if err != nil {
+			return nil, err
+		}
+
+		doc = docCompacted
 	}
 
 	// build canonical document
-	return suite.GetCanonicalDocument(docCompacted)
+	return suite.GetCanonicalDocument(doc)
 }
 
 func getCompactedWithSecuritySchema(docMap map[string]interface{}) (map[string]interface{}, error) {

--- a/pkg/doc/signature/signer/signer.go
+++ b/pkg/doc/signature/signer/signer.go
@@ -29,6 +29,9 @@ type signatureSuite interface {
 
 	// Sign will sign document and return signature
 	Sign(doc []byte) ([]byte, error)
+
+	// CompactProof indicates weather to compact the proof doc before canonization
+	CompactProof() bool
 }
 
 // DocumentSigner implements signing of JSONLD documents

--- a/pkg/doc/signature/verifier/verifier.go
+++ b/pkg/doc/signature/verifier/verifier.go
@@ -26,6 +26,9 @@ type signatureSuite interface {
 
 	// Accept registers this signature suite with the given signature type
 	Accept(signatureType string) bool
+
+	// CompactProof indicates weather to compact the proof doc before canonization
+	CompactProof() bool
 }
 
 // PublicKey contains a result of public key resolution.

--- a/pkg/doc/signature/verifier/verifier_test.go
+++ b/pkg/doc/signature/verifier/verifier_test.go
@@ -158,6 +158,8 @@ type testSignatureSuite struct {
 	verifyError error
 
 	accept bool
+
+	compactProof bool
 }
 
 func (s *testSignatureSuite) GetCanonicalDocument(map[string]interface{}) ([]byte, error) {
@@ -174,4 +176,8 @@ func (s *testSignatureSuite) Verify(*PublicKey, []byte, []byte) error {
 
 func (s *testSignatureSuite) Accept(string) bool {
 	return s.accept
+}
+
+func (s *testSignatureSuite) CompactProof() bool {
+	return s.compactProof
 }

--- a/pkg/doc/verifiable/example_credential_test.go
+++ b/pkg/doc/verifiable/example_credential_test.go
@@ -387,7 +387,7 @@ func ExampleCredential_AddLinkedDataProof() {
 	//	},
 	//	"proof": {
 	//		"created": "2010-01-01T19:23:24Z",
-	//		"jws": "eyJhbGciOiJFZDI1NTE5U2lnbmF0dXJlMjAxOCIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Io85NnajfPXWBtB60QRI-OEfJtKEVv_ij2QTVLYqXdHTs01zCVMbUTyi6m5zIfH6YZELPgty2NujKYlun4L8Dg",
+	//		"jws": "eyJhbGciOiJFZDI1NTE5U2lnbmF0dXJlMjAxOCIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..oAPHkQW8YOPwWSuto6v0m1_gbnSwXtqPHyQIQw51AHNk5T9ncMFYu2Q8zhrY09wCwCguDTMyj4DDn06AcC-oAA",
 	//		"type": "Ed25519Signature2018",
 	//		"verificationMethod": "did:example:123456#key1"
 	//	},

--- a/pkg/doc/verifiable/linked_data_proof.go
+++ b/pkg/doc/verifiable/linked_data_proof.go
@@ -31,6 +31,9 @@ type signatureSuite interface {
 
 	// Accept registers this signature suite with the given signature type
 	Accept(signatureType string) bool
+
+	// CompactProof indicates weather to compact the proof doc before canonization
+	CompactProof() bool
 }
 
 type verifierSignatureSuite interface {

--- a/pkg/doc/verifiable/linked_data_proof_test.go
+++ b/pkg/doc/verifiable/linked_data_proof_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/btcsuite/btcutil/base58"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/ed25519signature2018"
@@ -51,58 +50,9 @@ func Test_keyResolverAdapter_Resolve(t *testing.T) {
 	})
 }
 
-type dummyKeyResolver []byte
-
-func (kr dummyKeyResolver) Resolve(string) (*verifier.PublicKey, error) {
-	return &verifier.PublicKey{Value: kr, Type: kms.ED25519}, nil
-}
-
 // This example is generated using https://transmute-industries.github.io/vc-greeting-card
-func TestLinkedDataProofVerifier(t *testing.T) {
-	pubKeyBytes := base58.Decode("BoLcfbmL1yXgfCvc1MDAQg4xsR7D8Wo9zYLCu2vvCwgn")
-	pubKey := ed25519.PublicKey(pubKeyBytes)
-
+func TestLinkedDataProofSignerAndVerifier(t *testing.T) {
 	//nolint:lll
-	vcStr := `
-{
-  "@context": [
-    "https://www.w3.org/2018/credentials/v1",
-    "https://www.w3.org/2018/credentials/examples/v1"
-  ],
-  "id": "https://example.com/credentials/1872",
-  "type": [
-    "VerifiableCredential",
-    "UniversityDegreeCredential"
-  ],
-  "issuer": "did:key:z6Mkj7of2aaooXhTJvJ5oCL9ZVcAS472ZBuSjYyXDa4bWT32",
-  "issuanceDate": "2020-01-17T15:14:09.724Z",
-  "credentialSubject": {
-    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-    "degree": {
-      "type": "BachelorDegree"
-    },
-    "name": "Jayden Doe",
-    "spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
-  },
-  "proof": {
-    "type": "Ed25519Signature2018",
-    "created": "2018-03-15T00:00:00Z",
-    "jws": "eyJhbGciOiJFZDI1NTE5U2lnbmF0dXJlMjAxOCIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..vc5PCbRaTId2IRptkqJwNDlzZqW-wfGdcl0MWcNrrNCFxZgmgiNU7ZYUtz7ui9yVrVl-NL84F8KrCra7pyruDw",
-    "verificationMethod": "did:example:123456#key1"
-  }
-}
-`
-
-	documentVerifier := verifier.New(dummyKeyResolver(pubKey),
-		ed25519signature2018.New(ed25519signature2018.WithVerifier(&ed25519signature2018.PublicKeyVerifier{})))
-	err := documentVerifier.Verify([]byte(vcStr))
-	require.NoError(t, err)
-}
-
-func TestLinkedDataProofSigner(t *testing.T) {
-	privKeyBytes := base58.Decode("2XYB4TtEgPZxTuRocH8DGoZjjnnPwpwUW9acH1kTCTC8SM9177XHNhzMZu2DNxHdFhi7DACECdieY9D2yngmXZcj") //nolint:lll
-	privKey := ed25519.PrivateKey(privKeyBytes)
-
 	vcJSON := `
 {
   "@context": [
@@ -127,15 +77,21 @@ func TestLinkedDataProofSigner(t *testing.T) {
 }
 `
 
-	vc, _, err := NewCredential([]byte(vcJSON))
+	vc, err := NewUnverifiedCredential([]byte(vcJSON))
 	require.NoError(t, err)
 
 	created, err := time.Parse(time.RFC3339, "2018-03-15T00:00:00Z")
 	require.NoError(t, err)
 
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	signerSuite := ed25519signature2018.New(
+		ed25519signature2018.WithSigner(getEd25519TestSigner(privKey)),
+		ed25519signature2018.WithCompactProof())
 	err = vc.AddLinkedDataProof(&LinkedDataProofContext{
 		SignatureType:           "Ed25519Signature2018",
-		Suite:                   ed25519signature2018.New(ed25519signature2018.WithSigner(getEd25519TestSigner(privKey))),
+		Suite:                   signerSuite,
 		SignatureRepresentation: SignatureJWS,
 		Created:                 &created,
 		VerificationMethod:      "did:example:123456#key1",
@@ -144,10 +100,15 @@ func TestLinkedDataProofSigner(t *testing.T) {
 
 	require.Len(t, vc.Proofs, 1)
 
-	p := vc.Proofs[0]
+	vcWithProofBytes, err := vc.MarshalJSON()
+	require.NoError(t, err)
 
-	require.Equal(t, "Ed25519Signature2018", p["type"])
-	require.Equal(t, "2018-03-15T00:00:00Z", p["created"])
-	require.Equal(t, "did:example:123456#key1", p["verificationMethod"])
-	require.Equal(t, "eyJhbGciOiJFZDI1NTE5U2lnbmF0dXJlMjAxOCIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..quV5KM2HNIEe4qldY3CwAm8o266UEWWFqVuvJ4P7nYC7bWkQhtH8py5uZanrTkEFjIn0ly1TQgpR3nuC9q2ZCQ", p["jws"]) //nolint:lll
+	verifierSuite := ed25519signature2018.New(
+		ed25519signature2018.WithVerifier(&ed25519signature2018.PublicKeyVerifier{}),
+		ed25519signature2018.WithCompactProof())
+	vcDecoded, _, err := NewCredential(vcWithProofBytes,
+		WithEmbeddedSignatureSuites(verifierSuite),
+		WithPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)))
+	require.NoError(t, err)
+	require.Equal(t, vc, vcDecoded)
 }


### PR DESCRIPTION
closes #1517

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

compactProof option is supported by Digitalbazaar library: https://github.com/digitalbazaar/jsonld-signatures/blob/531058bf1af7101bd261f540e4b875f3e5101076/lib/ProofSet.js#L90

This option will be used to solve https://github.com/hyperledger/aries-framework-go/issues/1415