### PR TITLE
refactor: add support for IEEE1363 sig key format

### DIFF
--- a/pkg/doc/signature/suite/jsonwebsignature2020/suite_crypto_test.go
+++ b/pkg/doc/signature/suite/jsonwebsignature2020/suite_crypto_test.go
@@ -26,7 +26,7 @@ import (
 func TestNewCryptoSignerAndVerifier(t *testing.T) {
 	lKMS := createKMS()
 
-	kid, kh := createKeyHandle(lKMS, kmsapi.ECDSAP256Type)
+	kid, kh := createKeyHandle(lKMS, kmsapi.ECDSAP256TypeIEEE1363)
 
 	tinkCrypto, err := tinkcrypto.New()
 	require.NoError(t, err)
@@ -48,7 +48,7 @@ func TestNewCryptoSignerAndVerifier(t *testing.T) {
 	require.NoError(t, err)
 
 	pubKey := &sigverifier.PublicKey{
-		Type:  kmsapi.ECDSAP256,
+		Type:  kmsapi.ECDSAP256IEEE1363,
 		Value: pubKeyBytes,
 	}
 
@@ -104,8 +104,8 @@ func createKMS() *localkms.LocalKMS {
 
 func mapKeyTypeToKMS(t string) (kmsapi.KeyType, error) {
 	switch t {
-	case kmsapi.ECDSAP256:
-		return kmsapi.ECDSAP256Type, nil
+	case kmsapi.ECDSAP256IEEE1363:
+		return kmsapi.ECDSAP256TypeIEEE1363, nil
 	default:
 		return "", fmt.Errorf("unsupported key type: %s", t)
 	}

--- a/pkg/doc/signature/verifier/public_key_verifier.go
+++ b/pkg/doc/signature/verifier/public_key_verifier.go
@@ -7,14 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package verifier
 
 import (
-	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rsa"
 	"crypto/x509"
-	"encoding/asn1"
 	"errors"
 	"fmt"
 	"math/big"
@@ -230,39 +228,6 @@ const (
 	secp256k1KeySize = 32
 )
 
-// ECDSASignature is a struct holding r and s values of an ECDSA signature.
-// TODO remove ECDSASignature and asn1decode() when Verify() uses pkg.Crypto interface
-type ECDSASignature struct {
-	R, S *big.Int
-}
-
-// NewECDSASignature creates a new ecdsaSignature object.
-func NewECDSASignature(r, s *big.Int) *ECDSASignature {
-	return &ECDSASignature{R: r, S: s}
-}
-
-func asn1decode(b []byte) (*ECDSASignature, error) {
-	// parse the signature
-	sig := new(ECDSASignature)
-
-	_, err := asn1.Unmarshal(b, sig)
-	if err != nil {
-		return nil, fmt.Errorf("decode failure")
-	}
-
-	// encode the signature again
-	encoded, err := asn1.Marshal(*sig)
-	if err != nil {
-		return nil, fmt.Errorf("decode failure")
-	}
-
-	if !bytes.Equal(b, encoded) {
-		return nil, fmt.Errorf("decode failure")
-	}
-
-	return sig, nil
-}
-
 // ECDSASignatureVerifier verifies elliptic curve signatures.
 type ECDSASignatureVerifier struct {
 	baseSignatureVerifier
@@ -271,7 +236,6 @@ type ECDSASignatureVerifier struct {
 }
 
 // Verify verifies the signature.
-// TODO replace logic of Verify() and call Crypto.Verify() instead
 func (sv *ECDSASignatureVerifier) Verify(pubKey *PublicKey, msg, signature []byte) error {
 	pubKeyJWK := pubKey.JWK
 	if pubKeyJWK == nil {
@@ -290,6 +254,10 @@ func (sv *ECDSASignatureVerifier) Verify(pubKey *PublicKey, msg, signature []byt
 		return errors.New("ecdsa: invalid public key type")
 	}
 
+	if len(signature) != 2*ec.keySize {
+		return errors.New("ecdsa: invalid signature size")
+	}
+
 	hasher := ec.hash.New()
 
 	_, err := hasher.Write(msg)
@@ -299,13 +267,10 @@ func (sv *ECDSASignatureVerifier) Verify(pubKey *PublicKey, msg, signature []byt
 
 	hash := hasher.Sum(nil)
 
-	// DER format decode signature
-	sig, err := asn1decode(signature)
-	if err != nil {
-		return fmt.Errorf("ecdsa: %w", err)
-	}
+	r := big.NewInt(0).SetBytes(signature[:ec.keySize])
+	s := big.NewInt(0).SetBytes(signature[ec.keySize:])
 
-	verified := ecdsa.Verify(ecdsaPubKey, hash, sig.R, sig.S)
+	verified := ecdsa.Verify(ecdsaPubKey, hash, r, s)
 	if !verified {
 		return errors.New("ecdsa: invalid signature")
 	}

--- a/pkg/doc/verifiable/credential_ldp_test.go
+++ b/pkg/doc/verifiable/credential_ldp_test.go
@@ -10,7 +10,6 @@ import (
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -155,7 +154,7 @@ func TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_Ed25519(t *testin
 func TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_ecdsaP256(t *testing.T) {
 	r := require.New(t)
 
-	// TODO replace ecdsa.GenerateKey with KMS.Create(kms.ECDSAP256Type) and use localkms and Crypto for signing
+	// TODO replace ecdsa.GenerateKey with KMS.Create(kms.ECDSAP256TypeIEEE1363) and use localkms and Crypto for signing
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
@@ -179,8 +178,7 @@ func TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_ecdsaP256(t *test
 	vcBytes, err := json.Marshal(vc)
 	r.NoError(err)
 
-	pubKeyBytes, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
-	r.NoError(err)
+	pubKeyBytes := elliptic.Marshal(privateKey.Curve, privateKey.X, privateKey.Y)
 
 	vcWithLdp, _, err := NewCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
@@ -395,11 +393,11 @@ func mapJWKToKMSKeyType(jwk *jose.JWK) (kms.KeyType, error) {
 	case "EC":
 		switch jwk.Crv {
 		case "P-256":
-			return kms.ECDSAP256Type, nil
+			return kms.ECDSAP256TypeIEEE1363, nil
 		case "P-384":
-			return kms.ECDSAP384Type, nil
+			return kms.ECDSAP384TypeIEEE1363, nil
 		case "P-521":
-			return kms.ECDSAP521Type, nil
+			return kms.ECDSAP521TypeIEEE1363, nil
 		}
 	}
 

--- a/pkg/kms/api.go
+++ b/pkg/kms/api.go
@@ -42,12 +42,18 @@ const (
 	ChaCha20Poly1305 = "ChaCha20Poly1305"
 	// XChaCha20Poly1305 key type value
 	XChaCha20Poly1305 = "XChaCha20Poly1305"
-	// ECDSAP256 key type value
-	ECDSAP256 = "ECDSAP256"
-	// ECDSAP384 key type value
-	ECDSAP384 = "ECDSAP384"
-	// ECDSAP521 key type value
-	ECDSAP521 = "ECDSAP521"
+	// ECDSAP256DER key type value
+	ECDSAP256DER = "ECDSAP256DER"
+	// ECDSAP384DER key type value
+	ECDSAP384DER = "ECDSAP384DER"
+	// ECDSAP521DER key type value
+	ECDSAP521DER = "ECDSAP521DER"
+	// ECDSAP256IEEE1363 key type value
+	ECDSAP256IEEE1363 = "ECDSAP256IEEE1363"
+	// ECDSAP384IEEE1363 key type value
+	ECDSAP384IEEE1363 = "ECDSAP384IEEE1363"
+	// ECDSAP521IEEE1363 key type value
+	ECDSAP521IEEE1363 = "ECDSAP521IEEE1363"
 	// ED25519 key type value
 	ED25519 = "ED25519"
 	// RSA key type value
@@ -72,12 +78,18 @@ const (
 	ChaCha20Poly1305Type = KeyType(ChaCha20Poly1305)
 	// XChaCha20Poly1305Type key type value
 	XChaCha20Poly1305Type = KeyType(XChaCha20Poly1305)
-	// ECDSAP256Type key type value
-	ECDSAP256Type = KeyType(ECDSAP256)
-	// ECDSAP384Type key type value
-	ECDSAP384Type = KeyType(ECDSAP384)
-	// ECDSAP521Type key type value
-	ECDSAP521Type = KeyType(ECDSAP521)
+	// ECDSAP256TypeDER key type value
+	ECDSAP256TypeDER = KeyType(ECDSAP256DER)
+	// ECDSAP384TypeDER key type value
+	ECDSAP384TypeDER = KeyType(ECDSAP384DER)
+	// ECDSAP521TypeDER key type value
+	ECDSAP521TypeDER = KeyType(ECDSAP521DER)
+	// ECDSAP256TypeIEEE1363 key type value
+	ECDSAP256TypeIEEE1363 = KeyType(ECDSAP256IEEE1363)
+	// ECDSAP384TypeIEEE1363 key type value
+	ECDSAP384TypeIEEE1363 = KeyType(ECDSAP384IEEE1363)
+	// ECDSAP521TypeIEEE1363 key type value
+	ECDSAP521TypeIEEE1363 = KeyType(ECDSAP521IEEE1363)
 	// ED25519Type key type value
 	ED25519Type = KeyType(ED25519)
 	// RSAType key type value

--- a/pkg/kms/localkms/localkms_test.go
+++ b/pkg/kms/localkms/localkms_test.go
@@ -199,9 +199,12 @@ func TestLocalKMS_Success(t *testing.T) {
 		kms.AES256GCMType,
 		kms.ChaCha20Poly1305Type,
 		kms.XChaCha20Poly1305Type,
-		kms.ECDSAP256Type,
-		kms.ECDSAP384Type,
-		kms.ECDSAP521Type,
+		kms.ECDSAP256TypeDER,
+		kms.ECDSAP384TypeDER,
+		kms.ECDSAP521TypeDER,
+		kms.ECDSAP256TypeIEEE1363,
+		kms.ECDSAP384TypeIEEE1363,
+		kms.ECDSAP521TypeIEEE1363,
 		kms.ED25519Type,
 	}
 

--- a/pkg/kms/localkms/pubkey_export_import_test.go
+++ b/pkg/kms/localkms/pubkey_export_import_test.go
@@ -29,21 +29,39 @@ func TestPubKeyExportAndRead(t *testing.T) {
 		doSign      bool
 	}{
 		{
-			tcName:      "export then read ECDSAP256 public key",
-			keyType:     kms.ECDSAP256Type,
+			tcName:      "export then read ECDSAP256DER public key",
+			keyType:     kms.ECDSAP256TypeDER,
 			keyTemplate: signature.ECDSAP256KeyWithoutPrefixTemplate(),
 			doSign:      true,
 		},
 		{
-			tcName:      "export then read ECDSAP384 public key",
-			keyType:     kms.ECDSAP384Type,
+			tcName:      "export then read ECDSAP384DER public key",
+			keyType:     kms.ECDSAP384TypeDER,
 			keyTemplate: signature.ECDSAP384KeyWithoutPrefixTemplate(),
 			doSign:      true,
 		},
 		{
-			tcName:      "export then read ECDSAP521 public key",
-			keyType:     kms.ECDSAP521Type,
+			tcName:      "export then read ECDSAP521DER public key",
+			keyType:     kms.ECDSAP521TypeDER,
 			keyTemplate: signature.ECDSAP521KeyWithoutPrefixTemplate(),
+			doSign:      true,
+		},
+		{
+			tcName:      "export then read ECDSAP256IEEE1363 public key",
+			keyType:     kms.ECDSAP256TypeIEEE1363,
+			keyTemplate: createECDSAIEEE1363KeyTemplate(commonpb.HashType_SHA256, commonpb.EllipticCurveType_NIST_P256),
+			doSign:      true,
+		},
+		{
+			tcName:      "export then read ECDSAP384IEEE1363 public key",
+			keyType:     kms.ECDSAP384TypeIEEE1363,
+			keyTemplate: createECDSAIEEE1363KeyTemplate(commonpb.HashType_SHA512, commonpb.EllipticCurveType_NIST_P384),
+			doSign:      true,
+		},
+		{
+			tcName:      "export then read ECDSAP521IEEE1363 public key",
+			keyType:     kms.ECDSAP521TypeIEEE1363,
+			keyTemplate: createECDSAIEEE1363KeyTemplate(commonpb.HashType_SHA512, commonpb.EllipticCurveType_NIST_P521),
 			doSign:      true,
 		},
 		{
@@ -115,7 +133,7 @@ func exportRawPublicKeyBytes(t *testing.T, keyTemplate *tinkpb.KeyTemplate, expe
 
 func TestNegativeCases(t *testing.T) {
 	t.Run("test publicKeyBytesToHandle with empty pubKey", func(t *testing.T) {
-		kh, err := publicKeyBytesToHandle([]byte{}, kms.ECDSAP256Type)
+		kh, err := publicKeyBytesToHandle([]byte{}, kms.ECDSAP256TypeIEEE1363)
 		require.EqualError(t, err, "pubKey is empty")
 		require.Empty(t, kh)
 	})
@@ -126,26 +144,53 @@ func TestNegativeCases(t *testing.T) {
 		require.Empty(t, kh)
 	})
 
-	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP256Type", func(t *testing.T) {
-		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP256Type)
+	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP256TypeDER", func(t *testing.T) {
+		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP256TypeDER)
 		require.EqualError(t, err, "error getting marshalled proto key: asn1: syntax error: truncated tag or length")
 		require.Empty(t, kh)
 	})
 
-	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP384Type", func(t *testing.T) {
-		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP384Type)
+	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP256TypeIEEE1363", func(t *testing.T) {
+		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP256TypeIEEE1363)
+		require.EqualError(t, err, "error getting marshalled proto key: failed to unamrshal public ecdsa key")
+		require.Empty(t, kh)
+	})
+
+	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP384TypeDER", func(t *testing.T) {
+		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP384TypeDER)
 		require.EqualError(t, err, "error getting marshalled proto key: asn1: syntax error: truncated tag or length")
 		require.Empty(t, kh)
 	})
 
-	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP521Type", func(t *testing.T) {
-		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP521Type)
+	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP384TypeIEEE1363", func(t *testing.T) {
+		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP384TypeIEEE1363)
+		require.EqualError(t, err, "error getting marshalled proto key: failed to unamrshal public ecdsa key")
+		require.Empty(t, kh)
+	})
+
+	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP521TypeDER", func(t *testing.T) {
+		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP521TypeDER)
 		require.EqualError(t, err, "error getting marshalled proto key: asn1: syntax error: truncated tag or length")
+		require.Empty(t, kh)
+	})
+
+	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP521TypeIEEE1363", func(t *testing.T) {
+		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP521TypeIEEE1363)
+		require.EqualError(t, err, "error getting marshalled proto key: failed to unamrshal public ecdsa key")
 		require.Empty(t, kh)
 	})
 
 	t.Run("test getMarshalledECDSAKey with empty curveName", func(t *testing.T) {
-		kh, err := getMarshalledECDSAKey([]byte{},
+		kh, err := getMarshalledECDSADERKey([]byte{},
+			"",
+			commonpb.EllipticCurveType_NIST_P521,
+			commonpb.HashType_SHA512)
+		require.EqualError(t, err, "undefined curve")
+		require.Empty(t, kh)
+	})
+
+	t.Run("test getMarshalledECDSAKey with empty curveName", func(t *testing.T) {
+		kh, err := getMarshalledECDSAIEEE1363Key([]byte{},
 			"",
 			commonpb.EllipticCurveType_NIST_P521,
 			commonpb.HashType_SHA512)


### PR DESCRIPTION
To support JWS signature, LocalKMS now has this new key format.

DER key format is still available for X509 support.

closes #1703

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
