### PR TITLE
feat: add Core ECDH-ES crypto logic

### DIFF
--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_common.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_common.go
@@ -1,0 +1,30 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package subtle
+
+// EncryptedData represents the Encryption's output data as a result of ECDHESEncrypt.Encrypt(pt, aad) call
+// The user of the primitive must unmarshal the result and build their own ECDH-ES compliant message (ie JWE msg)
+type EncryptedData struct {
+	Ciphertext []byte                 `json:"Ciphertext,omitempty"`
+	IV         []byte                 `json:"IV,omitempty"`
+	Tag        []byte                 `json:"Tag,omitempty"`
+	Recipients []*RecipientWrappedKey `json:"Recipients,omitempty"`
+}
+
+// RecipientWrappedKey contains recipient key material required to unwrap CEK
+type RecipientWrappedKey struct {
+	EncryptedCEK []byte      `json:"EncryptedCEK,omitempty"`
+	EPK          ECPublicKey `json:"EPK,omitempty"`
+	Alg          string      `json:"Alg,omitempty"`
+}
+
+// ECPublicKey mainly to exchange EPK in RecipientWrappedKey
+type ECPublicKey struct {
+	X     []byte `json:"X,omitempty"`
+	Y     []byte `json:"Y,omitempty"`
+	Curve string `json:"curve,omitempty"`
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_decrypt.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_decrypt.go
@@ -1,0 +1,80 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package subtle
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/tink/go/subtle/hybrid"
+)
+
+// ECDHESAEADCompositeDecrypt is an instance of ECDH-ES decryption with Concat KDF
+// and AEAD content decryption
+type ECDHESAEADCompositeDecrypt struct {
+	privateKey  *hybrid.ECPrivateKey
+	pointFormat string
+	encHelper   EncrypterHelper
+}
+
+// NewECDHESAEADCompositeDecrypt returns ECDH-ES composite decryption construct with Concat KDF/ECDH-ES key unwrapping
+// and AEAD payload decryption.
+func NewECDHESAEADCompositeDecrypt(pvt *hybrid.ECPrivateKey, ptFormat string,
+	encHelper EncrypterHelper) (*ECDHESAEADCompositeDecrypt, error) {
+	return &ECDHESAEADCompositeDecrypt{
+		privateKey:  pvt,
+		pointFormat: ptFormat,
+		encHelper:   encHelper,
+	}, nil
+}
+
+// Decrypt using composite ECDH-ES with a Concat KDF key unwrap and AEAD content decryption
+func (d *ECDHESAEADCompositeDecrypt) Decrypt(ciphertext, aad []byte) ([]byte, error) {
+	if d.privateKey == nil {
+		return nil, fmt.Errorf("ECDHESAEADCompositeDecrypt: missing recipient private key for key unwrapping")
+	}
+
+	keySize := d.encHelper.GetSymmetricKeySize()
+
+	var cek []byte
+
+	encData := new(EncryptedData)
+
+	err := json.Unmarshal(ciphertext, encData)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rec := range encData.Recipients {
+		recipientKW := &ECDHESConcatKDFRecipientKW{
+			recipientPrivateKey: d.privateKey,
+		}
+
+		// TODO: add support for 25519 key unwrapping https://github.com/hyperledger/aries-framework-go/issues/1637
+		cek, err = recipientKW.unwrapKey(rec, keySize)
+		if err == nil {
+			break
+		}
+	}
+
+	if cek == nil {
+		return nil, fmt.Errorf("ecdh-es decrypt: cek unwrap failed for all recipients keys")
+	}
+
+	aead, err := d.encHelper.GetAEAD(cek)
+	if err != nil {
+		return nil, err
+	}
+
+	iv := encData.IV
+	tag := encData.Tag
+	ct := encData.Ciphertext
+	finalCT := append(iv, ct...)
+	finalCT = append(finalCT, tag...)
+
+	return aead.Decrypt(finalCT, aad)
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_encrypt.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_encrypt.go
@@ -1,0 +1,104 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package subtle
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/tink/go/subtle/hybrid"
+	"github.com/google/tink/go/subtle/random"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/api"
+)
+
+// ECDHESAEADCompositeEncrypt is an instance of ECDH-ES encryption with Concat KDF
+// and AEAD content encryption
+type ECDHESAEADCompositeEncrypt struct {
+	recPublicKeys []*hybrid.ECPublicKey
+	pointFormat   string
+	encHelper     EncrypterHelper
+}
+
+var _ api.CompositeEncrypt = (*ECDHESAEADCompositeEncrypt)(nil)
+
+// NewECDHESAEADCompositeEncrypt returns ECDH-ES encryption construct with Concat KDF key wrapping
+// and AEAD content encryption
+func NewECDHESAEADCompositeEncrypt(recipientsKeys []*hybrid.ECPublicKey, ptFormat string,
+	encHelper EncrypterHelper) (*ECDHESAEADCompositeEncrypt, error) {
+	var recipients []*hybrid.ECPublicKey
+
+	for _, pub := range recipientsKeys {
+		pubKey := &hybrid.ECPublicKey{
+			Curve: pub.Curve,
+			Point: hybrid.ECPoint{
+				X: pub.Point.X,
+				Y: pub.Point.Y,
+			},
+		}
+
+		recipients = append(recipients, pubKey)
+	}
+
+	return &ECDHESAEADCompositeEncrypt{
+		recPublicKeys: recipients,
+		pointFormat:   ptFormat,
+		encHelper:     encHelper,
+	}, nil
+}
+
+// Encrypt using composite ECDH-ES with a Concat KDF key wrap and AEAD content encryption
+func (e *ECDHESAEADCompositeEncrypt) Encrypt(plaintext, aad []byte) ([]byte, error) {
+	if len(e.recPublicKeys) == 0 {
+		return nil, fmt.Errorf("ECDHESAEADCompositeEncrypt: missing recipients public keys for key wrapping")
+	}
+
+	keySize := e.encHelper.GetSymmetricKeySize()
+	tagSize := e.encHelper.GetTagSize()
+	ivSize := e.encHelper.GetIVSize()
+	cek := random.GetRandomBytes(uint32(keySize))
+
+	var recipientsWK []*RecipientWrappedKey
+
+	for _, rec := range e.recPublicKeys {
+		senderKW := &ECDHESConcatKDFSenderKW{
+			recipientPublicKey: rec,
+			cek:                cek,
+		}
+
+		// TODO: add support for 25519 key wrapping https://github.com/hyperledger/aries-framework-go/issues/1637
+		kek, err := senderKW.wrapKey(A256KWAlg, keySize)
+		if err != nil {
+			return nil, err
+		}
+
+		recipientsWK = append(recipientsWK, kek)
+	}
+
+	aead, err := e.encHelper.GetAEAD(cek)
+	if err != nil {
+		return nil, err
+	}
+
+	ct, err := aead.Encrypt(plaintext, aad)
+	if err != nil {
+		return nil, err
+	}
+
+	iv := ct[:ivSize]
+	ctAndTag := ct[ivSize:]
+	tagOffset := len(ctAndTag) - tagSize
+
+	encData := &EncryptedData{
+		Ciphertext: ctAndTag[:tagOffset],
+		IV:         iv,
+		Tag:        ctAndTag[tagOffset:],
+		Recipients: recipientsWK,
+	}
+
+	return json.Marshal(encData)
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package subtle
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/tink/go/aead"
+	"github.com/google/tink/go/keyset"
+	commonpb "github.com/google/tink/go/proto/common_go_proto"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+	subtleaead "github.com/google/tink/go/subtle/aead"
+	"github.com/google/tink/go/subtle/hybrid"
+	"github.com/google/tink/go/tink"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptDecrypt(t *testing.T) {
+	recipientsPrivKeys, recipientsPubKeys := buildRecipientsKeys(t, 10)
+	aeadPrimitive := getAEADPrimitive(t, aead.AES256GCMKeyTemplate())
+
+	mEncHelper := &MockEncHelper{
+		KeySizeValue: 32,
+		AEADValue:    aeadPrimitive,
+		TagSizeValue: subtleaead.AESGCMTagSize,
+		IVSizeValue:  subtleaead.AESGCMIVSize,
+	}
+
+	cEnc, err := NewECDHESAEADCompositeEncrypt(recipientsPubKeys, commonpb.EcPointFormat_UNCOMPRESSED.String(),
+		mEncHelper)
+	require.NoError(t, err)
+
+	pt := []byte("secret message")
+	aad := []byte("aad message")
+
+	ct, err := cEnc.Encrypt(pt, aad)
+	require.NoError(t, err)
+
+	for _, privKey := range recipientsPrivKeys {
+		dEnc, err := NewECDHESAEADCompositeDecrypt(privKey, commonpb.EcPointFormat_UNCOMPRESSED.String(), mEncHelper)
+		require.NoError(t, err)
+
+		dpt, err := dEnc.Decrypt(ct, aad)
+		require.NoError(t, err)
+		require.EqualValues(t, pt, dpt)
+	}
+}
+
+func TestEncryptDecryptNegativeTCs(t *testing.T) {
+	recipientsPrivKeys, recipientsPubKeys := buildRecipientsKeys(t, 10)
+	aeadPrimitive := getAEADPrimitive(t, aead.AES256GCMKeyTemplate())
+
+	mEncHelper := &MockEncHelper{
+		KeySizeValue: 32,
+		AEADValue:    aeadPrimitive,
+		TagSizeValue: subtleaead.AESGCMTagSize,
+		IVSizeValue:  subtleaead.AESGCMIVSize,
+	}
+
+	pt := []byte("secret message")
+	aad := []byte("aad message")
+
+	// test with empty recipients public keys
+	cEnc, err := NewECDHESAEADCompositeEncrypt(nil, commonpb.EcPointFormat_UNCOMPRESSED.String(),
+		mEncHelper)
+	require.NoError(t, err)
+
+	// Encrypt should fail with empty recipients public keys
+	_, err = cEnc.Encrypt(pt, aad)
+	require.Error(t, err)
+
+	// test with large key size
+	mEncHelper.KeySizeValue = 100
+
+	cEnc, err = NewECDHESAEADCompositeEncrypt(recipientsPubKeys, commonpb.EcPointFormat_UNCOMPRESSED.String(),
+		mEncHelper)
+	require.NoError(t, err)
+
+	// Encrypt should fail with large AEAD key size value
+	_, err = cEnc.Encrypt(pt, aad)
+	require.Error(t, err)
+
+	mEncHelper.KeySizeValue = 32
+
+	// test with GetAEAD() returning error
+	mEncHelper.AEADErrValue = fmt.Errorf("error from GetAEAD")
+
+	cEnc, err = NewECDHESAEADCompositeEncrypt(recipientsPubKeys, commonpb.EcPointFormat_UNCOMPRESSED.String(),
+		mEncHelper)
+	require.NoError(t, err)
+
+	// Encrypt should fail with large AEAD key size value
+	_, err = cEnc.Encrypt(pt, aad)
+	require.EqualError(t, err, "error from GetAEAD")
+
+	mEncHelper.AEADErrValue = nil
+
+	// create a valid ciphertext to test Decrypt for all recipients
+	cEnc, err = NewECDHESAEADCompositeEncrypt(recipientsPubKeys, commonpb.EcPointFormat_UNCOMPRESSED.String(),
+		mEncHelper)
+	require.NoError(t, err)
+
+	// test with empty plaintext
+	ct, err := cEnc.Encrypt([]byte{}, aad)
+	require.NoError(t, err)
+
+	encData := new(EncryptedData)
+	err = json.Unmarshal(ct, encData)
+
+	require.NoError(t, err)
+	// encrypting empty plaintext should result in empty ciphertext
+	require.Empty(t, encData.Ciphertext)
+	require.Len(t, encData.Tag, subtleaead.AESGCMTagSize)
+	require.Len(t, encData.IV, subtleaead.AESGCMIVSize)
+
+	ct, err = cEnc.Encrypt(pt, aad)
+	require.NoError(t, err)
+
+	for _, privKey := range recipientsPrivKeys {
+		// test with nil recipient private key
+		dEnc, err := NewECDHESAEADCompositeDecrypt(nil, commonpb.EcPointFormat_UNCOMPRESSED.String(), mEncHelper)
+		require.NoError(t, err)
+
+		_, err = dEnc.Decrypt(ct, aad)
+		require.Error(t, err)
+
+		// test with large key size
+		mEncHelper.KeySizeValue = 100
+		dEnc, err = NewECDHESAEADCompositeDecrypt(privKey, commonpb.EcPointFormat_UNCOMPRESSED.String(), mEncHelper)
+		require.NoError(t, err)
+
+		_, err = dEnc.Decrypt(ct, aad)
+		require.Error(t, err)
+
+		mEncHelper.KeySizeValue = 32
+
+		// test with GetAEAD() returning error
+		mEncHelper.AEADErrValue = fmt.Errorf("error from GetAEAD")
+
+		dEnc, err = NewECDHESAEADCompositeDecrypt(privKey, commonpb.EcPointFormat_UNCOMPRESSED.String(), mEncHelper)
+		require.NoError(t, err)
+
+		_, err = dEnc.Decrypt(ct, aad)
+		require.Error(t, err)
+
+		mEncHelper.AEADErrValue = nil
+
+		// create a valid Decrypt message and test against ct
+		dEnc, err = NewECDHESAEADCompositeDecrypt(privKey, commonpb.EcPointFormat_UNCOMPRESSED.String(), mEncHelper)
+		require.NoError(t, err)
+
+		// try decrypting empty ct
+		_, err = dEnc.Decrypt([]byte{}, aad)
+		require.Error(t, err)
+
+		// finally try successful decrypt
+		dpt, err := dEnc.Decrypt(ct, aad)
+		require.NoError(t, err)
+		require.EqualValues(t, pt, dpt)
+	}
+}
+
+func buildRecipientsKeys(t *testing.T, nbOfRecipients int) ([]*hybrid.ECPrivateKey, []*hybrid.ECPublicKey) {
+	t.Helper()
+
+	var (
+		recipientsPrivKeys []*hybrid.ECPrivateKey
+		recipientsPubKeys  []*hybrid.ECPublicKey
+	)
+
+	curvProto := commonpb.EllipticCurveType_NIST_P256
+	curve, err := hybrid.GetCurve(curvProto.String())
+	require.NoError(t, err)
+
+	for i := 0; i < nbOfRecipients; i++ {
+		recipientPriv, err := hybrid.GenerateECDHKeyPair(curve)
+		require.NoError(t, err)
+
+		recipientsPrivKeys = append(recipientsPrivKeys, recipientPriv)
+		recipientsPubKeys = append(recipientsPubKeys, &recipientPriv.PublicKey)
+	}
+
+	return recipientsPrivKeys, recipientsPubKeys
+}
+
+func getAEADPrimitive(t *testing.T, kt *tinkpb.KeyTemplate) tink.AEAD {
+	t.Helper()
+
+	kh, err := keyset.NewHandle(kt)
+	require.NoError(t, err)
+
+	ps, err := kh.Primitives()
+	require.NoError(t, err)
+
+	p, ok := (ps.Primary.Primitive).(tink.AEAD)
+	require.True(t, ok)
+
+	return p
+}
+
+// MockEncHelper an mocked AEAD helper of Composite Encrypt/Decrypt primitives
+type MockEncHelper struct {
+	KeySizeValue int
+	AEADValue    tink.AEAD
+	AEADErrValue error
+	TagSizeValue int
+	IVSizeValue  int
+}
+
+// GetSymmetricKeySize gives the size of the Encryption key (CEK) in bytes
+func (me *MockEncHelper) GetSymmetricKeySize() int {
+	return me.KeySizeValue
+}
+
+// GetAEAD returns the newly created AEAD primitive used for the content Encryption
+func (me *MockEncHelper) GetAEAD(symmetricKeyValue []byte) (tink.AEAD, error) {
+	return me.AEADValue, me.AEADErrValue
+}
+
+// GetTagSize provides the aead primitive tag size
+func (me *MockEncHelper) GetTagSize() int {
+	return me.TagSizeValue
+}
+
+// GetIVSize provides the aead primitive nonce size
+func (me *MockEncHelper) GetIVSize() int {
+	return me.IVSizeValue
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_enc_helper.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_enc_helper.go
@@ -1,0 +1,26 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package subtle
+
+import (
+	"github.com/google/tink/go/tink"
+)
+
+// EncrypterHelper is a helper for Content Encryption of composite ECDH-ES key wrapping + AEAD content encryption
+type EncrypterHelper interface {
+	// GetSymmetricKeySize gives the size of the Encryption key (CEK) in bytes
+	GetSymmetricKeySize() int
+
+	// GetAEAD returns the newly created AEAD primitive used for the content Encryption
+	GetAEAD(symmetricKeyValue []byte) (tink.AEAD, error)
+
+	// GetTagSize provides the aead primitive tag size
+	GetTagSize() int
+
+	// GetIVSize provides the aead primitive nonce size
+	GetIVSize() int
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_concatkdf_kw_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_concatkdf_kw_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package subtle
+
+import (
+	"testing"
+
+	commonpb "github.com/google/tink/go/proto/common_go_proto"
+	"github.com/google/tink/go/subtle/hybrid"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrap(t *testing.T) {
+	keySize := 32
+	curve, err := hybrid.GetCurve(commonpb.EllipticCurveType_NIST_P256.String())
+	require.NoError(t, err)
+
+	recPvt, err := hybrid.GenerateECDHKeyPair(curve)
+	require.NoError(t, err)
+
+	recPubKey := &recPvt.PublicKey
+
+	senderKW := &ECDHESConcatKDFSenderKW{
+		recipientPublicKey: recPubKey,
+		cek:                random.GetRandomBytes(uint32(keySize)),
+	}
+
+	wrappedKey, err := senderKW.wrapKey(A256KWAlg, keySize)
+	require.NoError(t, err)
+	require.NotEmpty(t, wrappedKey)
+	require.EqualValues(t, A256KWAlg, wrappedKey.Alg)
+
+	recipientKW := &ECDHESConcatKDFRecipientKW{
+		recipientPrivateKey: recPvt,
+	}
+
+	cek, err := recipientKW.unwrapKey(wrappedKey, keySize)
+	require.NoError(t, err)
+	require.EqualValues(t, senderKW.cek, cek)
+
+	// error test cases
+	_, err = recipientKW.unwrapKey(nil, keySize)
+	require.Error(t, err)
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_concatkdf_recipient_kuw.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_concatkdf_recipient_kuw.go
@@ -1,0 +1,60 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package subtle
+
+import (
+	"crypto/aes"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+
+	"github.com/google/tink/go/subtle/hybrid"
+	josecipher "github.com/square/go-jose/v3/cipher"
+)
+
+// ECDHESConcatKDFRecipientKW represents concat KDF based ECDH-ES KW (key wrapping)
+// for ECDH-ES recipient's unwrapping of CEK
+type ECDHESConcatKDFRecipientKW struct {
+	recipientPrivateKey *hybrid.ECPrivateKey
+}
+
+// unwrapKey will do ECDH-ES key unwrapping
+func (s *ECDHESConcatKDFRecipientKW) unwrapKey(recWK *RecipientWrappedKey, keySize int) ([]byte, error) {
+	if recWK == nil {
+		return nil, fmt.Errorf("unwrapKey: RecipientWrappedKey is empty")
+	}
+
+	recPrivKey := &ecdsa.PrivateKey{
+		PublicKey: ecdsa.PublicKey{
+			Curve: s.recipientPrivateKey.PublicKey.Curve,
+			X:     s.recipientPrivateKey.PublicKey.Point.X,
+			Y:     s.recipientPrivateKey.PublicKey.Point.Y,
+		},
+		D: s.recipientPrivateKey.D,
+	}
+
+	epkCurve, err := hybrid.GetCurve(recWK.EPK.Curve)
+	if err != nil {
+		return nil, err
+	}
+
+	epkPubKey := &ecdsa.PublicKey{
+		Curve: epkCurve,
+		X:     new(big.Int).SetBytes(recWK.EPK.X),
+		Y:     new(big.Int).SetBytes(recWK.EPK.Y),
+	}
+
+	// DeriveECDHES checks if keys are on the same curve
+	kek := josecipher.DeriveECDHES(recWK.Alg, []byte{}, []byte{}, recPrivKey, epkPubKey, keySize)
+
+	block, err := aes.NewCipher(kek)
+	if err != nil {
+		return nil, err
+	}
+
+	return josecipher.KeyUnwrap(block, recWK.EncryptedCEK)
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_concatkdf_sender_kw.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_concatkdf_sender_kw.go
@@ -1,0 +1,62 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package subtle
+
+import (
+	"crypto/aes"
+	"crypto/ecdsa"
+	"crypto/rand"
+
+	"github.com/google/tink/go/subtle/hybrid"
+	josecipher "github.com/square/go-jose/v3/cipher"
+)
+
+// A256KWAlg is the ECDH-ES key wrapping algorithm
+const A256KWAlg = "ECDH-ES+A256KW"
+
+// ECDHESConcatKDFSenderKW represents concat KDF based ECDH-ES KW (key wrapping)
+// for ECDH-ES sender
+type ECDHESConcatKDFSenderKW struct {
+	recipientPublicKey *hybrid.ECPublicKey
+	cek                []byte
+}
+
+// wrapKey will do ECDH-ES key wrapping
+func (s *ECDHESConcatKDFSenderKW) wrapKey(kwAlg string, keySize int) (*RecipientWrappedKey, error) {
+	recPubKey := &ecdsa.PublicKey{
+		Curve: s.recipientPublicKey.Curve,
+		X:     s.recipientPublicKey.Point.X,
+		Y:     s.recipientPublicKey.Point.Y,
+	}
+
+	ephemeralPriv, err := ecdsa.GenerateKey(recPubKey.Curve, rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	kek := josecipher.DeriveECDHES(kwAlg, []byte{}, []byte{}, ephemeralPriv, recPubKey, keySize)
+
+	block, err := aes.NewCipher(kek)
+	if err != nil {
+		return nil, err
+	}
+
+	wk, err := josecipher.KeyWrap(block, s.cek)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RecipientWrappedKey{
+		EncryptedCEK: wk,
+		EPK: ECPublicKey{
+			X:     ephemeralPriv.PublicKey.X.Bytes(),
+			Y:     ephemeralPriv.PublicKey.Y.Bytes(),
+			Curve: ephemeralPriv.PublicKey.Curve.Params().Name,
+		},
+		Alg: kwAlg,
+	}, nil
+}


### PR DESCRIPTION
This is a second part of the ECDH-ES KW + AEAD crypto change.
It includes the core crypto logic for key wrapping and AEAD encryption
In a subtle package. This package is not meant to be used outside of ecdhes
package. Its use will be relavant in the next change.

Key wrapping is considered complete as part of this change.

part of ##1469
closes  #1472
closes  #1470

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
