### PR TITLE
feat: Add ECDH-ES+AEAD Tink factory, key managers and templates

### DIFF
--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes.go
@@ -1,0 +1,107 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package ecdhes provides implementations of payload encryption using ECDH-ES KW key wrapping with AEAD primitives.
+//
+// The functionality of ecdhes Encryption is represented as a pair of
+// primitives (interfaces):
+//
+//  * ECDHESEncrypt for encryption of data and aad for a given list of recipients keys
+//
+//  * ECDHESDecrypt for decryption of data for a certain recipient key and returning decrypted plaintext
+//
+//
+// Example:
+//
+//  package main
+//
+//  import (
+//      "bytes"
+//
+//      "github.com/google/tink/go/keyset"
+//
+//	    ecdhessubtle "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle"
+//      "github.com/aries-framework-go/pkg/crypto/tinkcrypto/composite/ecdhes"
+//  )
+//
+//  func main() {
+//      // create recipient side keyset handle
+//      recKH, err := keyset.NewHandle(ecdhes.ECDHES256KWAES256GCMKeyTemplate())
+//      if err != nil {
+//          //handle error
+//      }
+//
+//      // extract recipient public keyset handle and key
+//      recPubKH, err := recKH.Public()
+//      if err != nil {
+//          //handle error
+//      }
+//
+//      buf := new(bytes.Buffer)
+//      pubKeyWriter := ecdhes.NewWriter(buf)
+//      err = recPubKH.WriteWithNoSecrets(pubKeyWriter)
+//      if err != nil {
+//          //handle error
+//      }
+//
+//      ecPubKey := new(ecdhessubtle.ECPublicKey)
+//      err := json.Unmarshal(buf.Bytes(), ecPubKey)
+//
+//      // now create sender keyset handle with recipient public key (ecPubKey)
+//      sKH, err := keyset.NewHandle(ECDHES256KWAES256GCMKeyTemplateWithRecipients(
+//     		[]ecdhessubtle.ECPublicKey{*ecPubKey}))
+//      if err != nil {
+//          // handle error
+//      }
+//
+//      // for more recipient keys pass in a list: []ecdhessubtle.ECPublicKey{*ecPubKey1, *ecPubKey2, *ecPubKey3, etc.})
+//      // at least 1 recipient is required.
+//
+//      // extract sender public keyset handle to encrypt
+//      senderPubKH, err := sKH.Public()
+//      if err != nil {
+//          //handle error
+//      }
+//
+//      e := ecdhes.NewECDHESEncrypt(senderPubKH)
+//
+//      ct, err = e.Encrypt([]byte("secret message"), []byte("some aad"))
+//      if err != nil {
+//          // handle error
+//      }
+//
+//      // get a handle on the decryption key material for a recipient
+//      // this is usually reloading the recipient's keyset handle (ie: `recKH` above) from a kms
+//      refRecKH , err := keyset.NewHandle( .....reference/rebuild `recKH` here...);
+//      d := ecdhes.NewECDHESDecrypt(refRecKH)
+//
+//      pt, err := d.Decrypt(ct)
+//      if err != nil {
+//          // handle error
+//      }
+//  }
+package ecdhes
+
+import (
+	"fmt"
+
+	"github.com/google/tink/go/core/registry"
+)
+
+// TODO - find a better way to setup tink than init.
+// nolint: gochecknoinits
+func init() {
+	// TODO - avoid the tink registry singleton.
+	err := registry.RegisterKeyManager(newECDHESPrivateKeyManager())
+	if err != nil {
+		panic(fmt.Sprintf("ecdhes.init() failed: %v", err))
+	}
+
+	err = registry.RegisterKeyManager(newECDHESPublicKeyManager())
+	if err != nil {
+		panic(fmt.Sprintf("ecdhes.init() failed: %v", err))
+	}
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_aead_private_key_manager.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_aead_private_key_manager.go
@@ -1,0 +1,188 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"crypto/elliptic"
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/core/registry"
+	"github.com/google/tink/go/keyset"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+	"github.com/google/tink/go/subtle/hybrid"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle"
+	ecdhespb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdhes_aead_go_proto"
+)
+
+const (
+	ecdhesPrivateKeyVersion = 0
+	ecdhesPrivateKeyTypeURL = "type.hyperledger.org/hyperledger.aries.crypto.tink.EcdhesAeadPrivateKey"
+)
+
+// common errors
+var errInvalidECDHESPrivateKey = fmt.Errorf("ecdhes_private_key_manager: invalid key")
+var errInvalidECDHESPrivateKeyFormat = fmt.Errorf("ecdhes_private_key_manager: invalid key format")
+
+// ecdhesPrivateKeyManager is an implementation of PrivateKeyManager interface.
+// It generates new ECDHESPrivateKey keys and produces new instances of ECDHESAEADCompositeDecrypt subtle.
+type ecdhesPrivateKeyManager struct{}
+
+// Assert that ecdhesPrivateKeyManager implements the PrivateKeyManager interface.
+var _ registry.PrivateKeyManager = (*ecdhesPrivateKeyManager)(nil)
+
+// newECDHESPrivateKeyManager creates a new ecdhesPrivateKeyManager.
+func newECDHESPrivateKeyManager() *ecdhesPrivateKeyManager {
+	return new(ecdhesPrivateKeyManager)
+}
+
+// Primitive creates an ECDHESPrivateKey subtle for the given serialized ECDHESPrivateKey proto.
+func (km *ecdhesPrivateKeyManager) Primitive(serializedKey []byte) (interface{}, error) {
+	if len(serializedKey) == 0 {
+		return nil, errInvalidECDHESPrivateKey
+	}
+
+	key := new(ecdhespb.EcdhesAeadPrivateKey)
+
+	err := proto.Unmarshal(serializedKey, key)
+	if err != nil {
+		return nil, errInvalidECDHESPrivateKey
+	}
+
+	curve, err := km.validateKey(key)
+	if err != nil {
+		return nil, errInvalidECDHESPrivateKey
+	}
+
+	pvt := hybrid.GetECPrivateKey(curve, key.KeyValue)
+
+	rEnc, err := newRegisterECDHESAEADEncHelper(key.PublicKey.Params.EncParams.AeadEnc)
+	if err != nil {
+		return nil, err
+	}
+
+	ptFormat := key.PublicKey.Params.EcPointFormat.String()
+
+	return subtle.NewECDHESAEADCompositeDecrypt(pvt, ptFormat, rEnc)
+}
+
+// NewKey creates a new key according to the specification of ECDHESPrivateKey format.
+func (km *ecdhesPrivateKeyManager) NewKey(serializedKeyFormat []byte) (proto.Message, error) {
+	if len(serializedKeyFormat) == 0 {
+		return nil, errInvalidECDHESPrivateKeyFormat
+	}
+
+	keyFormat := new(ecdhespb.EcdhesAeadKeyFormat)
+
+	err := proto.Unmarshal(serializedKeyFormat, keyFormat)
+	if err != nil {
+		return nil, errInvalidECDHESPrivateKeyFormat
+	}
+
+	curve, err := validateKeyFormat(keyFormat.Params)
+	if err != nil {
+		return nil, errInvalidECDHESPrivateKeyFormat
+	}
+
+	pvt, err := hybrid.GenerateECDHKeyPair(curve)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ecdhespb.EcdhesAeadPrivateKey{
+		Version:  ecdhesPrivateKeyVersion,
+		KeyValue: pvt.D.Bytes(),
+		PublicKey: &ecdhespb.EcdhesAeadPublicKey{
+			Version: ecdhesPrivateKeyVersion,
+			Params:  keyFormat.Params,
+			X:       pvt.PublicKey.Point.X.Bytes(),
+			Y:       pvt.PublicKey.Point.Y.Bytes(),
+		},
+	}, nil
+}
+
+// NewKeyData creates a new KeyData according to the specification of ECDHESPrivateKey Format.
+// It should be used solely by the key management API.
+func (km *ecdhesPrivateKeyManager) NewKeyData(serializedKeyFormat []byte) (*tinkpb.KeyData, error) {
+	key, err := km.NewKey(serializedKeyFormat)
+	if err != nil {
+		return nil, err
+	}
+
+	serializedKey, err := proto.Marshal(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tinkpb.KeyData{
+		TypeUrl:         ecdhesPrivateKeyTypeURL,
+		Value:           serializedKey,
+		KeyMaterialType: tinkpb.KeyData_ASYMMETRIC_PRIVATE,
+	}, nil
+}
+
+// PublicKeyData returns the enclosed public key data of serializedPrivKey
+func (km *ecdhesPrivateKeyManager) PublicKeyData(serializedPrivKey []byte) (*tinkpb.KeyData, error) {
+	privKey := new(ecdhespb.EcdhesAeadPrivateKey)
+
+	err := proto.Unmarshal(serializedPrivKey, privKey)
+	if err != nil {
+		return nil, errInvalidECDHESPrivateKey
+	}
+
+	serializedPubKey, err := proto.Marshal(privKey.PublicKey)
+	if err != nil {
+		return nil, errInvalidECDHESPrivateKey
+	}
+
+	return &tinkpb.KeyData{
+		TypeUrl:         ecdhesPublicKeyTypeURL,
+		Value:           serializedPubKey,
+		KeyMaterialType: tinkpb.KeyData_ASYMMETRIC_PUBLIC,
+	}, nil
+}
+
+// DoesSupport indicates if this key manager supports the given key type.
+func (km *ecdhesPrivateKeyManager) DoesSupport(typeURL string) bool {
+	return typeURL == ecdhesPrivateKeyTypeURL
+}
+
+// TypeURL returns the key type of keys managed by this key manager.
+func (km *ecdhesPrivateKeyManager) TypeURL() string {
+	return ecdhesPrivateKeyTypeURL
+}
+
+// validateKey validates the given ECDHESPrivateKey and erturns the KW curve.
+func (km *ecdhesPrivateKeyManager) validateKey(key *ecdhespb.EcdhesAeadPrivateKey) (elliptic.Curve, error) {
+	err := keyset.ValidateKeyVersion(key.Version, ecdhesPrivateKeyVersion)
+	if err != nil {
+		return nil, fmt.Errorf("ecdhes_private_key_manager: invalid key: %s", err)
+	}
+
+	return validateKeyFormat(key.PublicKey.Params)
+}
+
+// validateKeyFormat validates the given ECDHESKeyFormat and returns the KW Curve.
+func validateKeyFormat(params *ecdhespb.EcdhesAeadParams) (elliptic.Curve, error) {
+	c, err := hybrid.GetCurve(params.KwParams.CurveType.String())
+	if err != nil {
+		return nil, err
+	}
+
+	km, err := registry.GetKeyManager(params.EncParams.AeadEnc.TypeUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = km.NewKeyData(params.EncParams.AeadEnc.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_aead_private_key_manager_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_aead_private_key_manager_test.go
@@ -1,0 +1,314 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"bytes"
+	"crypto/elliptic"
+	"crypto/rand"
+	"strings"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/aead"
+	gcmpb "github.com/google/tink/go/proto/aes_gcm_go_proto"
+	commonpb "github.com/google/tink/go/proto/common_go_proto"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+	"github.com/google/tink/go/subtle/hybrid"
+	"github.com/stretchr/testify/require"
+
+	ecdhespb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdhes_aead_go_proto"
+)
+
+func TestECDHESPrivateKeyManager_Primitive(t *testing.T) {
+	km := newECDHESPrivateKeyManager()
+
+	t.Run("Test private key manager Primitive() with empty serialized key", func(t *testing.T) {
+		p, err := km.Primitive([]byte(""))
+		require.EqualError(t, err, errInvalidECDHESPrivateKey.Error(),
+			"ECDHESPrivate primitive from empty serialized key must fail")
+		require.Empty(t, p)
+	})
+
+	t.Run("Test private key manager Primitive() with bad serialize key", func(t *testing.T) {
+		p, err := km.Primitive([]byte("bad.data"))
+		require.EqualError(t, err, errInvalidECDHESPrivateKey.Error(),
+			"ECDHESPrivate primitive from bad serialized key must fail")
+		require.Empty(t, p)
+	})
+
+	format := &gcmpb.AesGcmKeyFormat{
+		KeySize: 32,
+	}
+	serializedFormat, err := proto.Marshal(format)
+	require.NoError(t, err)
+
+	format = &gcmpb.AesGcmKeyFormat{
+		KeySize: 99, // bad AES128GCM size
+	}
+
+	badSerializedFormat, err := proto.Marshal(format)
+	require.NoError(t, err)
+
+	var flagTests = []struct {
+		tcName    string
+		version   uint32
+		curveType commonpb.EllipticCurveType
+		ecPtFmt   commonpb.EcPointFormat
+		encTmp    *tinkpb.KeyTemplate
+	}{
+		{
+			tcName:    "private key manager Primitive() using key with bad version",
+			version:   9999,
+			curveType: commonpb.EllipticCurveType_NIST_P256,
+			ecPtFmt:   commonpb.EcPointFormat_COMPRESSED,
+			encTmp:    aead.AES128GCMKeyTemplate(),
+		},
+		{
+			tcName:    "private key manager Primitive() using key with bad curve",
+			version:   0,
+			curveType: commonpb.EllipticCurveType_UNKNOWN_CURVE,
+			ecPtFmt:   commonpb.EcPointFormat_COMPRESSED,
+			encTmp:    aead.AES128GCMKeyTemplate(),
+		},
+		{
+			tcName:    "success private key manager Primitive()",
+			version:   0,
+			curveType: commonpb.EllipticCurveType_NIST_P256,
+			ecPtFmt:   commonpb.EcPointFormat_UNCOMPRESSED,
+			encTmp:    aead.AES128GCMKeyTemplate(),
+		},
+		{
+			tcName:    "private key manager Primitive() using key with bad key template URL",
+			version:   0,
+			curveType: commonpb.EllipticCurveType_NIST_P256,
+			ecPtFmt:   commonpb.EcPointFormat_COMPRESSED,
+			encTmp: &tinkpb.KeyTemplate{
+				TypeUrl:          "bad.type/url/value",
+				Value:            serializedFormat,
+				OutputPrefixType: tinkpb.OutputPrefixType_RAW,
+			},
+		},
+		{
+			tcName:    "private key manager Primitive() using key with bad dem key size",
+			version:   0,
+			curveType: commonpb.EllipticCurveType_NIST_P256,
+			ecPtFmt:   commonpb.EcPointFormat_COMPRESSED,
+			encTmp: &tinkpb.KeyTemplate{
+				TypeUrl:          aesGCMTypeURL,
+				Value:            badSerializedFormat,
+				OutputPrefixType: tinkpb.OutputPrefixType_RAW,
+			},
+		},
+	}
+
+	for _, tc := range flagTests {
+		tt := tc
+		t.Run("Test "+tt.tcName, func(t *testing.T) {
+			c := tt.curveType
+			encT := tt.encTmp
+			ptFmt := tt.ecPtFmt
+			v := tt.version
+
+			// temporarily reset curvType if its unknown type so subtle.GetCurve() below doesn't fail
+			if tt.curveType.String() == commonpb.EllipticCurveType_UNKNOWN_CURVE.String() {
+				c = commonpb.EllipticCurveType_NIST_P256
+			}
+
+			crv, err := hybrid.GetCurve(c.String())
+			require.NoError(t, err)
+			d, x, y, err := elliptic.GenerateKey(crv, rand.Reader)
+			require.NoError(t, err)
+
+			// set back curvType if it was unknown to proceed with the test
+			if tt.curveType.String() == commonpb.EllipticCurveType_UNKNOWN_CURVE.String() {
+				c = tt.curveType
+			}
+
+			pubKeyProto := &ecdhespb.EcdhesAeadPrivateKey{
+				Version: v,
+				PublicKey: &ecdhespb.EcdhesAeadPublicKey{
+					Version: v, // if v > 0  to force an error when calling km.Primitive()
+					Params: &ecdhespb.EcdhesAeadParams{
+						KwParams: &ecdhespb.EcdhesKwParams{
+							CurveType: c, // unknown curve type to force an error when calling km.Primitive()
+						},
+						EncParams: &ecdhespb.EcdhesAeadEncParams{
+							AeadEnc: encT, // invalid data enc key template to get an error when calling km.Primitive()
+						},
+						EcPointFormat: ptFmt,
+					},
+					X: x.Bytes(),
+					Y: y.Bytes(),
+				},
+				KeyValue: d,
+			}
+
+			sPubKey, err := proto.Marshal(pubKeyProto)
+			require.NoError(t, err)
+
+			p, err := km.Primitive(sPubKey)
+			if bytes.Equal(tt.encTmp.Value, badSerializedFormat) {
+				require.EqualError(t, err, errInvalidECDHESPrivateKey.Error(),
+					"ECDHESPrivate primitive from serialized key with invalid serialized key")
+				require.Empty(t, p)
+
+				return
+			}
+
+			if strings.Contains(tt.tcName, "success") {
+				require.NoError(t, err)
+				require.NotEmpty(t, p)
+				return
+			}
+
+			require.Errorf(t, err, tt.tcName)
+			require.Empty(t, p)
+		})
+	}
+}
+
+func TestEcdhesPrivateKeyManager_DoesSupport(t *testing.T) {
+	km := newECDHESPrivateKeyManager()
+	require.False(t, km.DoesSupport("bad/url"))
+	require.True(t, km.DoesSupport(ecdhesPrivateKeyTypeURL))
+}
+
+func TestEcdhesPrivateKeyManager_NewKey(t *testing.T) {
+	km := newECDHESPrivateKeyManager()
+
+	t.Run("Test private key manager NewKey() with nil key", func(t *testing.T) {
+		k, err := km.NewKey(nil)
+		require.EqualError(t, err, errInvalidECDHESPrivateKeyFormat.Error())
+		require.Empty(t, k)
+	})
+
+	t.Run("Test private key manager NewKey() with bad serialize key", func(t *testing.T) {
+		p, err := km.NewKey([]byte("bad.data"))
+		require.EqualError(t, err, errInvalidECDHESPrivateKeyFormat.Error(),
+			"ECDHESPrivate NewKey() from bad serialized key must fail")
+		require.Empty(t, p)
+	})
+
+	format := &gcmpb.AesGcmKeyFormat{
+		KeySize: 32,
+	}
+
+	serializedFormat, err := proto.Marshal(format)
+	require.NoError(t, err)
+
+	format = &gcmpb.AesGcmKeyFormat{
+		KeySize: 99, // bad AES128GCM size
+	}
+
+	badSerializedFormat, err := proto.Marshal(format)
+	require.NoError(t, err)
+
+	var flagTests = []struct {
+		tcName    string
+		curveType commonpb.EllipticCurveType
+		ecPtFmt   commonpb.EcPointFormat
+		encTmp    *tinkpb.KeyTemplate
+	}{
+		{
+			tcName:    "success private key manager NewKey() and NewKeyData()",
+			curveType: commonpb.EllipticCurveType_NIST_P256,
+			ecPtFmt:   commonpb.EcPointFormat_COMPRESSED,
+			encTmp:    aead.AES128GCMKeyTemplate(),
+		},
+		{
+			tcName:    "private key manager NewKey() and NewKeyData() using key with bad curve",
+			curveType: commonpb.EllipticCurveType_UNKNOWN_CURVE,
+			ecPtFmt:   commonpb.EcPointFormat_COMPRESSED,
+			encTmp:    aead.AES128GCMKeyTemplate(),
+		},
+		{
+			tcName:    "private key manager NewKey() and NewKeyData() using key with bad key template URL",
+			curveType: commonpb.EllipticCurveType_NIST_P256,
+			ecPtFmt:   commonpb.EcPointFormat_COMPRESSED,
+			encTmp: &tinkpb.KeyTemplate{
+				TypeUrl:          "bad.type/url/value",
+				Value:            serializedFormat,
+				OutputPrefixType: tinkpb.OutputPrefixType_RAW,
+			},
+		},
+		{
+			tcName:    "private key manager NewKey() and NewKeyData() using key with bad dem key size",
+			curveType: commonpb.EllipticCurveType_NIST_P256,
+			ecPtFmt:   commonpb.EcPointFormat_COMPRESSED,
+			encTmp: &tinkpb.KeyTemplate{
+				TypeUrl:          aesGCMTypeURL,
+				Value:            badSerializedFormat,
+				OutputPrefixType: tinkpb.OutputPrefixType_RAW,
+			},
+		},
+	}
+
+	for _, tc := range flagTests {
+		tt := tc
+		t.Run("Test "+tt.tcName, func(t *testing.T) {
+			c := tt.curveType
+			encT := tt.encTmp
+			ptFmt := tt.ecPtFmt
+
+			privKeyProto := &ecdhespb.EcdhesAeadKeyFormat{
+				Params: &ecdhespb.EcdhesAeadParams{
+					KwParams: &ecdhespb.EcdhesKwParams{
+						CurveType: c, // unknown curve type to force an error when calling km.Primitive()
+					},
+					EncParams: &ecdhespb.EcdhesAeadEncParams{
+						AeadEnc: encT, // invalid data enc key template to force an error when calling km.Primitive()
+					},
+					EcPointFormat: ptFmt, // unknown EC Point format type to force an error when calling km.Primitive()
+				},
+			}
+
+			sPrivKey, err := proto.Marshal(privKeyProto)
+			require.NoError(t, err)
+
+			p, err := km.NewKey(sPrivKey)
+			if strings.Contains(tt.tcName, "success") {
+				require.NoError(t, err)
+				require.NotEmpty(t, p)
+
+				sp, e := proto.Marshal(p)
+				require.NoError(t, e)
+				require.NotEmpty(t, sp)
+
+				// try PublicKeyData() with bad serialized private key
+				pubK, e := km.PublicKeyData([]byte("bad serialized private key"))
+				require.Error(t, e)
+				require.Empty(t, pubK)
+
+				// try PublicKeyData() with valid serialized private key
+				pubK, e = km.PublicKeyData(sp)
+				require.NoError(t, e)
+				require.NotEmpty(t, pubK)
+			}
+
+			kd, err := km.NewKeyData(sPrivKey)
+			if strings.Contains(tt.tcName, "success") {
+				require.NoError(t, err)
+				require.NotEmpty(t, kd)
+				require.Equal(t, kd.TypeUrl, ecdhesPrivateKeyTypeURL)
+				require.Equal(t, kd.KeyMaterialType, tinkpb.KeyData_ASYMMETRIC_PRIVATE)
+				return
+			}
+
+			if bytes.Equal(tt.encTmp.Value, badSerializedFormat) {
+				require.EqualError(t, err, errInvalidECDHESPrivateKeyFormat.Error(),
+					"ECDHESPrivate NewKey from serialized key with invalid serialized key")
+				require.Empty(t, p)
+
+				return
+			}
+
+			require.Errorf(t, err, tt.tcName)
+			require.Empty(t, p)
+		})
+	}
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_aead_public_key_manager.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_aead_public_key_manager.go
@@ -1,0 +1,134 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"crypto/elliptic"
+	"fmt"
+	"math/big"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/core/registry"
+	"github.com/google/tink/go/keyset"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+	"github.com/google/tink/go/subtle/hybrid"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle"
+	ecdhespb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdhes_aead_go_proto"
+)
+
+const (
+	ecdhesPublicKeyVersion = 0
+	ecdhesPublicKeyTypeURL = "type.hyperledger.org/hyperledger.aries.crypto.tink.EcdhesAeadPublicKey"
+)
+
+// common errors
+var errInvalidECDHESPublicKey = fmt.Errorf("ecdhes_public_key_manager: invalid key")
+
+// ecdhesPublicKeyManager is an implementation of KeyManager interface.
+// It generates new ECDHESPublicKey keys and produces new instances of ECDHESAEADCompositeEncrypt subtle.
+type ecdhesPublicKeyManager struct{}
+
+// Assert that ecdhesPublicKeyManager implements the KeyManager interface.
+var _ registry.KeyManager = (*ecdhesPublicKeyManager)(nil)
+
+// newECDHESPublicKeyManager creates a new ecdhesPublicKeyManager.
+func newECDHESPublicKeyManager() *ecdhesPublicKeyManager {
+	return new(ecdhesPublicKeyManager)
+}
+
+// Primitive creates an ECDHESPublicKey subtle for the given serialized ECDHESPublicKey proto.
+func (km *ecdhesPublicKeyManager) Primitive(serializedKey []byte) (interface{}, error) {
+	if len(serializedKey) == 0 {
+		return nil, errInvalidECDHESPublicKey
+	}
+
+	ecdhesPubKey := new(ecdhespb.EcdhesAeadPublicKey)
+
+	err := proto.Unmarshal(serializedKey, ecdhesPubKey)
+	if err != nil {
+		return nil, errInvalidECDHESPublicKey
+	}
+
+	_, err = km.validateKey(ecdhesPubKey)
+	if err != nil {
+		return nil, errInvalidECDHESPublicKey
+	}
+
+	var recipientsKeys []*hybrid.ECPublicKey
+
+	for _, recKey := range ecdhesPubKey.Params.KwParams.Recipients {
+		recCurve, e := km.validateRecKey(recKey)
+		if e != nil {
+			return nil, errInvalidECDHESPublicKey
+		}
+
+		pub := &hybrid.ECPublicKey{
+			Curve: recCurve,
+			Point: hybrid.ECPoint{
+				X: new(big.Int).SetBytes(recKey.X),
+				Y: new(big.Int).SetBytes(recKey.Y),
+			},
+		}
+
+		recipientsKeys = append(recipientsKeys, pub)
+	}
+
+	rEnc, err := newRegisterECDHESAEADEncHelper(ecdhesPubKey.Params.EncParams.AeadEnc)
+	if err != nil {
+		return nil, err
+	}
+
+	ptFormat := ecdhesPubKey.Params.EcPointFormat.String()
+
+	return subtle.NewECDHESAEADCompositeEncrypt(recipientsKeys, ptFormat, rEnc)
+}
+
+// DoesSupport indicates if this key manager supports the given key type.
+func (km *ecdhesPublicKeyManager) DoesSupport(typeURL string) bool {
+	return typeURL == ecdhesPublicKeyTypeURL
+}
+
+// TypeURL returns the key type of keys managed by this key manager.
+func (km *ecdhesPublicKeyManager) TypeURL() string {
+	return ecdhesPublicKeyTypeURL
+}
+
+// NewKey is not implemented for public key manager.
+func (km *ecdhesPublicKeyManager) NewKey(serializedKeyFormat []byte) (proto.Message, error) {
+	return nil, fmt.Errorf("ecdhes_public_key_manager: NewKey not implemented")
+}
+
+// NewKeyData is not implemented for public key manager.
+func (km *ecdhesPublicKeyManager) NewKeyData(serializedKeyFormat []byte) (*tinkpb.KeyData, error) {
+	return nil, fmt.Errorf("ecdhes_public_key_manager: NewKeyData not implemented")
+}
+
+// validateKey validates the given ECDHESPublicKey.
+func (km *ecdhesPublicKeyManager) validateKey(key *ecdhespb.EcdhesAeadPublicKey) (elliptic.Curve, error) {
+	err := keyset.ValidateKeyVersion(key.Version, ecdhesPublicKeyVersion)
+	if err != nil {
+		return nil, fmt.Errorf("ecdhes_publie_key_manager: invalid key: %s", err)
+	}
+
+	return validateKeyFormat(key.Params)
+}
+
+// validateRecKey validates the given recipient's ECDHESPublicKey.
+func (km *ecdhesPublicKeyManager) validateRecKey(key *ecdhespb.EcdhesAeadRecipientPublicKey) (elliptic.Curve, error) {
+	err := keyset.ValidateKeyVersion(key.Version, ecdhesPublicKeyVersion)
+	if err != nil {
+		return nil, fmt.Errorf("ecdhes_public_key_manager: invalid key: %s", err)
+	}
+
+	c, err := hybrid.GetCurve(key.CurveType.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_aead_public_key_manager_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_aead_public_key_manager_test.go
@@ -1,0 +1,258 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"crypto/elliptic"
+	"crypto/rand"
+	"strings"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/aead"
+	gcmpb "github.com/google/tink/go/proto/aes_gcm_go_proto"
+	commonpb "github.com/google/tink/go/proto/common_go_proto"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+	"github.com/google/tink/go/subtle/hybrid"
+	"github.com/stretchr/testify/require"
+
+	ecdhespb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdhes_aead_go_proto"
+)
+
+func TestECDHESPublicKeyManager_Primitive(t *testing.T) {
+	km := newECDHESPublicKeyManager()
+
+	t.Run("Test public key manager Primitive() with empty serialized key", func(t *testing.T) {
+		p, err := km.Primitive([]byte(""))
+		require.EqualError(t, err, errInvalidECDHESPublicKey.Error(),
+			"ECDHESPublic primitive from empty serialized key must fail")
+		require.Empty(t, p)
+	})
+
+	t.Run("Test public key manager Primitive() with bad serialize key", func(t *testing.T) {
+		p, err := km.Primitive([]byte("bad.data"))
+		require.EqualError(t, err, errInvalidECDHESPublicKey.Error(),
+			"ECDHESPublic primitive from bad serialized key must fail")
+		require.Empty(t, p)
+	})
+
+	format := &gcmpb.AesGcmKeyFormat{
+		KeySize: 32,
+	}
+	serializedFormat, err := proto.Marshal(format)
+	require.NoError(t, err)
+
+	format = &gcmpb.AesGcmKeyFormat{
+		KeySize: 99, // bad AES128GCM size
+	}
+
+	badSerializedFormat, err := proto.Marshal(format)
+	require.NoError(t, err)
+
+	recipients := generateRecipients(t)
+
+	badRecipients := generateBadRecipients(t)
+
+	var flagTests = []struct {
+		tcName     string
+		version    uint32
+		curveType  commonpb.EllipticCurveType
+		ecPtFmt    commonpb.EcPointFormat
+		encTmp     *tinkpb.KeyTemplate
+		recipients []*ecdhespb.EcdhesAeadRecipientPublicKey
+	}{
+		{
+			tcName:     "public key manager Primitive() using key with bad version",
+			version:    9999,
+			curveType:  commonpb.EllipticCurveType_NIST_P256,
+			ecPtFmt:    commonpb.EcPointFormat_COMPRESSED,
+			encTmp:     aead.AES128GCMKeyTemplate(),
+			recipients: recipients,
+		},
+		{
+			tcName:     "public key manager Primitive() using key with bad curve",
+			version:    0,
+			curveType:  commonpb.EllipticCurveType_UNKNOWN_CURVE,
+			ecPtFmt:    commonpb.EcPointFormat_COMPRESSED,
+			encTmp:     aead.AES128GCMKeyTemplate(),
+			recipients: recipients,
+		},
+		{
+			tcName:     "success public key manager Primitive()",
+			version:    0,
+			curveType:  commonpb.EllipticCurveType_NIST_P256,
+			ecPtFmt:    commonpb.EcPointFormat_UNCOMPRESSED,
+			encTmp:     aead.AES128GCMKeyTemplate(),
+			recipients: recipients,
+		},
+		{
+			tcName:    "public key manager Primitive() using key with bad key template URL",
+			version:   0,
+			curveType: commonpb.EllipticCurveType_NIST_P256,
+			ecPtFmt:   commonpb.EcPointFormat_COMPRESSED,
+			encTmp: &tinkpb.KeyTemplate{
+				TypeUrl:          "bad.type/url/value",
+				Value:            serializedFormat,
+				OutputPrefixType: tinkpb.OutputPrefixType_RAW,
+			},
+			recipients: recipients,
+		},
+		{
+			tcName:    "public key manager Primitive() using key with bad content encryption key size",
+			version:   0,
+			curveType: commonpb.EllipticCurveType_NIST_P256,
+			ecPtFmt:   commonpb.EcPointFormat_COMPRESSED,
+			encTmp: &tinkpb.KeyTemplate{
+				TypeUrl:          aesGCMTypeURL,
+				Value:            badSerializedFormat,
+				OutputPrefixType: tinkpb.OutputPrefixType_RAW,
+			},
+			recipients: recipients,
+		},
+		{
+			tcName:     "public key manager Primitive() with bad recipients keys",
+			version:    0,
+			curveType:  commonpb.EllipticCurveType_NIST_P256,
+			ecPtFmt:    commonpb.EcPointFormat_UNCOMPRESSED,
+			encTmp:     aead.AES128GCMKeyTemplate(),
+			recipients: badRecipients,
+		},
+	}
+
+	for _, tc := range flagTests {
+		tt := tc
+		t.Run("Test "+tt.tcName, func(t *testing.T) {
+			c := tt.curveType
+			encT := tt.encTmp
+			ptFmt := tt.ecPtFmt
+			v := tt.version
+			recipientsKeys := tt.recipients
+
+			// temporarily reset curvType if its unknown type so subtle.GetCurve() below doesn't fail
+			if tt.curveType.String() == commonpb.EllipticCurveType_UNKNOWN_CURVE.String() {
+				c = commonpb.EllipticCurveType_NIST_P256
+			}
+
+			crv, err := hybrid.GetCurve(c.String())
+			require.NoError(t, err)
+			_, x, y, err := elliptic.GenerateKey(crv, rand.Reader)
+			require.NoError(t, err)
+
+			// set back curvType if it was unknown to proceed with the test
+			if tt.curveType.String() == commonpb.EllipticCurveType_UNKNOWN_CURVE.String() {
+				c = tt.curveType
+			}
+
+			pubKeyProto := &ecdhespb.EcdhesAeadPublicKey{
+				Version: v, // if v > 0  to force an error when calling km.Primitive()
+				Params: &ecdhespb.EcdhesAeadParams{
+					KwParams: &ecdhespb.EcdhesKwParams{
+						CurveType:  c, // unknown curve type to force an error when calling km.Primitive()
+						Recipients: recipientsKeys,
+					},
+					EncParams: &ecdhespb.EcdhesAeadEncParams{
+						AeadEnc: encT, // invalid data enc key template to force an error when calling km.Primitive()
+					},
+					EcPointFormat: ptFmt, // unknown EC Pint format type to force an error when calling km.Primitive()
+				},
+				X: x.Bytes(),
+				Y: y.Bytes(),
+			}
+
+			sPubKey, err := proto.Marshal(pubKeyProto)
+			require.NoError(t, err)
+
+			p, err := km.Primitive(sPubKey)
+			if strings.Contains(tt.tcName, "with bad content encryption key size") {
+				require.EqualError(t, err, errInvalidECDHESPublicKey.Error(),
+					"ECDHESPublic primitive from serialized key with invalid serialized key")
+				require.Empty(t, p)
+
+				return
+			}
+
+			if strings.Contains(tt.tcName, "success") {
+				require.NoError(t, err)
+				require.NotEmpty(t, p)
+				return
+			}
+
+			require.Errorf(t, err, tt.tcName)
+			require.Empty(t, p)
+		})
+	}
+}
+
+func generateBadRecipients(t *testing.T) []*ecdhespb.EcdhesAeadRecipientPublicKey {
+	recipients := generateRecipients(t)
+
+	for _, rec := range recipients {
+		rec.Version = 999
+	}
+
+	return recipients
+}
+
+func generateRecipients(t *testing.T) []*ecdhespb.EcdhesAeadRecipientPublicKey {
+	t.Helper()
+
+	curvProto := commonpb.EllipticCurveType_NIST_P256
+	curve, err := hybrid.GetCurve(curvProto.String())
+	require.NoError(t, err)
+
+	recipient1Priv, err := hybrid.GenerateECDHKeyPair(curve)
+	require.NoError(t, err)
+
+	recipient2Priv, err := hybrid.GenerateECDHKeyPair(curve)
+	require.NoError(t, err)
+
+	recipient3Priv, err := hybrid.GenerateECDHKeyPair(curve)
+	require.NoError(t, err)
+
+	return []*ecdhespb.EcdhesAeadRecipientPublicKey{
+		{
+			Version:   0,
+			CurveType: curvProto,
+			X:         recipient1Priv.PublicKey.Point.X.Bytes(),
+			Y:         recipient1Priv.PublicKey.Point.Y.Bytes(),
+		},
+		{
+			Version:   0,
+			CurveType: curvProto,
+			X:         recipient2Priv.PublicKey.Point.X.Bytes(),
+			Y:         recipient2Priv.PublicKey.Point.Y.Bytes(),
+		},
+		{
+			Version:   0,
+			CurveType: curvProto,
+			X:         recipient3Priv.PublicKey.Point.X.Bytes(),
+			Y:         recipient3Priv.PublicKey.Point.Y.Bytes(),
+		},
+	}
+}
+
+func TestEcdhesPublicKeyManager_DoesSupport(t *testing.T) {
+	km := newECDHESPublicKeyManager()
+	require.False(t, km.DoesSupport("bad/url"))
+	require.True(t, km.DoesSupport(ecdhesPublicKeyTypeURL))
+}
+
+func TestEcdhesPublicKeyManager_NewKeyAndNewKeyData(t *testing.T) {
+	km := newECDHESPublicKeyManager()
+
+	t.Run("Test public key manager NewKey()", func(t *testing.T) {
+		k, err := km.NewKey(nil)
+		require.EqualError(t, err, "ecdhes_public_key_manager: NewKey not implemented")
+		require.Empty(t, k)
+	})
+
+	t.Run("Test private key manager NewKeyData()", func(t *testing.T) {
+		p, err := km.NewKeyData(nil)
+		require.EqualError(t, err, "ecdhes_public_key_manager: NewKeyData not implemented")
+		require.Empty(t, p)
+	})
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_common.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_common.go
@@ -1,0 +1,27 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"fmt"
+
+	commonpb "github.com/google/tink/go/proto/common_go_proto"
+)
+
+// GetCurveType is a utility function that converts a string EC curve name into an EC curve proto type
+func GetCurveType(curve string) (commonpb.EllipticCurveType, error) {
+	switch curve {
+	case "secp256r1", "NIST_P256", "P-256", "EllipticCurveType_NIST_P256":
+		return commonpb.EllipticCurveType_NIST_P256, nil
+	case "secp384r1", "NIST_P384", "P-384", "EllipticCurveType_NIST_P384":
+		return commonpb.EllipticCurveType_NIST_P384, nil
+	case "secp521r1", "NIST_P521", "P-521", "EllipticCurveType_NIST_P521":
+		return commonpb.EllipticCurveType_NIST_P521, nil
+	default:
+		return 0, fmt.Errorf("curve %s not supported", curve)
+	}
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_common_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_common_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"testing"
+
+	commonpb "github.com/google/tink/go/proto/common_go_proto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCurveType(t *testing.T) {
+	tcs := []struct {
+		tcName       string
+		curveName    string
+		expectedType commonpb.EllipticCurveType
+		isError      bool
+	}{
+		{
+			tcName:       "test get secp256r1 curve type",
+			curveName:    "secp256r1",
+			expectedType: commonpb.EllipticCurveType_NIST_P256,
+			isError:      false,
+		},
+		{
+			tcName:       "test get NIST_P256 curve type",
+			curveName:    "NIST_P256",
+			expectedType: commonpb.EllipticCurveType_NIST_P256,
+			isError:      false,
+		},
+		{
+			tcName:       "test get P-256 curve type",
+			curveName:    "P-256",
+			expectedType: commonpb.EllipticCurveType_NIST_P256,
+			isError:      false,
+		},
+		{
+			tcName:       "test get EllipticCurveType_NIST_P256 curve type",
+			curveName:    "EllipticCurveType_NIST_P256",
+			expectedType: commonpb.EllipticCurveType_NIST_P256,
+			isError:      false,
+		},
+		{
+			tcName:       "test get secp384r1 curve type",
+			curveName:    "secp384r1",
+			expectedType: commonpb.EllipticCurveType_NIST_P384,
+			isError:      false,
+		},
+		{
+			tcName:       "test get NIST_P384 curve type",
+			curveName:    "NIST_P384",
+			expectedType: commonpb.EllipticCurveType_NIST_P384,
+			isError:      false,
+		},
+		{
+			tcName:       "test get P-384 curve type",
+			curveName:    "P-384",
+			expectedType: commonpb.EllipticCurveType_NIST_P384,
+			isError:      false,
+		},
+		{
+			tcName:       "test get EllipticCurveType_NIST_P384 curve type",
+			curveName:    "EllipticCurveType_NIST_P384",
+			expectedType: commonpb.EllipticCurveType_NIST_P384,
+			isError:      false,
+		},
+		{
+			tcName:       "test get secp521r1 curve type",
+			curveName:    "secp521r1",
+			expectedType: commonpb.EllipticCurveType_NIST_P521,
+			isError:      false,
+		},
+		{
+			tcName:       "test get NIST_P521 curve type",
+			curveName:    "NIST_P521",
+			expectedType: commonpb.EllipticCurveType_NIST_P521,
+			isError:      false,
+		},
+		{
+			tcName:       "test get P-521 curve type",
+			curveName:    "P-521",
+			expectedType: commonpb.EllipticCurveType_NIST_P521,
+			isError:      false,
+		},
+		{
+			tcName:       "test get EllipticCurveType_NIST_P521 curve type",
+			curveName:    "EllipticCurveType_NIST_P521",
+			expectedType: commonpb.EllipticCurveType_NIST_P521,
+			isError:      false,
+		},
+		{
+			tcName:       "test unsupported curve type",
+			curveName:    "bad.curve",
+			expectedType: 0,
+			isError:      true,
+		},
+	}
+
+	for _, tc := range tcs {
+		tt := tc
+
+		t.Run(tt.tcName, func(t *testing.T) {
+			c, err := GetCurveType(tt.curveName)
+			if tt.isError {
+				require.Error(t, err)
+				require.Zero(t, c)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.EqualValues(t, c.String(), tt.expectedType.String())
+		})
+	}
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_decrypt_factory.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_decrypt_factory.go
@@ -1,0 +1,108 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"fmt"
+
+	"github.com/google/tink/go/core/cryptofmt"
+	"github.com/google/tink/go/core/primitiveset"
+	"github.com/google/tink/go/core/registry"
+	"github.com/google/tink/go/keyset"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/api"
+)
+
+// NewECDHESDecrypt returns an CompositeDecrypt primitive from the given keyset handle.
+func NewECDHESDecrypt(h *keyset.Handle) (api.CompositeDecrypt, error) {
+	return NewECDHESDecryptWithKeyManager(h, nil /*keyManager*/)
+}
+
+// NewECDHESDecryptWithKeyManager returns an CompositeDecrypt primitive from the given keyset handle and custom key
+// manager.
+func NewECDHESDecryptWithKeyManager(h *keyset.Handle, km registry.KeyManager) (api.CompositeDecrypt, error) {
+	ps, err := h.PrimitivesWithKeyManager(km)
+	if err != nil {
+		return nil, fmt.Errorf("ecdhes_factory: cannot obtain primitive set: %s", err)
+	}
+
+	return newDecryptPrimitiveSet(ps)
+}
+
+// decryptPrimitiveSet is an CompositeDecrypt implementation that uses the underlying primitive set for
+// decryption.
+type decryptPrimitiveSet struct {
+	ps *primitiveset.PrimitiveSet
+}
+
+// Asserts that primitiveSet implements the CompositeDecrypt interface.
+var _ api.CompositeDecrypt = (*decryptPrimitiveSet)(nil)
+
+func newDecryptPrimitiveSet(ps *primitiveset.PrimitiveSet) (*decryptPrimitiveSet, error) {
+	if _, ok := (ps.Primary.Primitive).(api.CompositeDecrypt); !ok {
+		return nil, fmt.Errorf("ecdhes_factory: not an CompositeDecrypt primitive")
+	}
+
+	for _, primitives := range ps.Entries {
+		for _, p := range primitives {
+			if _, ok := (p.Primitive).(api.CompositeDecrypt); !ok {
+				return nil, fmt.Errorf("ecdhes_factory: not an CompositeDecrypt primitive")
+			}
+		}
+	}
+
+	ret := new(decryptPrimitiveSet)
+	ret.ps = ps
+
+	return ret, nil
+}
+
+// Decrypt decrypts the given ciphertext and authenticates it with the given
+// additional authenticated data. It returns the corresponding plaintext if the
+// ciphertext is authenticated.
+func (a *decryptPrimitiveSet) Decrypt(ct, aad []byte) ([]byte, error) {
+	// try non-raw keys
+	prefixSize := cryptofmt.NonRawPrefixSize
+	if len(ct) > prefixSize {
+		prefix := ct[:prefixSize]
+		ctNoPrefix := ct[prefixSize:]
+
+		entries, err := a.ps.EntriesForPrefix(string(prefix))
+		if err == nil {
+			for i := 0; i < len(entries); i++ {
+				p, ok := (entries[i].Primitive).(api.CompositeDecrypt)
+				if !ok {
+					return nil, fmt.Errorf("ecdhes_factory: not an CompositeDecrypt primitive")
+				}
+
+				pt, e := p.Decrypt(ctNoPrefix, aad)
+				if e == nil {
+					return pt, nil
+				}
+			}
+		}
+	}
+
+	// try raw keys
+	entries, err := a.ps.RawEntries()
+	if err == nil {
+		for i := 0; i < len(entries); i++ {
+			p, ok := (entries[i].Primitive).(api.CompositeDecrypt)
+			if !ok {
+				return nil, fmt.Errorf("ecdhes_factory: not an CompositeDecrypt primitive")
+			}
+
+			pt, e := p.Decrypt(ct, aad)
+			if e == nil {
+				return pt, nil
+			}
+		}
+	}
+
+	// nothing worked
+	return nil, fmt.Errorf("ecdhes_factory: decryption failed")
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_encrypt_factory.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_encrypt_factory.go
@@ -1,0 +1,78 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"fmt"
+
+	"github.com/google/tink/go/core/primitiveset"
+	"github.com/google/tink/go/core/registry"
+	"github.com/google/tink/go/keyset"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/api"
+)
+
+// NewECDHESEncrypt returns an CompositeEncrypt primitive from the given keyset handle.
+func NewECDHESEncrypt(h *keyset.Handle) (api.CompositeEncrypt, error) {
+	return NewECDHESEncryptWithKeyManager(h, nil /*keyManager*/)
+}
+
+// NewECDHESEncryptWithKeyManager returns an CompositeEncrypt primitive from the given h keyset handle and
+// custom km key manager.
+func NewECDHESEncryptWithKeyManager(h *keyset.Handle, km registry.KeyManager) (api.CompositeEncrypt, error) {
+	ps, err := h.PrimitivesWithKeyManager(km)
+	if err != nil {
+		return nil, fmt.Errorf("ecdhes_factory: cannot obtain primitive set: %s", err)
+	}
+
+	return newEncryptPrimitiveSet(ps)
+}
+
+// encryptPrimitiveSet is an CompositeEncrypt implementation that uses the underlying primitive set for encryption.
+type encryptPrimitiveSet struct {
+	ps *primitiveset.PrimitiveSet
+}
+
+// Asserts that primitiveSet implements the CompositeEncrypt interface.
+var _ api.CompositeEncrypt = (*encryptPrimitiveSet)(nil)
+
+func newEncryptPrimitiveSet(ps *primitiveset.PrimitiveSet) (*encryptPrimitiveSet, error) {
+	if _, ok := (ps.Primary.Primitive).(api.CompositeEncrypt); !ok {
+		return nil, fmt.Errorf("ecdhes_factory: not an CompositeEncrypt primitive")
+	}
+
+	for _, primitives := range ps.Entries {
+		for _, p := range primitives {
+			if _, ok := (p.Primitive).(api.CompositeEncrypt); !ok {
+				return nil, fmt.Errorf("ecdhes_factory: not an CompositeEncrypt primitive")
+			}
+		}
+	}
+
+	ret := new(encryptPrimitiveSet)
+	ret.ps = ps
+
+	return ret, nil
+}
+
+// Encrypt encrypts the given plaintext using the recipient public key found in the enclosed primitive.
+// It returns the ciphertext being a serialized JWE []byte.
+func (a *encryptPrimitiveSet) Encrypt(pt, aad []byte) ([]byte, error) {
+	primary := a.ps.Primary
+
+	p, ok := (primary.Primitive).(api.CompositeEncrypt)
+	if !ok {
+		return nil, fmt.Errorf("ecdhes_factory: not an CompositeEncrypt primitive")
+	}
+
+	ct, err := p.Encrypt(pt, aad)
+	if err != nil {
+		return nil, err
+	}
+
+	return ct, nil
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_factory_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_factory_test.go
@@ -1,0 +1,380 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/aead"
+	"github.com/google/tink/go/core/primitiveset"
+	"github.com/google/tink/go/keyset"
+	commonpb "github.com/google/tink/go/proto/common_go_proto"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+	"github.com/google/tink/go/signature"
+	"github.com/google/tink/go/subtle/hybrid"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/google/tink/go/testkeyset"
+	"github.com/google/tink/go/testutil"
+	"github.com/stretchr/testify/require"
+
+	ecdhespb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdhes_aead_go_proto"
+)
+
+func TestECDHESFactory(t *testing.T) {
+	c := commonpb.EllipticCurveType_NIST_P256
+	primaryPtFmt := commonpb.EcPointFormat_UNCOMPRESSED
+	rawPtFmt := commonpb.EcPointFormat_COMPRESSED
+	primaryEncT := aead.AES128GCMKeyTemplate()
+	rawEncT := aead.AES256GCMKeyTemplate()
+
+	primaryPrivProto := generateECDHESAEADPrivateKey(t, c, primaryPtFmt, primaryEncT)
+
+	sPrimaryPriv, err := proto.Marshal(primaryPrivProto)
+	require.NoError(t, err)
+
+	primaryPrivKey := testutil.NewKey(
+		testutil.NewKeyData(ecdhesPrivateKeyTypeURL, sPrimaryPriv, tinkpb.KeyData_ASYMMETRIC_PRIVATE),
+		tinkpb.KeyStatusType_ENABLED, 8, tinkpb.OutputPrefixType_RAW)
+
+	rawPrivProto := generateECDHESAEADPrivateKey(t, c, rawPtFmt, rawEncT)
+
+	sRawPriv, err := proto.Marshal(rawPrivProto)
+	require.NoError(t, err)
+
+	rawPrivKey := testutil.NewKey(
+		testutil.NewKeyData(ecdhesPrivateKeyTypeURL, sRawPriv, tinkpb.KeyData_ASYMMETRIC_PRIVATE),
+		tinkpb.KeyStatusType_ENABLED, 11, tinkpb.OutputPrefixType_RAW)
+
+	privKeys := []*tinkpb.Keyset_Key{primaryPrivKey, rawPrivKey}
+	privKeyset := testutil.NewKeyset(privKeys[0].KeyId, privKeys)
+	khPriv, err := testkeyset.NewHandle(privKeyset)
+	require.NoError(t, err)
+
+	khPub, err := khPriv.Public()
+	if err != nil {
+		t.Error(err)
+	}
+
+	e, err := NewECDHESEncrypt(khPub)
+	require.NoError(t, err)
+
+	d, err := NewECDHESDecrypt(khPriv)
+	require.NoError(t, err)
+
+	for i := 0; i < 1000; i++ {
+		pt := random.GetRandomBytes(20)
+		aad := random.GetRandomBytes(10)
+		ct, err := e.Encrypt(pt, aad)
+		require.NoError(t, err)
+
+		gotpt, err := d.Decrypt(ct, aad)
+		require.NoError(t, err)
+
+		require.EqualValues(t, pt, gotpt)
+	}
+}
+
+// ecdhesAEADPublicKey returns a EcdhesAeadPublicKey with specified parameters.
+func ecdhesAEADPublicKey(t *testing.T, c commonpb.EllipticCurveType, ptfmt commonpb.EcPointFormat,
+	encT *tinkpb.KeyTemplate, x, y []byte) *ecdhespb.EcdhesAeadPublicKey {
+	t.Helper()
+
+	return &ecdhespb.EcdhesAeadPublicKey{
+		Version: 0,
+		Params: &ecdhespb.EcdhesAeadParams{
+			KwParams: &ecdhespb.EcdhesKwParams{
+				CurveType: c,
+				// add recipients for Encryption primitive
+				Recipients: []*ecdhespb.EcdhesAeadRecipientPublicKey{
+					{
+						CurveType: c,
+						X:         x,
+						Y:         y,
+					},
+				},
+			},
+			EncParams: &ecdhespb.EcdhesAeadEncParams{
+				AeadEnc: encT,
+			},
+			EcPointFormat: ptfmt,
+		},
+		X: x,
+		Y: y,
+	}
+}
+
+// eciesAEADESPrivateKey returns a EciesAeadHkdfPrivateKey with specified parameters
+func eciesAEADESPrivateKey(t *testing.T, p *ecdhespb.EcdhesAeadPublicKey, d []byte) *ecdhespb.EcdhesAeadPrivateKey {
+	t.Helper()
+
+	return &ecdhespb.EcdhesAeadPrivateKey{
+		Version:   0,
+		PublicKey: p,
+		KeyValue:  d,
+	}
+}
+
+// generateECDHESAEADPrivateKey generates a new EC key pair and returns the private key proto.
+func generateECDHESAEADPrivateKey(t *testing.T, c commonpb.EllipticCurveType, ptfmt commonpb.EcPointFormat,
+	encT *tinkpb.KeyTemplate) *ecdhespb.EcdhesAeadPrivateKey {
+	t.Helper()
+
+	curve, err := hybrid.GetCurve(c.String())
+	require.NoError(t, err)
+
+	pvt, err := hybrid.GenerateECDHKeyPair(curve)
+	require.NoError(t, err)
+
+	pubKey := ecdhesAEADPublicKey(t, c, ptfmt, encT, pvt.PublicKey.Point.X.Bytes(), pvt.PublicKey.Point.Y.Bytes())
+
+	return eciesAEADESPrivateKey(t, pubKey, pvt.D.Bytes())
+}
+
+func TestECDHESFactoryWithBadKeysetType(t *testing.T) {
+	c := commonpb.EllipticCurveType_NIST_P384
+	primaryPtFmt := commonpb.EcPointFormat_UNCOMPRESSED
+	rawPtFmt := commonpb.EcPointFormat_COMPRESSED
+	primaryEncT := aead.AES128GCMKeyTemplate()
+	rawEncT := aead.AES256GCMKeyTemplate()
+
+	primaryPrivProto := generateECDHESAEADPrivateKey(t, c, primaryPtFmt, primaryEncT)
+
+	sPrimaryPriv, err := proto.Marshal(primaryPrivProto)
+	require.NoError(t, err)
+
+	primaryPrivKey := testutil.NewKey(
+		testutil.NewKeyData(ecdhesPrivateKeyTypeURL, sPrimaryPriv, tinkpb.KeyData_ASYMMETRIC_PRIVATE),
+		tinkpb.KeyStatusType_ENABLED, 8, tinkpb.OutputPrefixType_RAW)
+
+	rawPrivProto := generateECDHESAEADPrivateKey(t, c, rawPtFmt, rawEncT)
+
+	sRawPriv, err := proto.Marshal(rawPrivProto)
+	require.NoError(t, err)
+
+	rawPrivKey := testutil.NewKey(
+		testutil.NewKeyData(ecdhesPrivateKeyTypeURL, sRawPriv, tinkpb.KeyData_ASYMMETRIC_PRIVATE),
+		tinkpb.KeyStatusType_ENABLED, 11, tinkpb.OutputPrefixType_RAW)
+
+	badPrivKeyProto, err := testutil.GenerateECIESAEADHKDFPrivateKey(c, commonpb.HashType_SHA256, primaryPtFmt,
+		aead.AES256GCMKeyTemplate(), []byte("some salt"))
+	require.NoError(t, err)
+
+	sBadKeyPriv, err := proto.Marshal(badPrivKeyProto)
+	require.NoError(t, err)
+
+	badKeyURLKeyTypeURL := "type.bad.type.url"
+	badPrivKey := testutil.NewKey(
+		testutil.NewKeyData(badKeyURLKeyTypeURL, sBadKeyPriv, tinkpb.KeyData_ASYMMETRIC_PRIVATE),
+		tinkpb.KeyStatusType_ENABLED, 12, tinkpb.OutputPrefixType_RAW)
+
+	privKeys := []*tinkpb.Keyset_Key{primaryPrivKey, rawPrivKey, badPrivKey}
+	privKeyset := testutil.NewKeyset(privKeys[0].KeyId, privKeys)
+	khPriv, err := testkeyset.NewHandle(privKeyset)
+	require.NoError(t, err)
+	require.NotEmpty(t, khPriv)
+
+	// calling Public() with a keyset containing an invalid key type should fail
+	_, err = khPriv.Public()
+	require.Error(t, err)
+
+	// creating new primitives with an invalid keyset (should be public keyset) should fail
+	e, err := NewECDHESEncrypt(khPriv)
+	require.Error(t, err)
+	require.Empty(t, e)
+
+	// creating new primitives with a keyset containing an invalid key type should fail
+	d, err := NewECDHESDecrypt(khPriv)
+	require.Error(t, err)
+	require.Empty(t, d)
+}
+
+func TestNewEncryptPrimitiveSetFail(t *testing.T) {
+	kh, err := keyset.NewHandle(signature.ECDSAP256KeyTemplate())
+	require.NoError(t, err)
+
+	primitiveSet, err := kh.Primitives()
+	require.NoError(t, err)
+
+	// calling newEncryptPrimitiveSet with non CompositeEncrypt primitiveSet should fail
+	encPrimitiveSet, err := newEncryptPrimitiveSet(primitiveSet)
+	require.Error(t, err)
+	require.Nil(t, encPrimitiveSet)
+
+	validKH, err := keyset.NewHandle(ECDHES256KWAES256GCMKeyTemplate())
+	require.NoError(t, err)
+
+	validPubKH, err := validKH.Public()
+	require.NoError(t, err)
+
+	// primitives of a valid Public keyset.Handle do Encrypt() (while Private Handle do Decrypt())
+	primitiveSet2, err := validPubKH.Primitives()
+	require.NoError(t, err)
+
+	// ensure calling newEncryptPrimitiveSet is successful with valid primitiveSet2 (ECDHESP256+AES256GCM enc primitive)
+	encPrimitiveSet, err = newEncryptPrimitiveSet(primitiveSet2)
+	require.NoError(t, err)
+	require.NotEmpty(t, encPrimitiveSet)
+
+	// create ECDSA key and add it to primitiveSet2
+	key := testutil.NewRandomECDSAPrivateKey(commonpb.HashType_SHA256, commonpb.EllipticCurveType_NIST_P256)
+	serializedKey, err := proto.Marshal(key)
+	require.NoError(t, err)
+
+	keyData := testutil.NewKeyData(testutil.ECDSASignerTypeURL,
+		serializedKey,
+		tinkpb.KeyData_ASYMMETRIC_PRIVATE)
+	privKey := testutil.NewKey(keyData, tinkpb.KeyStatusType_ENABLED, 109, tinkpb.OutputPrefixType_TINK)
+
+	// add invalid (signing) primitive to primitiveSet2
+	_, err = primitiveSet2.Add(primitiveSet.Primary.Primitive, privKey)
+	require.NoError(t, err)
+
+	// calling newEncryptPrimitiveSet with primitiveSet containing bad primitive entry should fail
+	encPrimitiveSet, err = newEncryptPrimitiveSet(primitiveSet2)
+	require.Error(t, err)
+	require.Nil(t, encPrimitiveSet)
+}
+
+func TestEncryptPrimitiveSetFail(t *testing.T) {
+	validKH, err := keyset.NewHandle(ECDHES256KWAES256GCMKeyTemplate())
+	require.NoError(t, err)
+
+	validPubKH, err := validKH.Public()
+	require.NoError(t, err)
+
+	// primitives of a valid Public keyset.Handle do Encrypt() (while Private Handle do Decrypt())
+	primitiveSet, err := validPubKH.Primitives()
+	require.NoError(t, err)
+
+	// ensure calling newEncryptPrimitiveSet is successful with valid primitiveSet2 (ECDHESP256+AES256GCM enc primitive)
+	encPrimitiveSet, err := newEncryptPrimitiveSet(primitiveSet)
+	require.NoError(t, err)
+	require.NotEmpty(t, encPrimitiveSet)
+
+	// Encrypt should fail as key set of primitive set do not have public recipients keys for encryption
+	_, err = encPrimitiveSet.Encrypt([]byte("plaintext"), []byte("aad"))
+	require.Error(t, err)
+
+	// create ECDSA key and set encPrimitiveSet's primary primtive to the ECDSA's primary
+	kh, err := keyset.NewHandle(signature.ECDSAP256KeyTemplate())
+	require.NoError(t, err)
+
+	sigPS, err := kh.Primitives()
+	require.NoError(t, err)
+
+	encPrimitiveSet.ps.Primary = sigPS.Primary
+
+	_, err = encPrimitiveSet.Encrypt([]byte("plaintext"), []byte("aad"))
+	require.Error(t, err)
+}
+
+func TestNewDecryptPrimitiveSetFail(t *testing.T) {
+	kh, err := keyset.NewHandle(signature.ECDSAP256KeyTemplate())
+	require.NoError(t, err)
+
+	primitiveSet, err := kh.Primitives()
+	require.NoError(t, err)
+
+	// calling newEncryptPrimitiveSet with non CompositeEncrypt primitiveSet should fail
+	decPrimitiveSet, err := newDecryptPrimitiveSet(primitiveSet)
+	require.Error(t, err)
+	require.Nil(t, decPrimitiveSet)
+
+	validKH, err := keyset.NewHandle(ECDHES256KWAES256GCMKeyTemplate())
+	require.NoError(t, err)
+
+	// primitives of a valid Private keyset.Handle do Decrypt() (while Public Handle do Encrypt())
+	primitiveSet2, err := validKH.Primitives()
+	require.NoError(t, err)
+
+	// ensure calling newDecryptPrimitiveSet is successful with valid primitiveSet2 (ECDHESP256+AES256GCM enc primitive)
+	decPrimitiveSet, err = newDecryptPrimitiveSet(primitiveSet2)
+	require.NoError(t, err)
+	require.NotEmpty(t, decPrimitiveSet)
+
+	// create ECDSA key and add it to primitiveSet2
+	key := testutil.NewRandomECDSAPrivateKey(commonpb.HashType_SHA256, commonpb.EllipticCurveType_NIST_P256)
+	serializedKey, err := proto.Marshal(key)
+	require.NoError(t, err)
+
+	keyData := testutil.NewKeyData(testutil.ECDSASignerTypeURL,
+		serializedKey,
+		tinkpb.KeyData_ASYMMETRIC_PRIVATE)
+	privKey := testutil.NewKey(keyData, tinkpb.KeyStatusType_ENABLED, 109, tinkpb.OutputPrefixType_TINK)
+
+	// add invalid (signing) primitive to primitiveSet2
+	_, err = primitiveSet2.Add(primitiveSet.Primary.Primitive, privKey)
+	require.NoError(t, err)
+
+	// calling newEncryptPrimitiveSet with primitiveSet containing bad primitive entry should fail
+	decPrimitiveSet, err = newDecryptPrimitiveSet(primitiveSet2)
+	require.Error(t, err)
+	require.Nil(t, decPrimitiveSet)
+}
+
+func TestDecryptPrimitiveSetFail(t *testing.T) {
+	validKH, err := keyset.NewHandle(ECDHES256KWAES256GCMKeyTemplate())
+	require.NoError(t, err)
+
+	validPubKH, err := validKH.Public()
+	require.NoError(t, err)
+
+	// primitives of a valid Private keyset.Handle do Decrypt() (while Public Handle do Encrypt())
+	primitiveSet, err := validKH.Primitives()
+	require.NoError(t, err)
+
+	// ensure calling newEncryptPrimitiveSet is successful with valid primitiveSet (ECDHESP256+AES256GCM enc primitive)
+	decPrimitiveSet, err := newDecryptPrimitiveSet(primitiveSet)
+	require.NoError(t, err)
+	require.NotEmpty(t, decPrimitiveSet)
+
+	// primitives of a valid Public Handle do Encrypt() so it should fail for newDecryptPrimitiveSet
+	primitiveSetBad, err := validPubKH.Primitives()
+	require.NoError(t, err)
+
+	// ensure calling newEncryptPrimitiveSet is successful with valid primitiveSet2 (ECDHESP256+AES256GCM enc primitive)
+	_, err = newDecryptPrimitiveSet(primitiveSetBad)
+	require.Error(t, err)
+
+	// Decrypt invalid cipher should fail
+	_, err = decPrimitiveSet.Decrypt([]byte("plaintext"), []byte("aad"))
+	require.Error(t, err)
+
+	// create ECDSA key and set decPrimitiveSet's primary primtive to the ECDSA's primary
+	kh, err := keyset.NewHandle(signature.ECDSAP256KeyTemplate())
+	require.NoError(t, err)
+
+	sigPS, err := kh.Primitives()
+	require.NoError(t, err)
+
+	// try decrypt with invalid primitive as RAW prefix (type set fail)
+	decPrimitiveSet.ps.Entries[""] = []*primitiveset.Entry{sigPS.Primary}
+	decPrimitiveSet.ps.Primary = sigPS.Primary
+
+	_, err = decPrimitiveSet.Decrypt([]byte("plaintext"), []byte("aad"))
+	require.Error(t, err)
+
+	// try decrypt with invalid primitive and prefix (type set fail)
+	decPrimitiveSet.ps.Entries["12345"] = []*primitiveset.Entry{sigPS.Primary}
+	decPrimitiveSet.ps.Primary = sigPS.Primary
+
+	_, err = decPrimitiveSet.Decrypt([]byte("12345plaintext"), []byte("aad"))
+	require.Error(t, err)
+
+	// try decrypt with valid primitiveset with raw prefix and a non raw prefix (decryption fail with valid type)
+	primitiveSet, err = validKH.Primitives()
+	require.NoError(t, err)
+
+	decPrimitiveSet.ps.Entries[""] = []*primitiveset.Entry{primitiveSet.Primary}
+	decPrimitiveSet.ps.Primary = primitiveSet.Primary
+	decPrimitiveSet.ps.Entries["12345"] = []*primitiveset.Entry{primitiveSet.Primary}
+	decPrimitiveSet.ps.Primary = primitiveSet.Primary
+
+	_, err = decPrimitiveSet.Decrypt([]byte("12345plaintext"), []byte("aad"))
+	require.Error(t, err)
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_key_export.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_key_export.go
@@ -1,0 +1,118 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/golang/protobuf/proto"
+	commonpb "github.com/google/tink/go/proto/common_go_proto"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+	"github.com/google/tink/go/subtle"
+
+	ecdhessubtle "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle"
+	ecdhespb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdhes_aead_go_proto"
+)
+
+// PubKeyWriter will write the raw bytes of a Tink KeySet's primary public key. The raw bytes are a marshaled
+// ecdhessubtle.ECPublicKey type.
+// The keyset must have a keyURL value equal to `ecdhesPublicKeyTypeURL` constant of this package
+// Note: This writer should be used only for ECDHES public key export. Other export of public keys should be called
+//       via localkms package.
+type PubKeyWriter struct {
+	w io.Writer
+}
+
+// NewWriter creates a new PubKeyWriter instance
+func NewWriter(w io.Writer) *PubKeyWriter {
+	return &PubKeyWriter{
+		w: w,
+	}
+}
+
+// Write writes the public keyset to the underlying w.Writer.
+func (p *PubKeyWriter) Write(keyset *tinkpb.Keyset) error {
+	return write(p.w, keyset)
+}
+
+// WriteEncrypted writes the encrypted keyset to the underlying w.Writer.
+func (p *PubKeyWriter) WriteEncrypted(keyset *tinkpb.EncryptedKeyset) error {
+	return fmt.Errorf("write encrypted function not supported")
+}
+
+func write(w io.Writer, msg *tinkpb.Keyset) error {
+	ks := msg.Key
+	primaryKID := msg.PrimaryKeyId
+	created := false
+
+	var err error
+
+	for _, key := range ks {
+		if key.KeyId == primaryKID && key.Status == tinkpb.KeyStatusType_ENABLED {
+			switch key.KeyData.TypeUrl {
+			case ecdhesPublicKeyTypeURL:
+				created, err = writePubKey(w, key)
+				if err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("key type not supported for writing raw key bytes: %s", key.KeyData.TypeUrl)
+			}
+
+			break
+		}
+	}
+
+	if !created {
+		return fmt.Errorf("key not written")
+	}
+
+	return nil
+}
+
+func writePubKey(w io.Writer, key *tinkpb.Keyset_Key) (bool, error) {
+	var marshaledPubKey []byte
+
+	switch key.KeyData.TypeUrl {
+	case ecdhesPublicKeyTypeURL:
+		pubKeyProto := new(ecdhespb.EcdhesAeadPublicKey)
+
+		err := proto.Unmarshal(key.KeyData.Value, pubKeyProto)
+		if err != nil {
+			return false, err
+		}
+
+		curveName := commonpb.EllipticCurveType_name[int32(pubKeyProto.Params.KwParams.CurveType)]
+
+		curve := subtle.GetCurve(curveName)
+		if curve == nil {
+			return false, fmt.Errorf("undefined curve")
+		}
+
+		pubKey := ecdhessubtle.ECPublicKey{
+			Curve: curveName,
+			X:     pubKeyProto.X,
+			Y:     pubKeyProto.Y,
+		}
+
+		marshaledPubKey, err = json.Marshal(pubKey)
+		if err != nil {
+			return false, err
+		}
+	default:
+		return false, fmt.Errorf("can't export key with keyURL:%s", key.KeyData.TypeUrl)
+	}
+
+	n, err := w.Write(marshaledPubKey)
+	if err != nil {
+		return false, nil
+	}
+
+	return n > 0, nil
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_key_export_import_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_key_export_import_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/tink/go/hybrid"
+	"github.com/google/tink/go/keyset"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPubKeyExportAndRead(t *testing.T) {
+	var flagTests = []struct {
+		tcName      string
+		keyTemplate *tinkpb.KeyTemplate
+	}{
+		{
+			tcName:      "export then read AES256GCM with ECDHES public key",
+			keyTemplate: ECDHES256KWAES256GCMKeyTemplate(),
+		},
+	}
+
+	for _, tc := range flagTests {
+		tt := tc
+		t.Run(tt.tcName, func(t *testing.T) {
+			exportedKeyBytes := exportRawPublicKeyBytes(t, tt.keyTemplate, false)
+
+			kh, err := publicKeyBytesToHandle(exportedKeyBytes)
+			require.NoError(t, err)
+			require.NotEmpty(t, kh)
+		})
+	}
+}
+
+func exportRawPublicKeyBytes(t *testing.T, keyTemplate *tinkpb.KeyTemplate, expectError bool) []byte {
+	t.Helper()
+
+	kh, err := keyset.NewHandle(keyTemplate)
+	require.NoError(t, err)
+	require.NotEmpty(t, kh)
+
+	pubKH, err := kh.Public()
+	require.NoError(t, err)
+	require.NotEmpty(t, pubKH)
+
+	buf := new(bytes.Buffer)
+	pubKeyWriter := NewWriter(buf)
+	require.NotEmpty(t, pubKeyWriter)
+
+	err = pubKH.WriteWithNoSecrets(pubKeyWriter)
+
+	if expectError {
+		require.Error(t, err)
+		return nil
+	}
+
+	require.NoError(t, err)
+	require.NotEmpty(t, buf.Bytes())
+
+	return buf.Bytes()
+}
+
+func TestNegativeCases(t *testing.T) {
+	t.Run("test publicKeyBytesToHandle with empty pubKey", func(t *testing.T) {
+		kh, err := publicKeyBytesToHandle([]byte{})
+		require.EqualError(t, err, "pubKey is empty")
+		require.Empty(t, kh)
+	})
+
+	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP256Type", func(t *testing.T) {
+		kh, err := publicKeyBytesToHandle([]byte{1})
+		require.Contains(t, err.Error(), "error getting marshalled proto key: invalid character")
+		require.Empty(t, kh)
+	})
+
+	t.Run("test exportRawPublicKeyBytes with an unsupported key template", func(t *testing.T) {
+		exportedKeyBytes := exportRawPublicKeyBytes(t, hybrid.ECIESHKDFAES128GCMKeyTemplate(), true)
+		require.Empty(t, exportedKeyBytes)
+	})
+
+	t.Run("test WriteEncrypted() should fail since it's not supported by Writer", func(t *testing.T) {
+		kh, err := keyset.NewHandle(ECDHES256KWAES256GCMKeyTemplate())
+		require.NoError(t, err)
+		require.NotEmpty(t, kh)
+
+		pubKH, err := kh.Public()
+		require.NoError(t, err)
+		require.NotEmpty(t, pubKH)
+
+		buf := new(bytes.Buffer)
+		pubKeyWriter := NewWriter(buf)
+		require.NotEmpty(t, pubKeyWriter)
+
+		err = pubKeyWriter.WriteEncrypted(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("test write() should fail with empty key set", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+
+		err := write(buf, &tinkpb.Keyset{})
+		require.Error(t, err)
+	})
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_key_import.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_key_import.go
@@ -1,0 +1,119 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/aead"
+	"github.com/google/tink/go/insecurecleartextkeyset"
+	"github.com/google/tink/go/keyset"
+	commonpb "github.com/google/tink/go/proto/common_go_proto"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+
+	ecdhessubtle "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle"
+	ecdhespb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdhes_aead_go_proto"
+)
+
+// publicKeyBytesToHandle for reading pubKey and get keyset.Handle of kt key type
+func publicKeyBytesToHandle(pubKey []byte) (*keyset.Handle, error) {
+	if len(pubKey) == 0 {
+		return nil, fmt.Errorf("pubKey is empty")
+	}
+
+	marshalledKey, tURL, err := getMarshalledProtoKeyAndKeyURL(pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("error getting marshalled proto key: %w", err)
+	}
+
+	keyData := &tinkpb.KeyData{
+		TypeUrl:         tURL,
+		Value:           marshalledKey,
+		KeyMaterialType: tinkpb.KeyData_ASYMMETRIC_PUBLIC,
+	}
+
+	ks := &tinkpb.Keyset{
+		Key: []*tinkpb.Keyset_Key{
+			{
+				KeyData:          keyData,
+				Status:           tinkpb.KeyStatusType_ENABLED,
+				KeyId:            1,
+				OutputPrefixType: tinkpb.OutputPrefixType_RAW,
+			}},
+		PrimaryKeyId: 1,
+	}
+
+	memReader := &keyset.MemReaderWriter{Keyset: ks}
+
+	parsedHandle, err := insecurecleartextkeyset.Read(memReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create key handle: %w", err)
+	}
+
+	return parsedHandle, nil
+}
+
+func getMarshalledProtoKeyAndKeyURL(pubKey []byte) ([]byte, string, error) {
+	var (
+		tURL     string
+		keyValue []byte
+		err      error
+	)
+
+	tURL = ecdhesPublicKeyTypeURL
+
+	keyValue, err = getMarshalledECDHESKey(pubKey)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return keyValue, tURL, nil
+}
+
+func getMarshalledECDHESKey(pubKey []byte) ([]byte, error) {
+	ecPubKey := new(ecdhessubtle.ECPublicKey)
+
+	err := json.Unmarshal(pubKey, ecPubKey)
+	if err != nil {
+		return nil, err
+	}
+
+	switch ecPubKey.Curve {
+	case "secp256r1", "NIST_P256", "P-256", "EllipticCurveType_NIST_P256":
+	default:
+		return nil, fmt.Errorf("ECDHES supports keys with NIST_P256 EC curve only")
+	}
+
+	if ecPubKey.X == nil || ecPubKey.Y == nil {
+		return nil, fmt.Errorf("invalid key")
+	}
+
+	curveType, err := GetCurveType(ecPubKey.Curve)
+	if err != nil {
+		return nil, fmt.Errorf("undefined curve type %w", err)
+	}
+
+	aeadEnc := aead.AES256GCMKeyTemplate()
+	pubKeyProto := new(ecdhespb.EcdhesAeadPublicKey)
+
+	pubKeyProto.X = ecPubKey.X
+	pubKeyProto.Y = ecPubKey.Y
+	pubKeyProto.Version = 0
+	pubKeyProto.Params = &ecdhespb.EcdhesAeadParams{
+		EncParams: &ecdhespb.EcdhesAeadEncParams{
+			AeadEnc: aeadEnc,
+		},
+		KwParams: &ecdhespb.EcdhesKwParams{
+			CurveType: curveType,
+		},
+		EcPointFormat: commonpb.EcPointFormat_UNCOMPRESSED,
+	}
+
+	return proto.Marshal(pubKeyProto)
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_key_template.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_key_template.go
@@ -1,0 +1,94 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/aead"
+	commonpb "github.com/google/tink/go/proto/common_go_proto"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle"
+	ecdhespb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdhes_aead_go_proto"
+)
+
+// ECDHES256KWAES256GCMKeyTemplate is a KeyTemplate that generates an ECDH-ES P-256 key wrapping and AES256-GCM CEK. It
+// is used to represent a recipient key to execute the CompositeDecrypt primitive with the following parameters:
+//  - Key Wrapping: ECDH-ES over A256KW as per https://tools.ietf.org/html/rfc7518#appendix-A.2
+//  - Content Encryption: AES256-GCM
+//  - KDF: Concat KDF as per https://tools.ietf.org/html/rfc7518#section-4.6
+// Keys from this template represent a valid recipient public/private key pairs and can be stored in the KMS
+func ECDHES256KWAES256GCMKeyTemplate() *tinkpb.KeyTemplate {
+	return createKeyTemplate(commonpb.EllipticCurveType_NIST_P256, commonpb.EcPointFormat_UNCOMPRESSED,
+		aead.AES256GCMKeyTemplate(), tinkpb.OutputPrefixType_RAW, nil)
+}
+
+// ECDHES256KWAES256GCMKeyTemplateWithRecipients is similar to ECDHES256KWAES256GCMKeyTemplate but adding recipients
+// keys to execute the CompositeEncrypt primitive for encrypting a message targeted to one ore more recipients.
+// Keys from this template offer valid CompositeEncrypt primitive execution only and should not be stored in the KMS
+func ECDHES256KWAES256GCMKeyTemplateWithRecipients(recPublicKeys []subtle.ECPublicKey) (*tinkpb.KeyTemplate, error) {
+	ecdhesRecipientKeys, err := createECDHESPublicKeys(recPublicKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	return createKeyTemplate(commonpb.EllipticCurveType_NIST_P256, commonpb.EcPointFormat_UNCOMPRESSED,
+		aead.AES256GCMKeyTemplate(), tinkpb.OutputPrefixType_RAW, ecdhesRecipientKeys), nil
+}
+
+func createECDHESPublicKeys(recRawPublicKeys []subtle.ECPublicKey) ([]*ecdhespb.EcdhesAeadRecipientPublicKey, error) {
+	var recKeys []*ecdhespb.EcdhesAeadRecipientPublicKey
+
+	for _, key := range recRawPublicKeys {
+		curveType, err := GetCurveType(key.Curve)
+		if err != nil {
+			return nil, err
+		}
+
+		rKey := &ecdhespb.EcdhesAeadRecipientPublicKey{
+			Version:   0,
+			CurveType: curveType,
+			X:         key.X,
+			Y:         key.Y,
+		}
+
+		recKeys = append(recKeys, rKey)
+	}
+
+	return recKeys, nil
+}
+
+// TODO add chacha key templates as well https://github.com/hyperledger/aries-framework-go/issues/1637
+
+// createKeyTemplate creates a new ECDHES-AEAD key template with the given key
+// size in bytes.
+func createKeyTemplate(c commonpb.EllipticCurveType, epf commonpb.EcPointFormat, contentEncKeyT *tinkpb.KeyTemplate,
+	prefixType tinkpb.OutputPrefixType, recipients []*ecdhespb.EcdhesAeadRecipientPublicKey) *tinkpb.KeyTemplate {
+	format := &ecdhespb.EcdhesAeadKeyFormat{
+		Params: &ecdhespb.EcdhesAeadParams{
+			KwParams: &ecdhespb.EcdhesKwParams{
+				CurveType:  c,
+				Recipients: recipients,
+			},
+			EncParams: &ecdhespb.EcdhesAeadEncParams{
+				AeadEnc: contentEncKeyT,
+			},
+			EcPointFormat: epf,
+		},
+	}
+
+	serializedFormat, err := proto.Marshal(format)
+	if err != nil {
+		panic("failed to marshal EcdhesAeadKeyFormat proto")
+	}
+
+	return &tinkpb.KeyTemplate{
+		TypeUrl:          ecdhesPrivateKeyTypeURL,
+		Value:            serializedFormat,
+		OutputPrefixType: prefixType,
+	}
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_key_template_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_key_template_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ecdhes
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/tink/go/keyset"
+	"github.com/stretchr/testify/require"
+
+	ecdhessubtle "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle"
+)
+
+func TestECDHESKeyTemplateTest(t *testing.T) {
+	recPubKeys, recKHs := createRecipients(t, 10)
+	kt, err := ECDHES256KWAES256GCMKeyTemplateWithRecipients(recPubKeys)
+	require.NoError(t, err)
+
+	kh, err := keyset.NewHandle(kt)
+	require.NoError(t, err)
+
+	pubKH, err := kh.Public()
+	require.NoError(t, err)
+
+	e, err := NewECDHESEncrypt(pubKH)
+	require.NoError(t, err)
+
+	pt := []byte("secret message")
+	aad := []byte("aad message")
+
+	ct, err := e.Encrypt(pt, aad)
+	require.NoError(t, err)
+	require.NotEmpty(t, ct)
+
+	// decrypt for all Recipients
+	for _, recKH := range recKHs {
+		d, er := NewECDHESDecrypt(recKH)
+		require.NoError(t, er)
+
+		dpt, er := d.Decrypt(ct, aad)
+		require.NoError(t, er)
+		require.Equal(t, pt, dpt)
+	}
+}
+
+// createRecipients and return their public key and keyset.Handle
+func createRecipients(t *testing.T, numberOfRecipients int) ([]ecdhessubtle.ECPublicKey, []*keyset.Handle) {
+	t.Helper()
+
+	var (
+		r   []ecdhessubtle.ECPublicKey
+		rKH []*keyset.Handle
+	)
+
+	for i := 0; i < numberOfRecipients; i++ {
+		mrKey, kh := createAndMarshalRecipient(t)
+		ecPubKey := new(ecdhessubtle.ECPublicKey)
+		err := json.Unmarshal(mrKey, ecPubKey)
+		require.NoError(t, err)
+
+		r = append(r, *ecPubKey)
+		rKH = append(rKH, kh)
+	}
+
+	return r, rKH
+}
+
+// createAndMarshalRecipient creates a new recipient keyset.Handle, extract public key, marshal it and return
+// both marshaled public key and original recipient keyset.Handle
+func createAndMarshalRecipient(t *testing.T) ([]byte, *keyset.Handle) {
+	t.Helper()
+
+	kh, err := keyset.NewHandle(ECDHES256KWAES256GCMKeyTemplate())
+	require.NoError(t, err)
+
+	pubKH, err := kh.Public()
+	require.NoError(t, err)
+
+	buf := new(bytes.Buffer)
+	pubKeyWriter := NewWriter(buf)
+	require.NotEmpty(t, pubKeyWriter)
+
+	err = pubKH.WriteWithNoSecrets(pubKeyWriter)
+	require.NoError(t, err)
+
+	return buf.Bytes(), kh
+}


### PR DESCRIPTION
Part 4 of ECDH-ES + AEAD logic. This change concludes the outer layer of
the new Tink primitives required to execute ECDH-ES kw and AEAD content
encryption. This layer is exposed to the user of the primitives.

This change includes:
1. New key templates
2. Primitives factory + their Tink registration
3. Key managers
4. Public key exporter/importer

closes #1469

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
