### PR TITLE
test: Add ECDSA P256 test of JsonWebSignature2020 suite

### DIFF
--- a/pkg/doc/signature/suite/jsonwebsignature2020/public_key_verifier.go
+++ b/pkg/doc/signature/suite/jsonwebsignature2020/public_key_verifier.go
@@ -1,0 +1,67 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package jsonwebsignature2020
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"errors"
+	"math/big"
+
+	sigverifier "github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
+)
+
+// PublicKeyVerifierP256 verifies a ECDSA signature taking public key bytes as input.
+// NOTE: this verifier is present for backward compatibility reasons and can be removed soon.
+// Please use CryptoVerifier or your own verifier.
+type PublicKeyVerifierP256 struct {
+}
+
+// Verify will verify a signature.
+func (v *PublicKeyVerifierP256) Verify(pubKey *sigverifier.PublicKey, doc, signature []byte) error {
+	pubKeyBytes := pubKey.Value
+
+	// TODO Read curve parameter from PublicKey, support P384 and P521 curves
+	//   (https://github.com/hyperledger/aries-framework-go/issues/1527)
+	curve := elliptic.P256()
+
+	x, y := elliptic.Unmarshal(curve, pubKeyBytes)
+	if x == nil {
+		return errors.New("ecdsa: invalid public key")
+	}
+
+	ecdsaPubKey := &ecdsa.PublicKey{
+		Curve: curve,
+		X:     x,
+		Y:     y,
+	}
+
+	p256KeySize := 32
+	if len(signature) != 2*p256KeySize {
+		return errors.New("ecdsa: invalid signature size")
+	}
+
+	hasher := crypto.SHA256.New()
+
+	_, err := hasher.Write(doc)
+	if err != nil {
+		return errors.New("ecdsa: hash error")
+	}
+
+	hash := hasher.Sum(nil)
+
+	r := big.NewInt(0).SetBytes(signature[:p256KeySize])
+	s := big.NewInt(0).SetBytes(signature[p256KeySize:])
+
+	verified := ecdsa.Verify(ecdsaPubKey, hash, r, s)
+	if !verified {
+		return errors.New("ecdsa: invalid signature")
+	}
+
+	return nil
+}

--- a/pkg/doc/signature/suite/jsonwebsignature2020/public_key_verifier_test.go
+++ b/pkg/doc/signature/suite/jsonwebsignature2020/public_key_verifier_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package jsonwebsignature2020
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sigverifier "github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+)
+
+func TestPublicKeyVerifier_Verify(t *testing.T) {
+	curve := elliptic.P256()
+	privKey, err := ecdsa.GenerateKey(curve, rand.Reader)
+	require.NoError(t, err)
+
+	msg := []byte("test message")
+
+	pubKeyBytes := elliptic.Marshal(curve, privKey.X, privKey.Y)
+	pubKey := &sigverifier.PublicKey{
+		Type:  kms.ED25519,
+		Value: pubKeyBytes,
+	}
+
+	v := &PublicKeyVerifierP256{}
+	signature := getSignature(privKey, msg)
+
+	t.Run("happy path", func(t *testing.T) {
+		verifyError := v.Verify(pubKey, msg, signature)
+		require.NoError(t, verifyError)
+	})
+
+	t.Run("invalid public key", func(t *testing.T) {
+		verifyError := v.Verify(&sigverifier.PublicKey{
+			Type:  kms.ED25519,
+			Value: []byte("invalid public key"),
+		}, msg, signature)
+		require.Error(t, verifyError)
+		require.EqualError(t, verifyError, "ecdsa: invalid public key")
+	})
+
+	t.Run("invalid signature", func(t *testing.T) {
+		verifyError := v.Verify(pubKey, msg, []byte("signature of invalid size"))
+		require.Error(t, verifyError)
+		require.EqualError(t, verifyError, "ecdsa: invalid signature size")
+
+		emptySig := make([]byte, 64)
+		verifyError = v.Verify(pubKey, msg, emptySig)
+		require.Error(t, verifyError)
+		require.EqualError(t, verifyError, "ecdsa: invalid signature")
+	})
+}
+
+func getSignature(privKey *ecdsa.PrivateKey, payload []byte) []byte {
+	hasher := crypto.SHA256.New()
+
+	// According to documentation, Write() on hash never fails
+	_, err := hasher.Write(payload)
+	if err != nil {
+		panic(err)
+	}
+
+	hashed := hasher.Sum(nil)
+
+	r, s, err := ecdsa.Sign(rand.Reader, privKey, hashed)
+	if err != nil {
+		panic(err)
+	}
+
+	curveBits := privKey.Curve.Params().BitSize
+
+	keyBytes := curveBits / 8
+	if curveBits%8 > 0 {
+		keyBytes++
+	}
+
+	// We serialize the outputs (r and s) into big-endian byte arrays and pad
+	// them with zeros on the left to make sure the sizes work out. Both arrays
+	// must be keyBytes long, and the output must be 2*keyBytes long.
+	rBytes := r.Bytes()
+	rBytesPadded := make([]byte, keyBytes)
+	copy(rBytesPadded[keyBytes-len(rBytes):], rBytes)
+
+	sBytes := s.Bytes()
+	sBytesPadded := make([]byte, keyBytes)
+	copy(sBytesPadded[keyBytes-len(sBytes):], sBytes)
+
+	out := append(rBytesPadded, sBytesPadded...)
+
+	return out
+}


### PR DESCRIPTION
closes #1532

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

I added a piece of ECDSA P256 verification as it's not working using tink crypto.
See TODO at `TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_ecdsaP256`  test.
Added a follow-up issue https://github.com/hyperledger/aries-framework-go/issues/1534.