### PR TITLE
feat: do not remove invalid data while verifying proofs

### DIFF
--- a/pkg/doc/signature/jsonld/processor.go
+++ b/pkg/doc/signature/jsonld/processor.go
@@ -8,8 +8,6 @@ package jsonld
 
 import (
 	"fmt"
-	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/piprate/json-gold/ld"
@@ -25,10 +23,28 @@ const (
 
 var logger = log.New("aries-framework/json-ld-processor")
 
-// nolint:gochecknoglobals
-var (
-	invalidRDFLinePattern = regexp.MustCompile("[0-9]*$")
-)
+// normalizeOpts holds options for canonicalization of JSON LD docs
+type normalizeOpts struct {
+	removeInvalidRDF bool
+	removeRDFMatches []string
+}
+
+// CanonicalizationOpts are the options for canonicalization of JSON LD docs
+type CanonicalizationOpts func(opts *normalizeOpts)
+
+// WithRemoveAllInvalidRDF option for removing all invalid RDF dataset from normalize document
+func WithRemoveAllInvalidRDF() CanonicalizationOpts {
+	return func(opts *normalizeOpts) {
+		opts.removeInvalidRDF = true
+	}
+}
+
+// WithRemoveInvalidRDF option for removing RDFs containing any one of the given matches
+func WithRemoveInvalidRDF(matches ...string) CanonicalizationOpts {
+	return func(opts *normalizeOpts) {
+		opts.removeRDFMatches = matches
+	}
+}
 
 // Processor is JSON-LD processor for aries.
 // processing mode JSON-LD 1.0 {RFC: https://www.w3.org/TR/2014/REC-json-ld-20140116}
@@ -51,7 +67,7 @@ func Default() *Processor {
 }
 
 // GetCanonicalDocument returns canonized document of given json ld
-func (p *Processor) GetCanonicalDocument(doc map[string]interface{}) ([]byte, error) {
+func (p *Processor) GetCanonicalDocument(doc map[string]interface{}, opts ...CanonicalizationOpts) ([]byte, error) {
 	proc := ld.NewJsonLdProcessor()
 	options := ld.NewJsonLdOptions("")
 	options.ProcessingMode = ld.JsonLd_1_1
@@ -64,9 +80,18 @@ func (p *Processor) GetCanonicalDocument(doc map[string]interface{}) ([]byte, er
 		return nil, fmt.Errorf("failed to normalize JSON-LD document: %w", err)
 	}
 
-	result, err := p.validateView(view.(string))
-	if err != nil {
-		return nil, fmt.Errorf("failed to normalize due to invalid RDF dataset: %w", err)
+	customOpts := prepareOpts(opts)
+
+	result, ok := view.(string)
+	if !ok {
+		return nil, fmt.Errorf("failed to normalize JSON-LD document, invalid view")
+	}
+
+	if customOpts.removeInvalidRDF || len(customOpts.removeRDFMatches) > 0 {
+		result, err = p.removeMatchingInvalidRDFs(result, customOpts.removeRDFMatches...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to normalize due to invalid RDF dataset: %w", err)
+		}
 	}
 
 	return []byte(result), nil
@@ -87,29 +112,52 @@ func (p *Processor) Compact(input, context interface{}, loader ld.DocumentLoader
 	return proc.Compact(input, context, options)
 }
 
-// validateView validates normalized view to find any invalid RDF. If found then it discards that data
-// and try again recursively until validation is passed and returns filtered view after removing all invalid data.
+// removeMatchingInvalidRDFs validates normalized view to find any invalid RDF and
+// returns filtered view after removing all invalid data except the ones given in rdfMatches argument.
 // [Note : handling invalid RDF data, by following pattern https://github.com/digitalbazaar/jsonld.js/issues/199]
-func (p *Processor) validateView(view string) (string, error) {
-	_, err := ld.ParseNQuads(view)
-	if err != nil {
-		if !strings.Contains(err.Error(), handleNormalizeErr) {
-			return "", err
+func (p *Processor) removeMatchingInvalidRDFs(view string, rdfMatches ...string) (string, error) {
+	views := strings.Split(view, "\n")
+
+	var filteredViews []string
+
+	var dirtyDataSet, foundInvalid bool
+
+	for _, v := range views {
+		_, err := ld.ParseNQuads(v)
+		if err != nil {
+			if !strings.Contains(err.Error(), handleNormalizeErr) {
+				return "", err
+			}
+
+			foundInvalid = true
+
+			if shouldSkipRDF(v, rdfMatches...) {
+				continue
+			}
+
+			logger.Warnf("Invalid RDF dataset in canonized JSON-LD document. %s", v)
+
+			dirtyDataSet = true
 		}
 
-		lineNumber, e := findLineNumber(err)
-		if e != nil {
-			return "", fmt.Errorf("failed to locate invalid RDF data:%w", e)
-		}
-
-		logger.Warnf("Found invalid data in normalized JSON-LD, removing invalid data at line number %d", lineNumber)
-
-		return p.validateView(removeQuad(view, lineNumber-1))
+		filteredViews = append(filteredViews, v)
 	}
 
-	// returning filtered view isn't enough since invalid RDF data might have messed up labelling prefix counter of nodes.
-	// so recreate json_ld from filtered view and get new  normalized RDF dataset view.
-	return p.normalizeFilteredDataset(view)
+	if !foundInvalid {
+		// clean RDF view, no need to regenerate
+		return view, nil
+	}
+
+	filteredView := strings.Join(filteredViews, "\n")
+	// not safe to re-generate RDF dataset from view containing invalid RDFs
+	if dirtyDataSet {
+		return filteredView, nil
+	}
+
+	logger.Debugf("Found invalid RDF dataset, Canonicalizing JSON-LD again after removing invalid data ")
+
+	// all invalid RDF dataset from view are removed, re-generate
+	return p.normalizeFilteredDataset(filteredView)
 }
 
 // normalizeFilteredDataset recreates json-ld from RDF view and
@@ -134,20 +182,28 @@ func (p *Processor) normalizeFilteredDataset(view string) (string, error) {
 	return result.(string), nil
 }
 
-// removeQuad removes quad from given index of view
-func removeQuad(view string, index int) string {
-	lines := strings.Split(view, "\n")
-	return strings.Join(append(lines[:index], lines[index+1:]...), "\n")
-}
-
-// findLineNumber finds problematic line number from error
-func findLineNumber(err error) (int, error) {
-	s := invalidRDFLinePattern.FindString(err.Error())
-
-	i, err := strconv.Atoi(s)
-	if err != nil {
-		return -1, fmt.Errorf("unable to locate invalid RDF data line number: %w", err)
+// shouldSkipRDF checks if given line of RDF view matches with any of the given matches
+func shouldSkipRDF(v string, matches ...string) bool {
+	if len(matches) == 0 {
+		return true
 	}
 
-	return i, nil
+	for _, m := range matches {
+		if strings.Contains(v, m) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// prepareOpts prepare normalizeOpts from given CanonicalizationOpts arguments.
+func prepareOpts(opts []CanonicalizationOpts) *normalizeOpts {
+	nOpts := &normalizeOpts{}
+	// apply opts
+	for _, opt := range opts {
+		opt(nOpts)
+	}
+
+	return nOpts
 }

--- a/pkg/doc/signature/proof/data_test.go
+++ b/pkg/doc/signature/proof/data_test.go
@@ -111,7 +111,8 @@ type mockSignatureSuite struct {
 }
 
 // GetCanonicalDocument will return normalized/canonical version of the document
-func (s *mockSignatureSuite) GetCanonicalDocument(doc map[string]interface{}) ([]byte, error) {
+func (s *mockSignatureSuite) GetCanonicalDocument(doc map[string]interface{},
+	opts ...jsonld.CanonicalizationOpts) ([]byte, error) {
 	return jsonld.Default().GetCanonicalDocument(doc)
 }
 

--- a/pkg/doc/signature/signer/signer.go
+++ b/pkg/doc/signature/signer/signer.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
+
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/proof"
 )
 
@@ -20,7 +22,7 @@ const defaultProofPurpose = "assertionMethod"
 // SignatureSuite encapsulates signature suite methods required for signing documents
 type SignatureSuite interface {
 	// GetCanonicalDocument will return normalized/canonical version of the document
-	GetCanonicalDocument(doc map[string]interface{}) ([]byte, error)
+	GetCanonicalDocument(doc map[string]interface{}, opts ...jsonld.CanonicalizationOpts) ([]byte, error)
 
 	// GetDigest returns document digest
 	GetDigest(doc []byte) []byte
@@ -119,7 +121,7 @@ func (signer *DocumentSigner) signObject(context *Context, jsonLdObject map[stri
 		p.JWS = proof.CreateDetachedJWTHeader(p) + ".."
 	}
 
-	message, err := proof.CreateVerifyData(suite, jsonLdObject, p)
+	message, err := proof.CreateVerifyData(suite, jsonLdObject, p, jsonld.WithRemoveAllInvalidRDF())
 	if err != nil {
 		return err
 	}

--- a/pkg/doc/signature/suite/ecdsasecp256k1signature2019/suite.go
+++ b/pkg/doc/signature/suite/ecdsasecp256k1signature2019/suite.go
@@ -41,8 +41,8 @@ func New(opts ...suite.Opt) *Suite {
 
 // GetCanonicalDocument will return normalized/canonical version of the document.
 // EcdsaSecp256k1Signature2019 signature suite uses RDF Dataset Normalization as canonicalization algorithm.
-func (s *Suite) GetCanonicalDocument(doc map[string]interface{}) ([]byte, error) {
-	return s.jsonldProcessor.GetCanonicalDocument(doc)
+func (s *Suite) GetCanonicalDocument(doc map[string]interface{}, opts ...jsonld.CanonicalizationOpts) ([]byte, error) {
+	return s.jsonldProcessor.GetCanonicalDocument(doc, opts...)
 }
 
 // GetDigest returns document digest.

--- a/pkg/doc/signature/suite/ed25519signature2018/suite.go
+++ b/pkg/doc/signature/suite/ed25519signature2018/suite.go
@@ -41,8 +41,8 @@ func New(opts ...suite.Opt) *Suite {
 
 // GetCanonicalDocument will return normalized/canonical version of the document
 // Ed25519Signature2018 signature SignatureSuite uses RDF Dataset Normalization as canonicalization algorithm
-func (s *Suite) GetCanonicalDocument(doc map[string]interface{}) ([]byte, error) {
-	return s.jsonldProcessor.GetCanonicalDocument(doc)
+func (s *Suite) GetCanonicalDocument(doc map[string]interface{}, opts ...jsonld.CanonicalizationOpts) ([]byte, error) {
+	return s.jsonldProcessor.GetCanonicalDocument(doc, opts...)
 }
 
 // GetDigest returns document digest

--- a/pkg/doc/signature/suite/jsonwebsignature2020/suite.go
+++ b/pkg/doc/signature/suite/jsonwebsignature2020/suite.go
@@ -49,8 +49,8 @@ func New(opts ...suite.Opt) *Suite {
 
 // GetCanonicalDocument will return normalized/canonical version of the document
 // Ed25519Signature2018 signature SignatureSuite uses RDF Dataset Normalization as canonicalization algorithm.
-func (s *Suite) GetCanonicalDocument(doc map[string]interface{}) ([]byte, error) {
-	return s.jsonldProcessor.GetCanonicalDocument(doc)
+func (s *Suite) GetCanonicalDocument(doc map[string]interface{}, opts ...jsonld.CanonicalizationOpts) ([]byte, error) {
+	return s.jsonldProcessor.GetCanonicalDocument(doc, opts...)
 }
 
 // GetDigest returns document digest.

--- a/pkg/doc/signature/verifier/verifier_test.go
+++ b/pkg/doc/signature/verifier/verifier_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/proof"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
@@ -180,7 +181,8 @@ type testSignatureSuite struct {
 	compactProof bool
 }
 
-func (s *testSignatureSuite) GetCanonicalDocument(map[string]interface{}) ([]byte, error) {
+func (s *testSignatureSuite) GetCanonicalDocument(map[string]interface{},
+	...jsonld.CanonicalizationOpts) ([]byte, error) {
 	return s.canonicalDocument, s.canonicalDocumentError
 }
 


### PR DESCRIPTION
- Added two options in jsonlod processor normalization process to
'remove all invalid RDFs' and 'remove only expected invalid RDFs'
- signers to use 'remove all' options
- verifiers to user 'remove only expected'
- Closes #1696

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>