### PR TITLE
feat: Present Proof - adds wasm/rest js BDD tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ bdd-test-go:
 bdd-test-js:
 	@scripts/check_js_integration.sh
 
+bdd-test-js-local:
+	@scripts/check_js_integration.sh test-local
+
 .PHONY: vc-test-suite
 vc-test-suite: clean
 	@scripts/run_vc_test_suite.sh

--- a/cmd/aries-js-worker/src/agent-rest-client.js
+++ b/cmd/aries-js-worker/src/agent-rest-client.js
@@ -222,6 +222,55 @@ const pkgs = {
             pathParam:"piid"
         },
     },
+    presentproof:{
+        Actions: {
+            path: "/presentproof/actions",
+            method: "GET",
+        },
+        SendRequestPresentation: {
+            path: "/presentproof/send-request-presentation",
+            method: "POST",
+        },
+        SendProposePresentation: {
+            path: "/presentproof/send-propose-presentation",
+            method: "POST",
+        },
+        AcceptRequestPresentation: {
+            path: "/presentproof/{piid}/accept-request-presentation",
+            method: "POST",
+            pathParam:"piid"
+        },
+        AcceptProposePresentation: {
+            path: "/presentproof/{piid}/accept-propose-presentation",
+            method: "POST",
+            pathParam:"piid"
+        },
+        AcceptPresentation: {
+            path: "/presentproof/{piid}/accept-presentation",
+            method: "POST",
+            pathParam:"piid"
+        },
+        NegotiateRequestPresentation: {
+            path: "/presentproof/{piid}/negotiate-request-presentation",
+            method: "POST",
+            pathParam:"piid"
+        },
+        DeclineRequestPresentation: {
+            path: "/presentproof/{piid}/decline-request-presentation",
+            method: "POST",
+            pathParam:"piid"
+        },
+        DeclineProposePresentation: {
+            path: "/presentproof/{piid}/decline-propose-presentation",
+            method: "POST",
+            pathParam:"piid"
+        },
+        DeclinePresentation: {
+            path: "/presentproof/{piid}/decline-presentation",
+            method: "POST",
+            pathParam:"piid"
+        },
+    },
     kms: {
         CreateKeySet: {
             path: "/kms/keyset",

--- a/cmd/aries-js-worker/src/aries.js
+++ b/cmd/aries-js-worker/src/aries.js
@@ -196,16 +196,19 @@ const Aries = function (opts) {
             }
         },
 
+        /**
+         * Issue Credential methods - Refer to [OpenAPI spec](docs/rest/openapi_spec.md#generate-openapi-spec) for
+         * input params and output return json values.
+         */
         issuecredential: {
             pkgname: "issuecredential",
             /**
              * Returns pending actions that have not yet to be executed or cancelled.
              *
-             * @param req - json document
              * @returns {Promise<Object>}
              */
-            actions: async function (req) {
-                return invoke(aw, pending, this.pkgname, "Actions", req, "timeout while getting actions")
+            actions: async function () {
+                return invoke(aw, pending, this.pkgname, "Actions", null, "timeout while getting actions")
             },
             /**
              * Sends an offer.
@@ -314,6 +317,103 @@ const Aries = function (opts) {
              */
             declineCredential: function (req) {
                 return invoke(aw, pending, this.pkgname, "DeclineCredential", req, "timeout while declining a credential")
+            },
+        },
+
+        /**
+         * Present Proof methods - Refer to [OpenAPI spec](docs/rest/openapi_spec.md#generate-openapi-spec) for
+         * input params and output return json values.
+         */
+        presentproof: {
+            pkgname: "presentproof",
+            /**
+             * Returns pending actions that have not yet to be executed or cancelled.
+             *
+             * @returns {Promise<Object>}
+             */
+            actions: async function () {
+                return invoke(aw, pending, this.pkgname, "Actions", null, "timeout while getting actions")
+            },
+            /**
+             * Sends a request presentation.
+             *
+             * @param req - json document
+             * @returns {Promise<Object>}
+             */
+            sendRequestPresentation: async function (req) {
+                return invoke(aw, pending, this.pkgname, "SendRequestPresentation", req, "timeout while sending a request presentation")
+            },
+            /**
+             * Sends a propose presentation.
+             *
+             * @param req - json document
+             * @returns {Promise<Object>}
+             */
+            sendProposePresentation: function (req) {
+                return invoke(aw, pending, this.pkgname, "SendProposePresentation", req, "timeout while sending a propose presentation")
+            },
+            /**
+             * Accepts a request presentation.
+             *
+             * @param req - json document
+             * @returns {Promise<Object>}
+             */
+            acceptRequestPresentation: function (req) {
+                return invoke(aw, pending, this.pkgname, "AcceptRequestPresentation", req, "timeout while accepting a request presentation")
+            },
+            /**
+             * Accepts a propose presentation.
+             *
+             * @param req - json document
+             * @returns {Promise<Object>}
+             */
+            acceptProposePresentation: function (req) {
+                return invoke(aw, pending, this.pkgname, "AcceptProposePresentation", req, "timeout while accepting a propose presentation")
+            },
+            /**
+             * Accepts a presentation.
+             *
+             * @param req - json document
+             * @returns {Promise<Object>}
+             */
+            acceptPresentation: function (req) {
+                return invoke(aw, pending, this.pkgname, "AcceptPresentation", req, "timeout while accepting a presentation")
+            },
+            /**
+             * Is used by the Prover to counter a presentation request they received with a proposal.
+             *
+             * @param req - json document
+             * @returns {Promise<Object>}
+             */
+            negotiateRequestPresentation: function (req) {
+                return invoke(aw, pending, this.pkgname, "NegotiateRequestPresentation", req, "timeout while negotiating a request presentation")
+            },
+            /**
+             * Declines a request presentation.
+             *
+             * @param req - json document
+             * @returns {Promise<Object>}
+             */
+            declineRequestPresentation: function (req) {
+                return invoke(aw, pending, this.pkgname, "DeclineRequestPresentation", req, "timeout while declining a request presentation")
+            },
+            /**
+             * Declines a propose presentation.
+             *
+             * @param req - json document
+             * @returns {Promise<Object>}
+             */
+            declineProposePresentation: function (req) {
+                return invoke(aw, pending, this.pkgname, "DeclineProposePresentation", req, "timeout while declining a propose presentation")
+            },
+            /**
+             * Declines a presentation.
+             *
+             * @param req - json document
+             * @returns {Promise<Object>}
+             */
+            declinePresentation: function (req) {
+                return invoke(aw, pending, this.pkgname, "DeclinePresentation", req, "timeout while declining a presentation")
             },
         },
 

--- a/pkg/controller/rest/presentproof/operation.go
+++ b/pkg/controller/rest/presentproof/operation.go
@@ -260,7 +260,7 @@ func (c *Operation) DeclinePresentation(rw http.ResponseWriter, req *http.Reques
 
 func isJSONMap(data []byte) bool {
 	var v struct{}
-	return isJSON(data, v)
+	return isJSON(data, &v)
 }
 
 func isJSON(data []byte, v interface{}) bool {

--- a/scripts/check_js_integration.sh
+++ b/scripts/check_js_integration.sh
@@ -32,7 +32,11 @@ echo "----> executing aries-js-worker tests"
 echo ""
 cd $ROOT/test/aries-js-worker
 # capture exit code if it fails
-npm test || code=$?
+command=$1
+if [ -z "$command" ]; then
+    command=test
+fi
+npm run "$command" || code=$?
 if [ -z ${code+x} ]; then
   # set exit code because it did not fail
   code=0

--- a/test/aries-js-worker/karma.conf.js
+++ b/test/aries-js-worker/karma.conf.js
@@ -25,14 +25,6 @@ const ENV_CONFIG_OUT = "test/environment.js";
     fs.writeFileSync(ENV_CONFIG_OUT, "export const environment = " + util.inspect(config))
 })()
 
-// if you want to run it in the browser and see all logs please do the following.
-//  browsers: ['Chrome_without_security'],
-//  singleRun: false,
-//  Chrome_without_security: {
-//      base: 'Chrome',
-//      flags: ['--disable-web-security', '--disable-site-isolation-trials']
-//  }
-
 module.exports = function(config) {
     config.set({
         frameworks: ["mocha", "chai"],
@@ -43,6 +35,7 @@ module.exports = function(config) {
             {pattern: "public/aries-framework-go/assets/*", included: false},
             {pattern: "node_modules/@hyperledger/aries-framework-go/dist/web/*", type: "module"},
             {pattern: "node_modules/@hyperledger/aries-framework-go/dist/rest/*", type: "module"},
+            {pattern: 'node_modules/axios/dist/axios.min.map', included: false},
             "node_modules/axios/dist/axios.min.js",
             {pattern: "test/common.js", included: false},
             {pattern: "test/environment.js", included: false},
@@ -53,7 +46,11 @@ module.exports = function(config) {
             ChromeHeadless_cors: {
                 base: "ChromeHeadless",
                 flags: ["--disable-web-security"]
-            }
+            },
+            Chrome_without_security: {
+                 base: 'Chrome',
+                 flags: ['--disable-web-security', '--disable-site-isolation-trials', '--auto-open-devtools-for-tabs']
+             },
         },
         client: {
             mocha: {

--- a/test/aries-js-worker/package.json
+++ b/test/aries-js-worker/package.json
@@ -5,7 +5,8 @@
   "description": "Tests",
   "main": "index.js",
   "scripts": {
-    "test": "bash scripts/setup_assets.sh && karma start"
+    "test": "bash scripts/setup_assets.sh && karma start",
+    "test-local": "bash scripts/setup_assets.sh && karma start --browsers=Chrome_without_security --single-run=false"
   },
   "author": "hyperledger/aries",
   "license": "Apache-2.0",

--- a/test/aries-js-worker/test/presentproof/presentproof.js
+++ b/test/aries-js-worker/test/presentproof/presentproof.js
@@ -1,0 +1,100 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {environment} from "../environment.js";
+import {newDIDExchangeClient,newDIDExchangeRESTClient} from "../didexchange/didexchange_e2e.js";
+
+const agent1ControllerApiUrl = `${environment.HTTP_SCHEME}://${environment.ROUTER_HOST}:${environment.ROUTER_API_PORT}`
+const agent2ControllerApiUrl = `${environment.HTTP_SCHEME}://${environment.USER_HOST}:${environment.USER_API_PORT}`
+
+const restMode = 'rest'
+const wasmMode = 'wasm'
+
+describe("Present Proof - The Verifier begins with a request presentation", async function() {
+    describe(restMode, function() { presentProof(restMode) })
+    describe(wasmMode, function() { presentProof(wasmMode) })
+})
+
+// scenarios
+async function presentProof (mode) {
+    const verifierID = "verifier"
+    const proverID = "prover"
+    let connections
+    let didClient
+    let verifier, prover
+
+    before(async () => {
+        if (mode === restMode){
+            didClient = await newDIDExchangeRESTClient(agent2ControllerApiUrl,agent1ControllerApiUrl)
+        }else {
+            didClient = await newDIDExchangeClient(verifierID,proverID)
+        }
+
+        assert.isNotNull(didClient)
+
+        connections = await didClient.performDIDExchangeE2E()
+        assert.isNotEmpty(connections)
+
+        verifier = didClient.agent1
+        prover = didClient.agent2
+    })
+
+    after(() => {
+        didClient.destroy()
+    })
+
+    it("Verifier sends a request presentation to the Prover", async function() {
+        let conn = await connection(verifier, connections[0])
+        return verifier.presentproof.sendRequestPresentation({
+            my_did: conn.MyDID,
+            their_did: conn.TheirDID,
+            request_presentation: {},
+        })
+    })
+
+    it("Prover accepts a request and sends a presentation to the Verifier", async function() {
+        let action = await getAction(prover)
+        return prover.presentproof.acceptRequestPresentation({
+            piid: action.piid,
+            // TODO need to add presentation depends on [Issue #1749]
+            presentation: {},
+            body: {}
+        })
+    })
+
+    it("Verifier accepts a presentation", async function() {
+        let action = await getAction(verifier)
+        return verifier.presentproof.acceptPresentation({
+            piid: action.piid,
+        })
+    })
+}
+
+const retries = 15;
+
+async function getAction(agent) {
+    for (let i = 0; i < retries; i++) {
+        let resp = await agent.presentproof.actions()
+        if (resp.actions.length > 0) {
+            return resp.actions[0]
+        }
+
+        await sleep(1000);
+    }
+
+    throw new Error("no action")
+}
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function connection(agent, conn) {
+    let res = await agent.didexchange.queryConnectionByID({
+        id: conn
+    })
+
+    return res.result
+}


### PR DESCRIPTION
Adds wasm/rest js BDD tests for the Present Proof protocol.

This PR also adds a new `make` command. It runs the browser which allows us to see the wasm input logs in the browser console.
```
make bdd-test-js-local
```
Closes: #1751 
Signed-off-by: Andrii Soluk <isoluchok@gmail.com>