### PR TITLE
refactor: Support JwsVerificationKey2020 for DID public key

### DIFF
--- a/cmd/aries-agent-rest/go.sum
+++ b/cmd/aries-agent-rest/go.sum
@@ -9,6 +9,7 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aws/aws-sdk-go v1.25.39/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d h1:yJzD/yFppdVCf6ApMkVy8cUxV0XrxdP9rVf6D87/Mng=

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ module github.com/hyperledger/aries-framework-go
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.5.7
+	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/btcsuite/btcutil v1.0.1
-	github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0
 	github.com/golang/mock v1.4.0
 	github.com/golang/protobuf v1.3.3
 	github.com/google/tink v1.3.0

--- a/pkg/doc/jose/jwk.go
+++ b/pkg/doc/jose/jwk.go
@@ -18,19 +18,190 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/decred/dcrd/dcrec/secp256k1/v2"
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/square/go-jose/v3"
 	"golang.org/x/crypto/ed25519"
 )
 
 const (
-	secp256k1Crv = "secp256k1"
-	secp256k1Kty = "EC"
-	bitsPerByte  = 8
+	secp256k1Alg  = "ES256K"
+	secp256k1Crv  = "secp256k1"
+	secp256k1Kty  = "EC"
+	secp256k1Size = 32
+	bitsPerByte   = 8
 )
 
 // JWK (JSON Web Key) is a JSON data structure that represents a cryptographic key.
