### PR TITLE
feat: add encHelper implementation for ECDH-ES crypto logic

### DIFF
--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/register_ecdhes_aead_enc_helper.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/register_ecdhes_aead_enc_helper.go
@@ -1,0 +1,204 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/core/registry"
+	gcmpb "github.com/google/tink/go/proto/aes_gcm_go_proto"
+	chachapb "github.com/google/tink/go/proto/chacha20_poly1305_go_proto"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+	xchachapb "github.com/google/tink/go/proto/xchacha20_poly1305_go_proto"
+	"github.com/google/tink/go/subtle/aead"
+	"github.com/google/tink/go/tink"
+	"golang.org/x/crypto/chacha20poly1305"
+	"golang.org/x/crypto/poly1305"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle"
+)
+
+const (
+	aesGCMTypeURL            = "type.googleapis.com/google.crypto.tink.AesGcmKey"
+	chaCha20Poly1305TypeURL  = "type.googleapis.com/google.crypto.tink.ChaCha20Poly1305Key"
+	xChaCha20Poly1305TypeURL = "type.googleapis.com/google.crypto.tink.XChaCha20Poly1305Key"
+)
+
+// registerECDHESAEADEncHelper registers a content encryption helper
+type registerECDHESAEADEncHelper struct {
+	encKeyURL        string
+	keyData          []byte
+	symmetricKeySize int
+	tagSize          int
+	ivSize           int
+}
+
+var _ subtle.EncrypterHelper = (*registerECDHESAEADEncHelper)(nil)
+
+// newRegisterECDHESAEADEncHelper initializes and returns a registerECDHESAEADEncHelper
+func newRegisterECDHESAEADEncHelper(k *tinkpb.KeyTemplate) (*registerECDHESAEADEncHelper, error) {
+	var (
+		keySize, tagSize, ivSize int
+		skf                      []byte
+		err                      error
+	)
+
+	switch k.TypeUrl {
+	case aesGCMTypeURL:
+		gcmKeyFormat := new(gcmpb.AesGcmKeyFormat)
+
+		err = proto.Unmarshal(k.Value, gcmKeyFormat)
+		if err != nil {
+			return nil, fmt.Errorf("registerECDHESAEADEncHelper: failed to unmarshal gcmKeyFormat: %w", err)
+		}
+
+		keySize = int(gcmKeyFormat.KeySize)
+		tagSize = aead.AESGCMTagSize
+		ivSize = aead.AESGCMIVSize
+
+		skf, err = proto.Marshal(gcmKeyFormat)
+		if err != nil {
+			return nil, fmt.Errorf("registerECDHESAEADEncHelper: failed to serialize key format, error: %w", err)
+		}
+	case chaCha20Poly1305TypeURL:
+		keySize = chacha20poly1305.KeySize
+		tagSize = poly1305.TagSize
+		ivSize = chacha20poly1305.NonceSize
+	case xChaCha20Poly1305TypeURL:
+		keySize = chacha20poly1305.KeySize
+		tagSize = poly1305.TagSize
+		ivSize = chacha20poly1305.NonceSizeX
+	default:
+		return nil, fmt.Errorf("registerECDHESAEADEncHelper: unsupported AEAD content encryption key type: %s",
+			k.TypeUrl)
+	}
+
+	km, err := registry.GetKeyManager(k.TypeUrl)
+	if err != nil {
+		return nil, fmt.Errorf("registerECDHESAEADEncHelper: failed to fetch KeyManager, error: %w", err)
+	}
+
+	// skf is nil for (X)Chahcha20Poly1305 km
+	key, err := km.NewKey(skf)
+	if err != nil {
+		return nil, fmt.Errorf("registerECDHESAEADEncHelper: failed to fetch key, error: %w", err)
+	}
+
+	sk, err := proto.Marshal(key)
+	if err != nil {
+		return nil, fmt.Errorf("registerECDHESAEADEncHelper: failed to serialize key, error: %w", err)
+	}
+
+	return &registerECDHESAEADEncHelper{
+		encKeyURL:        k.TypeUrl,
+		keyData:          sk,
+		symmetricKeySize: keySize,
+		tagSize:          tagSize,
+		ivSize:           ivSize,
+	}, nil
+}
+
+// GetSymmetricKeySize returns the symmetric key size
+func (r *registerECDHESAEADEncHelper) GetSymmetricKeySize() int {
+	return r.symmetricKeySize
+}
+
+// GetTagSize returns the primitive tag size
+func (r *registerECDHESAEADEncHelper) GetTagSize() int {
+	return r.tagSize
+}
+
+// GetIVSize returns the primitive IV size
+func (r *registerECDHESAEADEncHelper) GetIVSize() int {
+	return r.ivSize
+}
+
+// GetAEAD returns the AEAD primitive from the DEM
+func (r *registerECDHESAEADEncHelper) GetAEAD(symmetricKeyValue []byte) (tink.AEAD, error) {
+	if len(symmetricKeyValue) != r.GetSymmetricKeySize() {
+		return nil, fmt.Errorf("symmetric key has incorrect length")
+	}
+
+	sk, err := r.getSerializedKey(symmetricKeyValue)
+	if err != nil {
+		return nil, err
+	}
+
+	p, err := registry.Primitive(r.encKeyURL, sk)
+	if err != nil {
+		return nil, err
+	}
+
+	g, ok := p.(tink.AEAD)
+	if !ok {
+		return nil, fmt.Errorf("invalid primitive")
+	}
+
+	return g, nil
+}
+
+func (r *registerECDHESAEADEncHelper) getSerializedKey(symmetricKeyValue []byte) ([]byte, error) {
+	var (
+		sk  []byte
+		err error
+	)
+
+	switch r.encKeyURL {
+	case aesGCMTypeURL:
+		sk, err = r.getSerializedAESGCMKey(symmetricKeyValue)
+		if err != nil {
+			return nil, fmt.Errorf("registerECDHESAEADEncHelper: failed to serialize key, error: %w", err)
+		}
+	case chaCha20Poly1305TypeURL:
+		chachaKey := new(chachapb.ChaCha20Poly1305Key)
+
+		err = proto.Unmarshal(r.keyData, chachaKey)
+		if err != nil {
+			return nil, fmt.Errorf("registerECDHESAEADEncHelper: failed to unmarshal chacha key: %w", err)
+		}
+
+		chachaKey.KeyValue = symmetricKeyValue
+
+		sk, err = proto.Marshal(chachaKey)
+		if err != nil {
+			return nil, fmt.Errorf("registerECDHESAEADEncHelper: failed to serialize key, error: %w", err)
+		}
+	case xChaCha20Poly1305TypeURL:
+		xChachaKey := new(xchachapb.XChaCha20Poly1305Key)
+
+		err = proto.Unmarshal(r.keyData, xChachaKey)
+		if err != nil {
+			return nil, fmt.Errorf("registerECDHESAEADEncHelper: failed to unmarshal xchacha key: %w", err)
+		}
+
+		xChachaKey.KeyValue = symmetricKeyValue
+
+		sk, err = proto.Marshal(xChachaKey)
+		if err != nil {
+			return nil, fmt.Errorf("registerECDHESAEADEncHelper: failed to serialize key, error: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("registerECDHESAEADEncHelper: unsupported AEAD content encryption key type: %s",
+			r.encKeyURL)
+	}
+
+	return sk, err
+}
+
+func (r *registerECDHESAEADEncHelper) getSerializedAESGCMKey(symmetricKeyValue []byte) ([]byte, error) {
+	gcmKey := new(gcmpb.AesGcmKey)
+
+	err := proto.Unmarshal(r.keyData, gcmKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal gcmKeyFormat: %w", err)
+	}
+
+	gcmKey.KeyValue = symmetricKeyValue
+
+	return proto.Marshal(gcmKey)
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/register_ecdhes_aead_enc_helper_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/register_ecdhes_aead_enc_helper_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/google/tink/go/aead"
+	"github.com/google/tink/go/mac"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+	"github.com/google/tink/go/signature"
+	subtleaead "github.com/google/tink/go/subtle/aead"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/chacha20poly1305"
+	"golang.org/x/crypto/poly1305"
+)
+
+var (
+	// nolint:gochecknoglobals
+	keyTemplates = map[*tinkpb.KeyTemplate]int{
+		aead.ChaCha20Poly1305KeyTemplate():  32,
+		aead.XChaCha20Poly1305KeyTemplate(): 32,
+		aead.AES256GCMKeyTemplate():         32,
+		aead.AES128GCMKeyTemplate():         16,
+	}
+)
+
+func TestCipherGetters(t *testing.T) {
+	for c, l := range keyTemplates {
+		rDem, err := newRegisterECDHESAEADEncHelper(c)
+		require.NoError(t, err, "error generating a content encryption helper")
+
+		require.EqualValues(t, l, rDem.GetSymmetricKeySize(), "incorrect template key size")
+
+		switch rDem.encKeyURL {
+		case aesGCMTypeURL:
+			require.EqualValues(t, subtleaead.AESGCMIVSize, rDem.GetIVSize())
+			require.EqualValues(t, subtleaead.AESGCMTagSize, rDem.GetTagSize())
+		case chaCha20Poly1305TypeURL:
+			require.EqualValues(t, chacha20poly1305.NonceSize, rDem.GetIVSize())
+			require.EqualValues(t, poly1305.TagSize, rDem.GetTagSize())
+		case xChaCha20Poly1305TypeURL:
+			require.EqualValues(t, chacha20poly1305.NonceSizeX, rDem.GetIVSize())
+			require.EqualValues(t, poly1305.TagSize, rDem.GetTagSize())
+		}
+	}
+}
+
+func TestUnsupportedKeyTemplates(t *testing.T) {
+	var uTemplates = []*tinkpb.KeyTemplate{
+		signature.ECDSAP256KeyTemplate(),
+		mac.HMACSHA256Tag256KeyTemplate(),
+		{TypeUrl: "some url", Value: []byte{0}},
+		{TypeUrl: aesGCMTypeURL},
+		{TypeUrl: aesGCMTypeURL, Value: []byte("123")},
+	}
+
+	for _, l := range uTemplates {
+		_, err := newRegisterECDHESAEADEncHelper(l)
+		require.Errorf(t, err, "unsupported key template %s should have generated error: %v", l)
+	}
+}
+
+func TestAead(t *testing.T) {
+	for c := range keyTemplates {
+		pt := random.GetRandomBytes(20)
+		ad := random.GetRandomBytes(20)
+		rEnc, err := newRegisterECDHESAEADEncHelper(c)
+		require.NoError(t, err, "error generating a content encryption helper")
+
+		keySize := uint32(rEnc.GetSymmetricKeySize())
+		sk := random.GetRandomBytes(keySize)
+		a, err := rEnc.GetAEAD(sk)
+		require.NoError(t, err, "error getting AEAD primitive")
+
+		ct, err := a.Encrypt(pt, ad)
+		require.NoError(t, err, "error encrypting")
+
+		dt, err := a.Decrypt(ct, ad)
+		require.NoError(t, err, "error decrypting")
+
+		require.EqualValuesf(t, pt, dt, "decryption not inverse of encryption,\n want :%s,\n got: %s",
+			hex.Dump(pt), hex.Dump(dt))
+
+		// shorter symmetric key
+		sk = random.GetRandomBytes(keySize - 1)
+		_, err = rEnc.GetAEAD(sk)
+		require.Error(t, err, "retrieving AEAD primitive should have failed")
+
+		// longer symmetric key
+		sk = random.GetRandomBytes(keySize + 1)
+		_, err = rEnc.GetAEAD(sk)
+		require.Error(t, err, "retrieving AEAD primitive should have failed")
+
+		// set bad keyData
+		tmpKeyData := rEnc.keyData
+		rEnc.keyData = []byte{0, 1, 3}
+		sk = random.GetRandomBytes(keySize)
+		_, err = rEnc.GetAEAD(sk)
+		require.Error(t, err, "retrieving AEAD primitive should have failed")
+
+		// set bad key URL
+		rEnc.keyData = tmpKeyData
+		rEnc.encKeyURL = "bad.url"
+		_, err = rEnc.GetAEAD(sk)
+		require.Error(t, err, "retrieving AEAD primitive should have failed")
+	}
+}


### PR DESCRIPTION
Part 3 of ECDH-ES + AEAD logic. This change includes default
encHelper implementation needed to support the new primitives.

part of #1469

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
