### PR TITLE
fix: assign JWK from PublicKey of DID to resolved PublicKey

### DIFF
--- a/pkg/doc/verifiable/common.go
+++ b/pkg/doc/verifiable/common.go
@@ -90,6 +90,7 @@ func (r *DIDKeyResolver) resolvePublicKey(issuerDID, keyID string) (*verifier.Pu
 			return &verifier.PublicKey{
 				Type:  key.Type,
 				Value: key.Value,
+				JWK:   key.JSONWebKey(),
 			}, nil
 		}
 	}
@@ -102,6 +103,7 @@ func (r *DIDKeyResolver) resolvePublicKey(issuerDID, keyID string) (*verifier.Pu
 			return &verifier.PublicKey{
 				Type:  auth.PublicKey.Type,
 				Value: auth.PublicKey.Value,
+				JWK:   auth.PublicKey.JSONWebKey(),
 			}, nil
 		}
 	}

--- a/pkg/doc/verifiable/credential_jwt_proof_test.go
+++ b/pkg/doc/verifiable/credential_jwt_proof_test.go
@@ -244,12 +244,7 @@ func createDIDKeyFetcher(t *testing.T, pub ed25519.PublicKey, didID string) Publ
 
 	id := fmt.Sprintf(didFormat, method, didID)
 	pubKeyID := fmt.Sprintf(didPKID, id, 1)
-	pubKey := did.PublicKey{
-		ID:         pubKeyID,
-		Type:       "Ed25519VerificationKey2018",
-		Controller: id,
-		Value:      pub,
-	}
+	pubKey := did.NewPublicKeyFromBytes(pubKeyID, "Ed25519VerificationKey2018", id, pub)
 	services := []did.Service{
 		{
 			ID:              fmt.Sprintf(didServiceID, id, 1),
@@ -263,7 +258,7 @@ func createDIDKeyFetcher(t *testing.T, pub ed25519.PublicKey, didID string) Publ
 	didDoc := &did.Doc{
 		Context:   []string{did.Context},
 		ID:        id,
-		PublicKey: []did.PublicKey{pubKey},
+		PublicKey: []did.PublicKey{*pubKey},
 		Service:   services,
 		Created:   &createdTime,
 		Updated:   &createdTime,

--- a/test/bdd/features/verifiable_credential.feature
+++ b/test/bdd/features/verifiable_credential.feature
@@ -9,7 +9,7 @@
 Feature: Issue Verifiable Credential
   @issue_vc_ldp
   Scenario: Issue University Degree Credential with JWS Linked Data proof
-    When "Stanford University" issues credential at "2018-03-15" regarding "Bachelor Degree" to "Alice" with "JWS Linked data" proof
+    When "Stanford University" issues credential at "2018-03-15" regarding "Bachelor Degree" to "Alice" with "JWS Ed25519Signature2018 Linked data" proof
     Then "Alice" receives the credential and verifies it
 
   @issue_vc_jws

--- a/test/bdd/pkg/verifiable/verifiable_steps.go
+++ b/test/bdd/pkg/verifiable/verifiable_steps.go
@@ -35,7 +35,9 @@ func NewVerifiableCredentialSDKSteps() *SDKSteps {
 }
 
 const (
-	jwsLinkedDataProof = "JWS Linked data"
+	// TODO support JsonWebSignature2020 and EcdsaSecp256k1Signature2019 signature suites
+	//  (https://github.com/hyperledger/aries-framework-go/issues/1596)
+	jwsLinkedDataProofEd25519Signature2018 = "JWS Ed25519Signature2018 Linked data"
 
 	jwsProof = "JWS"
 )
@@ -107,7 +109,7 @@ func (s *SDKSteps) addVCProof(vc *verifiable.Credential, issuer, proofType strin
 	signer := newSigner(kms, base58.Encode(pubKey.Value))
 
 	switch proofType {
-	case jwsLinkedDataProof:
+	case jwsLinkedDataProofEd25519Signature2018:
 		err := vc.AddLinkedDataProof(&verifiable.LinkedDataProofContext{
 			SignatureType:           "Ed25519Signature2018",
 			Suite:                   ed25519signature2018.New(suite.WithSigner(signer)),


### PR DESCRIPTION
closes #1595

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

It should be also validated for the signature suites which use `JWK` from `verifier.PublicKey` in the VC BDD tests - https://github.com/hyperledger/aries-framework-go/issues/1596