### PR TITLE
feat: Handling invalid RDF in canonized JSON LD

### DIFF
--- a/pkg/doc/signature/jsonld/processor.go
+++ b/pkg/doc/signature/jsonld/processor.go
@@ -1,0 +1,129 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package jsonld
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/piprate/json-gold/ld"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+)
+
+const (
+	format             = "application/n-quads"
+	defaultAlgorithm   = "URDNA2015"
+	handleNormalizeErr = "Error while parsing N-Quads; invalid quad. line:"
+)
+
+var logger = log.New("aries-framework/json-ld-processor")
+
+// nolint:gochecknoglobals
+var (
+	invalidRDFLinePattern = regexp.MustCompile("[0-9]*$")
+)
+
+// Processor is JSON-LD processor for aries.
+// processing mode JSON-LD 1.0 {RFC: https://www.w3.org/TR/2014/REC-json-ld-20140116}
+type Processor struct {
+	algorithm string
+}
+
+// NewProcessor returns new JSON-LD processor for aries
+func NewProcessor(algorithm string) *Processor {
+	if algorithm == "" {
+		return Default()
+	}
+
+	return &Processor{algorithm}
+}
+
+// Default returns new JSON-LD processor with default RDF dataset algorithm
+func Default() *Processor {
+	return &Processor{defaultAlgorithm}
+}
+
+// GetCanonicalDocument returns canonized document of given json ld
+func (p *Processor) GetCanonicalDocument(doc map[string]interface{}) ([]byte, error) {
+	proc := ld.NewJsonLdProcessor()
+	options := ld.NewJsonLdOptions("")
+	options.ProcessingMode = ld.JsonLd_1_1
+	options.Algorithm = p.algorithm
+	options.Format = format
+	options.ProduceGeneralizedRdf = true
+
+	view, err := proc.Normalize(doc, options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to normalize JSON-LD document: %w", err)
+	}
+
+	result, err := p.validateView(view.(string))
+	if err != nil {
+		return nil, fmt.Errorf("failed to normalize due to invalid RDF dataset: %w", err)
+	}
+
+	return []byte(result), nil
+}
+
+// Compact compacts given json ld object
+func (p *Processor) Compact(input, context interface{}, loader ld.DocumentLoader) (map[string]interface{}, error) {
+	proc := ld.NewJsonLdProcessor()
+	options := ld.NewJsonLdOptions("")
+	options.ProcessingMode = ld.JsonLd_1_1
+	options.Format = format
+	options.ProduceGeneralizedRdf = true
+
+	if loader != nil {
+		options.DocumentLoader = loader
+	}
+
+	return proc.Compact(input, context, options)
+}
+
+// validateView validates normalized view to find any invalid RDF. If found then it discards that data
+// and try again recursively until validation is passed and returns filtered view after removing all invalid data.
+// [Note : handling invalid RDF data, by following pattern https://github.com/digitalbazaar/jsonld.js/issues/199]
+func (p *Processor) validateView(view string) (string, error) {
+	_, err := ld.ParseNQuads(view)
+	if err != nil {
+		if !strings.Contains(err.Error(), handleNormalizeErr) {
+			return "", err
+		}
+
+		lineNumber, e := findLineNumber(err)
+		if e != nil {
+			return "", fmt.Errorf("failed to locate invalid RDF data:%w", e)
+		}
+
+		logger.Warnf("Found invalid data in normalized JSON-LD, removing invalid data at line number %d", lineNumber)
+
+		return p.validateView(removeQuad(view, lineNumber-1))
+	}
+
+	return view, nil
+}
+
+// removeQuad removes quad from given index of view
+func removeQuad(view string, index int) string {
+	lines := strings.Split(view, "\n")
+	return strings.Join(append(lines[:index], lines[index+1:]...), "\n")
+}
+
+// findLineNumber finds problematic line number from error
+func findLineNumber(err error) (int, error) {
+	s := invalidRDFLinePattern.FindString(err.Error())
+
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return -1, fmt.Errorf("unable to locate invalid RDF data line number: %w", err)
+	}
+
+	return i, nil
+}

