### PR TITLE
feat: JWS signing/verification - include proof.Type in verification data

### DIFF
--- a/pkg/doc/signature/proof/jws.go
+++ b/pkg/doc/signature/proof/jws.go
@@ -101,7 +101,9 @@ func prepareJWSProof(suite signatureSuite, proofOptions map[string]interface{}) 
 
 	delete(proofOptionsCopy, jsonldJWS)
 	delete(proofOptionsCopy, jsonldProofValue)
-	delete(proofOptionsCopy, jsonldType)
+	// TODO not any where mentioned in RFCs to exclude type, this is causing issue while validating signature from
+	// other systems [Issue#1548]
+	// delete(proofOptionsCopy, jsonldType)
 
 	return suite.GetCanonicalDocument(proofOptionsCopy)
 }

--- a/pkg/doc/verifiable/example_credential_test.go
+++ b/pkg/doc/verifiable/example_credential_test.go
@@ -388,7 +388,7 @@ func ExampleCredential_AddLinkedDataProof() {
 	//	},
 	//	"proof": {
 	//		"created": "2010-01-01T19:23:24Z",
-	//		"jws": "eyJhbGciOiJFZDI1NTE5U2lnbmF0dXJlMjAxOCIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..oAPHkQW8YOPwWSuto6v0m1_gbnSwXtqPHyQIQw51AHNk5T9ncMFYu2Q8zhrY09wCwCguDTMyj4DDn06AcC-oAA",
+	//		"jws": "eyJhbGciOiJFZDI1NTE5U2lnbmF0dXJlMjAxOCIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Io85NnajfPXWBtB60QRI-OEfJtKEVv_ij2QTVLYqXdHTs01zCVMbUTyi6m5zIfH6YZELPgty2NujKYlun4L8Dg",
 	//		"type": "Ed25519Signature2018",
 	//		"verificationMethod": "did:example:123456#key1"
 	//	},


### PR DESCRIPTION
According to Linked Data Signatures specification for JSON-LD
("https://github.com/digitalbazaar/jsonld-signatures") proof value type
shouldn't be exluded while calculating checksum of proof value.

This problem was found while running signature verification tests with
signatures created by other systems using 'Ed25519Signature2018'.

- above specification may not apply for 'JsonWebSignature2020'.
Created issue #1548 to address this issue.

- closes #1549 

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
