### PR TITLE
feat: save credential and other fixes

### DIFF
--- a/cmd/aries-js-worker/src/aries.js
+++ b/cmd/aries-js-worker/src/aries.js
@@ -12,6 +12,9 @@ const inBrowser = typeof window !== 'undefined' && typeof window.document !== 'u
 // wait for 'notifierWait' milliseconds before retrying to check for incoming notifications
 const notifierWait = 10000
 
+// time out for command operations
+const commandTimeout = 20000
+
 // base path to load assets from at runtime
 const __publicPath = _ => {
     if (inNode) {
@@ -31,7 +34,7 @@ const {loadWorker} = require("worker_loader")
 // registers messages in pending and posts them to the worker
 async function invoke(w, pending, pkg, fn, arg, msgTimeout) {
     return new Promise((resolve, reject) => {
-        const timer = setTimeout(_ => reject(new Error(msgTimeout)), 5000)
+        const timer = setTimeout(_ => reject(new Error(msgTimeout)), commandTimeout)
         let payload = arg
         if (typeof arg === "string") {
             payload = JSON.parse(arg)

--- a/pkg/doc/verifiable/example_presentation_test.go
+++ b/pkg/doc/verifiable/example_presentation_test.go
@@ -180,7 +180,7 @@ func ExampleCredential_Presentation() {
 
 	fmt.Println(jws)
 
-	//Output: eyJhbGciOiJFZERTQSIsImtpZCI6IiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJkaWQ6ZXhhbXBsZTo0YTU3NTQ2OTczNDM2ZjZmNmM0YTRhNTc1NzMiLCJpc3MiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJqdGkiOiJ1cm46dXVpZDozOTc4MzQ0Zi04NTk2LTRjM2EtYTk3OC04ZmNhYmEzOTAzYzUiLCJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJdLCJ2ZXJpZmlhYmxlQ3JlZGVudGlhbCI6W3siQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy9leGFtcGxlcy92MSJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwidW5pdmVyc2l0eSI6Ik1JVCJ9LCJpZCI6ImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSIsIm5hbWUiOiJKYXlkZW4gRG9lIiwic3BvdXNlIjoiZGlkOmV4YW1wbGU6YzI3NmUxMmVjMjFlYmZlYjFmNzEyZWJjNmYxIn0sImV4cGlyYXRpb25EYXRlIjoiMjAyMC0wMS0wMVQxOToyMzoyNFoiLCJpZCI6Imh0dHA6Ly9leGFtcGxlLmVkdS9jcmVkZW50aWFscy8xODcyIiwiaXNzdWFuY2VEYXRlIjoiMjAxMC0wMS0wMVQxOToyMzoyNFoiLCJpc3N1ZXIiOnsiaWQiOiJkaWQ6ZXhhbXBsZTo3NmUxMmVjNzEyZWJjNmYxYzIyMWViZmViMWYiLCJuYW1lIjoiRXhhbXBsZSBVbml2ZXJzaXR5In0sInJlZmVyZW5jZU51bWJlciI6ODMyOTQ4NDcsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJVbml2ZXJzaXR5RGVncmVlQ3JlZGVudGlhbCJdfV19fQ.eK1cySQybVKqg-fHxe5FZRNM3ldAS9yQfwlesLVPsEodPjb6I67CJk7LdByToR9UiJaWMBuWggVsuvLiFfHyAw
+	//Output: eyJhbGciOiJFZERTQSIsImtpZCI6IiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJkaWQ6ZXhhbXBsZTo0YTU3NTQ2OTczNDM2ZjZmNmM0YTRhNTc1NzMiLCJpc3MiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJqdGkiOiJ1cm46dXVpZDozOTc4MzQ0Zi04NTk2LTRjM2EtYTk3OC04ZmNhYmEzOTAzYzUiLCJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sInR5cGUiOiJWZXJpZmlhYmxlUHJlc2VudGF0aW9uIiwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjEiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsiZGVncmVlIjp7InR5cGUiOiJCYWNoZWxvckRlZ3JlZSIsInVuaXZlcnNpdHkiOiJNSVQifSwiaWQiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJuYW1lIjoiSmF5ZGVuIERvZSIsInNwb3VzZSI6ImRpZDpleGFtcGxlOmMyNzZlMTJlYzIxZWJmZWIxZjcxMmViYzZmMSJ9LCJleHBpcmF0aW9uRGF0ZSI6IjIwMjAtMDEtMDFUMTk6MjM6MjRaIiwiaWQiOiJodHRwOi8vZXhhbXBsZS5lZHUvY3JlZGVudGlhbHMvMTg3MiIsImlzc3VhbmNlRGF0ZSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiaXNzdWVyIjp7ImlkIjoiZGlkOmV4YW1wbGU6NzZlMTJlYzcxMmViYzZmMWMyMjFlYmZlYjFmIiwibmFtZSI6IkV4YW1wbGUgVW5pdmVyc2l0eSJ9LCJyZWZlcmVuY2VOdW1iZXIiOjgzMjk0ODQ3LCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiVW5pdmVyc2l0eURlZ3JlZUNyZWRlbnRpYWwiXX1dfX0.unVpRimElebEyR-mly26IMkm-XVCCcKh3Ja-BRgw97OOwRl6pAJz-JjPzRN3amF3A2o8i8gcyfWWdsv37UMTDQ
 }
 
 //nolint:lll
@@ -261,13 +261,9 @@ func ExamplePresentation_SetCredentials() {
 
 	//Output:
 	//{
-	//	"@context": [
-	//		"https://www.w3.org/2018/credentials/v1"
-	//	],
+	//	"@context": "https://www.w3.org/2018/credentials/v1",
 	//	"id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c",
-	//	"type": [
-	//		"VerifiablePresentation"
-	//	],
+	//	"type": "VerifiablePresentation",
 	//	"verifiableCredential": [
 	//		{
 	//			"@context": [
@@ -374,13 +370,9 @@ func ExamplePresentation_MarshalJSON() {
 	fmt.Println(string(vpJSON))
 
 	// Output: {
-	//	"@context": [
-	//		"https://www.w3.org/2018/credentials/v1"
-	//	],
+	//	"@context": "https://www.w3.org/2018/credentials/v1",
 	//	"id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c",
-	//	"type": [
-	//		"VerifiablePresentation"
-	//	],
+	//	"type": "VerifiablePresentation",
 	//	"verifiableCredential": [
 	//		{
 	//			"@context": [

--- a/pkg/doc/verifiable/presentation.go
+++ b/pkg/doc/verifiable/presentation.go
@@ -287,9 +287,9 @@ func (vp *Presentation) raw() (*rawPresentation, error) {
 	}
 
 	return &rawPresentation{
-		Context:        vp.Context,
+		Context:        typesToRaw(vp.Context),
 		ID:             vp.ID,
-		Type:           vp.Type,
+		Type:           typesToRaw(vp.Type),
 		Credential:     vp.credentials,
 		Holder:         vp.Holder,
 		Proof:          proof,

--- a/pkg/store/verifiable/store.go
+++ b/pkg/store/verifiable/store.go
@@ -78,11 +78,17 @@ func (s *Store) SaveCredential(name string, vc *verifiable.Credential) error {
 		return fmt.Errorf("failed to marshal vc: %w", err)
 	}
 
-	if e := s.store.Put(vc.ID, vcBytes); e != nil {
+	id = vc.ID
+	if id == "" {
+		// ID in VCs are not mandatory, use uuid to save in DB if id missing
+		id = uuid.New().String()
+	}
+
+	if e := s.store.Put(id, vcBytes); e != nil {
 		return fmt.Errorf("failed to put vc: %w", e)
 	}
 
-	recordBytes, err := getRecord(vc.ID, vc.Context, vc.Types)
+	recordBytes, err := getRecord(id, vc.Context, vc.Types)
 	if err != nil {
 		return fmt.Errorf("failed to prepare record: %w", err)
 	}
@@ -115,7 +121,7 @@ func (s *Store) SavePresentation(name string, vp *verifiable.Presentation) error
 	}
 
 	id = vp.ID
-	if vp.ID == "" {
+	if id == "" {
 		// ID in VPs are not mandatory, use uuid to save in DB
 		id = uuid.New().String()
 	}

--- a/pkg/store/verifiable/store_test.go
+++ b/pkg/store/verifiable/store_test.go
@@ -101,6 +101,38 @@ var udCredential = `
 }
 `
 
+//nolint:gochecknoglobals,lll
+var udCredentialWithoutID = `
+
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1"
+  ],
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ],
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "BachelorDegree"
+    },
+    "name": "Jayden Doe",
+    "spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
+  },
+
+  "issuer": {
+    "id": "did:example:76e12ec712ebc6f1c221ebfeb1f",
+    "name": "Example University"
+  },
+
+  "issuanceDate": "2010-01-01T19:23:24Z",
+
+  "expirationDate": "2020-01-01T19:23:24Z"
+}
+`
+
 //nolint:lll
 const udVerifiablePresentation = `{
         "@context": ["https://www.w3.org/2018/credentials/v1", "https://www.w3.org/2018/credentials/examples/v1"],
@@ -271,6 +303,24 @@ func TestGetVC(t *testing.T) {
 		vc, err := s.GetCredential("http://example.edu/credentials/1872")
 		require.NoError(t, err)
 		require.Equal(t, vc.ID, "http://example.edu/credentials/1872")
+	})
+
+	t.Run("test success - vc without ID", func(t *testing.T) {
+		s, err := New(&mockprovider.Provider{
+			StorageProviderValue: mockstore.NewMockStoreProvider(),
+		})
+		require.NoError(t, err)
+		udVC, _, err := verifiable.NewCredential([]byte(udCredentialWithoutID))
+		require.NoError(t, err)
+		require.NoError(t, s.SaveCredential(sampleCredentialName, udVC))
+
+		id, err := s.GetCredentialIDByName(sampleCredentialName)
+		require.NoError(t, err)
+		require.NotEmpty(t, id)
+
+		vc, err := s.GetCredential(id)
+		require.NoError(t, err)
+		require.NotEmpty(t, vc)
 	})
 
 	t.Run("test error from store get", func(t *testing.T) {


### PR DESCRIPTION
- VC id shouldn't be used as a store key  while saving verifiable
credentials since it is an optional field
- Verifiable presentation type and context can be compacted to string
from array if it has only one field.
- added more tests in json ld processor canonicalization to cover
compacted types and proper contexts
- increased default aries js worker timeout to 20 seconds
- Part of #1730
- Part of #1705
- Part of #1732

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
