### PR TITLE
feat: support embedded requests in outofband request messages

### DIFF
--- a/pkg/client/didexchange/event.go
+++ b/pkg/client/didexchange/event.go
@@ -6,11 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 package didexchange
 
-// Event properties related api. This can be used to cast Generic event properties to DID Exchange specific props.
-type Event interface {
-	// connection ID
-	ConnectionID() string
+import "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 
-	// invitation ID
-	InvitationID() string
-}
+// Event properties related api. This can be used to cast Generic event properties to DID Exchange specific props.
+type Event didexchange.Event

--- a/pkg/didcomm/protocol/decorator/decorator.go
+++ b/pkg/didcomm/protocol/decorator/decorator.go
@@ -6,7 +6,13 @@ SPDX-License-Identifier: Apache-2.0
 
 package decorator
 
-import "time"
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
 
 const (
 	// TransportReturnRouteNone return route option none
@@ -86,4 +92,33 @@ type AttachmentData struct {
 	// JSON is a directly embedded JSON data, when representing content inline instead of via links,
 	// and when the content is natively conveyable as JSON. Optional.
 	JSON interface{} `json:"json,omitempty"`
+}
+
+// Fetch this attachment's contents.
+func (d *AttachmentData) Fetch() ([]byte, error) {
+	if d.JSON != nil {
+		bits, err := json.Marshal(d.JSON)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal json contents : %w", err)
+		}
+
+		return bits, nil
+	}
+
+	if d.Base64 != "" {
+		bits, err := base64.StdEncoding.DecodeString(d.Base64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to base64 decode attachment contents : %w", err)
+		}
+
+		return bits, nil
+	}
+
+	// TODO add support for checksum verification
+
+	// TODO add support to fetch links
+
+	// TODO add support for jws signatures
+
+	return nil, errors.New("no contents in this attachment")
 }

--- a/pkg/didcomm/protocol/decorator/decorator_test.go
+++ b/pkg/didcomm/protocol/decorator/decorator_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package decorator
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttachmentData_Fetch(t *testing.T) {
+	t.Run("json", func(t *testing.T) {
+		expected := map[string]interface{}{
+			"FirstName": "John",
+			"LastName":  "Doe",
+		}
+		bits, err := (&AttachmentData{JSON: expected}).Fetch()
+		require.NoError(t, err)
+		result := make(map[string]interface{})
+		err = json.Unmarshal(bits, &result)
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+	})
+	t.Run("base64", func(t *testing.T) {
+		expected := &testStruct{
+			FirstName: "John",
+			LastName:  "Doe",
+		}
+		tmp, err := json.Marshal(expected)
+		require.NoError(t, err)
+		encoded := base64.StdEncoding.EncodeToString(tmp)
+		bytes, err := (&AttachmentData{Base64: encoded}).Fetch()
+		require.NoError(t, err)
+		result := &testStruct{}
+		err = json.Unmarshal(bytes, result)
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+	})
+	t.Run("invalid json", func(t *testing.T) {
+		_, err := (&AttachmentData{JSON: func() {}}).Fetch()
+		require.Error(t, err)
+	})
+	t.Run("invalid base64", func(t *testing.T) {
+		_, err := (&AttachmentData{Base64: "invalid"}).Fetch()
+		require.Error(t, err)
+	})
+	t.Run("no contents", func(t *testing.T) {
+		_, err := (&AttachmentData{}).Fetch()
+		require.Error(t, err)
+	})
+}
+
+type testStruct struct {
+	FirstName string
+	LastName  string
+}

--- a/pkg/didcomm/protocol/didexchange/event.go
+++ b/pkg/didcomm/protocol/didexchange/event.go
@@ -6,6 +6,15 @@ SPDX-License-Identifier: Apache-2.0
 
 package didexchange
 
+// Event properties related api. This can be used to cast Generic event properties to DID Exchange specific props.
+type Event interface {
+	// connection ID
+	ConnectionID() string
+
+	// invitation ID
+	InvitationID() string
+}
+
 // didExchangeEvent implements didexchange.Event interface.
 type didExchangeEvent struct {
 	connectionID string

--- a/pkg/didcomm/protocol/didexchange/persistence.go
+++ b/pkg/didcomm/protocol/didexchange/persistence.go
@@ -49,7 +49,7 @@ func (c *connectionStore) saveConnectionRecord(record *connection.Record) error 
 		return fmt.Errorf(" failed to save connection record : %w", err)
 	}
 
