### PR TITLE
feat: Issue Credential adds REST support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,6 +94,9 @@ issues:
         - dupl
         - funlen
         - gomnd
+    - source: "swagger:route"
+      linters:
+        - lll
 
   exclude:
     # Allow package logger variables (for now)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
 	didexchangecmd "github.com/hyperledger/aries-framework-go/pkg/controller/command/didexchange"
+	issuecredentialcmd "github.com/hyperledger/aries-framework-go/pkg/controller/command/issuecredential"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/command/kms"
 	messagingcmd "github.com/hyperledger/aries-framework-go/pkg/controller/command/messaging"
 	routercmd "github.com/hyperledger/aries-framework-go/pkg/controller/command/route"
@@ -18,6 +19,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/controller/command/verifiable"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/rest"
 	didexchangerest "github.com/hyperledger/aries-framework-go/pkg/controller/rest/didexchange"
+	issuecredentialrest "github.com/hyperledger/aries-framework-go/pkg/controller/rest/issuecredential"
 	kmsrest "github.com/hyperledger/aries-framework-go/pkg/controller/rest/kms"
 	messagingrest "github.com/hyperledger/aries-framework-go/pkg/controller/rest/messaging"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/rest/route"
@@ -76,7 +78,7 @@ func WithMessageHandler(handler command.MessageHandler) Opt {
 }
 
 // GetRESTHandlers returns all REST handlers provided by controller.
