### PR TITLE
fix: proofPurpose not used for credentials and presentations

### DIFF
--- a/pkg/doc/signature/signer/signer.go
+++ b/pkg/doc/signature/signer/signer.go
@@ -15,6 +15,8 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/proof"
 )
 
+const defaultProofPurpose = "assertionMethod"
+
 // signatureSuite encapsulates signature suite methods required for signing documents
 type signatureSuite interface {
 
@@ -102,6 +104,9 @@ func (signer *DocumentSigner) signObject(context *Context, jsonLdObject map[stri
 		Domain:                  context.Domain,
 		Nonce:                   context.Nonce,
 		VerificationMethod:      context.VerificationMethod,
+		// TODO support custom proof purpose
+		//  (https://github.com/hyperledger/aries-framework-go/issues/1586)
+		ProofPurpose: defaultProofPurpose,
 	}
 
 	if context.SignatureRepresentation == proof.SignatureJWS {

--- a/pkg/doc/signature/signer/signer_test.go
+++ b/pkg/doc/signature/signer/signer_test.go
@@ -35,6 +35,26 @@ func TestDocumentSigner_Sign(t *testing.T) {
 	signedJWSDoc, err := s.Sign(context, []byte(validDoc))
 	require.NoError(t, err)
 	require.NotNil(t, signedJWSDoc)
+
+	var signedJWSMap map[string]interface{}
+	err = json.Unmarshal(signedJWSDoc, &signedJWSMap)
+	require.NoError(t, err)
+
+	proofsIface, ok := signedJWSMap["proof"]
+	require.True(t, ok)
+
+	proofs, ok := proofsIface.([]interface{})
+	require.True(t, ok)
+	require.Len(t, proofs, 1)
+
+	proofMap, ok := proofs[0].(map[string]interface{})
+	require.True(t, ok)
+
+	require.Equal(t, "creator", proofMap["creator"])
+	require.Equal(t, "assertionMethod", proofMap["proofPurpose"])
+	require.Equal(t, "Ed25519Signature2018", proofMap["type"])
+	require.Contains(t, proofMap, "created")
+	require.Contains(t, proofMap, "jws")
 }
 
 func TestDocumentSigner_SignErrors(t *testing.T) {

--- a/pkg/doc/verifiable/example_credential_test.go
+++ b/pkg/doc/verifiable/example_credential_test.go
@@ -388,7 +388,8 @@ func ExampleCredential_AddLinkedDataProof() {
 	//	},
 	//	"proof": {
 	//		"created": "2010-01-01T19:23:24Z",
-	//		"jws": "eyJhbGciOiJFZDI1NTE5U2lnbmF0dXJlMjAxOCIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Io85NnajfPXWBtB60QRI-OEfJtKEVv_ij2QTVLYqXdHTs01zCVMbUTyi6m5zIfH6YZELPgty2NujKYlun4L8Dg",
+	//		"jws": "eyJhbGciOiJFZDI1NTE5U2lnbmF0dXJlMjAxOCIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..hC0uWFmcwp5Fp7nVx3y0LbxZdwReduCde2tyVAwmx3oetNkmn9AP7wvKNbWIBnbVItbGNxib46ld4-YpZhxXDA",
+	//		"proofPurpose": "assertionMethod",
 	//		"type": "Ed25519Signature2018",
 	//		"verificationMethod": "did:example:123456#key1"
 	//	},


### PR DESCRIPTION
closes #1578

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

We put default `assertionMethod` into `proofPurpose`. At the follow-up issue https://github.com/hyperledger/aries-framework-go/issues/1586 we need to support it fully.