-type JWK jose.JSONWebKey
+type JWK struct {
+	jose.JSONWebKey
+
+	Kty string
+	Crv string
+}
+
+// PublicKeyBytes converts a public key to bytes.
+func (j *JWK) PublicKeyBytes() ([]byte, error) {
+	if isSecp256k1(j.Algorithm, j.Kty, j.Crv) {
+		var ecPubKey *ecdsa.PublicKey
+
+		ecPubKey, ok := j.Key.(*ecdsa.PublicKey)
+		if !ok {
+			ecPubKey = &j.Key.(*ecdsa.PrivateKey).PublicKey
+		}
+
+		pubKey := &btcec.PublicKey{
+			Curve: btcec.S256(),
+			X:     ecPubKey.X,
+			Y:     ecPubKey.Y,
+		}
+
+		return pubKey.SerializeCompressed(), nil
+	}
+
+	switch pubKey := j.Public().Key.(type) {
+	case *ecdsa.PublicKey, *rsa.PublicKey, ed25519.PublicKey:
+		pubKBytes, err := x509.MarshalPKIXPublicKey(pubKey)
+		if err != nil {
+			return nil, errors.New("failed to read public key bytes")
+		}
+
+		return pubKBytes, nil
+	default:
+		return nil, fmt.Errorf("unsupported public key type in kid '%s'", j.KeyID)
+	}
+}
+
+// UnmarshalJSON reads a key from its JSON representation.
+func (j *JWK) UnmarshalJSON(jwkBytes []byte) error {
+	var key jsonWebKey
+
+	marshalErr := json.Unmarshal(jwkBytes, &key)
+	if marshalErr != nil {
+		return fmt.Errorf("unable to read JWK: %w", marshalErr)
+	}
+
+	if isSecp256k1(key.Alg, key.Kty, key.Crv) {
+		jwk, err := unmarshalSecp256k1(&key)
+		if err != nil {
+			return fmt.Errorf("unable to read JWK: %w", err)
+		}
+
+		*j = *jwk
+	} else {
+		var joseJWK jose.JSONWebKey
+
+		err := json.Unmarshal(jwkBytes, &joseJWK)
+		if err != nil {
+			return fmt.Errorf("unable to read jose JWK, %w", err)
+		}
+
+		j.JSONWebKey = joseJWK
+	}
+
+	j.Kty = key.Kty
+	j.Crv = key.Crv
+
+	return nil
+}
+
+// MarshalJSON serializes the given key to its JSON representation.
+func (j *JWK) MarshalJSON() ([]byte, error) {
+	if isSecp256k1(j.Algorithm, j.Kty, j.Crv) {
+		return marshalSecp256k1(j)
+	}
+
+	return (&j.JSONWebKey).MarshalJSON()
+}
+
+func isSecp256k1(alg, kty, crv string) bool {
+	return strings.EqualFold(alg, secp256k1Alg) ||
+		(strings.EqualFold(kty, secp256k1Kty) && strings.EqualFold(crv, secp256k1Crv))
+}
+
+func unmarshalSecp256k1(jwk *jsonWebKey) (*JWK, error) {
+	if jwk.X == nil {
+		return nil, ErrInvalidKey
+	}
+
+	if jwk.Y == nil {
+		return nil, ErrInvalidKey
+	}
+
+	curve := btcec.S256()
+
+	if curveSize(curve) != len(jwk.X.data) {
+		return nil, ErrInvalidKey
+	}
+
+	if curveSize(curve) != len(jwk.Y.data) {
+		return nil, ErrInvalidKey
+	}
+
+	if jwk.D != nil && dSize(curve) != len(jwk.D.data) {
+		return nil, ErrInvalidKey
+	}
+
+	x := jwk.X.bigInt()
+	y := jwk.Y.bigInt()
+
+	if !curve.IsOnCurve(x, y) {
+		return nil, ErrInvalidKey
+	}
+
+	var key interface{}
+
+	if jwk.D != nil {
+		key = &ecdsa.PrivateKey{
+			PublicKey: ecdsa.PublicKey{
+				Curve: curve,
+				X:     x,
+				Y:     y,
+			},
+			D: jwk.D.bigInt(),
+		}
+	} else {
+		key = &ecdsa.PublicKey{
+			Curve: curve,
+			X:     x,
+			Y:     y,
+		}
+	}
+
+	return &JWK{
+		JSONWebKey: jose.JSONWebKey{
+			Key: key, KeyID: jwk.Kid, Algorithm: jwk.Alg, Use: jwk.Use,
+		},
+	}, nil
+}
+
+func marshalSecp256k1(jwk *JWK) ([]byte, error) {
+	var raw jsonWebKey
+
+	switch ecdsaKey := jwk.Key.(type) {
+	case *ecdsa.PublicKey:
+		raw = jsonWebKey{
+			Kty: secp256k1Kty,
+			Crv: secp256k1Crv,
+			X:   newFixedSizeBuffer(ecdsaKey.X.Bytes(), secp256k1Size),
+			Y:   newFixedSizeBuffer(ecdsaKey.Y.Bytes(), secp256k1Size),
+		}
+
+	case *ecdsa.PrivateKey:
+		raw = jsonWebKey{
+			Kty: secp256k1Kty,
+			Crv: secp256k1Crv,
+			X:   newFixedSizeBuffer(ecdsaKey.X.Bytes(), secp256k1Size),
+			Y:   newFixedSizeBuffer(ecdsaKey.Y.Bytes(), secp256k1Size),
+			D:   newFixedSizeBuffer(ecdsaKey.D.Bytes(), dSize(ecdsaKey.Curve)),
+		}
+	}
+
+	raw.Kid = jwk.KeyID
+	raw.Alg = jwk.Algorithm
+	raw.Use = jwk.Use
+
+	return json.Marshal(raw)
+}
 
 // JWK gets JWK from JOSE headers.
 func (h Headers) JWK() (*JWK, bool) {
@@ -51,74 +222,16 @@ func (h Headers) JWK() (*JWK, bool) {
 
 // jsonWebKey contains subset of json web key json properties
 type jsonWebKey struct {
-	Kty string      `json:"kty,omitempty"`
-	Kid string      `json:"kid,omitempty"`
-	Crv string      `json:"crv,omitempty"`
-	X   *byteBuffer `json:"x,omitempty"`
-	Y   *byteBuffer `json:"y,omitempty"`
-}
+	Use string `json:"use,omitempty"`
+	Kty string `json:"kty,omitempty"`
+	Kid string `json:"kid,omitempty"`
+	Crv string `json:"crv,omitempty"`
+	Alg string `json:"alg,omitempty"`
 
-// DecodePublicKey reads a public key from its JSON Web Key representation.
-// TODO : to be part of jose.JWK [Issue#1513]
-func DecodePublicKey(jwkBytes []byte) ([]byte, error) {
-	key := &jsonWebKey{}
+	X *byteBuffer `json:"x,omitempty"`
+	Y *byteBuffer `json:"y,omitempty"`
 
-	err := json.Unmarshal(jwkBytes, key)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read JWK, %w", err)
-	}
-
-	if strings.EqualFold(key.Kty, secp256k1Kty) && strings.EqualFold(key.Crv, secp256k1Crv) {
-		//  if kty="EC" and Crv="secp256k1", then handle differently
-		return btcPublicKey(key.X, key.Y)
-	}
-
-	jwk := jose.JSONWebKey{}
-
-	// read key from its JSON representation.
-	err = jwk.UnmarshalJSON(jwkBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read: %w", err)
-	}
-
-	// get public key bytes from jwk
-	switch pubKey := jwk.Public().Key.(type) {
-	case *ecdsa.PublicKey, *rsa.PublicKey, ed25519.PublicKey:
-		pubKBytes, err := x509.MarshalPKIXPublicKey(pubKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read public key: %w", err)
-		}
-
-		return pubKBytes, nil
-	default:
-		return nil, fmt.Errorf("unsupported public key type in kid '%s'", key.Kid)
-	}
-}
-
-// return public key bytes using given(x,y) using curve=secp256k1
-func btcPublicKey(xBuffer, yBuffer *byteBuffer) ([]byte, error) {
-	curve := secp256k1.S256()
-
-	if xBuffer == nil || yBuffer == nil {
-		return nil, errors.New("invalid EC key, missing x/y values")
-	}
-
-	if curveSize(curve) != len(xBuffer.data) {
-		return nil, fmt.Errorf("invalid EC public key, wrong length for x")
-	}
-
-	if curveSize(curve) != len(yBuffer.data) {
-		return nil, fmt.Errorf("invalid EC public key, wrong length for y")
-	}
-
-	x := xBuffer.bigInt()
-	y := yBuffer.bigInt()
-
-	if !curve.IsOnCurve(x, y) {
-		return nil, errors.New("invalid EC key, X/Y are not on declared curve")
-	}
-
-	return secp256k1.NewPublicKey(x, y).Serialize(), nil
+	D *byteBuffer `json:"d,omitempty"`
 }
 
 // Get size of curve in bytes
@@ -133,6 +246,18 @@ func curveSize(crv elliptic.Curve) int {
 	}
 
 	return div + 1
+}
+
+func dSize(curve elliptic.Curve) int {
+	order := curve.Params().P
+	bitLen := order.BitLen()
+	size := bitLen / bitsPerByte
+
+	if bitLen%bitsPerByte != 0 {
+		size++
+	}
+
+	return size
 }
 
 // byteBuffer represents a slice of bytes that can be serialized to url-safe base64.
