### PR TITLE
feat: implement did:key method support on vdri

### DIFF
--- a/pkg/vdri/key/creator.go
+++ b/pkg/vdri/key/creator.go
@@ -1,0 +1,97 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package key
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcutil/base58"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/cryptoutil"
+)
+
+const (
+	schemaV1                   = "https://w3id.org/did/v1"
+	ed25519VerificationKey2018 = "Ed25519VerificationKey2018"
+	x25519KeyAgreementKey2019  = "X25519KeyAgreementKey2019"
+)
+
+const (
+	ed25519pub = 0xed // Ed25519 public key in multicodec table
+	x25519pub  = 0xec // Curve25519 public key in multicodec table
+)
+
+// Build builds new DID document.
+func (v *VDRI) Build(pubKey *vdriapi.PubKey, opts ...vdriapi.DocOpts) (*did.Doc, error) {
+	if pubKey.Type != ed25519VerificationKey2018 {
+		return nil, fmt.Errorf("not supported public key type: %s", pubKey.Type)
+	}
+
+	return createDoc(base58.Decode(pubKey.Value))
+}
+
+func createDoc(pubKeyValue []byte) (*did.Doc, error) {
+	methodID := keyFingerprint(multicodec(ed25519pub), pubKeyValue)
+	didKey := fmt.Sprintf("did:key:%s", methodID)
+	keyID := fmt.Sprintf("%s#%s", didKey, methodID)
+
+	pubKey := did.NewPublicKeyFromBytes(keyID, ed25519VerificationKey2018, didKey, pubKeyValue)
+
+	keyAgreement, err := keyAgreement(didKey, pubKeyValue)
+	if err != nil {
+		return nil, err
+	}
+
+	// Created/Updated time
+	t := time.Now()
+
+	return &did.Doc{
+		Context:              []string{schemaV1},
+		ID:                   didKey,
+		PublicKey:            []did.PublicKey{*pubKey},
+		Authentication:       []did.VerificationMethod{{PublicKey: *pubKey}},
+		AssertionMethod:      []did.VerificationMethod{{PublicKey: *pubKey}},
+		CapabilityDelegation: []did.VerificationMethod{{PublicKey: *pubKey}},
+		CapabilityInvocation: []did.VerificationMethod{{PublicKey: *pubKey}},
+		KeyAgreement:         []did.VerificationMethod{{PublicKey: *keyAgreement}},
+		Created:              &t,
+		Updated:              &t,
+	}, nil
+}
+
+func keyFingerprint(multicodecValue, pubKeyValue []byte) string {
+	mcLength := len(multicodecValue)
+	buf := make([]uint8, mcLength+len(pubKeyValue))
+	copy(buf, multicodecValue)
+	copy(buf[mcLength:], pubKeyValue)
+
+	return fmt.Sprintf("z%s", base58.Encode(buf))
+}
+
+func keyAgreement(didKey string, ed25519PubKey []byte) (*did.PublicKey, error) {
+	curve25519PubKey, err := cryptoutil.PublicEd25519toCurve25519(ed25519PubKey)
+	if err != nil {
+		return nil, err
+	}
+
+	fingerprint := keyFingerprint(multicodec(x25519pub), curve25519PubKey)
+	keyID := fmt.Sprintf("%s#%s", didKey, fingerprint)
+	pubKey := did.NewPublicKeyFromBytes(keyID, x25519KeyAgreementKey2019, didKey, curve25519PubKey)
+
+	return pubKey, nil
+}
+
+func multicodec(code uint64) []byte {
+	buf := make([]byte, 2)
+	binary.PutUvarint(buf, code)
+
+	return buf
+}

