### PR TITLE
feat: Present Proof - adds command support

### DIFF
--- a/pkg/client/presentproof/client.go
+++ b/pkg/client/presentproof/client.go
@@ -22,6 +22,8 @@ type (
 	// presentation process, or in response to a request-presentation message when the Prover wants to
 	// propose using a different presentation format.
 	ProposePresentation presentproof.ProposePresentation
+	// Action contains helpful information about action
+	Action presentproof.Action
 )
 
 var (
@@ -68,8 +70,18 @@ func New(ctx Provider) (*Client, error) {
 }
 
 // Actions returns pending actions that have yet to be executed or cancelled.
-func (c *Client) Actions() ([]presentproof.Action, error) {
-	return c.service.Actions()
+func (c *Client) Actions() ([]Action, error) {
+	actions, err := c.service.Actions()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]Action, len(actions))
+	for i, action := range actions {
+		result[i] = Action(action)
+	}
+
+	return result, nil
 }
 
 // SendRequestPresentation is used by the Verifier to send a request presentation.

--- a/pkg/controller/command/errors.go
+++ b/pkg/controller/command/errors.go
@@ -55,6 +55,9 @@ const (
 
 	// IssueCredential error group for issue credential command errors
 	IssueCredential = 8000
+
+	// PresentProof error group for present proof command errors
+	PresentProof = 9000
 )
 
 // Error is the  interface for representing an command error condition, with the nil value representing no error.

--- a/pkg/controller/command/issuecredential/command.go
+++ b/pkg/controller/command/issuecredential/command.go
@@ -134,7 +134,7 @@ func (c *Command) GetHandlers() []command.Handler {
 	}
 }
 
