### PR TITLE
feat: refactor didexchange service to accept out-of-band invitation

### DIFF
--- a/pkg/didcomm/protocol/didexchange/models.go
+++ b/pkg/didcomm/protocol/didexchange/models.go
@@ -11,11 +11,32 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 )
 
+// OOBInvitation to connect with did-exchange.
+type OOBInvitation struct {
+	// ID of this invitation (for record-keeping purposes).
+	// TODO can we remove this?
+	ID string
+	// TODO remove this
+	Type string `json:"@type"`
+	// ID of the thread from which this invitation originated.
+	// This will become the parent thread ID of the didexchange protocol instance.
+	ThreadID string
+	// Label of the connection invitation.
+	Label string
+	// Target destination.
+	// This can be any on of:
+	// - a string with a valid DID
+	// - a valid `did.Service`
+	Target interface{}
+}
+
 // Invitation model
 //
 // Invitation defines DID exchange invitation message
 // https://github.com/hyperledger/aries-rfcs/tree/master/features/0023-did-exchange#0-invitation-to-exchange
 //
+// TODO all uses of this invitation struct should be replaced with the new OOB one. The new one should be renamed
+//  to 'Invitation'.
 type Invitation struct {
 	// the Image URL of the connection invitation
 	ImageURL string `json:"imageUrl,omitempty"`

--- a/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/internal/mock/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
@@ -35,6 +36,7 @@ type MockDIDExchangeSvc struct {
 	UnregisterMsgEventErr    error
 	AcceptError              error
 	ImplicitInvitationErr    error
+	RespondToFunc            func(*didexchange.OOBInvitation) (string, error)
 }
 
 // HandleInbound msg
@@ -134,6 +136,15 @@ func (m *MockDIDExchangeSvc) CreateImplicitInvitation(inviterLabel, inviterDID, 
 	}
 
 	return "connection-id", nil
+}
+
+// RespondTo this invitation.
+func (m *MockDIDExchangeSvc) RespondTo(i *didexchange.OOBInvitation) (string, error) {
+	if m.RespondToFunc != nil {
+		return m.RespondToFunc(i)
+	}
+
+	return "", nil
 }
 
 // MockProvider is provider for DIDExchange Service

--- a/pkg/store/connection/connection_lookup.go
+++ b/pkg/store/connection/connection_lookup.go
@@ -51,6 +51,7 @@ type Record struct {
 	MyDID           string
 	ServiceEndPoint string
 	RecipientKeys   []string
+	RoutingKeys     []string
 	InvitationID    string
 	InvitationDID   string
 	Implicit        bool


### PR DESCRIPTION
closes #1501

* defines a new type to start the did-exchange protocol with (suggestions on the name are welcome)
* out-of-band service refactored to use this new type

The did-exchange protocol service still accepts didexchange.Invitations - that would be removed in a followup PR.