--- a/pkg/vdri/key/creator_test.go
+++ b/pkg/vdri/key/creator_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package key
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcutil/base58"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
+)
+
+const (
+	didKey         = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+	didKeyID       = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH" //nolint:lll
+	agreementKeyID = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc" //nolint:lll
+
+	pubKeyBase58       = "B12NYF8RrR3h41TDCTJojY59usg3mbtbjnFs7Eud1Y6u"
+	keyAgreementBase58 = "JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr"
+)
+
+func TestBuild(t *testing.T) {
+	t.Run("validate not supported public key", func(t *testing.T) {
+		v := newVDRI(t)
+
+		pubKey := &vdriapi.PubKey{
+			Type: "not-supported-type",
+		}
+
+		doc, err := v.Build(pubKey)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not supported public key type: not-supported-type")
+		require.Nil(t, doc)
+	})
+
+	t.Run("validate did:key compliance with generic syntax", func(t *testing.T) {
+		v := newVDRI(t)
+
+		pubKey := &vdriapi.PubKey{
+			Type:  ed25519VerificationKey2018,
+			Value: pubKeyBase58,
+		}
+
+		doc, err := v.Build(pubKey)
+		require.NoError(t, err)
+		require.NotNil(t, doc)
+
+		d, err := did.Parse(doc.ID)
+		require.NoError(t, err)
+		require.NotNil(t, d)
+	})
+
+	t.Run("build with default key type", func(t *testing.T) {
+		v := newVDRI(t)
+
+		pubKey := &vdriapi.PubKey{
+			Type:  ed25519VerificationKey2018,
+			Value: pubKeyBase58,
+		}
+
+		doc, err := v.Build(pubKey)
+		require.NoError(t, err)
+		require.NotNil(t, doc)
+
+		assertDoc(t, doc)
+	})
+}
+
+func newVDRI(t *testing.T) *VDRI {
+	v, err := New()
+	require.NoError(t, err)
+	require.NotNil(t, v)
+
+	return v
+}
+
+func assertDoc(t *testing.T, doc *did.Doc) {
+	// validate @context
+	require.Equal(t, schemaV1, doc.Context[0])
+
+	// validate id
+	require.Equal(t, didKey, doc.ID)
+
+	expectedPubKey := &did.PublicKey{
+		ID:         didKeyID,
+		Type:       ed25519VerificationKey2018,
+		Controller: didKey,
+		Value:      base58.Decode(pubKeyBase58),
+	}
+
+	expectedKeyAgreement := &did.PublicKey{
+		ID:         agreementKeyID,
+		Type:       x25519KeyAgreementKey2019,
+		Controller: didKey,
+		Value:      base58.Decode(keyAgreementBase58),
+	}
+
+	// validate publicKey
+	assertPubKey(t, expectedPubKey, &doc.PublicKey[0])
+
+	// validate assertionMethod
+	assertPubKey(t, expectedPubKey, &doc.AssertionMethod[0].PublicKey)
+
+	// validate authentication
+	assertPubKey(t, expectedPubKey, &doc.Authentication[0].PublicKey)
+
+	// validate capabilityDelegation
+	assertPubKey(t, expectedPubKey, &doc.CapabilityDelegation[0].PublicKey)
+
+	// validate capabilityInvocation
+	assertPubKey(t, expectedPubKey, &doc.CapabilityInvocation[0].PublicKey)
+
+	// validate keyAgreement
+	assertPubKey(t, expectedKeyAgreement, &doc.KeyAgreement[0].PublicKey)
+}
+
+func assertPubKey(t *testing.T, expectedPubKey, actualPubKey *did.PublicKey) {
+	require.NotNil(t, actualPubKey)
+	require.Equal(t, expectedPubKey.ID, actualPubKey.ID)
+	require.Equal(t, expectedPubKey.Type, actualPubKey.Type)
+	require.Equal(t, expectedPubKey.Controller, actualPubKey.Controller)
+	require.Equal(t, expectedPubKey.Value, actualPubKey.Value)
+}