-// Actions returns pending actions that have yet to be executed or cancelled.
+// Actions returns pending actions that have not yet to be executed or canceled.
 func (c *Command) Actions(rw io.Writer, _ io.Reader) command.Error {
 	result, err := c.client.Actions()
 	if err != nil {
@@ -145,6 +145,8 @@ func (c *Command) Actions(rw io.Writer, _ io.Reader) command.Error {
 	command.WriteNillableResponse(rw, &ActionsResponse{
 		Actions: result,
 	}, logger)
+
+	logutil.LogDebug(logger, commandName, actions, successString)
 
 	return nil
 }
@@ -346,6 +348,8 @@ func (c *Command) DeclineProposal(rw io.Writer, req io.Reader) command.Error {
 
 	command.WriteNillableResponse(rw, &DeclineProposalResponse{}, logger)
 
+	logutil.LogDebug(logger, commandName, declineProposal, successString)
+
 	return nil
 }
 
@@ -396,6 +400,8 @@ func (c *Command) DeclineOffer(rw io.Writer, req io.Reader) command.Error {
 	}
 
 	command.WriteNillableResponse(rw, &DeclineOfferResponse{}, logger)
+
+	logutil.LogDebug(logger, commandName, declineOffer, successString)
 
 	return nil
 }
@@ -454,10 +460,13 @@ func (c *Command) DeclineRequest(rw io.Writer, req io.Reader) command.Error {
 
 	command.WriteNillableResponse(rw, &DeclineRequestResponse{}, logger)
 
+	logutil.LogDebug(logger, commandName, declineRequest, successString)
+
 	return nil
 }
 
 // AcceptCredential is used when the Holder is willing to accept the IssueCredential.
+// nolint: dupl
 func (c *Command) AcceptCredential(rw io.Writer, req io.Reader) command.Error {
 	var args AcceptCredentialArgs
 
@@ -504,6 +513,8 @@ func (c *Command) DeclineCredential(rw io.Writer, req io.Reader) command.Error {
 	}
 
 	command.WriteNillableResponse(rw, &DeclineCredentialResponse{}, logger)
+
+	logutil.LogDebug(logger, commandName, declineCredential, successString)
 
 	return nil
 }

--- a/pkg/controller/command/issuecredential/models.go
+++ b/pkg/controller/command/issuecredential/models.go
@@ -134,7 +134,7 @@ type DeclineOfferResponse struct{}
 type DeclineRequestArgs struct {
 	// PIID protocol state machine identifier
 	PIID string `json:"piid"`
-	// Reason why offer is declined
+	// Reason why request is declined
 	Reason string `json:"reason"`
 }
 
@@ -151,7 +151,7 @@ type DeclineRequestResponse struct{}
 type DeclineCredentialArgs struct {
 	// PIID protocol state machine identifier
 	PIID string `json:"piid"`
-	// Reason why offer is declined
+	// Reason why credential is declined
 	Reason string `json:"reason"`
 }
 
@@ -222,7 +222,7 @@ type SendRequestResponse struct{}
 
 // ActionsResponse model
 //
-// Represents a Actions response message
+// Represents Actions response message
 //
 type ActionsResponse struct {
 	Actions []issuecredential.Action `json:"actions"`

--- a/pkg/controller/command/presentproof/command.go
+++ b/pkg/controller/command/presentproof/command.go
@@ -1,0 +1,417 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package presentproof
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/hyperledger/aries-framework-go/pkg/client/presentproof"
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/internal/cmdutil"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/logutil"
+)
+
+const (
+	// InvalidRequestErrorCode is typically a code for validation errors
+	// for invalid present proof controller requests
+	InvalidRequestErrorCode = command.Code(iota + command.PresentProof)
+	// ActionsErrorCode is for failures in actions command
+	ActionsErrorCode
+	// SendRequestPresentationErrorCode is for failures in send request presentation command
+	SendRequestPresentationErrorCode
+	// AcceptRequestPresentationErrorCode is for failures in accept request presentation command
+	AcceptRequestPresentationErrorCode
+	// NegotiateRequestPresentationErrorCode is for failures in negotiate request presentation command
+	NegotiateRequestPresentationErrorCode
+	// DeclineRequestPresentationErrorCode is for failures in decline request presentation command
+	DeclineRequestPresentationErrorCode
+	// SendProposePresentationErrorCode is for failures in send propose presentation command
+	SendProposePresentationErrorCode
+	// AcceptProposePresentationErrorCode is for failures in accept propose presentation command
+	AcceptProposePresentationErrorCode
+	// DeclineProposePresentationErrorCode is for failures in decline propose presentation command
+	DeclineProposePresentationErrorCode
+	// AcceptPresentationErrorCode is for failures in accept presentation command
+	AcceptPresentationErrorCode
+	// DeclinePresentationErrorCode is for failures in decline presentation command
+	DeclinePresentationErrorCode
+)
+
+const (
+	// command name
+	commandName = "presentproof"
+
+	actions                      = "Actions"
+	sendRequestPresentation      = "SendRequestPresentation"
+	acceptRequestPresentation    = "AcceptRequestPresentation"
+	negotiateRequestPresentation = "NegotiateRequestPresentation"
+	declineRequestPresentation   = "DeclineRequestPresentation"
+	sendProposePresentation      = "SendProposePresentation"
+	acceptProposePresentation    = "AcceptProposePresentation"
+	declineProposePresentation   = "DeclineProposePresentation"
+	acceptPresentation           = "AcceptPresentation"
+	declinePresentation          = "DeclinePresentation"
+)
+
+const (
+	// error messages
+	errEmptyPIID                = "empty PIID"
+	errEmptyMyDID               = "empty MyDID"
+	errEmptyTheirDID            = "empty TheirDID"
+	errEmptyPresentation        = "empty Presentation"
+	errEmptyProposePresentation = "empty ProposePresentation"
+	errEmptyRequestPresentation = "empty RequestPresentation"
+
+	// log constants
+	successString = "success"
+)
+
+var logger = log.New("aries-framework/controller/presentproof")
+
+// Command is controller command for present proof
+type Command struct {
+	client *presentproof.Client
+}
+
+// New returns new present proof controller command instance
+func New(ctx presentproof.Provider) (*Command, error) {
+	client, err := presentproof.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create a client: %w", err)
+	}
+
+	// creates action channel
+	actions := make(chan service.DIDCommAction)
+	// registers action channel to listen for events
+	if err := client.RegisterActionEvent(actions); err != nil {
+		return nil, fmt.Errorf("register action event: %w", err)
+	}
+
+	// this code listens for the action events and does nothing
+	// this trick is used to avoid error such as `no clients are registered to handle the message`
+	go func() {
+		for range actions {
+		}
+	}()
+
+	return &Command{client: client}, nil
+}
+
+// GetHandlers returns list of all commands supported by this controller command
+func (c *Command) GetHandlers() []command.Handler {
+	return []command.Handler{
+		cmdutil.NewCommandHandler(commandName, actions, c.Actions),
+		cmdutil.NewCommandHandler(commandName, sendRequestPresentation, c.SendRequestPresentation),
+		cmdutil.NewCommandHandler(commandName, acceptRequestPresentation, c.AcceptRequestPresentation),
+		cmdutil.NewCommandHandler(commandName, negotiateRequestPresentation, c.NegotiateRequestPresentation),
+		cmdutil.NewCommandHandler(commandName, declineRequestPresentation, c.DeclineRequestPresentation),
+		cmdutil.NewCommandHandler(commandName, sendProposePresentation, c.SendProposePresentation),
+		cmdutil.NewCommandHandler(commandName, acceptProposePresentation, c.AcceptProposePresentation),
+		cmdutil.NewCommandHandler(commandName, declineProposePresentation, c.DeclineProposePresentation),
+		cmdutil.NewCommandHandler(commandName, acceptPresentation, c.AcceptPresentation),
+		cmdutil.NewCommandHandler(commandName, declinePresentation, c.DeclinePresentation),
+	}
+}
+
+// Actions returns pending actions that have not yet to be executed or canceled.
+func (c *Command) Actions(rw io.Writer, _ io.Reader) command.Error {
+	result, err := c.client.Actions()
+	if err != nil {
+		logutil.LogError(logger, commandName, actions, err.Error())
+		return command.NewExecuteError(ActionsErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &ActionsResponse{
+		Actions: result,
+	}, logger)
+
+	logutil.LogDebug(logger, commandName, actions, successString)
+
+	return nil
+}
+
+// SendRequestPresentation is used by the Verifier to send a request presentation.
+// nolint: dupl
+func (c *Command) SendRequestPresentation(rw io.Writer, req io.Reader) command.Error {
+	var args SendRequestPresentationArgs
+
+	if err := json.NewDecoder(req).Decode(&args); err != nil {
+		logutil.LogInfo(logger, commandName, sendRequestPresentation, err.Error())
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if args.MyDID == "" {
+		logutil.LogDebug(logger, commandName, sendRequestPresentation, errEmptyMyDID)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyMyDID))
+	}
+
+	if args.TheirDID == "" {
+		logutil.LogDebug(logger, commandName, sendRequestPresentation, errEmptyTheirDID)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyTheirDID))
+	}
+
+	if args.RequestPresentation == nil {
+		logutil.LogDebug(logger, commandName, sendRequestPresentation, errEmptyRequestPresentation)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyRequestPresentation))
+	}
+
+	if err := c.client.SendRequestPresentation(args.RequestPresentation, args.MyDID, args.TheirDID); err != nil {
+		logutil.LogError(logger, commandName, sendRequestPresentation, err.Error())
+		return command.NewExecuteError(SendRequestPresentationErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &SendRequestPresentationResponse{}, logger)
+
+	logutil.LogDebug(logger, commandName, sendRequestPresentation, successString)
+
+	return nil
+}
+
+// SendProposePresentation is used by the Prover to send a propose presentation.
+// nolint: dupl
+func (c *Command) SendProposePresentation(rw io.Writer, req io.Reader) command.Error {
+	var args SendProposePresentationArgs
+
+	if err := json.NewDecoder(req).Decode(&args); err != nil {
+		logutil.LogInfo(logger, commandName, sendProposePresentation, err.Error())
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if args.MyDID == "" {
+		logutil.LogDebug(logger, commandName, sendProposePresentation, errEmptyMyDID)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyMyDID))
+	}
+
+	if args.TheirDID == "" {
+		logutil.LogDebug(logger, commandName, sendProposePresentation, errEmptyTheirDID)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyTheirDID))
+	}
+
+	if args.ProposePresentation == nil {
+		logutil.LogDebug(logger, commandName, sendProposePresentation, errEmptyProposePresentation)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyProposePresentation))
+	}
+
+	if err := c.client.SendProposePresentation(args.ProposePresentation, args.MyDID, args.TheirDID); err != nil {
+		logutil.LogError(logger, commandName, sendProposePresentation, err.Error())
+		return command.NewExecuteError(SendProposePresentationErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &SendProposePresentationResponse{}, logger)
+
+	logutil.LogDebug(logger, commandName, sendProposePresentation, successString)
+
+	return nil
+}
+
+// AcceptRequestPresentation is used by the Prover is to accept a presentation request.
+// nolint: dupl
+func (c *Command) AcceptRequestPresentation(rw io.Writer, req io.Reader) command.Error {
+	var args AcceptRequestPresentationArgs
+
+	if err := json.NewDecoder(req).Decode(&args); err != nil {
+		logutil.LogInfo(logger, commandName, acceptRequestPresentation, err.Error())
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if args.PIID == "" {
+		logutil.LogDebug(logger, commandName, acceptRequestPresentation, errEmptyPIID)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyPIID))
+	}
+
+	if args.Presentation == nil {
+		logutil.LogDebug(logger, commandName, acceptRequestPresentation, errEmptyPresentation)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyPresentation))
+	}
+
+	if err := c.client.AcceptRequestPresentation(args.PIID, args.Presentation); err != nil {
+		logutil.LogError(logger, commandName, acceptRequestPresentation, err.Error())
+		return command.NewExecuteError(AcceptRequestPresentationErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &AcceptRequestPresentationResponse{}, logger)
+
+	logutil.LogDebug(logger, commandName, acceptRequestPresentation, successString)
+
+	return nil
+}
+
+// NegotiateRequestPresentation is used by the Prover to counter a presentation request they received with a proposal.
+// nolint: dupl
+func (c *Command) NegotiateRequestPresentation(rw io.Writer, req io.Reader) command.Error {
+	var args NegotiateRequestPresentationArgs
+
+	if err := json.NewDecoder(req).Decode(&args); err != nil {
+		logutil.LogInfo(logger, commandName, negotiateRequestPresentation, err.Error())
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if args.PIID == "" {
+		logutil.LogDebug(logger, commandName, negotiateRequestPresentation, errEmptyPIID)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyPIID))
+	}
+
+	if args.ProposePresentation == nil {
+		logutil.LogDebug(logger, commandName, negotiateRequestPresentation, errEmptyProposePresentation)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyProposePresentation))
+	}
+
+	if err := c.client.NegotiateRequestPresentation(args.PIID, args.ProposePresentation); err != nil {
+		logutil.LogError(logger, commandName, negotiateRequestPresentation, err.Error())
+		return command.NewExecuteError(NegotiateRequestPresentationErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &NegotiateRequestPresentationResponse{}, logger)
+
+	logutil.LogDebug(logger, commandName, negotiateRequestPresentation, successString)
+
+	return nil
+}
+
+// DeclineRequestPresentation is used when the Prover does not want to accept the request presentation.
+// nolint: dupl
+func (c *Command) DeclineRequestPresentation(rw io.Writer, req io.Reader) command.Error {
+	var args DeclineRequestPresentationArgs
+
+	if err := json.NewDecoder(req).Decode(&args); err != nil {
+		logutil.LogInfo(logger, commandName, declineRequestPresentation, err.Error())
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if args.PIID == "" {
+		logutil.LogDebug(logger, commandName, declineRequestPresentation, errEmptyPIID)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyPIID))
+	}
+
+	if err := c.client.DeclineRequestPresentation(args.PIID, args.Reason); err != nil {
+		logutil.LogError(logger, commandName, declineRequestPresentation, err.Error())
+		return command.NewExecuteError(DeclineRequestPresentationErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &DeclineRequestPresentationResponse{}, logger)
+
+	logutil.LogDebug(logger, commandName, declineRequestPresentation, successString)
+
+	return nil
+}
+
+// AcceptProposePresentation is used when the Verifier is willing to accept the propose presentation.
+// nolint: dupl
+func (c *Command) AcceptProposePresentation(rw io.Writer, req io.Reader) command.Error {
+	var args AcceptProposePresentationArgs
+
+	if err := json.NewDecoder(req).Decode(&args); err != nil {
+		logutil.LogInfo(logger, commandName, acceptProposePresentation, err.Error())
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if args.PIID == "" {
+		logutil.LogDebug(logger, commandName, acceptProposePresentation, errEmptyPIID)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyPIID))
+	}
+
+	if args.RequestPresentation == nil {
+		logutil.LogDebug(logger, commandName, acceptProposePresentation, errEmptyRequestPresentation)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyRequestPresentation))
+	}
+
+	if err := c.client.AcceptProposePresentation(args.PIID, args.RequestPresentation); err != nil {
+		logutil.LogError(logger, commandName, acceptProposePresentation, err.Error())
+		return command.NewExecuteError(AcceptProposePresentationErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &AcceptProposePresentationResponse{}, logger)
+
+	logutil.LogDebug(logger, commandName, acceptProposePresentation, successString)
+
+	return nil
+}
+
+// DeclineProposePresentation is used when the Verifier does not want to accept the propose presentation.
+// nolint: dupl
+func (c *Command) DeclineProposePresentation(rw io.Writer, req io.Reader) command.Error {
+	var args DeclineProposePresentationArgs
+
+	if err := json.NewDecoder(req).Decode(&args); err != nil {
+		logutil.LogInfo(logger, commandName, declineProposePresentation, err.Error())
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if args.PIID == "" {
+		logutil.LogDebug(logger, commandName, declineProposePresentation, errEmptyPIID)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyPIID))
+	}
+
+	if err := c.client.DeclineProposePresentation(args.PIID, args.Reason); err != nil {
+		logutil.LogError(logger, commandName, declineProposePresentation, err.Error())
+		return command.NewExecuteError(DeclineProposePresentationErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &DeclineProposePresentationResponse{}, logger)
+
+	logutil.LogDebug(logger, commandName, declineProposePresentation, successString)
+
+	return nil
+}
+
+// AcceptPresentation is used by the Verifier to accept a presentation.
+// nolint: dupl
+func (c *Command) AcceptPresentation(rw io.Writer, req io.Reader) command.Error {
+	var args AcceptPresentationArgs
+
+	if err := json.NewDecoder(req).Decode(&args); err != nil {
+		logutil.LogInfo(logger, commandName, acceptPresentation, err.Error())
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if args.PIID == "" {
+		logutil.LogDebug(logger, commandName, acceptPresentation, errEmptyPIID)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyPIID))
+	}
+
+	if err := c.client.AcceptPresentation(args.PIID); err != nil {
+		logutil.LogError(logger, commandName, acceptPresentation, err.Error())
+		return command.NewExecuteError(AcceptPresentationErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &AcceptPresentationResponse{}, logger)
+
+	logutil.LogDebug(logger, commandName, acceptPresentation, successString)
+
+	return nil
+}
+
+// DeclinePresentation is used by the Verifier to decline a presentation.
+// nolint: dupl
+func (c *Command) DeclinePresentation(rw io.Writer, req io.Reader) command.Error {
+	var args DeclinePresentationArgs
+
+	if err := json.NewDecoder(req).Decode(&args); err != nil {
+		logutil.LogInfo(logger, commandName, declinePresentation, err.Error())
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if args.PIID == "" {
+		logutil.LogDebug(logger, commandName, declinePresentation, errEmptyPIID)
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyPIID))
+	}
+
+	if err := c.client.DeclinePresentation(args.PIID, args.Reason); err != nil {
+		logutil.LogError(logger, commandName, declinePresentation, err.Error())
+		return command.NewExecuteError(DeclinePresentationErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &DeclinePresentationResponse{}, logger)
+
+	logutil.LogDebug(logger, commandName, declinePresentation, successString)
+
+	return nil
+}

