### PR TITLE
fix: inlined keys in did docs for didcomm

### DIFF
--- a/pkg/vdri/httpbinding/vdri.go
+++ b/pkg/vdri/httpbinding/vdri.go
@@ -105,7 +105,7 @@ func (v *VDRI) Build(pubKey *vdriapi.PubKey, opts ...vdriapi.DocOpts) (*did.Doc,
 		}
 
 		if docOpts.ServiceType == vdriapi.DIDCommServiceType {
-			s.RecipientKeys = []string{publicKey.ID}
+			s.RecipientKeys = []string{pubKey.Value}
 			s.Priority = 0
 		}
 

--- a/pkg/vdri/peer/creator.go
+++ b/pkg/vdri/peer/creator.go
@@ -53,7 +53,7 @@ func build(pubKey *vdriapi.PubKey, docOpts *vdriapi.CreateDIDOpts) (*did.Doc, er
 		}
 
 		if docOpts.ServiceType == vdriapi.DIDCommServiceType {
-			s.RecipientKeys = []string{publicKey.ID}
+			s.RecipientKeys = []string{pubKey.Value}
 			s.Priority = 0
 		}
 

--- a/pkg/vdri/peer/creator_test.go
+++ b/pkg/vdri/peer/creator_test.go
@@ -71,6 +71,23 @@ func TestDIDCreator(t *testing.T) {
 	})
 }
 
+func TestBuild(t *testing.T) {
+	t.Run("inlined recipient keys for didcomm", func(t *testing.T) {
+		expected := getSigningKey()
+		c, err := New(&storage.MockStoreProvider{})
+		require.NoError(t, err)
+
+		result, err := c.Build(
+			expected,
+			api.WithServiceType("did-communication"),
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, result.Service)
+		require.NotEmpty(t, result.Service[0].RecipientKeys)
+		require.Equal(t, expected.Value, result.Service[0].RecipientKeys[0])
+	})
+}
+
 func getSigningKey() *api.PubKey {
 	pub, _, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {


### PR DESCRIPTION
While working on #1568 I realized that service entries of type `did-communication` were not created properly in did documents (keys must be did:keys and must be inlined).

This PR:

* Fixes this bug in the `peer` and `httpbinding` VDRIs
* Fixes this bug in `didcomm/common/service/destination.go`
* Refactors the `didexchange` protocol service to use `service.Destination()` to get didcomm recipient keys
* Leaves a TODO to validate that the inlined keys are `did:key` (#1604)


Signed-off-by: George Aristy <george.aristy@securekey.com>