-	if record.State == stateNameCompleted {
+	if record.State == StateIDCompleted {
 		if err := c.SaveDIDByResolving(record.TheirDID, record.RecipientKeys...); err != nil {
 			return fmt.Errorf(" failed to save DID by resolving : %w", err)
 		}

--- a/pkg/didcomm/protocol/didexchange/persistence_test.go
+++ b/pkg/didcomm/protocol/didexchange/persistence_test.go
@@ -47,7 +47,7 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 		require.NoError(t, err)
 		connRec := &connection.Record{ThreadID: threadIDValue,
 
-			ConnectionID: connIDValue, State: stateNameInvited, Namespace: theirNSPrefix}
+			ConnectionID: connIDValue, State: StateIDInvited, Namespace: theirNSPrefix}
 		err = record.saveConnectionRecordWithMapping(connRec)
 		require.NoError(t, err)
 
@@ -60,7 +60,7 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 		require.NoError(t, err)
 		connRec := &connection.Record{ThreadID: threadIDValue,
 
-			ConnectionID: connIDValue, State: stateNameInvited}
+			ConnectionID: connIDValue, State: StateIDInvited}
 		err = record.saveConnectionRecordWithMapping(connRec)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "empty")
@@ -75,7 +75,7 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 		})
 		require.NoError(t, err)
 		connRec := &connection.Record{ThreadID: "",
-			ConnectionID: "test", State: stateNameInvited, Namespace: theirNSPrefix}
+			ConnectionID: "test", State: StateIDInvited, Namespace: theirNSPrefix}
 		err = record.saveConnectionRecord(connRec)
 		require.Contains(t, err.Error(), errMsg)
 	})
@@ -89,7 +89,7 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 		})
 		require.NoError(t, err)
 		connRec := &connection.Record{ThreadID: threadIDValue,
-			ConnectionID: connIDValue, State: stateNameInvited, Namespace: theirNSPrefix}
+			ConnectionID: connIDValue, State: StateIDInvited, Namespace: theirNSPrefix}
 		err = record.saveConnectionRecordWithMapping(connRec)
 		require.Contains(t, err.Error(), errMsg)
 	})
@@ -105,7 +105,7 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 
 		require.NotNil(t, record)
 		connRec := &connection.Record{ThreadID: threadIDValue,
-			ConnectionID: connIDValue, State: stateNameCompleted, Namespace: theirNSPrefix}
+			ConnectionID: connIDValue, State: StateIDCompleted, Namespace: theirNSPrefix}
 		err = record.saveConnectionRecordWithMapping(connRec)
 		require.Contains(t, err.Error(), errMsg)
 	})
@@ -123,7 +123,7 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 		require.NoError(t, err)
 
 		connRec := &connection.Record{ThreadID: threadIDValue, MyDID: "did:foo",
-			ConnectionID: connIDValue, State: stateNameCompleted, Namespace: theirNSPrefix}
+			ConnectionID: connIDValue, State: StateIDCompleted, Namespace: theirNSPrefix}
 		err = record.saveConnectionRecordWithMapping(connRec)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "resolve error")
@@ -146,7 +146,7 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 		require.NoError(t, err)
 
 		connRec := &connection.Record{ThreadID: threadIDValue, MyDID: "did:foo",
-			ConnectionID: connIDValue, State: stateNameCompleted, Namespace: theirNSPrefix}
+			ConnectionID: connIDValue, State: StateIDCompleted, Namespace: theirNSPrefix}
 		err = record.saveConnectionRecord(connRec)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "resolve error")
@@ -165,7 +165,7 @@ func TestConnectionRecorder_GetConnectionRecordByNSThreadID(t *testing.T) {
 
 		require.NotNil(t, record)
 		connRec := &connection.Record{ThreadID: threadIDValue,
-			ConnectionID: connIDValue, State: stateNameInvited, Namespace: myNSPrefix}
+			ConnectionID: connIDValue, State: StateIDInvited, Namespace: myNSPrefix}
 		err = record.saveConnectionRecordWithMapping(connRec)
 		require.NoError(t, err)
 
@@ -181,7 +181,7 @@ func TestConnectionRecorder_GetConnectionRecordByNSThreadID(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, record)
 		connRec := &connection.Record{ThreadID: threadIDValue,
-			ConnectionID: connIDValue, State: stateNameInvited, Namespace: theirNSPrefix}
+			ConnectionID: connIDValue, State: StateIDInvited, Namespace: theirNSPrefix}
 		err = record.saveConnectionRecordWithMapping(connRec)
 		require.NoError(t, err)
 