--- a/pkg/controller/command/presentproof/command_test.go
+++ b/pkg/controller/command/presentproof/command_test.go
@@ -1,0 +1,906 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package presentproof
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/client/presentproof"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
+	protocol "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/presentproof"
+	mocks "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/client/presentproof"
+)
+
+const jsonPayload = `{"piid":"id"}`
+
+func TestNew(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("Success", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+	})
+
+	t.Run("Create client (error)", func(t *testing.T) {
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(nil, nil)
+
+		cmd, err := New(provider)
+		require.EqualError(t, err, "cannot create a client: cast service to presentproof service failed")
+		require.Nil(t, cmd)
+	})
+
+	t.Run("Register action event (error)", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(errors.New("error"))
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.EqualError(t, err, "register action event: error")
+		require.Nil(t, cmd)
+	})
+}
+
+func TestCommand_SendRequestPresentation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service := mocks.NewMockProtocolService(ctrl)
+	service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil).AnyTimes()
+
+	provider := mocks.NewMockProvider(ctrl)
+	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+
+	t.Run("Decode error", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.SendRequestPresentation(&b, bytes.NewBufferString("}"))
+
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty MyDID", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.SendRequestPresentation(&b, bytes.NewBufferString("{}"))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyMyDID)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty TheirDID", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.SendRequestPresentation(&b, bytes.NewBufferString(`{"my_did":"id"}`))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyTheirDID)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty RequestPresentation", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.SendRequestPresentation(&b, bytes.NewBufferString(`{"my_did":"id","their_did":"id"}`))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyRequestPresentation)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("SendRequestPresentation (error)", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().HandleInbound(
+			gomock.Any(), gomock.Any(),
+			gomock.Any(),
+		).Return("", errors.New("some error message"))
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		const jsonPayload = `{"my_did":"id","their_did":"id","request_presentation":{}}`
+		cmdErr := cmd.SendRequestPresentation(&b, bytes.NewBufferString(jsonPayload))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), "some error message")
+		require.Equal(t, SendRequestPresentationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().HandleInbound(gomock.Any(), gomock.Any(), gomock.Any())
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		const jsonPayload = `{"my_did":"id","their_did":"id","request_presentation":{}}`
+		require.NoError(t, cmd.SendRequestPresentation(&b, bytes.NewBufferString(jsonPayload)))
+	})
+}
+
+func TestCommand_SendProposePresentation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service := mocks.NewMockProtocolService(ctrl)
+	service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil).AnyTimes()
+
+	provider := mocks.NewMockProvider(ctrl)
+	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+
+	t.Run("Decode error", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.SendProposePresentation(&b, bytes.NewBufferString("}"))
+
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty MyDID", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.SendProposePresentation(&b, bytes.NewBufferString("{}"))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyMyDID)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty TheirDID", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.SendProposePresentation(&b, bytes.NewBufferString(`{"my_did":"id"}`))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyTheirDID)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty ProposePresentation", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.SendProposePresentation(&b, bytes.NewBufferString(`{"my_did":"id","their_did":"id"}`))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyProposePresentation)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("SendProposePresentation (error)", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().HandleInbound(
+			gomock.Any(), gomock.Any(),
+			gomock.Any(),
+		).Return("", errors.New("some error message"))
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		const jsonPayload = `{"my_did":"id","their_did":"id","propose_presentation":{}}`
+		cmdErr := cmd.SendProposePresentation(&b, bytes.NewBufferString(jsonPayload))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), "some error message")
+		require.Equal(t, SendProposePresentationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().HandleInbound(gomock.Any(), gomock.Any(), gomock.Any())
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		const jsonPayload = `{"my_did":"id","their_did":"id","propose_presentation":{}}`
+		require.NoError(t, cmd.SendProposePresentation(&b, bytes.NewBufferString(jsonPayload)))
+	})
+}
+
+func TestCommand_AcceptRequestPresentation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service := mocks.NewMockProtocolService(ctrl)
+	service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil).AnyTimes()
+
+	provider := mocks.NewMockProvider(ctrl)
+	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+
+	t.Run("Decode error", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptRequestPresentation(&b, bytes.NewBufferString("}"))
+
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty PIID", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptRequestPresentation(&b, bytes.NewBufferString("{}"))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyPIID)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty Presentation", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptRequestPresentation(&b, bytes.NewBufferString(`{"piid":"id"}`))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyPresentation)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("AcceptRequestPresentation (error)", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionContinue(gomock.Any(), gomock.Any()).Return(errors.New("some error message"))
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		const jsonPayload = `{"piid":"id","presentation":{}}`
+		cmdErr := cmd.AcceptRequestPresentation(&b, bytes.NewBufferString(jsonPayload))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), "some error message")
+		require.Equal(t, AcceptRequestPresentationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionContinue(gomock.Any(), gomock.Any())
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		const jsonPayload = `{"piid":"id","presentation":{}}`
+		require.NoError(t, cmd.AcceptRequestPresentation(&b, bytes.NewBufferString(jsonPayload)))
+	})
+}
+
+func TestCommand_NegotiateRequestPresentation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service := mocks.NewMockProtocolService(ctrl)
+	service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil).AnyTimes()
+
+	provider := mocks.NewMockProvider(ctrl)
+	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+
+	t.Run("Decode error", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.NegotiateRequestPresentation(&b, bytes.NewBufferString("}"))
+
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty PIID", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.NegotiateRequestPresentation(&b, bytes.NewBufferString("{}"))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyPIID)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty ProposePresentation", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.NegotiateRequestPresentation(&b, bytes.NewBufferString(`{"piid":"id"}`))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyProposePresentation)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("NegotiateRequestPresentation (error)", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionContinue(gomock.Any(), gomock.Any()).Return(errors.New("some error message"))
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		const jsonPayload = `{"piid":"id","propose_presentation":{}}`
+		cmdErr := cmd.NegotiateRequestPresentation(&b, bytes.NewBufferString(jsonPayload))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), "some error message")
+		require.Equal(t, NegotiateRequestPresentationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionContinue(gomock.Any(), gomock.Any())
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		const jsonPayload = `{"piid":"id","propose_presentation":{}}`
+		require.NoError(t, cmd.NegotiateRequestPresentation(&b, bytes.NewBufferString(jsonPayload)))
+	})
+}
+
+func TestCommand_AcceptProposePresentation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service := mocks.NewMockProtocolService(ctrl)
+	service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil).AnyTimes()
+
+	provider := mocks.NewMockProvider(ctrl)
+	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+
+	t.Run("Decode error", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptProposePresentation(&b, bytes.NewBufferString("}"))
+
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty PIID", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptProposePresentation(&b, bytes.NewBufferString("{}"))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyPIID)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty RequestPresentation", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptProposePresentation(&b, bytes.NewBufferString(`{"piid":"id"}`))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyRequestPresentation)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("AcceptProposePresentation (error)", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionContinue(gomock.Any(), gomock.Any()).Return(errors.New("some error message"))
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		const jsonPayload = `{"piid":"id","request_presentation":{}}`
+		cmdErr := cmd.AcceptProposePresentation(&b, bytes.NewBufferString(jsonPayload))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), "some error message")
+		require.Equal(t, AcceptProposePresentationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionContinue(gomock.Any(), gomock.Any())
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		const jsonPayload = `{"piid":"id","request_presentation":{}}`
+		require.NoError(t, cmd.AcceptProposePresentation(&b, bytes.NewBufferString(jsonPayload)))
+	})
+}
+
+func TestCommand_Actions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service := mocks.NewMockProtocolService(ctrl)
+	service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil).AnyTimes()
+
+	provider := mocks.NewMockProvider(ctrl)
+	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+
+	t.Run("Success", func(t *testing.T) {
+		expected := ActionsResponse{Actions: []presentproof.Action{{
+			PIID: "ID1",
+		}, {
+			PIID: "ID2",
+		}}}
+
+		service.EXPECT().Actions().Return(toProtocolActions(expected.Actions), nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		require.NoError(t, cmd.Actions(&b, nil))
+
+		response := ActionsResponse{}
+		require.NoError(t, json.NewDecoder(&b).Decode(&response))
+		require.Equal(t, expected, response)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		service.EXPECT().Actions().Return(nil, errors.New("some error message"))
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		cmdErr := cmd.Actions(nil, nil)
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), "some error message")
+		require.Equal(t, ActionsErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+}
+
+func TestCommand_AcceptPresentation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service := mocks.NewMockProtocolService(ctrl)
+	service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil).AnyTimes()
+
+	provider := mocks.NewMockProvider(ctrl)
+	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+
+	t.Run("Decode error", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptPresentation(&b, bytes.NewBufferString("}"))
+
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty PIID", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptPresentation(&b, bytes.NewBufferString("{}"))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyPIID)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("AcceptPresentation (error)", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionContinue(gomock.Any(), gomock.Any()).Return(errors.New("some error message"))
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptPresentation(&b, bytes.NewBufferString(jsonPayload))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), "some error message")
+		require.Equal(t, AcceptPresentationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionContinue(gomock.Any(), gomock.Any())
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		require.NoError(t, cmd.AcceptPresentation(&b, bytes.NewBufferString(jsonPayload)))
+	})
+}
+
+func TestCommand_DeclineRequestPresentation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service := mocks.NewMockProtocolService(ctrl)
+	service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil).AnyTimes()
+
+	provider := mocks.NewMockProvider(ctrl)
+	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+
+	t.Run("Decode error", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.DeclineRequestPresentation(&b, bytes.NewBufferString("}"))
+
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty PIID", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.DeclineRequestPresentation(&b, bytes.NewBufferString("{}"))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyPIID)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("DeclineRequestPresentation (error)", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionStop(gomock.Any(), gomock.Any()).Return(errors.New("some error message"))
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.DeclineRequestPresentation(&b, bytes.NewBufferString(jsonPayload))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), "some error message")
+		require.Equal(t, DeclineRequestPresentationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionStop(gomock.Any(), gomock.Any())
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		require.NoError(t, cmd.DeclineRequestPresentation(&b, bytes.NewBufferString(jsonPayload)))
+	})
+}
+
+func TestCommand_DeclineProposePresentation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service := mocks.NewMockProtocolService(ctrl)
+	service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil).AnyTimes()
+
+	provider := mocks.NewMockProvider(ctrl)
+	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+
+	t.Run("Decode error", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.DeclineProposePresentation(&b, bytes.NewBufferString("}"))
+
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty PIID", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.DeclineProposePresentation(&b, bytes.NewBufferString("{}"))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyPIID)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("DeclineProposePresentation (error)", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionStop(gomock.Any(), gomock.Any()).Return(errors.New("some error message"))
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.DeclineProposePresentation(&b, bytes.NewBufferString(jsonPayload))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), "some error message")
+		require.Equal(t, DeclineProposePresentationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionStop(gomock.Any(), gomock.Any())
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		require.NoError(t, cmd.DeclineProposePresentation(&b, bytes.NewBufferString(jsonPayload)))
+	})
+}
+
+func TestCommand_DeclinePresentation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service := mocks.NewMockProtocolService(ctrl)
+	service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil).AnyTimes()
+
+	provider := mocks.NewMockProvider(ctrl)
+	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+
+	t.Run("Decode error", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.DeclinePresentation(&b, bytes.NewBufferString("}"))
+
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty PIID", func(t *testing.T) {
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.DeclinePresentation(&b, bytes.NewBufferString("{}"))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyPIID)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("DeclinePresentation (error)", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionStop(gomock.Any(), gomock.Any()).Return(errors.New("some error message"))
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.DeclinePresentation(&b, bytes.NewBufferString(jsonPayload))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), "some error message")
+		require.Equal(t, DeclinePresentationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionStop(gomock.Any(), gomock.Any())
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		require.NoError(t, cmd.DeclinePresentation(&b, bytes.NewBufferString(jsonPayload)))
+	})
+}
+
+func toProtocolActions(actions []presentproof.Action) []protocol.Action {
+	res := make([]protocol.Action, len(actions))
+	for i, action := range actions {
+		res[i] = protocol.Action(action)
+	}
+
+	return res
+}

