### PR TITLE
feat: Support relative DID URLs in verification methods

### DIFF
--- a/pkg/doc/did/doc_test.go
+++ b/pkg/doc/did/doc_test.go
@@ -854,7 +854,7 @@ func TestValidateDidDocProof(t *testing.T) {
 }
 
 func TestJSONConversion(t *testing.T) {
-	docs := []string{validDoc, validDocV011, validDocWithProofAndJWK}
+	docs := []string{validDoc, validDocV011, validDocWithProofAndJWK, docV011WithVerificationRelationships}
 	for _, d := range docs {
 		// setup -> create Document from json byte data
 		doc, err := ParseDocument([]byte(d))
@@ -1588,7 +1588,7 @@ const docV011WithVerificationRelationships = `{
 		"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
 	],
 	"authentication": [
-		"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+		"#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
 	],
 	"capabilityDelegation": [
 		"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"

--- a/pkg/vdri/peer/did_test.go
+++ b/pkg/vdri/peer/did_test.go
@@ -21,7 +21,7 @@ func TestComputeDID(t *testing.T) {
 	peerDID, err := computeDid(storedDoc)
 	require.NoError(t, err)
 	require.Len(t, peerDID, 57)
-	require.Equal(t, "did:peer:1zQmNyG6jwmVybr5J8z6FKQWQ1FsrZeQezYhcAj9iW7QWh5q", peerDID)
+	require.Equal(t, "did:peer:1zQmPm3QtmoaidrLT6hBKR7wcepq4u6385ENbddYXLN3c2vx", peerDID)
 }
 
 func TestComputeDIDError(t *testing.T) {


### PR DESCRIPTION
closes #1662, #1646, #1663

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

1. Relative DID URLs in Verification Method-s are supported.
2. Marshal all verification methods of DID Doc.