### PR TITLE
fix: temporary work around for json ld canonizing issue

### DIFF
--- a/pkg/doc/signature/proof/jws.go
+++ b/pkg/doc/signature/proof/jws.go
@@ -86,6 +86,9 @@ func createVerifyJWS(suite signatureSuite, jsonldDoc map[string]interface{}, p *
 
 	proofOptionsDigest := suite.GetDigest(canonicalProofOptions)
 
+	// TODO this filter function to be removed [Issue #1592]
+	filterJsonldObject(jsonldDoc)
+
 	canonicalDoc, err := prepareDocumentForJWS(suite, jsonldDoc)
 	if err != nil {
 		return nil, err
@@ -101,6 +104,18 @@ func createVerifyJWS(suite signatureSuite, jsonldDoc map[string]interface{}, p *
 	}
 
 	return append([]byte(jwtHeader+"."), verifyData...), nil
+}
+
+// TODO this is a temporary fix to remove fields from JSON LD doc which is causing incorrect
+// canonized docs. To be removed as part of [Issue #1592]
+func filterJsonldObject(jsonldDoc map[string]interface{}) {
+	// remove 'type' from credential status object
+	if crStatus, ok := jsonldDoc["credentialStatus"]; ok {
+		if crstatusMap, ok := crStatus.(map[string]interface{}); ok {
+			delete(crstatusMap, "type")
+			jsonldDoc["credentialStatus"] = crstatusMap
+		}
+	}
 }
 
 func prepareJWSProof(suite signatureSuite, proofOptions map[string]interface{}) ([]byte, error) {

--- a/pkg/doc/signature/proof/jws_test.go
+++ b/pkg/doc/signature/proof/jws_test.go
@@ -131,3 +131,33 @@ func TestGetJWTSignature(t *testing.T) {
 	require.EqualError(t, err, "invalid JWT")
 	require.Empty(t, signature)
 }
+
+func TestFilterJsonldObject(t *testing.T) {
+	const doc = `{
+  		"@context": [
+    		"https://www.w3.org/2018/credentials/v1",
+    		"https://www.w3.org/2018/credentials/examples/v1"
+  		],
+  		"credentialSchema": [],
+  		"credentialStatus": {
+    		"id": "http://issuer.vc.rest.example.com:8070/status/1",
+    		"type": "CredentialStatusList2017"
+  		}
+	}`
+
+	var jsonldDoc map[string]interface{}
+	err := json.Unmarshal([]byte(doc), &jsonldDoc)
+	require.NoError(t, err)
+	require.NotEmpty(t, jsonldDoc)
+
+	credStatus, ok := jsonldDoc["credentialStatus"].(map[string]interface{})
+	require.True(t, ok)
+
+	l := len(credStatus)
+
+	filterJsonldObject(jsonldDoc)
+
+	credStatus, ok = jsonldDoc["credentialStatus"].(map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, credStatus, l-1)
+}


### PR DESCRIPTION
- Excluding "credentialStatus.type" from VC which is causing document
canonizing issue (#1592)
- closes #1593

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