-func GetRESTHandlers(ctx *context.Provider, opts ...Opt) ([]rest.Handler, error) {
+func GetRESTHandlers(ctx *context.Provider, opts ...Opt) ([]rest.Handler, error) { // nolint: funlen
 	restAPIOpts := &allOpts{}
 	// Apply options
 	for _, opt := range opts {
@@ -119,6 +121,12 @@ func GetRESTHandlers(ctx *context.Provider, opts ...Opt) ([]rest.Handler, error)
 		return nil, fmt.Errorf("create verifiable rest command : %w", err)
 	}
 
+	// issuecredential REST operation
+	issuecredentialOp, err := issuecredentialrest.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create issue-credential rest command : %w", err)
+	}
+
 	// kms command operation
 	kmscmd := kmsrest.New(ctx)
 
@@ -129,6 +137,7 @@ func GetRESTHandlers(ctx *context.Provider, opts ...Opt) ([]rest.Handler, error)
 	allHandlers = append(allHandlers, messagingOp.GetRESTHandlers()...)
 	allHandlers = append(allHandlers, routeOp.GetRESTHandlers()...)
 	allHandlers = append(allHandlers, verifiablecmd.GetRESTHandlers()...)
+	allHandlers = append(allHandlers, issuecredentialOp.GetRESTHandlers()...)
 	allHandlers = append(allHandlers, kmscmd.GetRESTHandlers()...)
 
 	nhp, ok := notifier.(handlerProvider)
@@ -144,7 +153,7 @@ type handlerProvider interface {
 }
 
 // GetCommandHandlers returns all command handlers provided by controller.
-func GetCommandHandlers(ctx *context.Provider, opts ...Opt) ([]command.Handler, error) {
+func GetCommandHandlers(ctx *context.Provider, opts ...Opt) ([]command.Handler, error) { // nolint: funlen
 	cmdOpts := &allOpts{}
 	// Apply options
 	for _, opt := range opts {
@@ -187,6 +196,12 @@ func GetCommandHandlers(ctx *context.Provider, opts ...Opt) ([]command.Handler, 
 		return nil, fmt.Errorf("create verifiable command : %w", err)
 	}
 
+	// issuecredential command operation
+	issuecredential, err := issuecredentialcmd.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create issuecredential command : %w", err)
+	}
+
 	// kms command operation
 	kmscmd := kms.New(ctx)
 
@@ -197,6 +212,7 @@ func GetCommandHandlers(ctx *context.Provider, opts ...Opt) ([]command.Handler, 
 	allHandlers = append(allHandlers, routecmd.GetHandlers()...)
 	allHandlers = append(allHandlers, verifiablecmd.GetHandlers()...)
 	allHandlers = append(allHandlers, kmscmd.GetHandlers()...)
+	allHandlers = append(allHandlers, issuecredential.GetHandlers()...)
 
 	return allHandlers, nil
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -36,65 +36,86 @@ func TestGetCommandHandlers(t *testing.T) {
 }
 
 func TestGetCommandHandlers_Success(t *testing.T) {
-	path, cleanup := generateTempDir(t)
-	defer cleanup()
+	t.Run("Default", func(t *testing.T) {
+		path, cleanup := generateTempDir(t)
+		defer cleanup()
 
-	framework, err := aries.New(defaults.WithStorePath(path), defaults.WithInboundHTTPAddr(":26508", ""))
-	require.NoError(t, err)
-	require.NotNil(t, framework)
+		framework, err := aries.New(defaults.WithStorePath(path), defaults.WithInboundHTTPAddr(":26508", ""))
+		require.NoError(t, err)
+		require.NotNil(t, framework)
 
-	defer func() {
-		e := framework.Close()
-		if e != nil {
-			t.Fatal(e)
-		}
-	}()
+		defer func() { require.NoError(t, framework.Close()) }()
 
-	ctx, err := framework.Context()
-	require.NoError(t, err)
-	require.NotNil(t, ctx)
+		ctx, err := framework.Context()
+		require.NoError(t, err)
+		require.NotNil(t, ctx)
 
-	handlers, err := GetCommandHandlers(ctx)
-	require.NoError(t, err)
-	require.NotEmpty(t, handlers)
+		handlers, err := GetCommandHandlers(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, handlers)
+	})
 
-	// test with options
-	handlers, err = GetCommandHandlers(ctx, WithMessageHandler(msghandler.NewMockMsgServiceProvider()),
-		WithAutoAccept(true), WithDefaultLabel("sample-label"),
-		WithWebhookURLs("sample-wh-url"), WithNotifier(webhook.NewMockWebhookNotifier()))
-	require.NoError(t, err)
-	require.NotEmpty(t, handlers)
+	t.Run("With options", func(t *testing.T) {
+		path, cleanup := generateTempDir(t)
+		defer cleanup()
+
+		framework, err := aries.New(defaults.WithStorePath(path), defaults.WithInboundHTTPAddr(":26508", ""))
+		require.NoError(t, err)
+		require.NotNil(t, framework)
+
+		defer func() { require.NoError(t, framework.Close()) }()
+
+		ctx, err := framework.Context()
+		require.NoError(t, err)
+		require.NotNil(t, ctx)
+
+		handlers, err := GetCommandHandlers(ctx, WithMessageHandler(msghandler.NewMockMsgServiceProvider()),
+			WithAutoAccept(true), WithDefaultLabel("sample-label"),
+			WithWebhookURLs("sample-wh-url"), WithNotifier(webhook.NewMockWebhookNotifier()))
+		require.NoError(t, err)
+		require.NotEmpty(t, handlers)
+	})
 }
 
 func TestGetRESTHandlers_Success(t *testing.T) {
-	path, cleanup := generateTempDir(t)
-	defer cleanup()
+	t.Run("", func(t *testing.T) {
+		path, cleanup := generateTempDir(t)
+		defer cleanup()
 
-	framework, err := aries.New(defaults.WithStorePath(path), defaults.WithInboundHTTPAddr(":26508", ""))
-	require.NoError(t, err)
-	require.NotNil(t, framework)
+		framework, err := aries.New(defaults.WithStorePath(path), defaults.WithInboundHTTPAddr(":26508", ""))
+		require.NoError(t, err)
+		require.NotNil(t, framework)
 
-	defer func() {
-		e := framework.Close()
-		if e != nil {
-			t.Fatal(e)
-		}
-	}()
+		defer func() { require.NoError(t, framework.Close()) }()
 
-	ctx, err := framework.Context()
-	require.NoError(t, err)
-	require.NotNil(t, ctx)
+		ctx, err := framework.Context()
+		require.NoError(t, err)
+		require.NotNil(t, ctx)
 
-	handlers, err := GetRESTHandlers(ctx)
-	require.NoError(t, err)
-	require.NotEmpty(t, handlers)
+		handlers, err := GetRESTHandlers(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, handlers)
+	})
+	t.Run("", func(t *testing.T) {
+		path, cleanup := generateTempDir(t)
+		defer cleanup()
 
-	// test with options
-	handlers, err = GetRESTHandlers(ctx, WithMessageHandler(msghandler.NewMockMsgServiceProvider()),
-		WithAutoAccept(true), WithDefaultLabel("sample-label"),
-		WithWebhookURLs("sample-wh-url"))
-	require.NoError(t, err)
-	require.NotEmpty(t, handlers)
+		framework, err := aries.New(defaults.WithStorePath(path), defaults.WithInboundHTTPAddr(":26508", ""))
+		require.NoError(t, err)
+		require.NotNil(t, framework)
+
+		defer func() { require.NoError(t, framework.Close()) }()
+
+		ctx, err := framework.Context()
+		require.NoError(t, err)
+		require.NotNil(t, ctx)
+
+		handlers, err := GetRESTHandlers(ctx, WithMessageHandler(msghandler.NewMockMsgServiceProvider()),
+			WithAutoAccept(true), WithDefaultLabel("sample-label"),
+			WithWebhookURLs("sample-wh-url"))
+		require.NoError(t, err)
+		require.NotEmpty(t, handlers)
+	})
 }
 
 func TestWithWebhookNotifierOption(t *testing.T) {

--- a/pkg/controller/rest/issuecredential/models.go
+++ b/pkg/controller/rest/issuecredential/models.go
@@ -1,0 +1,317 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package issuecredential
+
+import protocol "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/issuecredential"
+
+// issueCredentialAcceptProposalRequest model
+//
+// This is used for operation to accept proposal
+//
+// swagger:parameters issueCredentialAcceptProposal
+type issueCredentialAcceptProposalRequest struct { // nolint: unused,deadcode
+	// Protocol instance ID
+	//
+	// in: path
+	// required: true
+	PIID string `json:"piid"`
+
+	// in: body
+	// required: true
+	OfferCredential protocol.OfferCredential `json:""`
+}
+
+// issueCredentialAcceptProposalResponse model
+//
+// Represents a AcceptProposal response message
+//
+// swagger:response issueCredentialAcceptProposalResponse
+type issueCredentialAcceptProposalResponse struct{} // nolint: unused,deadcode
+
+// issueCredentialAcceptOfferRequest model
+//
+// This is used for operation to accept an offer
+//
+// swagger:parameters issueCredentialAcceptOffer
+type issueCredentialAcceptOfferRequest struct { // nolint: unused,deadcode
+	// Protocol instance ID
+	//
+	// in: path
+	// required: true
+	PIID string `json:"piid"`
+}
+
+// issueCredentialAcceptOfferResponse model
+//
+// Represents a AcceptOffer response message
+//
+// swagger:response issueCredentialAcceptOfferResponse
+type issueCredentialAcceptOfferResponse struct{} // nolint: unused,deadcode
+
+// issueCredentialAcceptRequestRequest model
+//
+// This is used for operation to accept a request
+//
+// swagger:parameters issueCredentialAcceptRequest
+type issueCredentialAcceptRequestRequest struct { // nolint: unused,deadcode
+	// Protocol instance ID
+	//
+	// in: path
+	// required: true
+	PIID string `json:"piid"`
+
+	// in: body
+	// required: true
+	IssueCredential protocol.IssueCredential `json:""`
+}
+
+// issueCredentialAcceptRequestResponse model
+//
+// Represents a AcceptRequest response message
+//
+// swagger:response issueCredentialAcceptRequestResponse
+type issueCredentialAcceptRequestResponse struct{} // nolint: unused,deadcode
+
+// issueCredentialAcceptCredentialRequest model
+//
+// This is used for operation to accept a credential
+//
+// swagger:parameters issueCredentialAcceptCredential
+type issueCredentialAcceptCredentialRequest struct { // nolint: unused,deadcode
+	// Protocol instance ID
+	//
+	// in: path
+	// required: true
+	PIID string `json:"piid"`
+
+	// in: body
+	// required: true
+	Names []string `json:""`
+}
+
+// issueCredentialAcceptCredentialResponse model
+//
+// Represents a AcceptCredential response message
+//
+// swagger:response issueCredentialAcceptCredentialResponse
+type issueCredentialAcceptCredentialResponse struct{} // nolint: unused,deadcode
+
+// issueCredentialDeclineCredentialRequest model
+//
+// This is used for operation to decline a credential
+//
+// swagger:parameters issueCredentialDeclineCredential
+type issueCredentialDeclineCredentialRequest struct { // nolint: unused,deadcode
+	// Protocol instance ID
+	//
+	// in: path
+	// required: true
+	PIID string `json:"piid"`
+
+	// Optional Reason is an explanation of why it was declined
+	Reason string `json:"reason"`
+}
+
+// issueCredentialDeclineCredentialResponse model
+//
+// Represents a DeclineCredential response message
+//
+// swagger:response issueCredentialDeclineCredentialResponse
+type issueCredentialDeclineCredentialResponse struct{} // nolint: unused,deadcode
+
+// issueCredentialDeclineRequestRequest model
+//
+// This is used for operation to decline a request
+//
+// swagger:parameters issueCredentialDeclineRequest
+type issueCredentialDeclineRequestRequest struct { // nolint: unused,deadcode
+	// Protocol instance ID
+	//
+	// in: path
+	// required: true
+	PIID string `json:"piid"`
+
+	// Optional Reason is an explanation of why it was declined
+	Reason string `json:"reason"`
+}
+
+// issueCredentialDeclineRequestResponse model
+//
+// Represents a DeclineRequest response message
+//
+// swagger:response issueCredentialDeclineRequestResponse
+type issueCredentialDeclineRequestResponse struct{} // nolint: unused,deadcode
+
+// issueCredentialDeclineOfferRequest model
+//
+// This is used for operation to decline an Offer
+//
+// swagger:parameters issueCredentialDeclineOffer
+type issueCredentialDeclineOfferRequest struct { // nolint: unused,deadcode
+	// Protocol instance ID
+	//
+	// in: path
+	// required: true
+	PIID string `json:"piid"`
+
+	// Optional Reason is an explanation of why it was declined
+	Reason string `json:"reason"`
+}
+
+// issueCredentialDeclineOfferResponse model
+//
+// Represents a DeclineOffer response message
+//
+// swagger:response issueCredentialDeclineOfferResponse
+type issueCredentialDeclineOfferResponse struct{} // nolint: unused,deadcode
+
+// issueCredentialDeclineProposalRequest model
+//
+// This is used for operation to decline a proposal
+//
+// swagger:parameters issueCredentialDeclineProposal
+type issueCredentialDeclineProposalRequest struct { // nolint: unused,deadcode
+	// Protocol instance ID
+	//
+	// in: path
+	// required: true
+	PIID string `json:"piid"`
+
+	// Optional Reason is an explanation of why it was declined
+	Reason string `json:"reason"`
+}
+
+// issueCredentialDeclineProposalResponse model
+//
+// Represents a DeclineProposal response message
+//
+// swagger:response issueCredentialDeclineProposalResponse
+type issueCredentialDeclineProposalResponse struct{} // nolint: unused,deadcode
+
+// issueCredentialNegotiateProposalRequest model
+//
+// This is used for operation when the Holder wants to negotiate about an offer he received.
+//
+// swagger:parameters issueCredentialNegotiateProposal
+type issueCredentialNegotiateProposalRequest struct { // nolint: unused,deadcode
+	// Protocol instance ID
+	//
+	// in: path
+	// required: true
+	PIID string `json:"piid"`
+
+	// in: body
+	// required: true
+	ProposeCredential protocol.ProposeCredential `json:""`
+}
+
+// issueCredentialNegotiateProposalResponse model
+//
+// Represents a NegotiateProposal response message
+//
+// swagger:response issueCredentialNegotiateProposalResponse
+type issueCredentialNegotiateProposalResponse struct{} // nolint: unused,deadcode
+
+// issueCredentialActionsRequest model
+//
+// Returns pending actions that have not yet to be executed or cancelled.
+//
+// swagger:parameters issueCredentialActions
+type issueCredentialActionsRequest struct{} // nolint: unused,deadcode
+
+// issueCredentialActionsResponse model
+//
+// Represents a Actions response message
+//
+// swagger:response issueCredentialActionsResponse
+type issueCredentialActionsResponse struct { // nolint: unused,deadcode
+	// in: body
+	Actions []protocol.Action `json:"actions"`
+}
+
+// issueCredentialSendOfferRequest model
+//
+// This is used for operation to send an offer.
+//
+// swagger:parameters issueCredentialSendOffer
+type issueCredentialSendOfferRequest struct { // nolint: unused,deadcode
+	// in: body
+	Body struct {
+		// MyDID sender's did
+		// required: true
+		MyDID string `json:"my_did"`
+		// TheirDID receiver's did
+		// required: true
+		TheirDID string `json:"their_did"`
+		// OfferCredential is a message describing the credential intend to offer and
+		// possibly the price they expect to be paid.
+		// required: true
+		OfferCredential *protocol.OfferCredential `json:"offer_credential"`
+	}
+}
+
+// issueCredentialSendOfferResponse model
+//
+// Represents a SendOffer response message
+//
+// swagger:response issueCredentialSendOfferResponse
+type issueCredentialSendOfferResponse struct{} // nolint: unused,deadcode
+
+// issueCredentialSendProposalRequest model
+//
+// This is used for operation to send a proposal
+//
+// swagger:parameters issueCredentialSendProposal
+type issueCredentialSendProposalRequest struct { // nolint: unused,deadcode
+	// in: body
+	Body struct {
+		// MyDID sender's did
+		// required: true
+		MyDID string `json:"my_did"`
+		// TheirDID receiver's did
+		// required: true
+		TheirDID string `json:"their_did"`
+		// ProposeCredential is a message sent by the potential Holder to the Issuer to initiate the protocol
+		// required: true
+		ProposeCredential *protocol.ProposeCredential `json:"propose_credential"`
+	}
+}
+
+// issueCredentialSendProposalResponse model
+//
+// Represents a SendProposal response message
+//
+// swagger:response issueCredentialSendProposalResponse
+type issueCredentialSendProposalResponse struct{} // nolint: unused,deadcode
+
+// issueCredentialSendRequestRequest model
+//
+// This is used for operation to send a request
+//
+// swagger:parameters issueCredentialSendRequest
+type issueCredentialSendRequestRequest struct { // nolint: unused,deadcode
+	// in: body
+	Body struct {
+		// MyDID sender's did
+		// required: true
+		MyDID string `json:"my_did"`
+		// TheirDID receiver's did
+		// required: true
+		TheirDID string `json:"their_did"`
+		// RequestCredential is a message sent by the potential Holder to the Issuer,
+		// to request the issuance of a credential.
+		// required: true
+		RequestCredential *protocol.RequestCredential `json:"request_credential"`
+	}
+}
+
+// issueCredentialSendRequestResponse model
+//
+// Represents a SendRequest response message
+//
+// swagger:response issueCredentialSendRequestResponse
+type issueCredentialSendRequestResponse struct{} // nolint: unused,deadcode

--- a/pkg/controller/rest/issuecredential/operation.go
+++ b/pkg/controller/rest/issuecredential/operation.go
@@ -1,0 +1,335 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package issuecredential
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	client "github.com/hyperledger/aries-framework-go/pkg/client/issuecredential"
+	command "github.com/hyperledger/aries-framework-go/pkg/controller/command/issuecredential"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/internal/cmdutil"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/rest"
+)
+
+const (
+	operationID       = "/issuecredential"
+	actions           = operationID + "/actions"
+	sendOffer         = operationID + "/send-offer"
+	sendProposal      = operationID + "/send-proposal"
+	sendRequest       = operationID + "/send-request"
+	acceptProposal    = operationID + "/{piid}/accept-proposal"
+	declineProposal   = operationID + "/{piid}/decline-proposal"
+	acceptOffer       = operationID + "/{piid}/accept-offer"
+	declineOffer      = operationID + "/{piid}/decline-offer"
+	negotiateProposal = operationID + "/{piid}/negotiate-proposal"
+	acceptRequest     = operationID + "/{piid}/accept-request"
+	declineRequest    = operationID + "/{piid}/decline-request"
+	acceptCredential  = operationID + "/{piid}/accept-credential"
+	declineCredential = operationID + "/{piid}/decline-credential"
+)
+
+// Operation is controller REST service controller for issue credential
+type Operation struct {
+	command  *command.Command
+	handlers []rest.Handler
+}
+
+// New returns new issue credential rest client protocol instance
+func New(ctx client.Provider) (*Operation, error) {
+	cmd, err := command.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("issue credential command : %w", err)
+	}
+
+	o := &Operation{command: cmd}
+	o.registerHandler()
+
+	return o, nil
+}
+
+// GetRESTHandlers get all controller API handler available for this protocol service
+func (c *Operation) GetRESTHandlers() []rest.Handler {
+	return c.handlers
+}
+
+// registerHandler register handlers to be exposed from this protocol service as REST API endpoints
+func (c *Operation) registerHandler() {
+	// Add more protocol endpoints here to expose them as controller API endpoints
+	c.handlers = []rest.Handler{
+		cmdutil.NewHTTPHandler(actions, http.MethodGet, c.Actions),
+		cmdutil.NewHTTPHandler(sendOffer, http.MethodPost, c.SendOffer),
+		cmdutil.NewHTTPHandler(sendProposal, http.MethodPost, c.SendProposal),
+		cmdutil.NewHTTPHandler(sendRequest, http.MethodPost, c.SendRequest),
+		cmdutil.NewHTTPHandler(acceptProposal, http.MethodPost, c.AcceptProposal),
+		cmdutil.NewHTTPHandler(declineProposal, http.MethodPost, c.DeclineProposal),
+		cmdutil.NewHTTPHandler(acceptOffer, http.MethodPost, c.AcceptOffer),
+		cmdutil.NewHTTPHandler(declineOffer, http.MethodPost, c.DeclineOffer),
+		cmdutil.NewHTTPHandler(negotiateProposal, http.MethodPost, c.NegotiateProposal),
+		cmdutil.NewHTTPHandler(acceptRequest, http.MethodPost, c.AcceptRequest),
+		cmdutil.NewHTTPHandler(declineRequest, http.MethodPost, c.DeclineRequest),
+		cmdutil.NewHTTPHandler(acceptCredential, http.MethodPost, c.AcceptCredential),
+		cmdutil.NewHTTPHandler(declineCredential, http.MethodPost, c.DeclineCredential),
+	}
+}
+
+// Actions swagger:route GET /issuecredential/actions issue-credential issueCredentialActions
+//
+// Returns pending actions that have not yet to be executed or cancelled.
+//
+// Responses:
+//    default: genericError
+//        200: issueCredentialActionsResponse
+func (c *Operation) Actions(rw http.ResponseWriter, _ *http.Request) {
+	rest.Execute(c.command.Actions, rw, nil)
+}
+
+// SendOffer swagger:route POST /issuecredential/send-offer issue-credential issueCredentialSendOffer
+//
+// Sends an offer
+//
+// Responses:
+//    default: genericError
+//        200: issueCredentialSendOfferResponse
+func (c *Operation) SendOffer(rw http.ResponseWriter, req *http.Request) {
+	rest.Execute(c.command.SendOffer, rw, req.Body)
+}
+
+// SendProposal swagger:route POST /issuecredential/send-proposal issue-credential issueCredentialSendProposal
+//
+// Sends a proposal
+//
+// Responses:
+//    default: genericError
+//        200: issueCredentialSendProposalResponse
+func (c *Operation) SendProposal(rw http.ResponseWriter, req *http.Request) {
+	rest.Execute(c.command.SendProposal, rw, req.Body)
+}
+
+// SendRequest swagger:route POST /issuecredential/send-request issue-credential issueCredentialSendRequest
+//
+// Sends a request
+//
+// Responses:
+//    default: genericError
+//        200: issueCredentialSendRequestResponse
+func (c *Operation) SendRequest(rw http.ResponseWriter, req *http.Request) {
+	rest.Execute(c.command.SendRequest, rw, req.Body)
+}
+
+// AcceptProposal swagger:route POST /issuecredential/{piid}/accept-proposal issue-credential issueCredentialAcceptProposal
+//
+// Accepts proposal
+//
+// Responses:
+//    default: genericError
+//        200: issueCredentialAcceptProposalResponse
+func (c *Operation) AcceptProposal(rw http.ResponseWriter, req *http.Request) { // nolint: dupl
+	var buf bytes.Buffer
+
+	if req.Body != nil {
+		// nolint: errcheck
+		_, _ = io.Copy(&buf, req.Body)
+	}
+
+	if !isJSONMap(buf.Bytes()) {
+		rest.SendHTTPStatusError(rw,
+			http.StatusBadRequest,
+			command.InvalidRequestErrorCode,
+			errors.New("offer credential payload was not provided"),
+		)
+
+		return
+	}
+
+	rest.Execute(c.command.AcceptProposal, rw, bytes.NewBufferString(fmt.Sprintf(`{
+		"piid":%q,
+		"offer_credential": %s
+	}`, mux.Vars(req)["piid"], buf.String())))
+}
+
+// DeclineProposal swagger:route POST /issuecredential/{piid}/decline-proposal issue-credential issueCredentialDeclineProposal
+//
+// Declines a proposal
+//
+// Responses:
+//    default: genericError
+//        200: issueCredentialDeclineProposalResponse
+func (c *Operation) DeclineProposal(rw http.ResponseWriter, req *http.Request) {
+	rest.Execute(c.command.DeclineProposal, rw, bytes.NewBufferString(fmt.Sprintf(`{
+		"piid":%q,
+		"reason":%q
+	}`, mux.Vars(req)["piid"], req.URL.Query().Get("reason"))))
+}
+
+// AcceptOffer swagger:route POST /issuecredential/{piid}/accept-offer issue-credential issueCredentialAcceptOffer
+//
+// Accepts an offer
+//
+// Responses:
+//    default: genericError
+//        200: issueCredentialAcceptOfferResponse
+func (c *Operation) AcceptOffer(rw http.ResponseWriter, req *http.Request) {
+	rest.Execute(c.command.AcceptOffer, rw, bytes.NewBufferString(fmt.Sprintf(`{
+		"piid":%q
+	}`, mux.Vars(req)["piid"])))
+}
+
+// DeclineOffer swagger:route POST /issuecredential/{piid}/decline-offer issue-credential issueCredentialDeclineOffer
+//
+// Declines an offer
+//
+// Responses:
+//    default: genericError
+//        200: issueCredentialDeclineOfferResponse
+func (c *Operation) DeclineOffer(rw http.ResponseWriter, req *http.Request) {
+	rest.Execute(c.command.DeclineOffer, rw, bytes.NewBufferString(fmt.Sprintf(`{
+		"piid":%q,
+		"reason":%q
+	}`, mux.Vars(req)["piid"], req.URL.Query().Get("reason"))))
+}
+
+// NegotiateProposal swagger:route POST /issuecredential/{piid}/negotiate-proposal issue-credential issueCredentialNegotiateProposal
+//
+// Is used when the Holder wants to negotiate about an offer he received.
+//
+// Responses:
+//    default: genericError
+//        200: issueCredentialNegotiateProposalResponse
+func (c *Operation) NegotiateProposal(rw http.ResponseWriter, req *http.Request) { // nolint: dupl
+	var buf bytes.Buffer
+
+	if req.Body != nil {
+		// nolint: errcheck
+		_, _ = io.Copy(&buf, req.Body)
+	}
+
+	if !isJSONMap(buf.Bytes()) {
+		rest.SendHTTPStatusError(rw,
+			http.StatusBadRequest,
+			command.InvalidRequestErrorCode,
+			errors.New("propose credential payload was not provided"),
+		)
+
+		return
+	}
+
+	rest.Execute(c.command.NegotiateProposal, rw, bytes.NewBufferString(fmt.Sprintf(`{
+		"piid":%q,
+		"propose_credential": %s
+	}`, mux.Vars(req)["piid"], buf.String())))
+}
+
+// AcceptRequest swagger:route POST /issuecredential/{piid}/accept-request issue-credential issueCredentialAcceptRequest
+//
+// Accepts a request
+//
+// Responses:
+//    default: genericError
+//        200: issueCredentialAcceptRequestResponse
+func (c *Operation) AcceptRequest(rw http.ResponseWriter, req *http.Request) { // nolint: dupl
+	var buf bytes.Buffer
+
+	if req.Body != nil {
+		// nolint: errcheck
+		_, _ = io.Copy(&buf, req.Body)
+	}
+
+	if !isJSONMap(buf.Bytes()) {
+		rest.SendHTTPStatusError(rw,
+			http.StatusBadRequest,
+			command.InvalidRequestErrorCode,
+			errors.New("issue credential payload was not provided"),
+		)
+
+		return
+	}
+
+	rest.Execute(c.command.AcceptRequest, rw, bytes.NewBufferString(fmt.Sprintf(`{
+		"piid":%q,
+		"issue_credential": %s
+	}`, mux.Vars(req)["piid"], buf.String())))
+}
+
+// DeclineRequest swagger:route POST /issuecredential/{piid}/decline-request issue-credential issueCredentialDeclineRequest
+//
+// Declines a request
+//
+// Responses:
+//    default: genericError
+//        200: issueCredentialDeclineRequestResponse
+func (c *Operation) DeclineRequest(rw http.ResponseWriter, req *http.Request) {
+	rest.Execute(c.command.DeclineRequest, rw, bytes.NewBufferString(fmt.Sprintf(`{
+		"piid":%q,
+		"reason":%q
+	}`, mux.Vars(req)["piid"], req.URL.Query().Get("reason"))))
+}
+
+// AcceptCredential swagger:route POST /issuecredential/{piid}/accept-credential issue-credential issueCredentialAcceptCredential
+//
+// Accepts a credential
+//
+// Responses:
+//    default: genericError
+//        200: issueCredentialAcceptCredentialResponse
+func (c *Operation) AcceptCredential(rw http.ResponseWriter, req *http.Request) { // nolint: dupl
+	var buf bytes.Buffer
+
+	if req.Body != nil {
+		// nolint: errcheck
+		_, _ = io.Copy(&buf, req.Body)
+	}
+
+	if !isJSONArray(buf.Bytes()) {
+		rest.SendHTTPStatusError(rw,
+			http.StatusBadRequest,
+			command.InvalidRequestErrorCode,
+			errors.New("names payload was not provided"),
+		)
+
+		return
+	}
+
+	rest.Execute(c.command.AcceptCredential, rw, bytes.NewBufferString(fmt.Sprintf(`{
+		"piid":%q,
+		"names": %s
+	}`, mux.Vars(req)["piid"], buf.String())))
+}
+
+// DeclineCredential swagger:route POST /issuecredential/{piid}/decline-credential issue-credential issueCredentialDeclineCredential
+//
+// Declines a credential
+//
+// Responses:
+//    default: genericError
+//        200: issueCredentialDeclineCredentialResponse
+func (c *Operation) DeclineCredential(rw http.ResponseWriter, req *http.Request) {
+	rest.Execute(c.command.DeclineCredential, rw, bytes.NewBufferString(fmt.Sprintf(`{
+		"piid":%q,
+		"reason":%q
+	}`, mux.Vars(req)["piid"], req.URL.Query().Get("reason"))))
+}
+
+func isJSONMap(data []byte) bool {
+	var v struct{}
+	return isJSON(data, v)
+}
+
+func isJSON(data []byte, v interface{}) bool {
+	return json.Unmarshal(data, &v) == nil
+}
+
+func isJSONArray(data []byte) bool {
+	var v []struct{}
+	return isJSON(data, v)
+}

--- a/pkg/controller/rest/issuecredential/operation_test.go
+++ b/pkg/controller/rest/issuecredential/operation_test.go
@@ -1,0 +1,302 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package issuecredential
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+
+	client "github.com/hyperledger/aries-framework-go/pkg/client/issuecredential"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/rest"
+	mocks "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/client/issuecredential"
+)
+
+func provider(ctrl *gomock.Controller) client.Provider {
+	service := mocks.NewMockProtocolService(ctrl)
+	service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+	service.EXPECT().ActionContinue(gomock.Any(), gomock.Any()).AnyTimes()
+	service.EXPECT().ActionStop(gomock.Any(), gomock.Any()).AnyTimes()
+
+	provider := mocks.NewMockProvider(ctrl)
+	provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+	return provider
+}
+
+func TestOperation_AcceptProposal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("No payload", func(t *testing.T) {
+		operation, err := New(provider(ctrl))
+		require.NoError(t, err)
+
+		buf, code, err := sendRequestToHandler(
+			handlerLookup(t, operation, acceptProposal), nil,
+			strings.Replace(acceptProposal, `{piid}`, "1234", 1),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, code)
+		require.Contains(t, buf.String(), "offer credential payload was not provided")
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		operation, err := New(provider(ctrl))
+		require.NoError(t, err)
+
+		_, code, err := sendRequestToHandler(
+			handlerLookup(t, operation, acceptProposal),
+			bytes.NewBufferString(`{}`),
+			strings.Replace(acceptProposal, `{piid}`, "1234", 1),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+	})
+}
+
+func TestOperation_AcceptOffer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("Success", func(t *testing.T) {
+		operation, err := New(provider(ctrl))
+		require.NoError(t, err)
+
+		_, code, err := sendRequestToHandler(
+			handlerLookup(t, operation, acceptOffer),
+			nil,
+			strings.Replace(acceptOffer, `{piid}`, "1234", 1),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+	})
+}
+
+func TestOperation_AcceptRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("No payload", func(t *testing.T) {
+		operation, err := New(provider(ctrl))
+		require.NoError(t, err)
+
+		buf, code, err := sendRequestToHandler(
+			handlerLookup(t, operation, acceptRequest), nil,
+			strings.Replace(acceptRequest, `{piid}`, "1234", 1),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, code)
+		require.Contains(t, buf.String(), "issue credential payload was not provided")
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		operation, err := New(provider(ctrl))
+		require.NoError(t, err)
+
+		_, code, err := sendRequestToHandler(
+			handlerLookup(t, operation, acceptRequest),
+			bytes.NewBufferString(`{}`),
+			strings.Replace(acceptRequest, `{piid}`, "1234", 1),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+	})
+}
+
+func TestOperation_NegotiateProposal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("No payload", func(t *testing.T) {
+		operation, err := New(provider(ctrl))
+		require.NoError(t, err)
+
+		buf, code, err := sendRequestToHandler(
+			handlerLookup(t, operation, negotiateProposal), nil,
+			strings.Replace(negotiateProposal, `{piid}`, "1234", 1),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, code)
+		require.Contains(t, buf.String(), "propose credential payload was not provided")
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		operation, err := New(provider(ctrl))
+		require.NoError(t, err)
+
+		_, code, err := sendRequestToHandler(
+			handlerLookup(t, operation, negotiateProposal),
+			bytes.NewBufferString(`{}`),
+			strings.Replace(negotiateProposal, `{piid}`, "1234", 1),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+	})
+}
+
+func TestOperation_AcceptCredential(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("No payload", func(t *testing.T) {
+		operation, err := New(provider(ctrl))
+		require.NoError(t, err)
+
+		buf, code, err := sendRequestToHandler(
+			handlerLookup(t, operation, acceptCredential), nil,
+			strings.Replace(acceptCredential, `{piid}`, "1234", 1),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, code)
+		require.Contains(t, buf.String(), "names payload was not provided")
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		operation, err := New(provider(ctrl))
+		require.NoError(t, err)
+
+		_, code, err := sendRequestToHandler(
+			handlerLookup(t, operation, acceptCredential),
+			bytes.NewBufferString(`[]`),
+			strings.Replace(acceptCredential, `{piid}`, "1234", 1),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+	})
+}
+
+func TestOperation_DeclineProposal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("Success", func(t *testing.T) {
+		operation, err := New(provider(ctrl))
+		require.NoError(t, err)
+
+		_, code, err := sendRequestToHandler(
+			handlerLookup(t, operation, declineProposal),
+			nil,
+			strings.Replace(declineProposal, `{piid}`, "1234", 1),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+	})
+}
+
+func TestOperation_DeclineOffer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("Success", func(t *testing.T) {
+		operation, err := New(provider(ctrl))
+		require.NoError(t, err)
+
+		_, code, err := sendRequestToHandler(
+			handlerLookup(t, operation, declineOffer),
+			nil,
+			strings.Replace(declineOffer, `{piid}`, "1234", 1),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+	})
+}
+
+func TestOperation_DeclineRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("Success", func(t *testing.T) {
+		operation, err := New(provider(ctrl))
+		require.NoError(t, err)
+
+		_, code, err := sendRequestToHandler(
+			handlerLookup(t, operation, declineRequest),
+			nil,
+			strings.Replace(declineRequest, `{piid}`, "1234", 1),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+	})
+}
+
+func TestOperation_DeclineCredential(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("Success", func(t *testing.T) {
+		operation, err := New(provider(ctrl))
+		require.NoError(t, err)
+
+		_, code, err := sendRequestToHandler(
+			handlerLookup(t, operation, declineCredential),
+			nil,
+			strings.Replace(declineCredential, `{piid}`, "1234", 1),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+	})
+}
+
+func handlerLookup(t *testing.T, op *Operation, lookup string) rest.Handler {
+	t.Helper()
+
+	handlers := op.GetRESTHandlers()
+	require.NotEmpty(t, handlers)
+
+	for _, h := range handlers {
+		if h.Path() == lookup {
+			return h
+		}
+	}
+
+	require.Fail(t, "unable to find handler")
+
+	return nil
+}
+
+// sendRequestToHandler reads response from given http handle func.
+func sendRequestToHandler(handler rest.Handler, requestBody io.Reader, path string) (*bytes.Buffer, int, error) {
+	// prepare request
+	req, err := http.NewRequest(handler.Method(), path, requestBody)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// prepare router
+	router := mux.NewRouter()
+
+	router.HandleFunc(handler.Path(), handler.Handle()).Methods(handler.Method())
+
+	// create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+
+	// serve http on given response and request
+	router.ServeHTTP(rr, req)
+
+	return rr.Body, rr.Code, nil
+}


### PR DESCRIPTION
Adds `REST` support for the  Issue Credential protocol.

Closes #1650 
Signed-off-by: Andrii Soluk <isoluchok@gmail.com>