--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -414,12 +414,12 @@ func (s *Service) startInternalListener() {
 
 // AcceptInvitation accepts/approves connection invitation.
 func (s *Service) AcceptInvitation(connectionID, publicDID, label string) error {
-	return s.accept(connectionID, publicDID, label, stateNameInvited, "accept exchange invitation")
+	return s.accept(connectionID, publicDID, label, StateIDInvited, "accept exchange invitation")
 }
 
 // AcceptExchangeRequest accepts/approves connection request.
 func (s *Service) AcceptExchangeRequest(connectionID, publicDID, label string) error {
-	return s.accept(connectionID, publicDID, label, stateNameRequested, "accept exchange request")
+	return s.accept(connectionID, publicDID, label, StateIDRequested, "accept exchange request")
 }
 
 // RespondTo this inbound invitation and return with the new connection record's ID.
@@ -512,7 +512,7 @@ func (s *Service) abandon(thID string, msg service.DIDCommMsg, processErr error)
 		ProtocolName: DIDExchange,
 		Type:         service.PostState,
 		Msg:          msg,
-		StateID:      stateNameAbandoned,
+		StateID:      StateIDAbandoned,
 		Properties:   createErrorEventProperties(connRec.ConnectionID, "", processErr),
 	})
 
@@ -552,9 +552,9 @@ func (s *Service) currentState(nsThID string) (state, error) {
 }
 
 func (s *Service) update(msgType string, connectionRecord *connection.Record) error {
-	if (msgType == RequestMsgType && connectionRecord.State == stateNameRequested) ||
-		(msgType == InvitationMsgType && connectionRecord.State == stateNameInvited) ||
-		(msgType == oobMsgType && connectionRecord.State == stateNameInvited) {
+	if (msgType == RequestMsgType && connectionRecord.State == StateIDRequested) ||
+		(msgType == InvitationMsgType && connectionRecord.State == StateIDInvited) ||
+		(msgType == oobMsgType && connectionRecord.State == StateIDInvited) {
 		return s.connectionStore.saveConnectionRecordWithMapping(connectionRecord)
 	}
 
@@ -715,7 +715,7 @@ func generateRandomID() string {
 // 1. Role is invitee and state is invited
 // 2. Role is inviter and state is requested
 func canTriggerActionEvents(stateID, ns string) bool {
-	return (stateID == stateNameInvited && ns == myNSPrefix) || (stateID == stateNameRequested && ns == theirNSPrefix)
+	return (stateID == StateIDInvited && ns == myNSPrefix) || (stateID == StateIDRequested && ns == theirNSPrefix)
 }
 
 type options struct {

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -347,9 +347,9 @@ func handleMessagesInvitee(statusCh chan service.StateMsg, requestedCh chan stri
 	for e := range statusCh {
 		if e.Type == service.PostState {
 			// receive the events
-			if e.StateID == stateNameCompleted {
+			if e.StateID == StateIDCompleted {
 				close(completedCh)
-			} else if e.StateID == stateNameRequested {
+			} else if e.StateID == StateIDRequested {
 				prop, ok := e.Properties.(event)
 				if !ok {
 					panic("Failed to cast the event properties to service.Event")
@@ -660,7 +660,7 @@ func TestEventsSuccess(t *testing.T) {
 
 	go func() {
 		for e := range statusCh {
-			if e.Type == service.PostState && e.StateID == stateNameRequested {
+			if e.Type == service.PostState && e.StateID == StateIDRequested {
 				done <- struct{}{}
 			}
 		}
@@ -770,7 +770,7 @@ func TestEventsUserError(t *testing.T) {
 			case e := <-actionCh:
 				e.Stop(errors.New("invalid id"))
 			case e := <-statusCh:
-				if e.Type == service.PostState && e.StateID == stateNameAbandoned {
+				if e.Type == service.PostState && e.StateID == StateIDAbandoned {
 					done <- struct{}{}
 				}
 			}
@@ -919,7 +919,7 @@ func TestServiceErrors(t *testing.T) {
 	require.Contains(t, err.Error(), "invalid state name:")
 
 	// invalid state name
-	message.NextStateName = stateNameInvited
+	message.NextStateName = StateIDInvited
 	message.ConnRecord = &connection.Record{ConnectionID: "abc"}
 	err = svc.handleWithoutAction(message)
 	require.Error(t, err)
@@ -1099,7 +1099,7 @@ func TestAcceptExchangeRequest(t *testing.T) {
 
 	go func() {
 		for e := range statusCh {
-			if e.Type == service.PostState && e.StateID == stateNameResponded {
+			if e.Type == service.PostState && e.StateID == StateIDResponded {
 				done <- struct{}{}
 			}
 		}
@@ -1165,7 +1165,7 @@ func TestAcceptExchangeRequestWithPublicDID(t *testing.T) {
 
 	go func() {
 		for e := range statusCh {
-			if e.Type == service.PostState && e.StateID == stateNameResponded {
+			if e.Type == service.PostState && e.StateID == StateIDResponded {
 				done <- struct{}{}
 			}
 		}
@@ -1219,11 +1219,11 @@ func TestAcceptInvitation(t *testing.T) {
 					require.Fail(t, "Failed to cast the event properties to service.Event")
 				}
 
-				if e.Type == service.PostState && e.StateID == stateNameInvited {
+				if e.Type == service.PostState && e.StateID == StateIDInvited {
 					require.NoError(t, svc.AcceptInvitation(prop.ConnectionID(), "", ""))
 				}
 
-				if e.Type == service.PostState && e.StateID == stateNameRequested {
+				if e.Type == service.PostState && e.StateID == StateIDRequested {
 					done <- struct{}{}
 				}
 			}
@@ -1273,7 +1273,7 @@ func TestAcceptInvitation(t *testing.T) {
 		id := generateRandomID()
 		connRecord := &connection.Record{
 			ConnectionID: id,
-			State:        stateNameRequested,
+			State:        StateIDRequested,
 		}
 		err = svc.connectionStore.saveConnectionRecord(connRecord)
 		require.NoError(t, err)
@@ -1297,7 +1297,7 @@ func TestAcceptInvitation(t *testing.T) {
 		id := generateRandomID()
 		connRecord := &connection.Record{
 			ConnectionID: id,
-			State:        stateNameRequested,
+			State:        StateIDRequested,
 		}
 
 		err = svc.storeEventTransientData(&message{ConnRecord: connRecord})
@@ -1351,11 +1351,11 @@ func TestAcceptInvitationWithPublicDID(t *testing.T) {
 					require.Fail(t, "Failed to cast the event properties to service.Event")
 				}
 
-				if e.Type == service.PostState && e.StateID == stateNameInvited {
+				if e.Type == service.PostState && e.StateID == StateIDInvited {
 					require.NoError(t, svc.AcceptInvitation(prop.ConnectionID(), publicDID, "sample-label"))
 				}
 
-				if e.Type == service.PostState && e.StateID == stateNameRequested {
+				if e.Type == service.PostState && e.StateID == StateIDRequested {
 					done <- struct{}{}
 				}
 			}
@@ -1405,7 +1405,7 @@ func TestAcceptInvitationWithPublicDID(t *testing.T) {
 		id := generateRandomID()
 		connRecord := &connection.Record{
 			ConnectionID: id,
-			State:        stateNameRequested,
+			State:        StateIDRequested,
 		}
 		err = svc.connectionStore.saveConnectionRecord(connRecord)
 		require.NoError(t, err)
@@ -1429,7 +1429,7 @@ func TestAcceptInvitationWithPublicDID(t *testing.T) {
 		id := generateRandomID()
 		connRecord := &connection.Record{
 			ConnectionID: id,
-			State:        stateNameRequested,
+			State:        StateIDRequested,
 		}
 
 		err = svc.storeEventTransientData(&message{ConnRecord: connRecord})
@@ -1522,7 +1522,7 @@ func TestNextState(t *testing.T) {
 
 		s, errState := svc.nextState(RequestMsgType, generateRandomID())
 		require.NoError(t, errState)
-		require.Equal(t, stateNameRequested, s.Name())
+		require.Equal(t, StateIDRequested, s.Name())
 	})
 }
 

--- a/pkg/didcomm/protocol/didexchange/states_test.go
+++ b/pkg/didcomm/protocol/didexchange/states_test.go
@@ -107,7 +107,7 @@ func TestCompletedState(t *testing.T) {
 
 func TestAbandonedState(t *testing.T) {
 	abandoned := &abandoned{}
-	require.Equal(t, stateNameAbandoned, abandoned.Name())
+	require.Equal(t, StateIDAbandoned, abandoned.Name())
 	require.False(t, abandoned.CanTransitionTo(&null{}))
 	require.False(t, abandoned.CanTransitionTo(&invited{}))
 	require.False(t, abandoned.CanTransitionTo(&requested{}))

--- a/pkg/framework/aries/api/protocol.go
+++ b/pkg/framework/aries/api/protocol.go
@@ -41,6 +41,7 @@ type Provider interface {
 	Signer() legacykms.Signer
 	TransientStorageProvider() storage.Provider
 	InboundMessageHandler() didcommtransport.InboundMessageHandler
+	OutboundMessageHandler() service.OutboundHandler
 }
 
 // ProtocolSvcCreator method to create new protocol service

--- a/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
+++ b/pkg/internal/mock/didcomm/protocol/didexchange/mock_didexchange.go
@@ -200,3 +200,19 @@ func (p *MockProvider) VDRIRegistry() vdriapi.Registry {
 
 	return &mockvdri.MockVDRIRegistry{}
 }
+
+// MockEventProperties is a didexchange.Event
+type MockEventProperties struct {
+	ConnID string
+	InvID  string
+}
+
+// ConnectionID returns the connection id
+func (m *MockEventProperties) ConnectionID() string {
+	return m.ConnID
+}
+
+// InvitationID returns the invitation id
+func (m *MockEventProperties) InvitationID() string {
+	return m.InvID
+}

--- a/pkg/internal/mock/didcomm/protocol/mock_protocol.go
+++ b/pkg/internal/mock/didcomm/protocol/mock_protocol.go
@@ -31,6 +31,7 @@ type MockProvider struct {
 	ServiceErr             error
 	ServiceMap             map[string]interface{}
 	InboundMsgHandler      transport.InboundMessageHandler
+	OutboundMsgHandler     service.OutboundHandler
 }
 
 // OutboundDispatcher is mock outbound dispatcher for DID exchange service
@@ -104,4 +105,9 @@ func (p *MockProvider) Messenger() service.Messenger {
 // InboundMessageHandler handles an unpacked inbound message.
 func (p *MockProvider) InboundMessageHandler() transport.InboundMessageHandler {
 	return p.InboundMsgHandler
+}
+
+// OutboundMessageHandler handles an outbound message.
+func (p *MockProvider) OutboundMessageHandler() service.OutboundHandler {
+	return p.OutboundMsgHandler
 }

--- a/test/bdd/features/introduce.feature
+++ b/test/bdd/features/introduce.feature
@@ -54,6 +54,18 @@ Feature: Introduce protocol
     Then  "Carol" has did exchange connection with "Bob"
     And   "Carol" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,done,done" and stop
 
+  @proposal_response_with_embedded_route_request
+  Scenario: Bob sends a response with approve and an out-of-band request with an embedded route-request.
+    Given   "Alice-Router,Bob" exchange DIDs with "Alice"
+    When   "Alice" sends introduce proposal to the "Alice-Router" and "Bob"
+    And   "Alice-Router" wants to know "Bob" and sends introduce response with approve and provides an out-of-band request with an embedded "route-request"
+    And   "Bob" wants to know "Alice-Router" and sends introduce response with approve
+    Then   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,arranging,arranging,arranging,arranging,delivering,delivering,confirming,confirming,done,done"
+    And   "Alice-Router" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,done,done"
+    Then  "Bob" has did exchange connection with "Alice-Router"
+    And   "Bob" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,done,done" and stop
+    Then  "Bob" confirms route registration with "Alice-Router"
+
   @proposal_with_request
   Scenario: Bob sends a response with approve and an out-of-band request. The protocol starts with introduce request
     Given   "Bob,Carol" exchange DIDs with "Alice"


### PR DESCRIPTION
This PR:

* Demonstrates automatic route registration immediately following an introduction between an edge agent and a router (`introduce` BDD test)
* Attaches a simple method to `decorator.AttachmentData` to fetch the bytes of an attachment (pending lots of TODOs)
* Add `OutboundMessageHandler()` to the framework's context. Used to dispatch outgoing messages embedded in outofband requests.
* Moves declaration of `client.didexchange.Event` to the service layer in order to access the connection ID following the successful completion of a didexchange protocol instance
* Exposes the didexchange service state IDs (outofband.Service needs one, and I've noticed copies of their values elsewhere in code)

closes #1493 

Signed-off-by: George Aristy <george.aristy@securekey.com>