### PR TITLE
fix: outofband + didexchange

### DIFF
--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -870,7 +870,7 @@ func TestServiceEvents(t *testing.T) {
 			didexchange.DIDExchange: didExSvc,
 			route.Coordination:      &mockroute.MockRouteSvc{},
 		},
-		KMSValue: &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"}})
+		KMSValue: &mockkms.CloseableKMS{CreateSigningKeyValue: "sample-key"}})
 	require.NoError(t, err)
 	require.NotNil(t, c)
 
@@ -961,7 +961,7 @@ func TestAcceptExchangeRequest(t *testing.T) {
 			didexchange.DIDExchange: didExSvc,
 			route.Coordination:      &mockroute.MockRouteSvc{},
 		},
-		KMSValue: &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"}},
+		KMSValue: &mockkms.CloseableKMS{CreateSigningKeyValue: "sample-key"}},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, c)

--- a/pkg/client/didexchange/example_test.go
+++ b/pkg/client/didexchange/example_test.go
@@ -138,7 +138,7 @@ func mockContext() provider {
 	}
 
 	context := &mockprovider.Provider{
-		KMSValue:                      &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
+		KMSValue:                      &mockkms.CloseableKMS{CreateSigningKeyValue: "sample-key"},
 		TransientStorageProviderValue: transientStoreProvider,
 		StorageProviderValue:          storeProvider,
 		ServiceMap: map[string]interface{}{

--- a/pkg/client/route/example_test.go
+++ b/pkg/client/route/example_test.go
@@ -40,7 +40,7 @@ func Example() {
 	// Register agent with the router
 	err = client.Register(routerConnID)
 	if err != nil {
-		fmt.Println("failed to register the agent with router")
+		fmt.Printf("failed to register the agent with router : %s\n", err.Error())
 	}
 
 	fmt.Println("successfully registered with router")
@@ -117,7 +117,7 @@ func didClientMockContext() *mockprovider.Provider {
 	}
 
 	context := &mockprovider.Provider{
-		KMSValue:                      &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
+		KMSValue:                      &mockkms.CloseableKMS{CreateSigningKeyValue: "sample-key"},
 		TransientStorageProviderValue: transientStoreProvider,
 		StorageProviderValue:          storeProvider,
 		ServiceMap: map[string]interface{}{

--- a/pkg/controller/command/didexchange/command_test.go
+++ b/pkg/controller/command/didexchange/command_test.go
@@ -709,7 +709,7 @@ func TestCommand_AcceptExchangeRequest(t *testing.T) {
 				didexsvc.DIDExchange: didExSvc,
 				route.Coordination:   &mockroute.MockRouteSvc{},
 			},
-			KMSValue: &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"}},
+			KMSValue: &mockkms.CloseableKMS{CreateSigningKeyValue: "sample-key"}},
 			&mockwebhook.Notifier{
 				NotifyFunc: func(topic string, message []byte) error {
 					require.Equal(t, connectionsWebhookTopic, topic)

--- a/pkg/didcomm/protocol/didexchange/models.go
+++ b/pkg/didcomm/protocol/didexchange/models.go
@@ -15,7 +15,7 @@ import (
 type OOBInvitation struct {
 	// ID of this invitation (for record-keeping purposes).
 	// TODO can we remove this?
-	ID string
+	ID string `json:"@id"`
 	// TODO remove this
 	Type string `json:"@type"`
 	// ID of the thread from which this invitation originated.

--- a/pkg/framework/aries/api/protocol.go
+++ b/pkg/framework/aries/api/protocol.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	didcommtransport "github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
@@ -39,6 +40,7 @@ type Provider interface {
 	VDRIRegistry() vdriapi.Registry
 	Signer() legacykms.Signer
 	TransientStorageProvider() storage.Provider
+	InboundMessageHandler() didcommtransport.InboundMessageHandler
 }
 
 // ProtocolSvcCreator method to create new protocol service

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/introduce"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/issuecredential"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/outofband"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/route"
 	arieshttp "github.com/hyperledger/aries-framework-go/pkg/didcomm/transport/http"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api"
@@ -52,7 +53,7 @@ func defFrameworkOpts(frameworkOpts *Aries) error {
 
 	// order is important as DIDExchange service depends on Route service and Introduce depends on DIDExchange
 	frameworkOpts.protocolSvcCreators = append(frameworkOpts.protocolSvcCreators,
-		newRouteSvc(), newExchangeSvc(), newIntroduceSvc(), newIssueCredentialSvc())
+		newRouteSvc(), newExchangeSvc(), newIntroduceSvc(), newIssueCredentialSvc(), newOutOfBandSvc())
 
 	if frameworkOpts.secretLock == nil && frameworkOpts.kmsCreator == nil {
 		err := createDefSecretLock(frameworkOpts)
@@ -91,6 +92,12 @@ func newIssueCredentialSvc() api.ProtocolSvcCreator {
 func newRouteSvc() api.ProtocolSvcCreator {
 	return func(prv api.Provider) (dispatcher.ProtocolService, error) {
 		return route.New(prv)
+	}
+}
+
+func newOutOfBandSvc() api.ProtocolSvcCreator {
+	return func(prv api.Provider) (dispatcher.ProtocolService, error) {
+		return outofband.New(prv)
 	}
 }
 

--- a/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
@@ -37,6 +37,7 @@ type MockDIDExchangeSvc struct {
 	AcceptError              error
 	ImplicitInvitationErr    error
 	RespondToFunc            func(*didexchange.OOBInvitation) (string, error)
+	SaveFunc                 func(invitation *didexchange.OOBInvitation) error
 }
 
 // HandleInbound msg
@@ -145,6 +146,15 @@ func (m *MockDIDExchangeSvc) RespondTo(i *didexchange.OOBInvitation) (string, er
 	}
 
 	return "", nil
+}
+
+// SaveInvitation this invitation.
+func (m *MockDIDExchangeSvc) SaveInvitation(i *didexchange.OOBInvitation) error {
+	if m.SaveFunc != nil {
+		return m.SaveFunc(i)
+	}
+
+	return nil
 }
 
 // MockProvider is provider for DIDExchange Service

--- a/pkg/store/connection/connection_lookup.go
+++ b/pkg/store/connection/connection_lookup.go
@@ -46,6 +46,7 @@ type Record struct {
 	ConnectionID    string
 	State           string
 	ThreadID        string
+	ParentThreadID  string
 	TheirLabel      string
 	TheirDID        string
 	MyDID           string


### PR DESCRIPTION
Working on the BDD tests for outofband+didexchange made me realize some mistaken assumptions I had about how the didexchange state machine works, and also that there were missing pieces to implement.

This PR will:

* Add `outofband.Client.AcceptRequest()` to receive `request`s received via out-of-band channels. It returns the new connection record's ID (similar to `didexchange.Client.HandleInvitation()`)
* Add `outofband.Service.AcceptRequest()` to accept another agent's request. This method returns the new connection record's ID.
* Add `outofband.Service.SaveRequest()` to save a request created by yourself
* Add `didexchange.Service.Save()` to save OOBInvitations created by yourself
* Hook `outofband.Service` into the framwork context's defaults                                                                
* Refactor `didexchange.Service.RespondTo()` to match what its `Accept*` methods do. This came about from the realization that I had mistaken assumptions about how the didexchange state machine works. Additional changes in the `Service` and state implementations were done to integrate `OOBInvitation` as close as possible to how regular `didexchange.Invitation`s are done.
* Fix existing examples and tests that are incorrectly setting the signing key on the mock KMS
* Add a few debug logging statements to aid troubleshooting

In general, the storing and much of the validation logic was pushed to/kept in the protocol services to keep things DRY and to avoid circular dependencies between client and service packages.

