### PR TITLE
feat: credential issurance, expired date and other fixes

### DIFF
--- a/pkg/controller/command/verifiable/command.go
+++ b/pkg/controller/command/verifiable/command.go
@@ -524,7 +524,7 @@ func (o *Command) GeneratePresentation(rw io.Writer, req io.Reader) command.Erro
 			fmt.Errorf("generate vp - parse presentation request: %w", err))
 	}
 
-	return o.generatePresentation(rw, credentials, presentation, opts)
+	return o.generatePresentation(rw, credentials, presentation, didDoc.ID, opts)
 }
 
 // GeneratePresentationByID generates verifiable presentation from a stored verifiable credential.
@@ -569,9 +569,9 @@ func (o *Command) GeneratePresentationByID(rw io.Writer, req io.Reader) command.
 }
 
 func (o *Command) generatePresentation(rw io.Writer, vcs []interface{}, p *verifiable.Presentation,
-	opts *ProofOptions) command.Error {
+	holder string, opts *ProofOptions) command.Error {
 	// prepare vp
-	vp, err := o.createAndSignPresentation(vcs, p, opts)
+	vp, err := o.createAndSignPresentation(vcs, p, holder, opts)
 	if err != nil {
 		logutil.LogError(logger, commandName, generatePresentationCommandMethod, "create and sign vp: "+err.Error())
 
@@ -608,7 +608,7 @@ func (o *Command) generatePresentationByID(rw io.Writer, vc *verifiable.Credenti
 }
 
 func (o *Command) createAndSignPresentation(credentials []interface{}, vp *verifiable.Presentation,
-	opts *ProofOptions) ([]byte, error) {
+	holder string, opts *ProofOptions) ([]byte, error) {
 	var err error
 	if vp == nil {
 		vp, err = credentials[0].(*verifiable.Credential).Presentation()
@@ -621,6 +621,9 @@ func (o *Command) createAndSignPresentation(credentials []interface{}, vp *verif
 			return nil, fmt.Errorf("failed to set credentials: %w", err)
 		}
 	}
+
+	// set holder
+	vp.Holder = holder
 
 	// Add proofs to vp - sign presentation
 	vp, err = o.addLinkedDataProof(vp, opts)

--- a/pkg/controller/command/verifiable/command_test.go
+++ b/pkg/controller/command/verifiable/command_test.go
@@ -800,6 +800,7 @@ func TestGeneratePresentation(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, vp)
+		require.Equal(t, presReq.DID, vp.Holder)
 		require.NotEmpty(t, vp.Proofs)
 		require.Len(t, vp.Proofs, 1)
 		require.Equal(t, vp.Proofs[0]["challenge"], presReq.Challenge)
@@ -840,6 +841,7 @@ func TestGeneratePresentation(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, vp)
+		require.Equal(t, presReq.DID, vp.Holder)
 		require.NotEmpty(t, vp.Proofs)
 		require.Len(t, vp.Proofs, 1)
 		require.Equal(t, vp.Proofs[0]["challenge"], presReq.Challenge)
@@ -891,6 +893,7 @@ func TestGeneratePresentation(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, vp)
+		require.Equal(t, presReq.DID, vp.Holder)
 		require.NotEmpty(t, vp.Proofs)
 		require.Len(t, vp.Proofs, 1)
 		require.Equal(t, vp.Proofs[0]["challenge"], presReq.Challenge)
@@ -1024,7 +1027,7 @@ func TestGeneratePresentation(t *testing.T) {
 
 	t.Run("test generate verifiable presentation with proof options & presentation - success", func(t *testing.T) {
 		pRaw := json.RawMessage([]byte(`{"@context": "https://www.w3.org/2018/credentials/v1",
-		"type": "VerifiablePresentation","holder": "did:web:vc.example.world"}`))
+		"type": "VerifiablePresentation"}`))
 
 		createdTime := time.Now().AddDate(-1, 0, 0)
 		presReq := PresentationRequest{
@@ -1058,7 +1061,7 @@ func TestGeneratePresentation(t *testing.T) {
 		require.NotNil(t, vp)
 		require.Empty(t, vp.Credentials())
 		require.NotEmpty(t, vp.Proofs)
-		require.Equal(t, vp.Holder, "did:web:vc.example.world")
+		require.Equal(t, vp.Holder, "did:peer:123456789abcdefghi#inbox")
 		require.Len(t, vp.Proofs, 1)
 		require.Equal(t, vp.Proofs[0]["challenge"], presReq.Challenge)
 		require.Equal(t, vp.Proofs[0]["domain"], presReq.Domain)
@@ -1248,7 +1251,7 @@ func TestGeneratePresentationHelperFunctions(t *testing.T) {
 		credList[0] = v
 
 		var b bytes.Buffer
-		err = cmd.generatePresentation(&b, credList, nil, &ProofOptions{VerificationMethod: "pk"})
+		err = cmd.generatePresentation(&b, credList, nil, "did:example", &ProofOptions{VerificationMethod: "pk"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "prepare vp: failed to sign vp: wrong id [pk] to resolve")
 	})

--- a/pkg/controller/rest/verifiable/operation_test.go
+++ b/pkg/controller/rest/verifiable/operation_test.go
@@ -611,7 +611,7 @@ func TestGeneratePresentation(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, vp)
 		require.NotEmpty(t, vp.Proofs)
-		require.Equal(t, vp.Holder, "did:web:vc.example.world")
+		require.Equal(t, vp.Holder, "did:peer:21tDAKCERh95uGgKbJNHYp")
 		require.Len(t, vp.Proofs, 1)
 		require.Equal(t, vp.Proofs[0]["challenge"], presReq.Challenge)
 		require.Equal(t, vp.Proofs[0]["domain"], presReq.Domain)

--- a/pkg/doc/verifiable/common.go
+++ b/pkg/doc/verifiable/common.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/piprate/json-gold/ld"
 	"github.com/xeipuuv/gojsonschema"
@@ -117,6 +118,59 @@ type Proof map[string]interface{}
 // CustomFields is a map of extra fields of struct build when unmarshalling JSON which are not
 // mapped to the struct fields.
 type CustomFields map[string]interface{}
+
+// rememberedFields is a map of raw fields used to preserve actual values of fields which pose risk of losing
+// information during parsing, such as dates.
+// TODO currently this is used only for date parsing issues, to be removed as part of [Issue#1772]
+type rememberedFields map[string]interface{}
+
+// fields to be remembered
+const (
+	issuanceDate   = "issuanceDate"
+	expirationDate = "expirationDate"
+)
+
+func (r rememberedFields) GetIssuanceDate(vcDate *time.Time) interface{} {
+	if issueDate, ok := r[issuanceDate]; ok && issueDate != nil {
+		if issueDate != nil && vcDate != nil {
+			t, err := time.Parse(time.RFC3339, issueDate.(string))
+			if err != nil {
+				return vcDate
+			}
+
+			if t.Equal(*vcDate) {
+				return issueDate
+			}
+		}
+	}
+
+	return vcDate
+}
+
+func (r rememberedFields) GetExpirationDate(vcDate *time.Time) interface{} {
+	if expiryDate, ok := r[expirationDate]; ok {
+		if expiryDate != nil && vcDate != nil {
+			t, err := time.Parse(time.RFC3339, expiryDate.(string))
+			if err != nil {
+				return vcDate
+			}
+
+			if t.Equal(*vcDate) {
+				return expiryDate
+			}
+		}
+	}
+
+	return vcDate
+}
+
+func (r rememberedFields) PushIssuanceDate(val interface{}) {
+	r[issuanceDate] = val
+}
+
+func (r rememberedFields) PushExpirationDate(val interface{}) {
+	r[expirationDate] = val
+}
 
 // TypedID defines a flexible structure with id and name fields and arbitrary extra fields
 // kept in CustomFields.

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -54,6 +54,40 @@ const issuerAsObject = `
 }
 `
 
+const credentialWithPreciseDate = `{
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://w3id.org/citizenship/v1"
+      ],
+      "id": "https://prc.uscis.gov/credentials/3dbd30a1-114b-4889-90b2-b37b07866125",
+      "type": [
+        "VerifiableCredential",
+        "PermanentResidentCard"
+      ],
+      "issuer": {"id": "did:v1:test:nym:z6MkqaFQ7SZdWMgUkiQLvxZBpmkmYmbgAcAvXftU7jfmMWLa"},
+      "issuanceDate": "2020-01-01T00:00:00.000Z",
+      "expirationDate": "2030-01-01T00:00:00.000Z",
+      "name": "Permanent Resident Card",
+      "description": "Permanent Resident Card of Mr.Louis Pasteur",
+      "credentialSubject": {
+        "id": "did:v1:test:nym:z6Mkoi4q6txuz3rJ3XeqJauhrHcKDWbTwHepfcewDm5BVN4N",
+        "type": [
+          "Person",
+          "PermanentResident"
+        ],
+        "givenName": "Louis",
+        "familyName": "Pasteur",
+        "gender": "Male",
+        "image": "data:image/png;base64,Jtvf7y4+Pjdxw/UiREBZDlwUAwoALFcm9QPcSTMzX2Rqsyr26dfDeBflf6uKaaRK5CYII=",
+        "residentSince": "2015-01-01T00:00:00.000Z",
+        "lprCategory": "C09",
+        "lprNumber": "999-999-999",
+        "birthCountry": "Mexico",
+        "birthDate": "1958-07-17T00:00:00.000Z"
+      }
+}
+`
+
 func TestNewCredential(t *testing.T) {
 	t.Run("test creation of new Verifiable Credential from JSON with valid structure", func(t *testing.T) {
 		vc, vcData, err := NewCredential([]byte(validCredential), WithStrictValidation())
@@ -1396,6 +1430,17 @@ func TestNewCredentialFromRaw(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "fill credential proof from raw")
 	require.Nil(t, vc)
+}
+
+func TestNewCredentialFromRaw_PreserveDates(t *testing.T) {
+	cred, _, err := NewCredential([]byte(credentialWithPreciseDate), WithDisabledProofCheck())
+	require.NoError(t, err)
+	require.NotEmpty(t, cred)
+
+	raw, err := cred.raw()
+	require.NoError(t, err)
+	require.Equal(t, raw.Issued.(string), "2020-01-01T00:00:00.000Z")
+	require.Equal(t, raw.Expired.(string), "2030-01-01T00:00:00.000Z")
 }
 
 func TestCredential_CreatePresentation(t *testing.T) {

--- a/pkg/store/verifiable/models.go
+++ b/pkg/store/verifiable/models.go
@@ -8,8 +8,9 @@ package verifiable
 
 // Record model containing name, ID and other fields of interest
 type Record struct {
-	Name    string   `json:"name,omitempty"`
-	ID      string   `json:"id,omitempty"`
-	Context []string `json:"context,omitempty"`
-	Type    []string `json:"type,omitempty"`
+	Name      string   `json:"name,omitempty"`
+	ID        string   `json:"id,omitempty"`
+	Context   []string `json:"context,omitempty"`
+	Type      []string `json:"type,omitempty"`
+	SubjectID string   `json:"subjectId,omitempty"`
 }


### PR DESCRIPTION
- credential type to preserve raw date values to avoid loss of
precisions
- credentials & presentation records to have subjecID/Holder info
- Generate presentation command to set holder info
- Closes #1767
- Closes #1770
- Closes #1773
- Closes #1774

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