@@ -167,3 +292,14 @@ func (b *byteBuffer) UnmarshalJSON(data []byte) error {
 func (b byteBuffer) bigInt() *big.Int {
 	return new(big.Int).SetBytes(b.data)
 }
+
+func newFixedSizeBuffer(data []byte, length int) *byteBuffer {
+	paddedData := make([]byte, length-len(data))
+
+	return &byteBuffer{
+		data: append(paddedData, data...),
+	}
+}
+
+// ErrInvalidKey is returned when passed JWK is invalid.
+var ErrInvalidKey = errors.New("invalid JWK")

--- a/pkg/doc/signature/suite/jsonwebsignature2020/public_key_verifier.go
+++ b/pkg/doc/signature/suite/jsonwebsignature2020/public_key_verifier.go
@@ -11,38 +11,45 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"errors"
+	"fmt"
 	"math/big"
+
+	"github.com/btcsuite/btcd/btcec"
 
 	sigverifier "github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 )
 
-// PublicKeyVerifierP256 verifies a ECDSA signature taking public key bytes as input.
+// PublicKeyVerifierEC verifies a ECDSA signature taking public key bytes as input.
 // NOTE: this verifier is present for backward compatibility reasons and can be removed soon.
 // Please use CryptoVerifier or your own verifier.
-type PublicKeyVerifierP256 struct {
+type PublicKeyVerifierEC struct {
 }
 
 // Verify will verify a signature.
-func (v *PublicKeyVerifierP256) Verify(pubKey *sigverifier.PublicKey, doc, signature []byte) error {
+func (v *PublicKeyVerifierEC) Verify(pubKey *sigverifier.PublicKey, doc, signature []byte) error {
+	if pubKey.JWK == nil {
+		return errors.New("JWK is not defined")
+	}
+
+	ec := parseEllipticCurve(pubKey.JWK.Crv)
+	if ec == nil {
+		return fmt.Errorf("ecdsa: unsupported elliptic curve '%s'", pubKey.JWK.Crv)
+	}
+
 	pubKeyBytes := pubKey.Value
 
-	// TODO Read curve parameter from PublicKey, support P384 and P521 curves
-	//   (https://github.com/hyperledger/aries-framework-go/issues/1527)
-	curve := elliptic.P256()
-
-	x, y := elliptic.Unmarshal(curve, pubKeyBytes)
+	x, y := elliptic.Unmarshal(ec.Curve, pubKeyBytes)
 	if x == nil {
 		return errors.New("ecdsa: invalid public key")
 	}
 
 	ecdsaPubKey := &ecdsa.PublicKey{
-		Curve: curve,
+		Curve: ec.Curve,
 		X:     x,
 		Y:     y,
 	}
 
-	p256KeySize := 32
-	if len(signature) != 2*p256KeySize {
+	if len(signature) != 2*ec.KeySize {
 		return errors.New("ecdsa: invalid signature size")
 	}
 
@@ -55,8 +62,8 @@ func (v *PublicKeyVerifierP256) Verify(pubKey *sigverifier.PublicKey, doc, signa
 
 	hash := hasher.Sum(nil)
 
-	r := big.NewInt(0).SetBytes(signature[:p256KeySize])
-	s := big.NewInt(0).SetBytes(signature[p256KeySize:])
+	r := big.NewInt(0).SetBytes(signature[:ec.KeySize])
+	s := big.NewInt(0).SetBytes(signature[ec.KeySize:])
 
 	verified := ecdsa.Verify(ecdsaPubKey, hash, r, s)
 	if !verified {
@@ -64,4 +71,43 @@ func (v *PublicKeyVerifierP256) Verify(pubKey *sigverifier.PublicKey, doc, signa
 	}
 
 	return nil
+}
+
+type ellipticCurve struct {
+	Curve   elliptic.Curve
+	KeySize int
+}
+
+const (
+	p256KeySize      = 32
+	p384KeySize      = 48
+	p521KeySize      = 66
+	secp256k1KeySize = 32
+)
+
+func parseEllipticCurve(curve string) *ellipticCurve {
+	switch curve {
+	case "P-256":
+		return &ellipticCurve{
+			Curve:   elliptic.P256(),
+			KeySize: p256KeySize,
+		}
+	case "P-384":
+		return &ellipticCurve{
+			Curve:   elliptic.P384(),
+			KeySize: p384KeySize,
+		}
+	case "P-521":
+		return &ellipticCurve{
+			Curve:   elliptic.P521(),
+			KeySize: p521KeySize,
+		}
+	case "secp256k1":
+		return &ellipticCurve{
+			Curve:   btcec.S256(),
+			KeySize: secp256k1KeySize,
+		}
+	default:
+		return nil
+	}
 }

--- a/pkg/doc/signature/suite/jsonwebsignature2020/public_key_verifier_test.go
+++ b/pkg/doc/signature/suite/jsonwebsignature2020/public_key_verifier_test.go
@@ -13,13 +13,16 @@ import (
 	"crypto/rand"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec"
+	gojose "github.com/square/go-jose/v3"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
 	sigverifier "github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
-func TestPublicKeyVerifier_Verify(t *testing.T) {
+func TestPublicKeyVerifierP256_Verify(t *testing.T) {
 	curve := elliptic.P256()
 	privKey, err := ecdsa.GenerateKey(curve, rand.Reader)
 	require.NoError(t, err)
@@ -30,9 +33,17 @@ func TestPublicKeyVerifier_Verify(t *testing.T) {
 	pubKey := &sigverifier.PublicKey{
 		Type:  kms.ED25519,
 		Value: pubKeyBytes,
+
+		JWK: &jose.JWK{
+			JSONWebKey: gojose.JSONWebKey{
+				Algorithm: "ES256",
+			},
+			Crv: "P-256",
+			Kty: "EC",
+		},
 	}
 
-	v := &PublicKeyVerifierP256{}
+	v := &PublicKeyVerifierEC{}
 	signature := getSignature(privKey, msg)
 
 	t.Run("happy path", func(t *testing.T) {
@@ -40,10 +51,42 @@ func TestPublicKeyVerifier_Verify(t *testing.T) {
 		require.NoError(t, verifyError)
 	})
 
+	t.Run("undefined JWK", func(t *testing.T) {
+		verifyError := v.Verify(&sigverifier.PublicKey{
+			Type:  kms.ED25519,
+			Value: pubKeyBytes,
+		}, msg, signature)
+		require.Error(t, verifyError)
+		require.EqualError(t, verifyError, "JWK is not defined")
+	})
+
+	t.Run("unsupported curve", func(t *testing.T) {
+		verifyError := v.Verify(&sigverifier.PublicKey{
+			Type:  kms.ED25519,
+			Value: pubKeyBytes,
+			JWK: &jose.JWK{
+				JSONWebKey: gojose.JSONWebKey{
+					Algorithm: "ES256",
+				},
+				Crv: "unsupported",
+				Kty: "EC",
+			},
+		}, msg, signature)
+		require.Error(t, verifyError)
+		require.EqualError(t, verifyError, "ecdsa: unsupported elliptic curve 'unsupported'")
+	})
+
 	t.Run("invalid public key", func(t *testing.T) {
 		verifyError := v.Verify(&sigverifier.PublicKey{
 			Type:  kms.ED25519,
 			Value: []byte("invalid public key"),
+			JWK: &jose.JWK{
+				JSONWebKey: gojose.JSONWebKey{
+					Algorithm: "ES256",
+				},
+				Crv: "P-256",
+				Kty: "EC",
+			},
 		}, msg, signature)
 		require.Error(t, verifyError)
 		require.EqualError(t, verifyError, "ecdsa: invalid public key")
@@ -61,10 +104,69 @@ func TestPublicKeyVerifier_Verify(t *testing.T) {
 	})
 }
 
+func TestPublicKeyVerifier_Verify(t *testing.T) {
+	tests := []struct {
+		curve     elliptic.Curve
+		curveName string
+		algorithm string
+	}{
+		{
+			curve:     elliptic.P256(),
+			curveName: "P-256",
+			algorithm: "ES256",
+		},
+		{
+			curve:     elliptic.P384(),
+			curveName: "P-384",
+			algorithm: "ES384",
+		},
+		{
+			curve:     elliptic.P521(),
+			curveName: "P-521",
+			algorithm: "ES521",
+		},
+		{
+			curve:     btcec.S256(),
+			curveName: "secp256k1",
+			algorithm: "ES256K",
+		},
+	}
+
+	t.Parallel()
+
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.curveName, func(t *testing.T) {
+			privKey, err := ecdsa.GenerateKey(tc.curve, rand.Reader)
+			require.NoError(t, err)
+
+			msg := []byte("test message")
+
+			pubKeyBytes := elliptic.Marshal(tc.curve, privKey.X, privKey.Y)
+			pubKey := &sigverifier.PublicKey{
+				Type:  kms.ED25519,
+				Value: pubKeyBytes,
+				JWK: &jose.JWK{
+					JSONWebKey: gojose.JSONWebKey{
+						Algorithm: tc.algorithm,
+					},
+					Crv: tc.curveName,
+					Kty: "EC",
+				},
+			}
+
+			v := &PublicKeyVerifierEC{}
+			signature := getSignature(privKey, msg)
+
+			err = v.Verify(pubKey, msg, signature)
+			require.NoError(t, err)
+		})
+	}
+}
+
 func getSignature(privKey *ecdsa.PrivateKey, payload []byte) []byte {
 	hasher := crypto.SHA256.New()
 
-	// According to documentation, Write() on hash never fails
 	_, err := hasher.Write(payload)
 	if err != nil {
 		panic(err)
@@ -84,18 +186,12 @@ func getSignature(privKey *ecdsa.PrivateKey, payload []byte) []byte {
 		keyBytes++
 	}
 
-	// We serialize the outputs (r and s) into big-endian byte arrays and pad
-	// them with zeros on the left to make sure the sizes work out. Both arrays
-	// must be keyBytes long, and the output must be 2*keyBytes long.
-	rBytes := r.Bytes()
-	rBytesPadded := make([]byte, keyBytes)
-	copy(rBytesPadded[keyBytes-len(rBytes):], rBytes)
+	return append(copyPadded(r.Bytes(), keyBytes), copyPadded(s.Bytes(), keyBytes)...)
+}
 
-	sBytes := s.Bytes()
-	sBytesPadded := make([]byte, keyBytes)
-	copy(sBytesPadded[keyBytes-len(sBytes):], sBytes)
+func copyPadded(source []byte, size int) []byte {
+	dest := make([]byte, size)
+	copy(dest[size-len(source):], source)
 
-	out := append(rBytesPadded, sBytesPadded...)
-
-	return out
+	return dest
 }

--- a/pkg/doc/signature/verifier/verifier.go
+++ b/pkg/doc/signature/verifier/verifier.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/proof"
 )
 
@@ -35,6 +36,7 @@ type signatureSuite interface {
 type PublicKey struct {
 	Type  string
 	Value []byte
+	JWK   *jose.JWK
 }
 
 // keyResolver encapsulates key resolution

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -17,6 +17,7 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/aws/aws-sdk-go v1.25.39/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d h1:yJzD/yFppdVCf6ApMkVy8cUxV0XrxdP9rVf6D87/Mng=


### PR DESCRIPTION
For linked data signatures with `JwsVerificationKey2020` type, it's not enough information to make signature verification based on the public key bytes and a type (JwsVerificationKey2020). We need to know additionally what signature algorithm (and/or curve) was used - e.g. `ES256` or `EdDSA`.
In the case of DID documents, we can read this information from the public key if it's defined as `publicKeyJwk`.
As a result, we extend `PublicKey` struct with `Curve`, `Alg` and `KeyType` fields and use them in the signature verifier implementations (e.g. in `PublicKeyVerifierEC`).

closes #1527, #1513

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>