### PR TITLE
refactor: API of signature verifier creation

### DIFF
--- a/pkg/doc/did/doc_test.go
+++ b/pkg/doc/did/doc_test.go
@@ -823,6 +823,11 @@ func TestVerifyProof(t *testing.T) {
 		err = doc.VerifyProof(s)
 		require.NoError(t, err)
 
+		// error - no suites are passed, verifier is not created
+		err = doc.VerifyProof()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "create verifier")
+
 		// error - doc with invalid proof value
 		doc.Proof[0].ProofValue = []byte("invalid")
 		err = doc.VerifyProof(s)

--- a/pkg/doc/signature/signer/signer.go
+++ b/pkg/doc/signature/signer/signer.go
@@ -17,8 +17,8 @@ import (
 
 const defaultProofPurpose = "assertionMethod"
 
-// signatureSuite encapsulates signature suite methods required for signing documents
-type signatureSuite interface {
+// SignatureSuite encapsulates signature suite methods required for signing documents
+type SignatureSuite interface {
 	// GetCanonicalDocument will return normalized/canonical version of the document
 	GetCanonicalDocument(doc map[string]interface{}) ([]byte, error)
 
@@ -37,7 +37,7 @@ type signatureSuite interface {
 
 // DocumentSigner implements signing of JSONLD documents
 type DocumentSigner struct {
-	signatureSuites []signatureSuite
+	signatureSuites []SignatureSuite
 }
 
 // Context holds signing options and private key
@@ -54,7 +54,7 @@ type Context struct {
 }
 
 // New returns new instance of document verifier
-func New(signatureSuites ...signatureSuite) *DocumentSigner {
+func New(signatureSuites ...SignatureSuite) *DocumentSigner {
 	return &DocumentSigner{signatureSuites: signatureSuites}
 }
 
@@ -144,7 +144,7 @@ func (signer *DocumentSigner) applySignatureValue(context *Context, p *proof.Pro
 }
 
 // getSignatureSuite returns signature suite based on signature type
-func (signer *DocumentSigner) getSignatureSuite(signatureType string) (signatureSuite, error) {
+func (signer *DocumentSigner) getSignatureSuite(signatureType string) (SignatureSuite, error) {
 	for _, s := range signer.signatureSuites {
 		if s.Accept(signatureType) {
 			return s, nil

--- a/pkg/doc/signature/verifier/verifier.go
+++ b/pkg/doc/signature/verifier/verifier.go
@@ -7,6 +7,7 @@ package verifier
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
@@ -53,10 +54,14 @@ type DocumentVerifier struct {
 }
 
 // New returns new instance of document verifier
-func New(resolver keyResolver, mainSuite SignatureSuite, extraSuites ...SignatureSuite) *DocumentVerifier {
+func New(resolver keyResolver, suites ...SignatureSuite) (*DocumentVerifier, error) {
+	if len(suites) == 0 {
+		return nil, errors.New("at least one suite must be provided")
+	}
+
 	return &DocumentVerifier{
-		signatureSuites: append([]SignatureSuite{mainSuite}, extraSuites...),
-		pkResolver:      resolver}
+		signatureSuites: suites,
+		pkResolver:      resolver}, nil
 }
 
 // Verify will verify document proofs

--- a/pkg/doc/signature/verifier/verifier_test.go
+++ b/pkg/doc/signature/verifier/verifier_test.go
@@ -25,8 +25,12 @@ func TestVerify(t *testing.T) {
 			Value: []byte("signature"),
 		},
 	}
-	v := New(okKeyResolver, &testSignatureSuite{accept: true})
-	err := v.Verify([]byte(validDoc))
+
+	v, err := New(okKeyResolver, &testSignatureSuite{accept: true})
+	require.NoError(t, err)
+	require.NotNil(t, v)
+
+	err = v.Verify([]byte(validDoc))
 	require.NoError(t, err)
 
 	// invalid json passed
@@ -56,36 +60,50 @@ func TestVerify(t *testing.T) {
 	require.EqualError(t, err, "no public key ID")
 
 	// public key is not resolved
-	v = New(&testKeyResolver{
+	v, err = New(&testKeyResolver{
 		err: errors.New("public key is not resolved"),
 	}, &testSignatureSuite{accept: true})
+	require.NoError(t, err)
+
 	err = v.Verify([]byte(validDoc))
 	require.Error(t, err)
 	require.EqualError(t, err, "public key is not resolved")
 
 	// signature suite is not found
-	v = New(okKeyResolver, &testSignatureSuite{accept: false})
+	v, err = New(okKeyResolver, &testSignatureSuite{accept: false})
+	require.NoError(t, err)
+
 	err = v.Verify([]byte(validDoc))
 	require.Error(t, err)
 	require.EqualError(t, err, "signature type Ed25519Signature2018 not supported")
 
 	// verify data creation error
-	v = New(okKeyResolver, &testSignatureSuite{
+	v, err = New(okKeyResolver, &testSignatureSuite{
 		canonicalDocumentError: errors.New("get canonical document error"),
 		accept:                 true,
 	})
+	require.NoError(t, err)
+
 	err = v.Verify([]byte(validDoc))
 	require.Error(t, err)
 	require.EqualError(t, err, "get canonical document error")
 
 	// verification error
-	v = New(okKeyResolver, &testSignatureSuite{
+	v, err = New(okKeyResolver, &testSignatureSuite{
 		verifyError: errors.New("verify data error"),
 		accept:      true,
 	})
+	require.NoError(t, err)
+
 	err = v.Verify([]byte(validDoc))
 	require.Error(t, err)
 	require.EqualError(t, err, "verify data error")
+
+	// no signature suite passed
+	v, err = New(okKeyResolver)
+	require.Error(t, err)
+	require.EqualError(t, err, "at least one suite must be provided")
+	require.Nil(t, v)
 }
 
 func Test_getProofVerifyValue(t *testing.T) {

--- a/pkg/doc/verifiable/credential.go
+++ b/pkg/doc/verifiable/credential.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jwt"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 )
 
 //go:generate testdata/scripts/openssl_env.sh testdata/scripts/generate_test_keys.sh
@@ -483,7 +484,7 @@ type credentialOpts struct {
 	disabledProofCheck    bool
 	jsonldDocumentLoader  ld.DocumentLoader
 	strictValidation      bool
-	ldpSuites             []VerifierSignatureSuite
+	ldpSuites             []verifier.SignatureSuite
 }
 
 // CredentialOpt is the Verifiable Credential decoding option
@@ -572,7 +573,7 @@ func WithStrictValidation() CredentialOpt {
 }
 
 // WithEmbeddedSignatureSuites defines the suites which are used to check embedded linked data proof of VC.
-func WithEmbeddedSignatureSuites(suites ...VerifierSignatureSuite) CredentialOpt {
+func WithEmbeddedSignatureSuites(suites ...verifier.SignatureSuite) CredentialOpt {
 	return func(opts *credentialOpts) {
 		opts.ldpSuites = suites
 	}

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ed25519signature2018"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
@@ -804,7 +805,7 @@ func TestWithEmbeddedSignatureSuites(t *testing.T) {
 
 	opts := &credentialOpts{}
 	credentialOpt(opts)
-	require.Equal(t, []VerifierSignatureSuite{ss}, opts.ldpSuites)
+	require.Equal(t, []verifier.SignatureSuite{ss}, opts.ldpSuites)
 }
 
 func TestCustomCredentialJsonSchemaValidator2018(t *testing.T) {

--- a/pkg/doc/verifiable/embedded_proof_test.go
+++ b/pkg/doc/verifiable/embedded_proof_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ed25519signature2018"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
@@ -50,7 +51,7 @@ func Test_checkEmbeddedProof(t *testing.T) {
 		vSuite := ed25519signature2018.New(suite.WithVerifier(ed25519signature2018.NewPublicKeyVerifier()))
 		proof, err := checkEmbeddedProof(vcBytes, &credentialOpts{
 			publicKeyFetcher: publicKeyFetcher,
-			ldpSuites:        []VerifierSignatureSuite{vSuite},
+			ldpSuites:        []verifier.SignatureSuite{vSuite},
 		})
 
 		require.NoError(t, err)

--- a/pkg/doc/verifiable/linked_data_proof_test.go
+++ b/pkg/doc/verifiable/linked_data_proof_test.go
@@ -112,7 +112,7 @@ func TestLinkedDataProofSignerAndVerifier(t *testing.T) {
 	})
 
 	t.Run("Several signature suites", func(t *testing.T) {
-		verifierSuites := []VerifierSignatureSuite{
+		verifierSuites := []verifier.SignatureSuite{
 			ed25519signature2018.New(
 				suite.WithVerifier(ed25519signature2018.NewPublicKeyVerifier()),
 				suite.WithCompactProof()),
@@ -150,7 +150,7 @@ func TestLinkedDataProofSignerAndVerifier(t *testing.T) {
 		vcDecoded, _, err := NewCredential(vcWithEd25519ProofBytes,
 			WithPublicKeyFetcher(SingleKey(ed25519PubKey, kms.ED25519)))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "undefined verifier signature suites")
+		require.Contains(t, err.Error(), "create new signature verifier")
 		require.Nil(t, vcDecoded)
 	})
 }

--- a/pkg/doc/verifiable/presentation.go
+++ b/pkg/doc/verifiable/presentation.go
@@ -13,6 +13,7 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jwt"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 )
 
 const basePresentationSchema = `
@@ -273,7 +274,7 @@ type rawPresentation struct {
 type presentationOpts struct {
 	publicKeyFetcher   PublicKeyFetcher
 	disabledProofCheck bool
-	ldpSuites          []VerifierSignatureSuite
+	ldpSuites          []verifier.SignatureSuite
 }
 
 // PresentationOpt is the Verifiable Presentation decoding option
@@ -288,7 +289,7 @@ func WithPresPublicKeyFetcher(fetcher PublicKeyFetcher) PresentationOpt {
 }
 
 // WithPresEmbeddedSignatureSuites defines the suites which are used to check embedded linked data proof of VP.
-func WithPresEmbeddedSignatureSuites(suites ...VerifierSignatureSuite) PresentationOpt {
+func WithPresEmbeddedSignatureSuites(suites ...verifier.SignatureSuite) PresentationOpt {
 	return func(opts *presentationOpts) {
 		opts.ldpSuites = suites
 	}

--- a/pkg/doc/verifiable/presentation_test.go
+++ b/pkg/doc/verifiable/presentation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ed25519signature2018"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
@@ -159,6 +160,7 @@ func TestValidateVP_Context(t *testing.T) {
 		bytes, err := json.Marshal(raw)
 		require.NoError(t, err)
 		vp, err := NewPresentation(bytes)
+		require.Error(t, err)
 		require.Contains(t, err.Error(), "does not match: \"https://www.w3.org/2018/credentials/v1\"")
 		require.Nil(t, vp)
 	})
@@ -419,7 +421,7 @@ func TestWithPresEmbeddedSignatureSuites(t *testing.T) {
 
 	opts := &presentationOpts{}
 	vpOpt(opts)
-	require.Equal(t, []VerifierSignatureSuite{suite}, opts.ldpSuites)
+	require.Equal(t, []verifier.SignatureSuite{suite}, opts.ldpSuites)
 }
 
 func TestNewUnverifiedPresentation(t *testing.T) {


### PR DESCRIPTION
closes #1616

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

Motivated by https://github.com/hyperledger/aries-framework-go/pull/1607#discussion_r407601652,  https://github.com/hyperledger/aries-framework-go/pull/1607#discussion_r407667285 and https://github.com/hyperledger/aries-framework-go/pull/1607#discussion_r407790992

Additionally, recently exposed `verifier.SignatureSuite` is used directly by API consumers.