### PR TITLE
ci: ignore dependabot push branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 name: build
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+    - 'dependabot/**'
+  pull_request:
 jobs:
   unitTest:
     name: Unit test

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -6,6 +6,8 @@
 name: test-suite
 on: 
   push:
+    branches-ignore:
+    - 'dependabot/**'
     paths:
     - 'pkg/doc/verifiable/**'
     - 'scripts/*_test_suite.sh'


### PR DESCRIPTION
Signed-off-by: Troy Ronda <troy@troyronda.com>