--- a/pkg/controller/command/presentproof/models.go
+++ b/pkg/controller/command/presentproof/models.go
@@ -1,0 +1,174 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package presentproof
+
+import "github.com/hyperledger/aries-framework-go/pkg/client/presentproof"
+
+// DeclinePresentationArgs model
+//
+// This is used when the presentation needs to be rejected
+//
+type DeclinePresentationArgs struct {
+	// PIID protocol state machine identifier
+	PIID string `json:"piid"`
+	// Reason why presentation is declined
+	Reason string `json:"reason"`
+}
+
+// DeclinePresentationResponse model
+//
+// Represents a DeclinePresentation response message
+//
+type DeclinePresentationResponse struct{}
+
+// DeclineProposePresentationArgs model
+//
+// This is used when proposal needs to be rejected
+//
+type DeclineProposePresentationArgs struct {
+	// PIID protocol state machine identifier
+	PIID string `json:"piid"`
+	// Reason why proposal is declined
+	Reason string `json:"reason"`
+}
+
+// DeclineProposePresentationResponse model
+//
+// Represents a DeclineProposePresentation response message
+//
+type DeclineProposePresentationResponse struct{}
+
+// DeclineRequestPresentationArgs model
+//
+// This is used when the request needs to be rejected
+//
+type DeclineRequestPresentationArgs struct {
+	// PIID protocol state machine identifier
+	PIID string `json:"piid"`
+	// Reason why request is declined
+	Reason string `json:"reason"`
+}
+
+// DeclineRequestPresentationResponse model
+//
+// Represents a DeclineRequestPresentation response message
+//
+type DeclineRequestPresentationResponse struct{}
+
+// ActionsResponse model
+//
+// Represents Actions response message
+//
+type ActionsResponse struct {
+	Actions []presentproof.Action `json:"actions"`
+}
+
+// AcceptPresentationArgs model
+//
+// This is used for accepting a presentation
+//
+type AcceptPresentationArgs struct {
+	// PIID protocol state machine identifier
+	PIID string `json:"piid"`
+}
+
+// AcceptPresentationResponse model
+//
+// Represents a AcceptPresentation response message
+//
+type AcceptPresentationResponse struct{}
+
+// AcceptRequestPresentationArgs model
+//
+// This is used for accepting a request presentation
+//
+type AcceptRequestPresentationArgs struct {
+	// PIID protocol state machine identifier
+	PIID string `json:"piid"`
+	// Presentation is a message that contains signed presentations.
+	Presentation *presentproof.Presentation `json:"presentation"`
+}
+
+// AcceptRequestPresentationResponse model
+//
+// Represents a AcceptRequestPresentation response message
+//
+type AcceptRequestPresentationResponse struct{}
+
+// AcceptProposePresentationArgs model
+//
+// This is used for accepting a propose presentation
+//
+type AcceptProposePresentationArgs struct {
+	// PIID protocol state machine identifier
+	PIID string `json:"piid"`
+	// RequestPresentation describes values that need to be revealed and predicates that need to be fulfilled.
+	RequestPresentation *presentproof.RequestPresentation `json:"request_presentation"`
+}
+
+// AcceptProposePresentationResponse model
+//
+// Represents a AcceptProposePresentation response message
+//
+type AcceptProposePresentationResponse struct{}
+
+// NegotiateRequestPresentationArgs model
+//
+// This is used by the Prover to counter a presentation request they received with a proposal.
+//
+type NegotiateRequestPresentationArgs struct {
+	// PIID protocol state machine identifier
+	PIID string `json:"piid"`
+	// ProposePresentation is a response message to a request-presentation message when the Prover wants to
+	// propose using a different presentation format.
+	ProposePresentation *presentproof.ProposePresentation `json:"propose_presentation"`
+}
+
+// NegotiateRequestPresentationResponse model
+//
+// Represents a NegotiateRequestPresentation response message
+//
+type NegotiateRequestPresentationResponse struct{}
+
+// SendProposePresentationArgs model
+//
+// This is used for sending a propose presentation
+//
+type SendProposePresentationArgs struct {
+	// MyDID sender's did
+	MyDID string `json:"my_did"`
+	// TheirDID receiver's did
+	TheirDID string `json:"their_did"`
+	// ProposePresentation is a message sent by the Prover to the verifier to initiate a proof
+	// presentation process.
+	ProposePresentation *presentproof.ProposePresentation `json:"propose_presentation"`
+}
+
+// SendProposePresentationResponse model
+//
+// Represents a SendProposePresentation response message
+//
+type SendProposePresentationResponse struct{}
+
+// SendRequestPresentationArgs model
+//
+// This is used for sending a request presentation
+//
+type SendRequestPresentationArgs struct {
+	// MyDID sender's did
+	MyDID string `json:"my_did"`
+	// TheirDID receiver's did
+	TheirDID string `json:"their_did"`
+	// RequestPresentation describes values that need to be revealed and predicates that need to be fulfilled.
+	RequestPresentation *presentproof.RequestPresentation `json:"request_presentation"`
+}
+
+// SendRequestPresentationResponse model
+//
+// Represents a SendRequestPresentation response message
+//
+type SendRequestPresentationResponse struct{}


### PR DESCRIPTION
Adds `command` support for the Present Proof protocol.

Closes #1633 
Signed-off-by: Andrii Soluk <isoluchok@gmail.com>