### PR TITLE
fix: wrong "alg" type in headers for JWS signer

### DIFF
--- a/pkg/doc/signature/proof/jws.go
+++ b/pkg/doc/signature/proof/jws.go
@@ -24,8 +24,21 @@ const (
 
 // CreateDetachedJWTHeader creates detached JWT header.
 func CreateDetachedJWTHeader(p *Proof) string {
+	var jwsAlg string
+
+	// TODO this is a hacky workaround, to be improved
+	//  (https://github.com/hyperledger/aries-framework-go/issues/1589)
+	switch p.Type {
+	case "EcdsaSecp256k1Signature2019":
+		jwsAlg = "ES256K"
+	case "Ed25519Signature2018":
+		jwsAlg = "EdDSA"
+	default:
+		jwsAlg = p.Type
+	}
+
 	jwtHeaderMap := map[string]interface{}{
-		"alg":  p.Type,
+		"alg":  jwsAlg,
 		"b64":  false,
 		"crit": []string{"b64"},
 	}

--- a/pkg/doc/signature/proof/jws_test.go
+++ b/pkg/doc/signature/proof/jws_test.go
@@ -67,10 +67,47 @@ func Test_createVerifyJWS(t *testing.T) {
 }
 
 func TestCreateDetachedJWTHeader(t *testing.T) {
+	getJwtHeaderMap := func(jwtHeaderB64 string) map[string]interface{} {
+		jwtHeaderBytes, err := base64.RawURLEncoding.DecodeString(jwtHeaderB64)
+		require.NoError(t, err)
+
+		var jwtHeaderMap map[string]interface{}
+		err = json.Unmarshal(jwtHeaderBytes, &jwtHeaderMap)
+		require.NoError(t, err)
+
+		return jwtHeaderMap
+	}
+
 	jwtHeader := CreateDetachedJWTHeader(&Proof{
 		Type: "Ed25519Signature2018",
 	})
 	require.NotEmpty(t, jwtHeader)
+
+	jwtHeaderMap := getJwtHeaderMap(jwtHeader)
+	require.Equal(t, "EdDSA", jwtHeaderMap["alg"])
+	require.Equal(t, false, jwtHeaderMap["b64"])
+	require.Equal(t, []interface{}{"b64"}, jwtHeaderMap["crit"])
+
+	jwtHeader = CreateDetachedJWTHeader(&Proof{
+		Type: "EcdsaSecp256k1Signature2019",
+	})
+	require.NotEmpty(t, jwtHeader)
+
+	jwtHeaderMap = getJwtHeaderMap(jwtHeader)
+	require.Equal(t, "ES256K", jwtHeaderMap["alg"])
+	require.Equal(t, false, jwtHeaderMap["b64"])
+	require.Equal(t, []interface{}{"b64"}, jwtHeaderMap["crit"])
+
+	jwtHeader = CreateDetachedJWTHeader(&Proof{
+		Type: "JsonWebSignature2020",
+	})
+	require.NotEmpty(t, jwtHeader)
+
+	jwtHeaderMap = getJwtHeaderMap(jwtHeader)
+	// TODO this should be improved (https://github.com/hyperledger/aries-framework-go/issues/1589)
+	require.Equal(t, "JsonWebSignature2020", jwtHeaderMap["alg"])
+	require.Equal(t, false, jwtHeaderMap["b64"])
+	require.Equal(t, []interface{}{"b64"}, jwtHeaderMap["crit"])
 }
 
 func TestGetJWTSignature(t *testing.T) {

--- a/pkg/doc/verifiable/example_credential_test.go
+++ b/pkg/doc/verifiable/example_credential_test.go
@@ -388,7 +388,7 @@ func ExampleCredential_AddLinkedDataProof() {
 	//	},
 	//	"proof": {
 	//		"created": "2010-01-01T19:23:24Z",
-	//		"jws": "eyJhbGciOiJFZDI1NTE5U2lnbmF0dXJlMjAxOCIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..hC0uWFmcwp5Fp7nVx3y0LbxZdwReduCde2tyVAwmx3oetNkmn9AP7wvKNbWIBnbVItbGNxib46ld4-YpZhxXDA",
+	//		"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..lrkhpRH4tWl6KzQKHlcyAwSm8qUTXIMSKmD3QASF_uI5QW8NWLxLebXmnQpIM8H7umhLA6dINSYVowcaPdpwBw",
 	//		"proofPurpose": "assertionMethod",
 	//		"type": "Ed25519Signature2018",
 	//		"verificationMethod": "did:example:123456#key1"


### PR DESCRIPTION
closes #1577

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

This is a dirty PR to quickly unblock testing of interop scenario of "Verifying our VCs using third party endpoints".

To be implemented properly at the follow-up https://github.com/hyperledger/aries-framework-go/issues/1589.