### PR TITLE
fix: didexchange handle inbound oob invitations

### DIFF
--- a/pkg/internal/mock/didcomm/protocol/route/mock_route.go
+++ b/pkg/internal/mock/didcomm/protocol/route/mock_route.go
@@ -27,6 +27,7 @@ type MockRouteSvc struct {
 	UnregisterErr      error
 	ConnectionID       string
 	GetConnectionIDErr error
+	AddKeyFunc         func(string) error
 }
 
 // HandleInbound msg
@@ -81,7 +82,15 @@ func (m *MockRouteSvc) Unregister() error {
 
 // AddKey adds agents recKey to the router
 func (m *MockRouteSvc) AddKey(recKey string) error {
-	return m.AddKeyErr
+	if m.AddKeyErr != nil {
+		return m.AddKeyErr
+	}
+
+	if m.AddKeyFunc != nil {
+		return m.AddKeyFunc(recKey)
+	}
+
+	return nil
 }
 
 // Config gives back the router configuration

--- a/pkg/mock/vdri/mock_registry.go
+++ b/pkg/mock/vdri/mock_registry.go
@@ -20,6 +20,7 @@ import (
 type MockVDRIRegistry struct {
 	CreateErr    error
 	CreateValue  *did.Doc
+	CreateFunc   func(string, ...vdriapi.DocOpts) (*did.Doc, error)
 	MemStore     map[string]*did.Doc
 	PutErr       error
 	ResolveErr   error
@@ -44,6 +45,10 @@ func (m *MockVDRIRegistry) Store(doc *did.Doc) error {
 func (m *MockVDRIRegistry) Create(method string, opts ...vdriapi.DocOpts) (*did.Doc, error) {
 	if m.CreateErr != nil {
 		return nil, m.CreateErr
+	}
+
+	if m.CreateFunc != nil {
+		return m.CreateFunc(method, opts...)
 	}
 
 	doc := m.CreateValue


### PR DESCRIPTION
This PR fixes the following bugs in the didexchange protocol service when responding to oob invitations:

* label not set in outgoing request
* new recipient keys not registered in the router

Signed-off-by: George Aristy <george.aristy@securekey.com>