--- a/pkg/vdri/key/resolver.go
+++ b/pkg/vdri/key/resolver.go
@@ -1,0 +1,53 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package key
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+
+	"github.com/btcsuite/btcutil/base58"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
+)
+
+// Read expands did:key value to a DID document.
+func (v *VDRI) Read(didKey string, opts ...vdriapi.ResolveOpts) (*did.Doc, error) {
+	parsed, err := did.Parse(didKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isValidMethodID(parsed.MethodSpecificID) {
+		return nil, fmt.Errorf("invalid did:key method ID: %s", parsed.MethodSpecificID)
+	}
+
+	pubKey, err := pubKeyFromFingerprint(parsed.MethodSpecificID)
+	if err != nil {
+		return nil, err
+	}
+
+	return createDoc(pubKey)
+}
+
+func isValidMethodID(id string) bool {
+	r := regexp.MustCompile(`(z)([1-9a-km-zA-HJ-NP-Z]{46})`)
+	return r.MatchString(id)
+}
+
+func pubKeyFromFingerprint(fingerprint string) ([]byte, error) {
+	// did:key:MULTIBASE(base58-btc, MULTICODEC(public-key-type, raw-public-key-bytes))
+	// https://w3c-ccg.github.io/did-method-key/#format
+	mc := base58.Decode(fingerprint[1:]) // skip leading "z"
+	if !bytes.Equal(multicodec(ed25519pub), mc[:2]) {
+		return nil, fmt.Errorf("not supported public key (multicodec code: %#x)", mc[0])
+	}
+
+	return mc[2:], nil
+}

--- a/pkg/vdri/key/resolver_test.go
+++ b/pkg/vdri/key/resolver_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package key
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRead(t *testing.T) {
+	t.Run("validate did:key", func(t *testing.T) {
+		v := newVDRI(t)
+
+		doc, err := v.Read("invalid")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid did: invalid")
+		require.Nil(t, doc)
+	})
+
+	t.Run("validate did:key method specific ID", func(t *testing.T) {
+		v := newVDRI(t)
+
+		doc, err := v.Read("did:key:invalid")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid did:key method ID: invalid")
+		require.Nil(t, doc)
+	})
+
+	t.Run("validate not supported public key", func(t *testing.T) {
+		v := newVDRI(t)
+
+		doc, err := v.Read("did:key:z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not supported public key (multicodec code: 0xec)") // Curve25519 public key
+		require.Nil(t, doc)
+	})
+
+	t.Run("resolve assuming default key type", func(t *testing.T) {
+		v := newVDRI(t)
+
+		doc, err := v.Read(didKey)
+		require.NoError(t, err)
+		require.NotNil(t, doc)
+
+		assertDoc(t, doc)
+	})
+}

--- a/pkg/vdri/key/vdri.go
+++ b/pkg/vdri/key/vdri.go
@@ -1,0 +1,38 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package key
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
+)
+
+const didMethod = "key"
+
+// VDRI implements did:key method support.
+type VDRI struct {
+}
+
+// New returns new instance of VDRI that works with did:key method.
+func New() (*VDRI, error) {
+	return &VDRI{}, nil
+}
+
+// Accept accepts did:key method.
+func (v *VDRI) Accept(method string) bool {
+	return method == didMethod
+}
+
+// Store saves a DID Document along with user key/signature.
+func (v *VDRI) Store(doc *did.Doc, by *[]vdri.ModifiedBy) error {
+	return nil
+}
+
+// Close frees resources being maintained by VDRI.
+func (v *VDRI) Close() error {
+	return nil
+}

--- a/pkg/vdri/key/vdri_test.go
+++ b/pkg/vdri/key/vdri_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package key
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
+)
+
+var _ vdri.VDRI = (*VDRI)(nil) // verify interface compliance
+
+func TestAccept(t *testing.T) {
+	t.Run("key method", func(t *testing.T) {
+		v, err := New()
+		require.NoError(t, err)
+		require.NotNil(t, v)
+
+		accept := v.Accept("key")
+		require.True(t, accept)
+	})
+
+	t.Run("other method", func(t *testing.T) {
+		v, err := New()
+		require.NoError(t, err)
+		require.NotNil(t, v)
+
+		accept := v.Accept("other")
+		require.False(t, accept)
+	})
+}
+
+func TestStore(t *testing.T) {
+	t.Run("test success", func(t *testing.T) {
+		v, err := New()
+		require.NoError(t, err)
+		require.NoError(t, v.Store(nil, nil))
+	})
+}
+
+func TestClose(t *testing.T) {
+	t.Run("test success", func(t *testing.T) {
+		v, err := New()
+		require.NoError(t, err)
+		require.NoError(t, v.Close())
+	})
+}


### PR DESCRIPTION
Defines did:key methods (build and read) on vdri.
Closes #1537.

Signed-off-by: Andriy Holovko <andriy.holovko@gmail.com>
