### PR TITLE
feat: VC strict validation based on JSON-LD context

### DIFF
--- a/pkg/doc/verifiable/credential_ldp_test.go
+++ b/pkg/doc/verifiable/credential_ldp_test.go
@@ -70,10 +70,22 @@ func TestNewCredentialFromLinkedDataProof_Ed25519Signature2018(t *testing.T) {
 }
 
 //nolint:lll
-func TestNewCredentialFromLinkedDataProof_Ed25519Signature2018_Transmute(t *testing.T) {
+func TestNewCredentialFromLinkedDataProof_JSONLD_Validation(t *testing.T) {
 	r := require.New(t)
 
-	vcFromTransmute := `
+	pubKeyBytes := base58.Decode("DqS5F3GVe3rCxucgi4JBNagjv4dKoHc8TDLDw9kR58Pz")
+
+	sigSuite := ed25519signature2018.New(
+		suite.WithVerifier(suite.NewCryptoVerifier(createLocalCrypto())))
+
+	vcOptions := []CredentialOpt{
+		WithEmbeddedSignatureSuites(sigSuite),
+		WithPublicKeyFetcher(SingleKey(pubKeyBytes, "Ed25519Signature2018")),
+		WithStrictValidation(),
+	}
+
+	t.Run("valid VC", func(t *testing.T) {
+		vcJSON := `
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -106,16 +118,94 @@ func TestNewCredentialFromLinkedDataProof_Ed25519Signature2018_Transmute(t *test
 }
 `
 
-	pubKeyBytes := base58.Decode("DqS5F3GVe3rCxucgi4JBNagjv4dKoHc8TDLDw9kR58Pz")
+		vcWithLdp, _, err := NewCredential([]byte(vcJSON), vcOptions...)
+		r.NoError(err)
+		r.NotNil(t, vcWithLdp)
+	})
 
-	sigSuite := ed25519signature2018.New(
-		suite.WithVerifier(suite.NewCryptoVerifier(createLocalCrypto())))
+	t.Run("VC with unknown field", func(t *testing.T) {
+		// "newProp" is a field not defined in any context.
+		vcJSON := `
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1"
+  ],
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ],
+  "id": "http://example.gov/credentials/3732",
+  "issuanceDate": "2020-03-16T22:37:26.544Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "BachelorDegree",
+      "degree": "MIT"
+    },
+    "name": "Jayden Doe",
+    "spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
+  },
+  "profile": "",
+  "issuer": "did:web:vc.transmute.world",
+  "proof": {
+    "type": "Ed25519Signature2018",
+    "created": "2019-12-11T03:50:55Z",
+    "verificationMethod": "did:web:vc.transmute.world#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+    "proofPurpose": "assertionMethod",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..MlJy4Sn47kgse7SKc56OKkJUhu-Z3CPiv2_MdjOQXJk8Bpzxa-JuinjJNN3YkYb6tPE6poIhBTlgnc_c5qQsBA"
+  },
+  "newProp": "foo"
+}
+`
 
-	vcWithLdp, _, err := NewCredential([]byte(vcFromTransmute),
-		WithEmbeddedSignatureSuites(sigSuite),
-		WithPublicKeyFetcher(SingleKey(pubKeyBytes, "Ed25519Signature2018")))
-	r.NoError(err)
-	r.NotNil(t, vcWithLdp)
+		vcWithLdp, _, err := NewCredential([]byte(vcJSON), vcOptions...)
+		r.Error(err)
+		r.EqualError(err, "JSON-LD doc has different structure after compaction")
+		r.Nil(vcWithLdp)
+	})
+
+	t.Run("VC with unknown proof field", func(t *testing.T) {
+		// "newProp" is a field not defined in any context.
+		vcJSON := `
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1"
+  ],
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ],
+  "id": "http://example.gov/credentials/3732",
+  "issuanceDate": "2020-03-16T22:37:26.544Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "BachelorDegree",
+      "degree": "MIT"
+    },
+    "name": "Jayden Doe",
+    "spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
+  },
+  "profile": "",
+  "issuer": "did:web:vc.transmute.world",
+  "proof": {
+    "type": "Ed25519Signature2018",
+    "created": "2019-12-11T03:50:55Z",
+    "verificationMethod": "did:web:vc.transmute.world#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+    "proofPurpose": "assertionMethod",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..MlJy4Sn47kgse7SKc56OKkJUhu-Z3CPiv2_MdjOQXJk8Bpzxa-JuinjJNN3YkYb6tPE6poIhBTlgnc_c5qQsBA",
+    "newProp": "foo"
+  }
+}
+`
+
+		vcWithLdp, _, err := NewCredential([]byte(vcJSON), vcOptions...)
+		r.Error(err)
+		r.EqualError(err, "JSON-LD doc has different structure after compaction")
+		r.Nil(vcWithLdp)
+	})
 }
 
 func TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_Ed25519(t *testing.T) {

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -56,13 +56,14 @@ const issuerAsObject = `
 
 func TestNewCredential(t *testing.T) {
 	t.Run("test creation of new Verifiable Credential from JSON with valid structure", func(t *testing.T) {
-		vc, vcData, err := NewCredential([]byte(validCredential))
+		vc, vcData, err := NewCredential([]byte(validCredential), WithStrictValidation())
 		require.NoError(t, err)
 		require.NotNil(t, vc)
 		require.NotEmpty(t, vcData)
 
 		// validate @context
-		require.Equal(t, []string{"https://www.w3.org/2018/credentials/v1"}, vc.Context)
+		require.Equal(t, []string{"https://www.w3.org/2018/credentials/v1",
+			"https://www.w3.org/2018/credentials/examples/v1"}, vc.Context)
 
 		// validate id
 		require.Equal(t, "http://example.edu/credentials/1872", vc.ID)

--- a/pkg/doc/verifiable/support_test.go
+++ b/pkg/doc/verifiable/support_test.go
@@ -33,7 +33,10 @@ const certPrefix = "testdata/crypto"
 
 //nolint:lll
 const validCredential = `{
-  "@context": "https://www.w3.org/2018/credentials/v1",
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1"
+  ],
   "id": "http://example.edu/credentials/1872",
   "type": "VerifiableCredential",
   "credentialSubject": {


### PR DESCRIPTION
Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

#1705

Validate that a VC JSON-LD document only contains defined vocabulary.

Example Scenarios:
* “newProp”: “bar” added to VC or VP (where newProp is not in the contexts).
* “newProp”: “bar” added to Proof (where newProp is not in the contexts).

To be added in the follow-up PRs:
1) VP strict validation.
2) Ability to add supplement contexts on VC/VP parsing (in particular, JSON-LD context vocabulary extension).