--- a/pkg/doc/signature/jsonld/processor_test.go
+++ b/pkg/doc/signature/jsonld/processor_test.go
@@ -1,0 +1,262 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package jsonld
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/piprate/json-gold/ld"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCanonicalDocument(t *testing.T) {
+	t.Run("Test get canonical document", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			doc    string
+			result string
+			err    string
+		}{
+			{
+				name:   "canonizing document with 1 incorrect RDF",
+				doc:    jsonLdWithIncorrectRDF,
+				result: canonizedIncorrectRDF,
+			},
+			{
+				name:   "canonizing valid document 1",
+				doc:    jsonLdSample1,
+				result: canonizedIncorrectRDF,
+			},
+			{
+				name:   "canonizing sample proof document",
+				doc:    jsonLDProofSample,
+				result: canonizedJsonLDProof,
+			},
+			{
+				name:   "canonizing sample document with multiple incorrect RDFs",
+				doc:    jsonLDMultipleInvalidRDFs,
+				result: canonizedSampleVP,
+			},
+			{
+				name:   "canonizing empty document",
+				doc:    `{}`,
+				result: "",
+			},
+		}
+
+		t.Parallel()
+
+		for _, test := range tests {
+			tc := test
+			t.Run(tc.name, func(t *testing.T) {
+				var jsonldDoc map[string]interface{}
+				err := json.Unmarshal([]byte(tc.doc), &jsonldDoc)
+				require.NoError(t, err)
+
+				response, err := NewProcessor(defaultAlgorithm).GetCanonicalDocument(jsonldDoc)
+				if tc.err != "" {
+					require.Error(t, err)
+					require.Contains(t, err.Error(), tc.err)
+					return
+				}
+
+				require.NoError(t, err)
+				require.EqualValues(t, tc.result, string(response))
+			})
+		}
+	})
+}
+
+func TestCompact(t *testing.T) {
+	t.Run("Test json ld processor compact", func(t *testing.T) {
+		doc := map[string]interface{}{
+			"@id": "http://example.org/test#book",
+			"http://example.org/vocab#contains": map[string]interface{}{
+				"@id": "http://example.org/test#chapter",
+			},
+			"http://purl.org/dc/elements/1.1/title": "Title",
+		}
+
+		context := map[string]interface{}{
+			"@context": map[string]interface{}{
+				"dc": "http://purl.org/dc/elements/1.1/",
+				"ex": "http://example.org/vocab#",
+				"ex:contains": map[string]interface{}{
+					"@type": "@id",
+				},
+			},
+		}
+
+		compactedDoc, err := Default().Compact(doc, context, ld.NewDefaultDocumentLoader(nil))
+		if err != nil {
+			log.Println("Error when compacting JSON-LD document:", err)
+			return
+		}
+
+		require.NoError(t, err)
+		require.NotEmpty(t, compactedDoc)
+		require.Len(t, compactedDoc, 4)
+	})
+}
+
+func TestUtilFunctions(t *testing.T) {
+	t.Run("Test find line number", func(t *testing.T) {
+		l, e := findLineNumber(fmt.Errorf("sample error"))
+		require.Error(t, e)
+		require.True(t, l < 0)
+	})
+	t.Run("Test validate view", func(t *testing.T) {
+		view, err := NewProcessor("").validateView(canonizedJsonLDProof)
+		require.NoError(t, err)
+		require.Equal(t, view, canonizedJsonLDProof)
+	})
+}
+
+const (
+	jsonLdWithIncorrectRDF = `{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1"
+  ],
+  "credentialSchema": [],
+  "credentialStatus": {
+    "id": "http://issuer.vc.rest.example.com:8070/status/1",
+    "type": "CredentialStatusList2017"
+  },
+  "credentialSubject": {
+    "degree": {
+      "degree": "MIT",
+      "type": "BachelorDegree"
+    },
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "name": "Jayden Doe",
+    "spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
+  },
+  "id": "https://example.com/credentials/932236e0-966c-44cf-9342-236c0a2c77a7",
+  "issuanceDate": "2020-03-16T22:37:26.544Z",
+  "issuer": {
+    "id": "did:elem:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg",
+    "name": "alice_f94db66c-be63-4f03-af10-4205d1f625e1"
+  },
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ]
+}
+`
+	jsonLdSample1 = `{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1"
+  ],
+  "credentialSchema": [],
+  "credentialStatus": {
+    "id": "http://issuer.vc.rest.example.com:8070/status/1"
+  },
+  "credentialSubject": {
+    "degree": {
+      "degree": "MIT",
+      "type": "BachelorDegree"
+    },
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "name": "Jayden Doe",
+    "spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
+  },
+  "id": "https://example.com/credentials/932236e0-966c-44cf-9342-236c0a2c77a7",
+  "issuanceDate": "2020-03-16T22:37:26.544Z",
+  "issuer": {
+    "id": "did:elem:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg",
+    "name": "alice_f94db66c-be63-4f03-af10-4205d1f625e1"
+  },
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ]
+}
+`
+	// nolint
+	canonizedIncorrectRDF = `<did:elem:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg> <http://schema.org/name> "alice_f94db66c-be63-4f03-af10-4205d1f625e1"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML> .
+<did:example:ebfeb1f712ebc6f1c276e12ec21> <http://schema.org/name> "Jayden Doe"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML> .
+<did:example:ebfeb1f712ebc6f1c276e12ec21> <http://schema.org/spouse> "did:example:c276e12ec21ebfeb1f712ebc6f1" .
+<did:example:ebfeb1f712ebc6f1c276e12ec21> <https://example.org/examples#degree> _:c14n0 .
+<https://example.com/credentials/932236e0-966c-44cf-9342-236c0a2c77a7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/examples#UniversityDegreeCredential> .
+<https://example.com/credentials/932236e0-966c-44cf-9342-236c0a2c77a7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<https://example.com/credentials/932236e0-966c-44cf-9342-236c0a2c77a7> <https://www.w3.org/2018/credentials#credentialStatus> <http://issuer.vc.rest.example.com:8070/status/1> .
+<https://example.com/credentials/932236e0-966c-44cf-9342-236c0a2c77a7> <https://www.w3.org/2018/credentials#credentialSubject> <did:example:ebfeb1f712ebc6f1c276e12ec21> .
+<https://example.com/credentials/932236e0-966c-44cf-9342-236c0a2c77a7> <https://www.w3.org/2018/credentials#issuanceDate> "2020-03-16T22:37:26.544Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://example.com/credentials/932236e0-966c-44cf-9342-236c0a2c77a7> <https://www.w3.org/2018/credentials#issuer> <did:elem:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg> .
+_:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/examples#BachelorDegree> .
+_:c14n0 <https://example.org/examples#degree> "MIT" .
+`
+	// nolint
+	jsonLDProofSample = `{
+  "@context": "https://w3id.org/security/v2",
+  "created": "2020-04-08T04:00:22Z",
+  "proofPurpose": "assertionMethod",
+  "type": "Ed25519Signature2018",
+  "verificationMethod": "did:elem:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg#xqc3gS1gz1vch7R3RvNebWMjLvBOY-n_14feCYRPsUo"
+}`
+
+	// nolint
+	canonizedJsonLDProof = `_:c14n0 <http://purl.org/dc/terms/created> "2020-04-08T04:00:22Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+_:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Ed25519Signature2018> .
+_:c14n0 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> .
+_:c14n0 <https://w3id.org/security#verificationMethod> <did:elem:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg#xqc3gS1gz1vch7R3RvNebWMjLvBOY-n_14feCYRPsUo> .
+`
+
+	jsonLDMultipleInvalidRDFs = `{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1"
+  ],
+  "credentialSchema": [],
+  "credentialStatus": {
+    "id": "http://issuer.vc.rest.example.com:8070/status/1",
+    "type": "CredentialStatusList2017"
+  },
+ "credentialStatus": {
+    "id": "http://issuer.vc.rest.example.com:8070/status/1",
+    "type": "CredentialStatusList2017"
+  },
+  "credentialSubject": {
+    "degree": {
+      "degree": "MIT",
+      "type": "BachelorDegree"
+    },
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "name": "Jayden Doe",
+    "spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
+  },
+  "id": "https://example.com/credentials/932236e0-966c-44cf-9342-236c0a2c77a7",
+  "issuanceDate": "2020-03-16T22:37:26.544Z",
+  "issuer": {
+    "id": "did:elem:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg",
+    "type": "alice_f94db66c-be63-4f03-af10-4205d1f625e1"
+  },
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ]
+}
+`
+	// nolint
+	canonizedSampleVP = `<did:example:ebfeb1f712ebc6f1c276e12ec21> <http://schema.org/name> "Jayden Doe"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML> .
+<did:example:ebfeb1f712ebc6f1c276e12ec21> <http://schema.org/spouse> "did:example:c276e12ec21ebfeb1f712ebc6f1" .
+<did:example:ebfeb1f712ebc6f1c276e12ec21> <https://example.org/examples#degree> _:c14n0 .
+<https://example.com/credentials/932236e0-966c-44cf-9342-236c0a2c77a7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/examples#UniversityDegreeCredential> .
+<https://example.com/credentials/932236e0-966c-44cf-9342-236c0a2c77a7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<https://example.com/credentials/932236e0-966c-44cf-9342-236c0a2c77a7> <https://www.w3.org/2018/credentials#credentialStatus> <http://issuer.vc.rest.example.com:8070/status/1> .
+<https://example.com/credentials/932236e0-966c-44cf-9342-236c0a2c77a7> <https://www.w3.org/2018/credentials#credentialSubject> <did:example:ebfeb1f712ebc6f1c276e12ec21> .
+<https://example.com/credentials/932236e0-966c-44cf-9342-236c0a2c77a7> <https://www.w3.org/2018/credentials#issuanceDate> "2020-03-16T22:37:26.544Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://example.com/credentials/932236e0-966c-44cf-9342-236c0a2c77a7> <https://www.w3.org/2018/credentials#issuer> <did:elem:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg> .
+_:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/examples#BachelorDegree> .
+_:c14n0 <https://example.org/examples#degree> "MIT" .
+`
+)

