### PR TITLE
refactor: support public key bytes in Ecdsa-based signature suite verifiers

### DIFF
--- a/pkg/doc/signature/suite/ecdsasecp256k1signature2019/public_key_verifier_test.go
+++ b/pkg/doc/signature/suite/ecdsasecp256k1signature2019/public_key_verifier_test.go
@@ -30,15 +30,14 @@ func TestPublicKeyVerifier_Verify(t *testing.T) {
 	msg := []byte("test message")
 
 	btcecPubKey := btcecPrivKey.PubKey()
-	pubKeyBytes := elliptic.Marshal(btcecPubKey.Curve, btcecPubKey.X, btcecPubKey.Y)
 
 	pubKey := &verifier.PublicKey{
-		Type:  "EcdsaSecp256k1VerificationKey2019",
-		Value: pubKeyBytes,
+		Type: "EcdsaSecp256k1VerificationKey2019",
 
 		JWK: &jose.JWK{
 			JSONWebKey: gojose.JSONWebKey{
 				Algorithm: "ES256K",
+				Key:       btcecPubKey.ToECDSA(),
 			},
 			Crv: "secp256k1",
 			Kty: "EC",
@@ -47,6 +46,15 @@ func TestPublicKeyVerifier_Verify(t *testing.T) {
 
 	v := NewPublicKeyVerifier()
 	signature := getSignature(ecdsaPrivKey, msg)
+
+	err = v.Verify(pubKey, msg, signature)
+	require.NoError(t, err)
+
+	pubKeyBytes := elliptic.Marshal(btcecPubKey.Curve, btcecPubKey.X, btcecPubKey.Y)
+	pubKey = &verifier.PublicKey{
+		Type:  "EcdsaSecp256k1VerificationKey2019",
+		Value: pubKeyBytes,
+	}
 
 	err = v.Verify(pubKey, msg, signature)
 	require.NoError(t, err)

--- a/pkg/doc/signature/suite/jsonwebsignature2020/public_key_verifier_test.go
+++ b/pkg/doc/signature/suite/jsonwebsignature2020/public_key_verifier_test.go
@@ -38,6 +38,7 @@ func TestPublicKeyVerifier_Verify_EC(t *testing.T) {
 
 		JWK: &jose.JWK{
 			JSONWebKey: gojose.JSONWebKey{
+				Key:       &privKey.PublicKey,
 				Algorithm: "ES256",
 			},
 			Crv: "P-256",
@@ -92,6 +93,7 @@ func TestPublicKeyVerifier_Verify_EC(t *testing.T) {
 					Value: pubKeyBytes,
 					JWK: &jose.JWK{
 						JSONWebKey: gojose.JSONWebKey{
+							Key:       &privKey.PublicKey,
 							Algorithm: tc.algorithm,
 						},
 						Crv: tc.curveName,

--- a/pkg/doc/verifiable/linked_data_proof_test.go
+++ b/pkg/doc/verifiable/linked_data_proof_test.go
@@ -136,6 +136,7 @@ func TestLinkedDataProofSignerAndVerifier(t *testing.T) {
 					JWK: &jose.JWK{
 						JSONWebKey: gojose.JSONWebKey{
 							Algorithm: "ES256K",
+							Key:       &ecdsaPrivKey.PublicKey,
 						},
 						Crv: "secp256k1",
 						Kty: "EC",


### PR DESCRIPTION
closes #1609

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

Use case: if the public key in DID is defined without JWK:
```
{
  "@context": ["https://w3id.org/security/v1"],
  "id": "did:example:123456789abcdefghi#keys-1",
  "type": "EcdsaSecp256k1VerificationKey2019",
  "controller": "did:example:123456789abcdefghi",
  "expires": "2017-02-08T16:02:20Z",
  "publicKeyHex" : "034ee0f670fc96bb75e8b89c068a1665007a41c98513d6a911b6137e2d16f1d300"
}
```

then we can create JWK from those bytes in case of ECDSA and use this key for signature verification.