### PR TITLE
fix: WK.PublicKeyBytes() for ed25519 and ecdsa case

### DIFF
--- a/pkg/doc/did/doc_test.go
+++ b/pkg/doc/did/doc_test.go
@@ -9,7 +9,6 @@ package did
 import (
 	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -906,14 +905,11 @@ func TestNewPublicKeyFromJWK(t *testing.T) {
 		},
 	}
 
-	pubKeyBytes, err := x509.MarshalPKIXPublicKey(pubKey)
-	require.NoError(t, err)
-
 	// Success.
 	signingKey, err := NewPublicKeyFromJWK(creator, keyType, did, jwk)
 	require.NoError(t, err)
 	require.Equal(t, jwk, signingKey.JSONWebKey())
-	require.Equal(t, pubKeyBytes, signingKey.Value)
+	require.Equal(t, []byte(pubKey), signingKey.Value)
 
 	// Error - invalid JWK.
 	jwk = &jose.JWK{

--- a/pkg/doc/jose/jwk.go
+++ b/pkg/doc/jose/jwk.go
@@ -59,13 +59,12 @@ func (j *JWK) PublicKeyBytes() ([]byte, error) {
 	}
 
 	switch pubKey := j.Public().Key.(type) {
-	case *ecdsa.PublicKey, *rsa.PublicKey, ed25519.PublicKey:
-		pubKBytes, err := x509.MarshalPKIXPublicKey(pubKey)
-		if err != nil {
-			return nil, errors.New("failed to read public key bytes")
-		}
-
-		return pubKBytes, nil
+	case ed25519.PublicKey:
+		return pubKey, nil
+	case *ecdsa.PublicKey:
+		return elliptic.Marshal(pubKey, pubKey.X, pubKey.Y), nil
+	case *rsa.PublicKey:
+		return x509.MarshalPKCS1PublicKey(pubKey), nil
 	default:
 		return nil, fmt.Errorf("unsupported public key type in kid '%s'", j.KeyID)
 	}

--- a/pkg/doc/jose/jwk_test.go
+++ b/pkg/doc/jose/jwk_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package jose
 
 import (
-	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -309,28 +308,15 @@ func TestCurveSize(t *testing.T) {
 }
 
 func TestJWK_PublicKeyBytesValidation(t *testing.T) {
-	// invalid public key
-	privKey, err := ecdsa.GenerateKey(btcec.S256(), rand.Reader)
-	require.NoError(t, err)
-
 	jwk := &JWK{
 		JSONWebKey: jose.JSONWebKey{
-			Key:       &privKey.PublicKey,
-			Algorithm: "ES256",
-			KeyID:     "pubkey#123",
+			Key:   "key of invalid type",
+			KeyID: "pubkey#123",
 		},
-		Crv: "P-256",
-		Kty: "EC",
 	}
 
-	pkBytes, err := jwk.PublicKeyBytes()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to read public key bytes")
-	require.Empty(t, pkBytes)
-
 	// unsupported public key type
-	jwk.Key = "key of invalid type"
-	pkBytes, err = jwk.PublicKeyBytes()
+	pkBytes, err := jwk.PublicKeyBytes()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported public key type in kid 'pubkey#123'")
 	require.Empty(t, pkBytes)


### PR DESCRIPTION
closes #1660

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

We don't need to use `MarshalPKCS1PublicKey()` for `ed25519` and `ecdsa` public keys. We can return `ed25519.PublicKey` directly without any conversion and use `elliptic.Marshal()` for `*ecdsa.PublicKey` case.