--- a/pkg/doc/signature/proof/data_test.go
+++ b/pkg/doc/signature/proof/data_test.go
@@ -11,8 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/piprate/json-gold/ld"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 )
 
 func TestCreateVerifyHashAlgorithm(t *testing.T) {
@@ -111,18 +112,7 @@ type mockSignatureSuite struct {
 
 // GetCanonicalDocument will return normalized/canonical version of the document
 func (s *mockSignatureSuite) GetCanonicalDocument(doc map[string]interface{}) ([]byte, error) {
-	proc := ld.NewJsonLdProcessor()
-	options := ld.NewJsonLdOptions("")
-	options.ProcessingMode = ld.JsonLd_1_1
-	options.Format = "application/n-quads"
-	options.ProduceGeneralizedRdf = true
-
-	canonicalDoc, err := proc.Normalize(doc, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return []byte(canonicalDoc.(string)), nil
+	return jsonld.Default().GetCanonicalDocument(doc)
 }
 
 // GetDigest returns document digest

--- a/pkg/doc/signature/proof/jws.go
+++ b/pkg/doc/signature/proof/jws.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/piprate/json-gold/ld"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 )
 
 const securityContext = "https://w3id.org/security/v2"
@@ -143,13 +143,7 @@ func getCompactedWithSecuritySchema(docMap map[string]interface{}) (map[string]i
 		return nil, err
 	}
 
-	proc := ld.NewJsonLdProcessor()
-	options := ld.NewJsonLdOptions("")
-	options.ProcessingMode = ld.JsonLd_1_1
-	options.Format = "application/n-quads"
-	options.ProduceGeneralizedRdf = true
-
-	return proc.Compact(docMap, contextMap, options)
+	return jsonld.Default().Compact(docMap, contextMap, nil)
 }
 
 // cached value from https://w3id.org/security/v2

--- a/pkg/doc/signature/suite/ecdsasecp256k1signature2019/suite.go
+++ b/pkg/doc/signature/suite/ecdsasecp256k1signature2019/suite.go
@@ -14,26 +14,25 @@ package ecdsasecp256k1signature2019
 import (
 	"crypto/sha256"
 
-	"github.com/piprate/json-gold/ld"
-
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
 )
 
 // Suite implements EcdsaSecp256k1Signature2019 signature suite.
 type Suite struct {
 	suite.SignatureSuite
+	jsonldProcessor *jsonld.Processor
 }
 
 const (
 	signatureType = "EcdsaSecp256k1Signature2019"
 	jwkType       = "EcdsaSecp256k1VerificationKey2019"
-	format        = "application/n-quads"
-	algorithm     = "URDNA2015"
+	rdfDataSetAlg = "URDNA2015"
 )
 
 // New an instance of Linked Data Signatures for JWS suite.
 func New(opts ...suite.Opt) *Suite {
-	s := &Suite{}
+	s := &Suite{jsonldProcessor: jsonld.NewProcessor(rdfDataSetAlg)}
 
 	suite.InitSuiteOptions(&s.SignatureSuite, opts...)
 
@@ -43,19 +42,7 @@ func New(opts ...suite.Opt) *Suite {
 // GetCanonicalDocument will return normalized/canonical version of the document.
 // EcdsaSecp256k1Signature2019 signature suite uses RDF Dataset Normalization as canonicalization algorithm.
 func (s *Suite) GetCanonicalDocument(doc map[string]interface{}) ([]byte, error) {
-	proc := ld.NewJsonLdProcessor()
-	options := ld.NewJsonLdOptions("")
-	options.ProcessingMode = ld.JsonLd_1_1
-	options.Format = format
-	options.ProduceGeneralizedRdf = true
-	options.Algorithm = algorithm
-
-	canonicalDoc, err := proc.Normalize(doc, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return []byte(canonicalDoc.(string)), nil
+	return s.jsonldProcessor.GetCanonicalDocument(doc)
 }
 
 // GetDigest returns document digest.

--- a/pkg/doc/signature/suite/ed25519signature2018/suite.go
+++ b/pkg/doc/signature/suite/ed25519signature2018/suite.go
@@ -14,7 +14,7 @@ package ed25519signature2018
 import (
 	"crypto/sha256"
 
-	"github.com/piprate/json-gold/ld"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
 )
@@ -22,16 +22,17 @@ import (
 // Suite implements ed25519 signature suite
 type Suite struct {
 	suite.SignatureSuite
+	jsonldProcessor *jsonld.Processor
 }
 
 const (
 	signatureType = "Ed25519Signature2018"
-	format        = "application/n-quads"
+	rdfDataSetAlg = "URDNA2015"
 )
 
 // New an instance of ed25519 signature suite
 func New(opts ...suite.Opt) *Suite {
-	s := &Suite{}
+	s := &Suite{jsonldProcessor: jsonld.NewProcessor(rdfDataSetAlg)}
 
 	suite.InitSuiteOptions(&s.SignatureSuite, opts...)
 
@@ -41,18 +42,7 @@ func New(opts ...suite.Opt) *Suite {
 // GetCanonicalDocument will return normalized/canonical version of the document
 // Ed25519Signature2018 signature SignatureSuite uses RDF Dataset Normalization as canonicalization algorithm
 func (s *Suite) GetCanonicalDocument(doc map[string]interface{}) ([]byte, error) {
-	proc := ld.NewJsonLdProcessor()
-	options := ld.NewJsonLdOptions("")
-	options.ProcessingMode = ld.JsonLd_1_1
-	options.Format = format
-	options.ProduceGeneralizedRdf = true
-
-	canonicalDoc, err := proc.Normalize(doc, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return []byte(canonicalDoc.(string)), nil
+	return s.jsonldProcessor.GetCanonicalDocument(doc)
 }
 
 // GetDigest returns document digest

--- a/pkg/doc/signature/suite/jsonwebsignature2020/suite.go
+++ b/pkg/doc/signature/suite/jsonwebsignature2020/suite.go
@@ -22,26 +22,25 @@ package jsonwebsignature2020
 import (
 	"crypto/sha256"
 
-	"github.com/piprate/json-gold/ld"
-
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
 )
 
 // Suite implements jsonWebSignature2020 signature suite
 type Suite struct {
 	suite.SignatureSuite
+	jsonldProcessor *jsonld.Processor
 }
 
 const (
 	signatureType = "JsonWebSignature2020"
 	jwkType       = "JwsVerificationKey2020"
-	format        = "application/n-quads"
-	algorithm     = "URDNA2015"
+	rdfDataSetAlg = "URDNA2015"
 )
 
 // New an instance of Linked Data Signatures for JWS suite.
 func New(opts ...suite.Opt) *Suite {
-	s := &Suite{}
+	s := &Suite{jsonldProcessor: jsonld.NewProcessor(rdfDataSetAlg)}
 
 	suite.InitSuiteOptions(&s.SignatureSuite, opts...)
 
@@ -51,19 +50,7 @@ func New(opts ...suite.Opt) *Suite {
 // GetCanonicalDocument will return normalized/canonical version of the document
 // Ed25519Signature2018 signature SignatureSuite uses RDF Dataset Normalization as canonicalization algorithm.
 func (s *Suite) GetCanonicalDocument(doc map[string]interface{}) ([]byte, error) {
-	proc := ld.NewJsonLdProcessor()
-	options := ld.NewJsonLdOptions("")
-	options.ProcessingMode = ld.JsonLd_1_1
-	options.Format = format
-	options.ProduceGeneralizedRdf = true
-	options.Algorithm = algorithm
-
-	canonicalDoc, err := proc.Normalize(doc, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return []byte(canonicalDoc.(string)), nil
+	return s.jsonldProcessor.GetCanonicalDocument(doc)
 }
 
 // GetDigest returns document digest.

--- a/pkg/doc/verifiable/jsonld.go
+++ b/pkg/doc/verifiable/jsonld.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	"github.com/piprate/json-gold/ld"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 )
 
 const vcJSONLD = `
@@ -279,14 +281,7 @@ func compactJSONLD(doc string, documentLoader ld.DocumentLoader, strict bool) er
 		return fmt.Errorf("extract context from JSON-LD doc: %w", err)
 	}
 
-	proc := ld.NewJsonLdProcessor()
-	options := ld.NewJsonLdOptions("")
-	options.ProcessingMode = ld.JsonLd_1_1
-	options.Format = "application/n-quads"
-	options.ProduceGeneralizedRdf = true
-	options.DocumentLoader = documentLoader
-
-	docCompactedMap, err := proc.Compact(docMap, contextMap, options)
+	docCompactedMap, err := jsonld.Default().Compact(docMap, contextMap, documentLoader)
 	if err != nil {
 		return fmt.Errorf("compact JSON-LD document: %w", err)
 	}


### PR DESCRIPTION
Previously: we weren't dropping undefined terms from RDFs.

Fix: changed normalization aproach through json-gold library so that it
returns parsing error whenever invalid data found in dataset.

Added error handling logic for invalid RDF data errors where aries json
ld processor is going to remove the invalid data from dataset and try
again recursively. (Following
https://github.com/digitalbazaar/jsonld.js/issues/199)

closes #1592

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
