### PR TITLE
feat: presentation/credential records to have query/filter args

### DIFF
--- a/pkg/controller/command/verifiable/command.go
+++ b/pkg/controller/command/verifiable/command.go
@@ -67,6 +67,12 @@ const (
 
 	// GetPresentationErrorCode for get vp error
 	GetPresentationErrorCode
+
+	// GetCredentialsErrorCode for get credential records
+	GetCredentialsErrorCode
+
+	// GetPresentationsErrorCode for get presentation records
+	GetPresentationsErrorCode
 )
 
 const (
@@ -437,7 +443,12 @@ func (o *Command) GetCredentialByName(rw io.Writer, req io.Reader) command.Error
 
 // GetCredentials retrieves the verifiable credential records containing name and fields of interest.
 func (o *Command) GetCredentials(rw io.Writer, req io.Reader) command.Error {
-	vcRecords := o.verifiableStore.GetCredentials()
+	vcRecords, err := o.verifiableStore.GetCredentials()
+	if err != nil {
+		logutil.LogError(logger, commandName, getCredentialsCommandMethod, "get credential records : "+err.Error())
+
+		return command.NewValidationError(GetCredentialsErrorCode, fmt.Errorf("get credential records : %w", err))
+	}
 
 	command.WriteNillableResponse(rw, &RecordResult{
 		Result: vcRecords,
@@ -450,7 +461,12 @@ func (o *Command) GetCredentials(rw io.Writer, req io.Reader) command.Error {
 
 // GetPresentations retrieves the verifiable presentation records containing name and fields of interest.
 func (o *Command) GetPresentations(rw io.Writer, req io.Reader) command.Error {
-	vpRecords := o.verifiableStore.GetPresentations()
+	vpRecords, err := o.verifiableStore.GetPresentations()
+	if err != nil {
+		logutil.LogError(logger, commandName, getPresentationsCommandMethod, "get presentation records : "+err.Error())
+
+		return command.NewValidationError(GetPresentationsErrorCode, fmt.Errorf("get presentation records : %w", err))
+	}
 
 	command.WriteNillableResponse(rw, &RecordResult{
 		Result: vpRecords,

--- a/pkg/controller/command/verifiable/command_test.go
+++ b/pkg/controller/command/verifiable/command_test.go
@@ -588,6 +588,8 @@ func TestGetCredentials(t *testing.T) {
 		// verify response
 		require.NotEmpty(t, response)
 		require.Equal(t, 1, len(response.Result))
+		require.Len(t, response.Result[0].Context, 1)
+		require.Len(t, response.Result[0].Type, 1)
 	})
 }
 
@@ -1495,7 +1497,9 @@ func TestGetPresentations(t *testing.T) {
 
 		// verify response
 		require.NotEmpty(t, response)
-		require.Equal(t, 1, len(response.Result))
+		require.Len(t, response.Result, 1)
+		require.Len(t, response.Result[0].Context, 2)
+		require.Len(t, response.Result[0].Type, 1)
 	})
 }
 

--- a/pkg/controller/rest/verifiable/operation_test.go
+++ b/pkg/controller/rest/verifiable/operation_test.go
@@ -437,6 +437,8 @@ func TestGetCredentials(t *testing.T) {
 		// verify response
 		require.NotEmpty(t, response)
 		require.Equal(t, 1, len(response.Result))
+		require.Len(t, response.Result[0].Context, 1)
+		require.Len(t, response.Result[0].Type, 1)
 	})
 }
 
@@ -860,6 +862,8 @@ func TestGetPresentations(t *testing.T) {
 		// verify response
 		require.NotEmpty(t, response)
 		require.Equal(t, 2, len(response.Result))
+		require.Len(t, response.Result[0].Context, 2)
+		require.Len(t, response.Result[0].Type, 1)
 	})
 }
 

--- a/pkg/didcomm/protocol/issuecredential/states_test.go
+++ b/pkg/didcomm/protocol/issuecredential/states_test.go
@@ -23,6 +23,7 @@ import (
 	serviceMocks "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/didcomm/common/service"
 	issuecredentialMocks "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/didcomm/protocol/issuecredential"
 	storageMocks "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	storeVerifiable "github.com/hyperledger/aries-framework-go/pkg/store/verifiable"
 )
 
@@ -655,7 +656,7 @@ func TestCredentialReceived_ExecuteInbound(t *testing.T) {
 		defer ctrl.Finish()
 
 		store := storageMocks.NewMockStore(ctrl)
-		store.EXPECT().Get(gomock.Any()).Return(nil, nil)
+		store.EXPECT().Get(gomock.Any()).Return(nil, storage.ErrDataNotFound)
 		store.EXPECT().Put(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
 		storeProvider := storageMocks.NewMockProvider(ctrl)

--- a/pkg/store/verifiable/models.go
+++ b/pkg/store/verifiable/models.go
@@ -8,6 +8,8 @@ package verifiable
 
 // Record model containing name, ID and other fields of interest
 type Record struct {
-	Name string `json:"name,omitempty"`
-	ID   string `json:"id,omitempty"`
+	Name    string   `json:"name,omitempty"`
+	ID      string   `json:"id,omitempty"`
+	Context []string `json:"context,omitempty"`
+	Type    []string `json:"type,omitempty"`
 }

--- a/test/aries-js-worker/test/verifiable/verifiable.js
+++ b/test/aries-js-worker/test/verifiable/verifiable.js
@@ -109,6 +109,8 @@ async function verifiableStore(newAries, mode = wasmMode) {
                     assert.equal(1, resp.result.length)
                     assert.equal(vcID, resp.result[0].id)
                     assert.equal(vcName, resp.result[0].name)
+                    assert.isNotEmpty(vcName, resp.result[0].type)
+                    assert.isNotEmpty(vcName, resp.result[0].context)
                 } catch (err) {
                     done(err)
                 }


### PR DESCRIPTION
- presentation/credentials to have more than just ID - added 'type', 'contexts'.
- these new fields can be used to query/filter records
- Closes #1708

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
