### PR TITLE
test: JWE deserialize interop tests

### DIFF
--- a/pkg/didcomm/packer/jwe/authcrypt/authcrypt_test.go
+++ b/pkg/didcomm/packer/jwe/authcrypt/authcrypt_test.go
@@ -572,7 +572,7 @@ func deepCopy(envelope, envelope2 *Envelope) {
 	for _, r := range envelope2.Recipients {
 		newRe := &jose.Recipient{
 			EncryptedKey: r.EncryptedKey,
-			Header: jose.RecipientHeaders{
+			Header: &jose.RecipientHeaders{
 				APU: r.Header.APU,
 				KID: r.Header.KID,
 				IV:  r.Header.IV,

--- a/pkg/didcomm/packer/jwe/authcrypt/pack.go
+++ b/pkg/didcomm/packer/jwe/authcrypt/pack.go
@@ -264,7 +264,7 @@ func (p *Packer) buildRecipient(key string, apu []byte, spkEncoded, nonceEncoded
 
 	recipient := &jose.Recipient{
 		EncryptedKey: key,
-		Header:       recipientHeaders,
+		Header:       &recipientHeaders,
 	}
 
 	return recipient, nil

--- a/pkg/doc/jose/encrypter.go
+++ b/pkg/doc/jose/encrypter.go
@@ -135,7 +135,7 @@ func (je *JWEEncrypt) Encrypt(plaintext, aad []byte) (*JSONWebEncryption, error)
 
 		recipients = append(recipients, &Recipient{
 			EncryptedKey: string(rec.EncryptedCEK),
-			Header: RecipientHeaders{
+			Header: &RecipientHeaders{
 				Alg: rec.Alg,
 				EPK: string(mRecJWK),
 			},

--- a/pkg/doc/jose/encrypter_decrypter_test.go
+++ b/pkg/doc/jose/encrypter_decrypter_test.go
@@ -91,7 +91,7 @@ func TestJWEEncryptRoundTrip(t *testing.T) {
 		badJWE.Recipients = []*Recipient{
 			{
 				EncryptedKey: "someKey",
-				Header: RecipientHeaders{
+				Header: &RecipientHeaders{
 					EPK: "somerawbytes",
 				},
 			},
@@ -120,7 +120,7 @@ func TestJWEEncryptRoundTrip(t *testing.T) {
 		badJWE.Recipients = []*Recipient{
 			{
 				EncryptedKey: "someKey",
-				Header: RecipientHeaders{
+				Header: &RecipientHeaders{
 					EPK: string(mk),
 				},
 			},


### PR DESCRIPTION
Also includes some minor spec conformity fixes and an update to the JWE serialize method to output flattened syntax when there's only one recipient in order to match go-jose's JWE serialize behaviour.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>