### PR TITLE
refactor: KMS export key templates using DER format

### DIFF
--- a/pkg/doc/verifiable/example_credential_test.go
+++ b/pkg/doc/verifiable/example_credential_test.go
@@ -12,6 +12,7 @@ import (
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/asn1"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -560,19 +561,13 @@ func (es *ecdsaSecp256k1Signer) Sign(payload []byte) ([]byte, error) {
 		panic(err)
 	}
 
-	curveBits := es.privKey.Curve.Params().BitSize
+	// use DER format of signature
+	ecdsaSig := sigverifier.NewECDSASignature(r, s)
 
-	keyBytes := curveBits / 8
-	if curveBits%8 > 0 {
-		keyBytes++
+	ret, err := asn1.Marshal(*ecdsaSig)
+	if err != nil {
+		return nil, fmt.Errorf("asn.1 encoding failed")
 	}
 
-	copyPadded := func(source []byte, size int) []byte {
-		dest := make([]byte, size)
-		copy(dest[size-len(source):], source)
-
-		return dest
-	}
-
-	return append(copyPadded(r.Bytes(), keyBytes), copyPadded(s.Bytes(), keyBytes)...), nil
+	return ret, nil
 }

--- a/pkg/kms/localkms/pubkey_export_import_test.go
+++ b/pkg/kms/localkms/pubkey_export_import_test.go
@@ -31,19 +31,19 @@ func TestPubKeyExportAndRead(t *testing.T) {
 		{
 			tcName:      "export then read ECDSAP256 public key",
 			keyType:     kms.ECDSAP256Type,
-			keyTemplate: ecdsaP256KeyWithoutPrefixTemplate(),
+			keyTemplate: signature.ECDSAP256KeyWithoutPrefixTemplate(),
 			doSign:      true,
 		},
 		{
 			tcName:      "export then read ECDSAP384 public key",
 			keyType:     kms.ECDSAP384Type,
-			keyTemplate: ecdsaP384KeyWithoutPrefixTemplate(),
+			keyTemplate: signature.ECDSAP384KeyWithoutPrefixTemplate(),
 			doSign:      true,
 		},
 		{
 			tcName:      "export then read ECDSAP521 public key",
 			keyType:     kms.ECDSAP521Type,
-			keyTemplate: ecdsaP521KeyWithoutPrefixTemplate(),
+			keyTemplate: signature.ECDSAP521KeyWithoutPrefixTemplate(),
 			doSign:      true,
 		},
 		{
@@ -128,19 +128,19 @@ func TestNegativeCases(t *testing.T) {
 
 	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP256Type", func(t *testing.T) {
 		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP256Type)
-		require.EqualError(t, err, "error getting marshalled proto key: invalid key")
+		require.EqualError(t, err, "error getting marshalled proto key: asn1: syntax error: truncated tag or length")
 		require.Empty(t, kh)
 	})
 
 	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP384Type", func(t *testing.T) {
 		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP384Type)
-		require.EqualError(t, err, "error getting marshalled proto key: invalid key")
+		require.EqualError(t, err, "error getting marshalled proto key: asn1: syntax error: truncated tag or length")
 		require.Empty(t, kh)
 	})
 
 	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP521Type", func(t *testing.T) {
 		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP521Type)
-		require.EqualError(t, err, "error getting marshalled proto key: invalid key")
+		require.EqualError(t, err, "error getting marshalled proto key: asn1: syntax error: truncated tag or length")
 		require.Empty(t, kh)
 	})
 


### PR DESCRIPTION
Revert updated Key templates in Kms Import/Export and use DER format for
signatures/verification.

Also replace all manual signatures/verifications to use DER format.

closes #1689

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
