### PR TITLE
feat: add JWE Encryption using new ECDH-ES+AEAD Tink templates

### DIFF
--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_factory_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_factory_test.go
@@ -260,7 +260,7 @@ func TestEncryptPrimitiveSetFail(t *testing.T) {
 	_, err = encPrimitiveSet.Encrypt([]byte("plaintext"), []byte("aad"))
 	require.Error(t, err)
 
-	// create ECDSA key and set encPrimitiveSet's primary primtive to the ECDSA's primary
+	// create ECDSA key and set encPrimitiveSet's primary primitive to the ECDSA's primary
 	kh, err := keyset.NewHandle(signature.ECDSAP256KeyTemplate())
 	require.NoError(t, err)
 

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_key_template_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/ecdhes_key_template_test.go
@@ -71,8 +71,8 @@ func createRecipients(t *testing.T, numberOfRecipients int) ([]ecdhessubtle.ECPu
 	return r, rKH
 }
 
-// createAndMarshalRecipient creates a new recipient keyset.Handle, extract public key, marshal it and return
-// both marshaled public key and original recipient keyset.Handle
+// createAndMarshalRecipient creates a new recipient keyset.Handle, extracts public key, marshals it and returns
+// both marshalled public key and original recipient keyset.Handle
 func createAndMarshalRecipient(t *testing.T) ([]byte, *keyset.Handle) {
 	t.Helper()
 

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_common.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_common.go
@@ -9,6 +9,7 @@ package subtle
 // EncryptedData represents the Encryption's output data as a result of ECDHESEncrypt.Encrypt(pt, aad) call
 // The user of the primitive must unmarshal the result and build their own ECDH-ES compliant message (ie JWE msg)
 type EncryptedData struct {
+	EncAlg     string                 `json:"EncAlg,omitempty"`
 	Ciphertext []byte                 `json:"Ciphertext,omitempty"`
 	IV         []byte                 `json:"IV,omitempty"`
 	Tag        []byte                 `json:"Tag,omitempty"`

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_decrypt.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_decrypt.go
@@ -49,6 +49,11 @@ func (d *ECDHESAEADCompositeDecrypt) Decrypt(ciphertext, aad []byte) ([]byte, er
 		return nil, err
 	}
 
+	// TODO: add support for Chacha content encryption https://github.com/hyperledger/aries-framework-go/issues/1684
+	if encData.EncAlg != A256GCM {
+		return nil, fmt.Errorf("invalid content encryption algorihm '%s' for Decrypt()", encData.EncAlg)
+	}
+
 	for _, rec := range encData.Recipients {
 		recipientKW := &ECDHESConcatKDFRecipientKW{
 			recipientPrivateKey: d.privateKey,

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_encrypt.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_encrypt.go
@@ -16,6 +16,10 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/api"
 )
 
+// A256GCM is the default content encryption algorithm value as per
+// the JWA specification: https://tools.ietf.org/html/rfc7518#section-5.1
+const A256GCM = "A256GCM"
+
 // ECDHESAEADCompositeEncrypt is an instance of ECDH-ES encryption with Concat KDF
 // and AEAD content encryption
 type ECDHESAEADCompositeEncrypt struct {
@@ -94,6 +98,7 @@ func (e *ECDHESAEADCompositeEncrypt) Encrypt(plaintext, aad []byte) ([]byte, err
 	tagOffset := len(ctAndTag) - tagSize
 
 	encData := &EncryptedData{
+		EncAlg:     A256GCM, // TODO add chacha alg too, https://github.com/hyperledger/aries-framework-go/issues/1684
 		Ciphertext: ctAndTag[:tagOffset],
 		IV:         iv,
 		Tag:        ctAndTag[tagOffset:],

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_test.go
@@ -159,6 +159,19 @@ func TestEncryptDecryptNegativeTCs(t *testing.T) {
 		_, err = dEnc.Decrypt([]byte{}, aad)
 		require.Error(t, err)
 
+		// try decrypting with empty encAlg
+		var encData EncryptedData
+		err = json.Unmarshal(ct, &encData)
+		require.NoError(t, err)
+
+		encData.EncAlg = ""
+
+		emptyAlgCiphertext, err := json.Marshal(encData)
+		require.NoError(t, err)
+
+		_, err = dEnc.Decrypt(emptyAlgCiphertext, aad)
+		require.Error(t, err)
+
 		// finally try successful decrypt
 		dpt, err := dEnc.Decrypt(ct, aad)
 		require.NoError(t, err)

--- a/pkg/didcomm/packer/jwe/authcrypt/authcrypt.go
+++ b/pkg/didcomm/packer/jwe/authcrypt/authcrypt.go
@@ -49,12 +49,12 @@ type Packer struct {
 
 // Envelope represents a JWE envelope as per the Aries Encryption envelope specs
 type Envelope struct {
-	Protected  string           `json:"protected,omitempty"`
-	Recipients []jose.Recipient `json:"recipients,omitempty"`
-	AAD        string           `json:"aad,omitempty"`
-	IV         string           `json:"iv,omitempty"`
-	Tag        string           `json:"tag,omitempty"`
-	CipherText string           `json:"ciphertext,omitempty"`
+	Protected  string            `json:"protected,omitempty"`
+	Recipients []*jose.Recipient `json:"recipients,omitempty"`
+	AAD        string            `json:"aad,omitempty"`
+	IV         string            `json:"iv,omitempty"`
+	Tag        string            `json:"tag,omitempty"`
+	CipherText string            `json:"ciphertext,omitempty"`
 }
 
 // jweHeaders are the Protected JWE headers in a map format

--- a/pkg/didcomm/packer/jwe/authcrypt/authcrypt_test.go
+++ b/pkg/didcomm/packer/jwe/authcrypt/authcrypt_test.go
@@ -570,7 +570,7 @@ func TestEncrypt(t *testing.T) {
 
 func deepCopy(envelope, envelope2 *Envelope) {
 	for _, r := range envelope2.Recipients {
-		newRe := jose.Recipient{
+		newRe := &jose.Recipient{
 			EncryptedKey: r.EncryptedKey,
 			Header: jose.RecipientHeaders{
 				APU: r.Header.APU,

--- a/pkg/didcomm/packer/jwe/authcrypt/pack.go
+++ b/pkg/didcomm/packer/jwe/authcrypt/pack.go
@@ -163,8 +163,8 @@ func extractCipherText(symOutput []byte) string {
 }
 
 // buildJWE builds the JSON object representing the JWE output of the encryption
-// and returns its marshaled []byte representation
-func (p *Packer) buildJWE(headers string, recipients []jose.Recipient, aad, iv, tag, cipherText string) ([]byte, error) { //nolint:lll
+// and returns its marshalled []byte representation
+func (p *Packer) buildJWE(headers string, recipients []*jose.Recipient, aad, iv, tag, cipherText string) ([]byte, error) { //nolint:lll
 	jwe := Envelope{
 		Protected:  headers,
 		Recipients: recipients,
@@ -205,8 +205,9 @@ func hashAAD(keys []string) []byte {
 
 // encodeRecipients is a utility function that will encrypt the cek (content encryption key) for each recipient
 // and return a list of encoded recipient keys in a JWE compliant format ([]Recipient)
-func (p *Packer) encodeRecipients(cek *[chacha.KeySize]byte, recipients []*[chacha.KeySize]byte, senderPubKey *[chacha.KeySize]byte) ([]jose.Recipient, error) { //nolint:lll
-	var encodedRecipients []jose.Recipient
+func (p *Packer) encodeRecipients(cek *[chacha.KeySize]byte, recipients []*[chacha.KeySize]byte,
+	senderPubKey *[chacha.KeySize]byte) ([]*jose.Recipient, error) {
+	var encodedRecipients []*jose.Recipient
 
 	for _, e := range recipients {
 		rec, err := p.encodeRecipient(cek, e, senderPubKey)
@@ -214,7 +215,7 @@ func (p *Packer) encodeRecipients(cek *[chacha.KeySize]byte, recipients []*[chac
 			return nil, err
 		}
 
-		encodedRecipients = append(encodedRecipients, *rec)
+		encodedRecipients = append(encodedRecipients, rec)
 	}
 
 	return encodedRecipients, nil
@@ -223,7 +224,7 @@ func (p *Packer) encodeRecipients(cek *[chacha.KeySize]byte, recipients []*[chac
 // encodeRecipient will encrypt the cek (content encryption key) with a recipientKey
 // by generating a new ephemeral key to be used by the recipient to later decrypt it
 // it returns a JWE compliant Recipient
-func (p *Packer) encodeRecipient(cek, recipientPubKey, senderPubKey *[chacha.KeySize]byte) (*jose.Recipient, error) { //nolint:lll
+func (p *Packer) encodeRecipient(cek, recipientPubKey, senderPubKey *[chacha.KeySize]byte) (*jose.Recipient, error) {
 	// generate a random APU value (Agreement PartyUInfo: https://tools.ietf.org/html/rfc7518#section-4.6.1.2)
 	apu := make([]byte, 64)
 

--- a/pkg/didcomm/packer/jwe/authcrypt/unpack.go
+++ b/pkg/didcomm/packer/jwe/authcrypt/unpack.go
@@ -97,7 +97,7 @@ func (p *Packer) decryptPayload(cek []byte, jwe *Envelope) ([]byte, error) {
 }
 
 // findRecipient will loop through jweRecipients and returns the first matching key from the legacyKMS
-func (p *Packer) findRecipient(jweRecipients []jose.Recipient) (*[chacha.KeySize]byte, *jose.Recipient, error) {
+func (p *Packer) findRecipient(jweRecipients []*jose.Recipient) (*[chacha.KeySize]byte, *jose.Recipient, error) {
 	var recipientsKeys []string
 	for _, recipient := range jweRecipients {
 		recipientsKeys = append(recipientsKeys, recipient.Header.KID)
@@ -111,7 +111,7 @@ func (p *Packer) findRecipient(jweRecipients []jose.Recipient) (*[chacha.KeySize
 	pubK := new([chacha.KeySize]byte)
 	copy(pubK[:], base58.Decode(recipientsKeys[i]))
 
-	return pubK, &jweRecipients[i], nil
+	return pubK, jweRecipients[i], nil
 }
 
 // decryptCEK will decrypt the CEK found in recipient using recipientKp's private key and senderPubKey

--- a/pkg/doc/jose/common.go
+++ b/pkg/doc/jose/common.go
@@ -13,6 +13,9 @@ const (
 	// For JWE: the cryptographic algorithm used to encrypt or determine the value of the CEK.
 	HeaderAlgorithm = "alg" // string
 
+	// HeaderEncryption identifies the JWE content encryption algorithm
+	HeaderEncryption = "enc" // string
+
 	// HeaderJWKSetURL is a URI that refers to a resource for a set of JSON-encoded public keys, one of which:
 	// For JWS: corresponds to the key used to digitally sign the JWS.
 	// For JWE: corresponds to the public key to which the JWE was encrypted.

--- a/pkg/doc/jose/encrypter.go
+++ b/pkg/doc/jose/encrypter.go
@@ -1,0 +1,216 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package jose
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	"github.com/google/tink/go/keyset"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+	"github.com/google/tink/go/subtle/hybrid"
+	"github.com/square/go-jose/v3"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/api"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle"
+)
+
+// EncAlg represents the JWE content encryption algorithm
+type EncAlg string
+
+const (
+	// A256GCM for AES256GCM content encryption
+	A256GCM = EncAlg(subtle.A256GCM)
+)
+
+// Encrypter interface to Encrypt/Decrypt JWE messages
+type Encrypter interface {
+	// Encrypt plaintext and aad sent to 1 or more recipients and return a valid JSONWebEncryption instance
+	Encrypt(plaintext, aad []byte) (*JSONWebEncryption, error)
+	// Decrypt a marshalledJWE, extract the corresponding recipient key to decrypt plaintext and return it
+	Decrypt(marshalledJWE []byte) ([]byte, error)
+}
+
+type encPrimitiveFunc func(*keyset.Handle) (api.CompositeEncrypt, error)
+
+// JWEEncrypt is responsible for encrypting a plaintext and its AAD into a protected JWE and decrypting it
+type JWEEncrypt struct {
+	recipients   []subtle.ECPublicKey
+	senderKH     *keyset.Handle
+	getPrimitive encPrimitiveFunc
+	encAlg       EncAlg
+}
+
+// NewJWEEncrypt creates a new JWEEncrypt instance to build/parse JWE with recipientsPubKeys
+func NewJWEEncrypt(encAlg EncAlg, recipientsPubKeys []subtle.ECPublicKey) (*JWEEncrypt, error) {
+	if len(recipientsPubKeys) == 0 {
+		return nil, fmt.Errorf("empty recipientsPubKeys list")
+	}
+
+	var (
+		kt  *tinkpb.KeyTemplate
+		err error
+	)
+
+	// TODO add support for Chacha content encryption, issue #1684
+	switch encAlg {
+	case A256GCM:
+		kt, err = ecdhes.ECDHES256KWAES256GCMKeyTemplateWithRecipients(recipientsPubKeys)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("encryption algorithm '%s' not supported", encAlg)
+	}
+
+	senderKH, err := keyset.NewHandle(kt)
+	if err != nil {
+		return nil, err
+	}
+
+	return &JWEEncrypt{
+		recipients:   recipientsPubKeys,
+		senderKH:     senderKH,
+		getPrimitive: getEncryptionPrimitive,
+		encAlg:       encAlg,
+	}, nil
+}
+
+func getEncryptionPrimitive(senderKH *keyset.Handle) (api.CompositeEncrypt, error) {
+	senderPubKH, err := senderKH.Public()
+	if err != nil {
+		return nil, err
+	}
+
+	return ecdhes.NewECDHESEncrypt(senderPubKH)
+}
+
+// Encrypt plaintext with AAD and return a JSONWebEncryption instance to serialize JWE instance
+func (je *JWEEncrypt) Encrypt(plaintext, aad []byte) (*JSONWebEncryption, error) {
+	encPrimitive, err := je.getPrimitive(je.senderKH)
+	if err != nil {
+		return nil, fmt.Errorf("jweencrypt: failed to get encryption primitive: %w", err)
+	}
+
+	protectedHeaders := map[string]interface{}{
+		HeaderEncryption: je.encAlg,
+	}
+
+	// TODO - Go jose adds CEK as part of protectedHeaders, see if this is valid. Also, for a single recipient,
+	//  Go jose merges recipient header into JWE protect protectedHeaders. See if this is needed too.
+
+	authData, err := computeAuthData(protectedHeaders, aad)
+	if err != nil {
+		return nil, err
+	}
+
+	serializedEncData, err := encPrimitive.Encrypt(plaintext, authData)
+	if err != nil {
+		return nil, fmt.Errorf("jweencrypt: failed to Encrypt: %w", err)
+	}
+
+	encData := new(subtle.EncryptedData)
+
+	err = json.Unmarshal(serializedEncData, encData)
+	if err != nil {
+		return nil, fmt.Errorf("jweencrypt: unmarshal encrypted data failed: %w", err)
+	}
+
+	var recipients []*Recipient
+
+	for _, rec := range encData.Recipients {
+		var mRecJWK []byte
+
+		mRecJWK, err = convertRecKeyToMarshalledJWK(rec)
+		if err != nil {
+			return nil, fmt.Errorf("jweencrypt: failed to convert recipient key to marshalled JWK: %w", err)
+		}
+
+		recipients = append(recipients, &Recipient{
+			EncryptedKey: string(rec.EncryptedCEK),
+			Header: RecipientHeaders{
+				Alg: rec.Alg,
+				EPK: string(mRecJWK),
+			},
+		})
+	}
+
+	jsonEncryption := &JSONWebEncryption{
+		IV:               string(encData.IV),
+		Tag:              string(encData.Tag),
+		Ciphertext:       string(encData.Ciphertext),
+		Recipients:       recipients,
+		ProtectedHeaders: protectedHeaders,
+	}
+
+	return jsonEncryption, nil
+}
+
+func convertRecKeyToMarshalledJWK(rec *subtle.RecipientWrappedKey) ([]byte, error) {
+	var c elliptic.Curve
+
+	c, err := hybrid.GetCurve(rec.EPK.Curve)
+	if err != nil {
+		return nil, err
+	}
+
+	recJWK := JWK{
+		JSONWebKey: jose.JSONWebKey{
+			Use: HeaderEncryption,
+			Key: &ecdsa.PublicKey{
+				Curve: c,
+				X:     new(big.Int).SetBytes(rec.EPK.X),
+				Y:     new(big.Int).SetBytes(rec.EPK.Y),
+			},
+		},
+		Kty: "EC", // TODO add support for X25519 content encryption, issue #1684
+		Crv: rec.EPK.Curve,
+	}
+
+	return recJWK.MarshalJSON()
+}
+
+// Decrypt serializedJWE by first deserializing it, then decrypting the underlying JWE instance and return plaintext
+func (je *JWEEncrypt) Decrypt(serializedJWE []byte) ([]byte, error) {
+	// TODO will need JWE Deserialization: https://github.com/hyperledger/aries-framework-go/issues/1507 to
+	//  implement this function
+	return nil, fmt.Errorf("TODO - implement me")
+}
+
+// Get the additional authenticated data from a JWE object.
+func computeAuthData(protectedHeaders map[string]interface{}, aad []byte) ([]byte, error) {
+	var protected string
+
+	if protectedHeaders != nil {
+		mProtected, err := json.Marshal(protectedHeaders)
+		if err != nil {
+			return nil, fmt.Errorf("jwe computeAuthData: marshal error %w", err)
+		}
+
+		protected = base64.RawURLEncoding.EncodeToString(mProtected)
+	} else {
+		protected = ""
+	}
+
+	output := []byte(protected)
+	if len(aad) > 0 {
+		output = append(output, '.')
+
+		encLen := base64.RawURLEncoding.EncodedLen(len(aad))
+		aadEncoded := make([]byte, encLen)
+
+		base64.RawURLEncoding.Encode(aadEncoded, aad)
+		output = append(output, aadEncoded...)
+	}
+
+	return output, nil
+}

--- a/pkg/doc/jose/encrypter_test.go
+++ b/pkg/doc/jose/encrypter_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package jose
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/tink/go/aead"
+	"github.com/google/tink/go/keyset"
+	"github.com/square/go-jose/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/api"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes"
+	ecdhessubtle "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle"
+)
+
+func TestJWEEncrypt(t *testing.T) {
+	_, err := NewJWEEncrypt("", nil)
+	require.EqualError(t, err, "empty recipientsPubKeys list",
+		"NewJWEEncrypt should fail with empty recipientPubKeys")
+
+	recECKeys, _ := createRecipients(t, 20)
+
+	_, err = NewJWEEncrypt("", recECKeys)
+	require.EqualError(t, err, "encryption algorithm '' not supported",
+		"NewJWEEncrypt should fail with empty encAlg")
+
+	jweEncrypter, err := NewJWEEncrypt(A256GCM, recECKeys)
+	require.NoError(t, err, "NewJWEEncrypt should not fail with non empty recipientPubKeys")
+
+	jwe, err := jweEncrypter.Encrypt([]byte("some msg"), []byte("aad value"))
+	require.NoError(t, err)
+	require.Equal(t, len(recECKeys), len(jwe.Recipients))
+
+	serializedJWE, err := jwe.Serialize(json.Marshal)
+	require.NoError(t, err)
+	require.NotEmpty(t, serializedJWE)
+
+	// try to deserialize with go-jose (can't decrypt in go-jose since private key is protected by Tink)
+	joseJWE, err := jose.ParseEncrypted(serializedJWE)
+	require.NoError(t, err)
+	require.NotEmpty(t, joseJWE)
+
+	_, err = jweEncrypter.Decrypt([]byte{})
+	require.EqualError(t, err, "TODO - implement me", "TODO implement Decrypt()")
+}
+
+// createRecipients and return their public key and keyset.Handle
+func createRecipients(t *testing.T, numberOfRecipients int) ([]ecdhessubtle.ECPublicKey, []*keyset.Handle) {
+	t.Helper()
+
+	var (
+		r   []ecdhessubtle.ECPublicKey
+		rKH []*keyset.Handle
+	)
+
+	for i := 0; i < numberOfRecipients; i++ {
+		mrKey, kh := createAndMarshalRecipient(t)
+		ecPubKey := new(ecdhessubtle.ECPublicKey)
+		err := json.Unmarshal(mrKey, ecPubKey)
+		require.NoError(t, err)
+
+		r = append(r, *ecPubKey)
+		rKH = append(rKH, kh)
+	}
+
+	return r, rKH
+}
+
+// createAndMarshalRecipient creates a new recipient keyset.Handle, extracts public key, marshals it and returns
+// both marshalled public key and original recipient keyset.Handle
+func createAndMarshalRecipient(t *testing.T) ([]byte, *keyset.Handle) {
+	t.Helper()
+
+	kh, err := keyset.NewHandle(ecdhes.ECDHES256KWAES256GCMKeyTemplate())
+	require.NoError(t, err)
+
+	pubKH, err := kh.Public()
+	require.NoError(t, err)
+
+	buf := new(bytes.Buffer)
+	pubKeyWriter := ecdhes.NewWriter(buf)
+	require.NotEmpty(t, pubKeyWriter)
+
+	err = pubKH.WriteWithNoSecrets(pubKeyWriter)
+	require.NoError(t, err)
+
+	return buf.Bytes(), kh
+}
+
+func TestFailConvertRecKeyToMarshalledJWK(t *testing.T) {
+	recKey := &ecdhessubtle.RecipientWrappedKey{
+		EPK: ecdhessubtle.ECPublicKey{
+			Curve: "badCurveName",
+		},
+	}
+
+	_, err := convertRecKeyToMarshalledJWK(recKey)
+	require.EqualError(t, err, "unsupported curve")
+}
+
+func TestEmptyComputeAuthData(t *testing.T) {
+	protecteHeaders := new(map[string]interface{})
+	aad := []byte("")
+	_, err := computeAuthData(*protecteHeaders, aad)
+	require.NoError(t, err, "computeAuthData with empty protectedHeaders and empty aad should not fail")
+}
+
+func TestBadSenderKH(t *testing.T) {
+	// create a keyset.Handle that doesn't
+	aeadKT := aead.AES256GCMKeyTemplate()
+	aeadKH, err := keyset.NewHandle(aeadKT)
+	require.NoError(t, err)
+
+	// create jweEncrypter manually with a bad sender type
+	jweEncrypter := JWEEncrypt{
+		senderKH:     aeadKH,
+		getPrimitive: getEncryptionPrimitive,
+	}
+
+	_, err = jweEncrypter.Encrypt([]byte{}, []byte{})
+	require.EqualError(t, err, "jweencrypt: failed to get encryption primitive: "+
+		"keyset.Handle: keyset.Handle: keyset contains a non-private key")
+}
+
+func TestBadCryptoEncrypt(t *testing.T) {
+	mockEncrypt := &mockCompositeEncrypt{
+		EncryptValue: "",
+		EncryptError: fmt.Errorf("encryption failed"),
+	}
+
+	// create JWEEncryption with above mockEncrypt
+	jweEncrypter := JWEEncrypt{
+		getPrimitive: func(senderKH *keyset.Handle) (api.CompositeEncrypt, error) {
+			return mockEncrypt, nil
+		},
+	}
+
+	_, err := jweEncrypter.Encrypt([]byte{}, []byte{})
+	require.EqualError(t, err, "jweencrypt: failed to Encrypt: encryption failed")
+}
+
+func TestCryptoWithBadCipherTextFormatEncrypt(t *testing.T) {
+	mockEncrypt := &mockCompositeEncrypt{
+		EncryptValue: "badEncryptContent",
+		EncryptError: nil,
+	}
+
+	// create JWEEncryption with above mockEncrypt
+	jweEncrypter := JWEEncrypt{
+		getPrimitive: func(senderKH *keyset.Handle) (api.CompositeEncrypt, error) {
+			return mockEncrypt, nil
+		},
+	}
+
+	_, err := jweEncrypter.Encrypt([]byte{}, []byte{})
+	require.EqualError(t, err, "jweencrypt: unmarshal encrypted data failed: invalid character 'b' "+
+		"looking for beginning of value")
+}
+
+type mockCompositeEncrypt struct {
+	EncryptValue string
+	EncryptError error
+}
+
+// Encrypt mocks Encrypt function
+func (e *mockCompositeEncrypt) Encrypt(plainText, aad []byte) ([]byte, error) {
+	return []byte(e.EncryptValue), e.EncryptError
+}

--- a/pkg/doc/jose/jwe.go
+++ b/pkg/doc/jose/jwe.go
@@ -16,7 +16,7 @@ import (
 type JSONWebEncryption struct {
 	ProtectedHeaders   Headers
 	UnprotectedHeaders Headers
-	Recipients         []Recipient
+	Recipients         []*Recipient
 	AAD                string
 	IV                 string
 	Ciphertext         string
@@ -31,11 +31,13 @@ type Recipient struct {
 
 // RecipientHeaders are the recipient headers
 type RecipientHeaders struct {
+	Alg string `json:"alg,omitempty"`
 	APU string `json:"apu,omitempty"`
 	IV  string `json:"iv,omitempty"`
 	Tag string `json:"tag,omitempty"`
 	KID string `json:"kid,omitempty"`
 	SPK string `json:"spk,omitempty"`
+	EPK string `json:"epk,omitempty"`
 }
 
 // rawJSONWebEncryption represents a RAW JWE that is used for serialization/deserialization.
@@ -66,6 +68,10 @@ func (e *JSONWebEncryption) Serialize(marshal marshalFunc) (string, error) {
 		// even if some or all of the array values are the empty JSON object "{}".
 		recipientsJSON = json.RawMessage("[{}]")
 	} else {
+		for i, rec := range e.Recipients {
+			e.Recipients[i].EncryptedKey = base64.RawURLEncoding.EncodeToString([]byte(rec.EncryptedKey))
+		}
+
 		nonEmptyRecipientsJSON, errMarshal := marshal(e.Recipients)
 		if errMarshal != nil {
 			return "", errMarshal

--- a/pkg/doc/jose/jwe_test.go
+++ b/pkg/doc/jose/jwe_test.go
@@ -17,15 +17,15 @@ import (
 const (
 	expectedJWEAllFields = `{"protected":"eyJwcm90ZWN0ZWRoZWFkZXIxIjoicHJvdGVjdGVkdGVzdHZhbHVlMSIsInByb3RlY3RlZG` +
 		`hlYWRlcjIiOiJwcm90ZWN0ZWR0ZXN0dmFsdWUyIn0","unprotected":{"unprotectedheader1":"unprotectedtestvalue1",` +
-		`"unprotectedheader2":"unprotectedtestvalue2"},"recipients":[{"encrypted_key":"TestKey","header":` +
+		`"unprotectedheader2":"unprotectedtestvalue2"},"recipients":[{"encrypted_key":"VGVzdEtleQ","header":` +
 		`{"apu":"TestAPU","iv":"TestIV","tag":"TestTag","kid":"TestKID","spk":"TestSPK"}}],"aad":"VGVzdEFBRA",` +
 		`"iv":"VGVzdElW","ciphertext":"VGVzdENpcGhlclRleHQ","tag":"VGVzdFRhZw"}`
 	expectedJWEProtectedFieldAbsent = `{"unprotected":{"unprotectedheader1":"unprotectedtestvalue1",` +
-		`"unprotectedheader2":"unprotectedtestvalue2"},"recipients":[{"encrypted_key":"TestKey","header":{"apu":` +
+		`"unprotectedheader2":"unprotectedtestvalue2"},"recipients":[{"encrypted_key":"VGVzdEtleQ","header":{"apu":` +
 		`"TestAPU","iv":"TestIV","tag":"TestTag","kid":"TestKID","spk":"TestSPK"}}],"aad":"VGVzdEFBRA",` +
 		`"iv":"VGVzdElW","ciphertext":"VGVzdENpcGhlclRleHQ","tag":"VGVzdFRhZw"}`
 	expectedJWEUnprotectedFieldAbsent = `{"protected":"eyJwcm90ZWN0ZWRoZWFkZXIxIjoicHJvdGVjdGVkdGVzdHZhbHVlMSIs` +
-		`InByb3RlY3RlZGhlYWRlcjIiOiJwcm90ZWN0ZWR0ZXN0dmFsdWUyIn0","recipients":[{"encrypted_key":"TestKey",` +
+		`InByb3RlY3RlZGhlYWRlcjIiOiJwcm90ZWN0ZWR0ZXN0dmFsdWUyIn0","recipients":[{"encrypted_key":"VGVzdEtleQ",` +
 		`"header":{"apu":"TestAPU","iv":"TestIV","tag":"TestTag","kid":"TestKID","spk":"TestSPK"}}],"aad":` +
 		`"VGVzdEFBRA","iv":"VGVzdElW","ciphertext":"VGVzdENpcGhlclRleHQ","tag":"VGVzdFRhZw"}`
 	expectedJWERecipientsFieldAbsent = `{"protected":"eyJwcm90ZWN0ZWRoZWFkZXIxIjoicHJvdGVjdGVkdGVzdHZhbHVlMSIsI` +
@@ -34,17 +34,17 @@ const (
 		`"VGVzdEFBRA","iv":"VGVzdElW","ciphertext":"VGVzdENpcGhlclRleHQ","tag":"VGVzdFRhZw"}`
 	expectedJWEAADFieldAbsent = `{"protected":"eyJwcm90ZWN0ZWRoZWFkZXIxIjoicHJvdGVjdGVkdGVzdHZhbHVlMSIsInByb3RlY3R` +
 		`lZGhlYWRlcjIiOiJwcm90ZWN0ZWR0ZXN0dmFsdWUyIn0","unprotected":{"unprotectedheader1":"unprotectedtestvalue1",` +
-		`"unprotectedheader2":"unprotectedtestvalue2"},"recipients":[{"encrypted_key":"TestKey","header":` +
+		`"unprotectedheader2":"unprotectedtestvalue2"},"recipients":[{"encrypted_key":"VGVzdEtleQ","header":` +
 		`{"apu":"TestAPU","iv":"TestIV","tag":"TestTag","kid":"TestKID","spk":"TestSPK"}}],` +
 		`"iv":"VGVzdElW","ciphertext":"VGVzdENpcGhlclRleHQ","tag":"VGVzdFRhZw"}`
 	expectedJWEIVFieldAbsent = `{"protected":"eyJwcm90ZWN0ZWRoZWFkZXIxIjoicHJvdGVjdGVkdGVzdHZhbHVlMSIsInByb3RlY3Rl` +
 		`ZGhlYWRlcjIiOiJwcm90ZWN0ZWR0ZXN0dmFsdWUyIn0","unprotected":{"unprotectedheader1":"unprotectedtestvalue1",` +
-		`"unprotectedheader2":"unprotectedtestvalue2"},"recipients":[{"encrypted_key":"TestKey","header":` +
+		`"unprotectedheader2":"unprotectedtestvalue2"},"recipients":[{"encrypted_key":"VGVzdEtleQ","header":` +
 		`{"apu":"TestAPU","iv":"TestIV","tag":"TestTag","kid":"TestKID","spk":"TestSPK"}}],"aad":"VGVzdEFBRA",` +
 		`"ciphertext":"VGVzdENpcGhlclRleHQ","tag":"VGVzdFRhZw"}`
 	expectedJWETagFieldAbsent = `{"protected":"eyJwcm90ZWN0ZWRoZWFkZXIxIjoicHJvdGVjdGVkdGVzdHZhbHVlMSIsInByb3RlY3R` +
 		`lZGhlYWRlcjIiOiJwcm90ZWN0ZWR0ZXN0dmFsdWUyIn0","unprotected":{"unprotectedheader1":"unprotectedtestvalue1"` +
-		`,"unprotectedheader2":"unprotectedtestvalue2"},"recipients":[{"encrypted_key":"TestKey","header":` +
+		`,"unprotectedheader2":"unprotectedtestvalue2"},"recipients":[{"encrypted_key":"VGVzdEtleQ","header":` +
 		`{"apu":"TestAPU","iv":"TestIV","tag":"TestTag","kid":"TestKID","spk":"TestSPK"}}],"aad":"VGVzdEFBRA",` +
 		`"iv":"VGVzdElW","ciphertext":"VGVzdENpcGhlclRleHQ"}`
 )
@@ -57,9 +57,9 @@ func TestJSONWebEncryption_Serialize(t *testing.T) {
 			"protectedheader2": "protectedtestvalue2"}
 		unprotectedHeaders := Headers{"unprotectedheader1": "unprotectedtestvalue1",
 			"unprotectedheader2": "unprotectedtestvalue2"}
-		recipients := make([]Recipient, 1)
+		recipients := make([]*Recipient, 1)
 
-		recipients[0] = Recipient{
+		recipients[0] = &Recipient{
 			EncryptedKey: "TestKey",
 			Header: RecipientHeaders{
 				APU: "TestAPU",
@@ -86,9 +86,9 @@ func TestJSONWebEncryption_Serialize(t *testing.T) {
 	t.Run("Successfully serialize JWE, protected header value is empty", func(t *testing.T) {
 		unprotectedHeaders := Headers{"unprotectedheader1": "unprotectedtestvalue1",
 			"unprotectedheader2": "unprotectedtestvalue2"}
-		recipients := make([]Recipient, 1)
+		recipients := make([]*Recipient, 1)
 
-		recipients[0] = Recipient{
+		recipients[0] = &Recipient{
 			EncryptedKey: "TestKey",
 			Header: RecipientHeaders{
 				APU: "TestAPU",
@@ -114,9 +114,9 @@ func TestJSONWebEncryption_Serialize(t *testing.T) {
 	t.Run("Successfully serialize JWE, unprotected header value is empty", func(t *testing.T) {
 		protectedHeaders := Headers{"protectedheader1": "protectedtestvalue1",
 			"protectedheader2": "protectedtestvalue2"}
-		recipients := make([]Recipient, 1)
+		recipients := make([]*Recipient, 1)
 
-		recipients[0] = Recipient{
+		recipients[0] = &Recipient{
 			EncryptedKey: "TestKey",
 			Header: RecipientHeaders{
 				APU: "TestAPU",
@@ -162,9 +162,9 @@ func TestJSONWebEncryption_Serialize(t *testing.T) {
 			"protectedheader2": "protectedtestvalue2"}
 		unprotectedHeaders := Headers{"unprotectedheader1": "unprotectedtestvalue1",
 			"unprotectedheader2": "unprotectedtestvalue2"}
-		recipients := make([]Recipient, 1)
+		recipients := make([]*Recipient, 1)
 
-		recipients[0] = Recipient{
+		recipients[0] = &Recipient{
 			EncryptedKey: "TestKey",
 			Header: RecipientHeaders{
 				APU: "TestAPU",
@@ -192,9 +192,9 @@ func TestJSONWebEncryption_Serialize(t *testing.T) {
 			"protectedheader2": "protectedtestvalue2"}
 		unprotectedHeaders := Headers{"unprotectedheader1": "unprotectedtestvalue1",
 			"unprotectedheader2": "unprotectedtestvalue2"}
-		recipients := make([]Recipient, 1)
+		recipients := make([]*Recipient, 1)
 
-		recipients[0] = Recipient{
+		recipients[0] = &Recipient{
 			EncryptedKey: "TestKey",
 			Header: RecipientHeaders{
 				APU: "TestAPU",
@@ -222,9 +222,9 @@ func TestJSONWebEncryption_Serialize(t *testing.T) {
 			"protectedheader2": "protectedtestvalue2"}
 		unprotectedHeaders := Headers{"unprotectedheader1": "unprotectedtestvalue1",
 			"unprotectedheader2": "unprotectedtestvalue2"}
-		recipients := make([]Recipient, 1)
+		recipients := make([]*Recipient, 1)
 
-		recipients[0] = Recipient{
+		recipients[0] = &Recipient{
 			EncryptedKey: "TestKey",
 			Header: RecipientHeaders{
 				APU: "TestAPU",
@@ -252,9 +252,9 @@ func TestJSONWebEncryption_Serialize(t *testing.T) {
 			"protectedheader2": "protectedtestvalue2"}
 		unprotectedHeaders := Headers{"unprotectedheader1": "unprotectedtestvalue1",
 			"unprotectedheader2": "unprotectedtestvalue2"}
-		recipients := make([]Recipient, 1)
+		recipients := make([]*Recipient, 1)
 
-		recipients[0] = Recipient{
+		recipients[0] = &Recipient{
 			EncryptedKey: "TestKey",
 			Header: RecipientHeaders{
 				APU: "TestAPU",
@@ -292,7 +292,7 @@ func TestJSONWebEncryption_Serialize(t *testing.T) {
 	})
 	t.Run("fail to marshal recipients", func(t *testing.T) {
 		jwe := JSONWebEncryption{
-			Recipients: make([]Recipient, 0),
+			Recipients: make([]*Recipient, 0),
 		}
 
 		fm := &failingMarshaller{

--- a/pkg/doc/jose/jws.go
+++ b/pkg/doc/jose/jws.go
@@ -164,7 +164,7 @@ func mergeHeaders(h1, h2 Headers) Headers {
 	return h
 }
 
-func sign(joseHeaders Headers, payload []byte, signer Signer) ([]byte, error) {
+func sign(joseHeaders Headers, payload []byte, signer Signer) ([]byte, error) { //nolint:interfacer
 	err := checkJWSHeaders(joseHeaders)
 	if err != nil {
 		return nil, fmt.Errorf("check JOSE headers: %w", err)


### PR DESCRIPTION
Using the new ECDH-ES + AEAD Tink key templates created in tinkcrypto package,
this change introduced JWE build + Encrypt() functionality to support Anoncrypt
JWE messages.

A follow up PR will introduce JWE Decryption

part of #1638

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
