### PR TITLE
feat: demonstration of redeemable routes

### DIFF
--- a/pkg/client/introduce/client.go
+++ b/pkg/client/introduce/client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/client/outofband"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/introduce"
 	outofbandsvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/outofband"
 )
@@ -54,8 +55,8 @@ func New(ctx Provider) (*Client, error) {
 
 // SendProposal sends a proposal to the introducees (the client has not published an out-of-band message).
 func (c *Client) SendProposal(recipient1, recipient2 *introduce.Recipient) error {
-	proposal1 := introduce.CreateProposal(recipient1.To)
-	proposal2 := introduce.CreateProposal(recipient2.To)
+	proposal1 := introduce.CreateProposal(recipient1)
+	proposal2 := introduce.CreateProposal(recipient2)
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 
@@ -71,7 +72,7 @@ func (c *Client) SendProposal(recipient1, recipient2 *introduce.Recipient) error
 
 // SendProposalWithOOBRequest sends a proposal to the introducee (the client has published an out-of-band request).
 func (c *Client) SendProposalWithOOBRequest(req *outofband.Request, recipient *introduce.Recipient) error {
-	proposal := introduce.CreateProposal(recipient.To)
+	proposal := introduce.CreateProposal(recipient)
 	cast := outofbandsvc.Request(*req)
 
 	introduce.WrapWithMetadataPublicOOBRequest(proposal, &cast)
@@ -132,10 +133,11 @@ func WithPublicOOBRequest(req *outofband.Request, to *introduce.To) introduce.Op
 	return introduce.WithPublicOOBRequest(&cast, to)
 }
 
-// WithOOBRequest is used when introducee wants to provide invitation.
-// NOTE: Introducee can provide invitation only after receiving ProposalMsgType
+// WithOOBRequest is used when introducee wants to provide an out-of-band request with an optional
+// series of attachments.
+// NOTE: Introducee can provide the request only after receiving ProposalMsgType
 // USAGE: event.Continue(WithOOBRequest(inv))
-func WithOOBRequest(req *outofband.Request) introduce.Opt {
+func WithOOBRequest(req *outofband.Request, a ...*decorator.Attachment) introduce.Opt {
 	cast := outofbandsvc.Request(*req)
-	return introduce.WithOOBRequest(&cast)
+	return introduce.WithOOBRequest(&cast, a...)
 }

--- a/pkg/client/route/client.go
+++ b/pkg/client/route/client.go
@@ -38,6 +38,9 @@ type protocolService interface {
 
 	// GetConnection returns the connectionID of the router.
 	GetConnection() (string, error)
+
+	// Config returns the router's configuration.
+	Config() (*route.Config, error)
 }
 
 // New return new instance of route client.
@@ -86,4 +89,14 @@ func (c *Client) GetConnection() (string, error) {
 	}
 
 	return connectionID, nil
+}
+
+// GetConfig returns the router's configuration.
+func (c *Client) GetConfig() (*route.Config, error) {
+	conf, err := c.routeSvc.Config()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch routing configuration : %w", err)
+	}
+
+	return conf, nil
 }

--- a/pkg/client/route/client_test.go
+++ b/pkg/client/route/client_test.go
@@ -123,3 +123,34 @@ func TestGetConnection(t *testing.T) {
 		require.Empty(t, connID)
 	})
 }
+
+func TestClient_GetConfig(t *testing.T) {
+	t.Run("returns configuration", func(t *testing.T) {
+		endpoint := "http://example.com"
+		keys := []string{"key1", "key2"}
+		c, err := New(&mockprovider.Provider{
+			ServiceValue: &mockroute.MockRouteSvc{
+				RouterEndpoint: endpoint,
+				RoutingKeys:    keys,
+			},
+		})
+		require.NoError(t, err)
+		result, err := c.GetConfig()
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, endpoint, result.Endpoint())
+		require.Equal(t, keys, result.Keys())
+	})
+	t.Run("wraps config error", func(t *testing.T) {
+		expected := errors.New("test")
+		c, err := New(&mockprovider.Provider{
+			ServiceValue: &mockroute.MockRouteSvc{
+				ConfigErr: expected,
+			},
+		})
+		require.NoError(t, err)
+		_, err = c.GetConfig()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, expected))
+	})
+}

--- a/pkg/client/route/models.go
+++ b/pkg/client/route/models.go
@@ -1,0 +1,29 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package route
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/route"
+)
+
+const (
+	// RequestMsgType defines the route coordination request message type.
+	RequestMsgType = route.RequestMsgType
+)
+
+// Request is the route-request message of this protocol.
+type Request = route.Request
+
+// NewRequest creates a new request.
+func NewRequest() *Request {
+	return &Request{
+		ID:   uuid.New().String(),
+		Type: RequestMsgType,
+	}
+}

--- a/pkg/client/route/models_test.go
+++ b/pkg/client/route/models_test.go
@@ -1,0 +1,19 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package route
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRequest(t *testing.T) {
+	result := NewRequest()
+	require.NotEmpty(t, result.ID)
+	require.Equal(t, "https://didcomm.org/routecoordination/1.0/route-request", result.Type)
+}

--- a/pkg/didcomm/protocol/introduce/metadata.go
+++ b/pkg/didcomm/protocol/introduce/metadata.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/outofband"
 )
 
@@ -19,6 +20,7 @@ const (
 	metaSkipProposal = Introduce + "_skip_proposal"
 	metaOOBMessage   = Introduce + "_oobmessage"
 	metaRecipients   = Introduce + "_recipients"
+	metaAttachment   = Introduce + "_attachment"
 )
 
 // Opt describes option signature for the Continue function
@@ -27,9 +29,10 @@ type Opt func(m map[string]interface{})
 // WithOOBRequest is used when introducee wants to provide an out-of-band request.
 // NOTE: Introducee can provide this request only after receiving ProposalMsgType
 // USAGE: event.Continue(WithOOBRequest(req))
-func WithOOBRequest(req *outofband.Request) Opt {
+func WithOOBRequest(req *outofband.Request, attachments ...*decorator.Attachment) Opt {
 	return func(m map[string]interface{}) {
 		m[metaOOBMessage] = service.NewDIDCommMsgMap(req)
+		m[metaAttachment] = attachments
 	}
 }
 

--- a/pkg/didcomm/protocol/introduce/models.go
+++ b/pkg/didcomm/protocol/introduce/models.go
@@ -12,12 +12,14 @@ import (
 
 // Proposal defines proposal request
 type Proposal struct {
-	Type   string            `json:"@type,omitempty"`
-	ID     string            `json:"@id,omitempty"`
-	To     *To               `json:"to,omitempty"`
-	NWise  bool              `json:"nwise,omitempty"`
-	Thread *decorator.Thread `json:"~thread,omitempty"`
-	Timing *decorator.Timing `json:"~timing,omitempty"`
+	Type     string            `json:"@type,omitempty"`
+	ID       string            `json:"@id,omitempty"`
+	To       *To               `json:"to,omitempty"`
+	NWise    bool              `json:"nwise,omitempty"`
+	Thread   *decorator.Thread `json:"~thread,omitempty"`
+	Timing   *decorator.Timing `json:"~timing,omitempty"`
+	Goal     string            `json:"goal,omitempty"`
+	GoalCode string            `json:"goal-code,omitempty"`
 }
 
 // To introducee descriptor keeps information about the introduction
@@ -82,9 +84,10 @@ type Request struct {
 
 // Response message that introducee usually sends in response to an introduction proposal
 type Response struct {
-	Type       string                 `json:"@type,omitempty"`
-	ID         string                 `json:"@id,omitempty"`
-	Thread     *decorator.Thread      `json:"~thread,omitempty"`
-	Approve    bool                   `json:"approve,omitempty"`
-	OOBMessage map[string]interface{} `json:"oob-message,omitempty"`
+	Type        string                  `json:"@type,omitempty"`
+	ID          string                  `json:"@id,omitempty"`
+	Thread      *decorator.Thread       `json:"~thread,omitempty"`
+	Approve     bool                    `json:"approve,omitempty"`
+	OOBMessage  map[string]interface{}  `json:"oob-message,omitempty"`
+	Attachments []*decorator.Attachment `json:"~attach,omitempty"`
 }

--- a/pkg/didcomm/protocol/introduce/service.go
+++ b/pkg/didcomm/protocol/introduce/service.go
@@ -59,6 +59,8 @@ type customError struct{ error }
 // 'MyDID' and 'TheirDID' fields are needed for sending messages e.g report-problem, proposal, ack etc.
 type Recipient struct {
 	To       *To
+	Goal     string
+	GoalCode string
 	MyDID    string `json:"my_did,omitempty"`
 	TheirDID string `json:"their_did,omitempty"`
 }

--- a/pkg/didcomm/protocol/introduce/service_test.go
+++ b/pkg/didcomm/protocol/introduce/service_test.go
@@ -246,7 +246,7 @@ func TestService_SkipProposal(t *testing.T) {
 		"done", "done",
 	), checkDIDCommAction(t, Bob, action{Expected: introduce.ProposalMsgType}))
 
-	proposal := introduce.CreateProposal(&introduce.To{Name: Carol})
+	proposal := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Carol}})
 	introduce.WrapWithMetadataPublicOOBRequest(proposal, &outofband.Request{
 		Type: outofband.RequestMsgType,
 	})
@@ -305,8 +305,8 @@ func TestService_Proposal(t *testing.T) {
 		"done", "done",
 	), checkDIDCommAction(t, Carol, action{Expected: introduce.ProposalMsgType}))
 
-	proposal1 := introduce.CreateProposal(&introduce.To{Name: Carol})
-	proposal2 := introduce.CreateProposal(&introduce.To{Name: Bob})
+	proposal1 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Carol}})
+	proposal2 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Bob}})
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 
@@ -371,8 +371,8 @@ func TestService_ProposalContinue(t *testing.T) {
 		"done", "done",
 	), checkDIDCommAction(t, Carol, action{Expected: introduce.ProposalMsgType}))
 
-	proposal1 := introduce.CreateProposal(&introduce.To{Name: Carol})
-	proposal2 := introduce.CreateProposal(&introduce.To{Name: Bob})
+	proposal1 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Carol}})
+	proposal2 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Bob}})
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 
@@ -433,8 +433,8 @@ func TestService_ProposalSecond(t *testing.T) {
 		},
 	))
 
-	proposal1 := introduce.CreateProposal(&introduce.To{Name: Carol})
-	proposal2 := introduce.CreateProposal(&introduce.To{Name: Bob})
+	proposal1 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Carol}})
+	proposal2 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Bob}})
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 
@@ -499,8 +499,8 @@ func TestService_ProposalSecondContinue(t *testing.T) {
 		runtime.Goexit()
 	})
 
-	proposal1 := introduce.CreateProposal(&introduce.To{Name: Carol})
-	proposal2 := introduce.CreateProposal(&introduce.To{Name: Bob})
+	proposal1 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Carol}})
+	proposal2 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Bob}})
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 
@@ -556,8 +556,8 @@ func TestService_ProposalNoInvitation(t *testing.T) {
 		"done", "done",
 	), checkDIDCommAction(t, Carol, action{Expected: introduce.ProposalMsgType}))
 
-	proposal1 := introduce.CreateProposal(&introduce.To{Name: Carol})
-	proposal2 := introduce.CreateProposal(&introduce.To{Name: Bob})
+	proposal1 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Carol}})
+	proposal2 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Bob}})
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 
@@ -600,7 +600,7 @@ func TestService_SkipProposalStopIntroducee(t *testing.T) {
 		runtime.Goexit()
 	})
 
-	proposal := introduce.CreateProposal(&introduce.To{Name: Carol})
+	proposal := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Carol}})
 	introduce.WrapWithMetadataPublicOOBRequest(proposal, &outofband.Request{
 		Type: outofband.RequestMsgType,
 	})
@@ -654,8 +654,8 @@ func TestService_ProposalStopIntroduceeFirst(t *testing.T) {
 		"done", "done",
 	), checkDIDCommAction(t, Carol, action{Expected: introduce.ProposalMsgType}))
 
-	proposal1 := introduce.CreateProposal(&introduce.To{Name: Carol})
-	proposal2 := introduce.CreateProposal(&introduce.To{Name: Bob})
+	proposal1 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Carol}})
+	proposal2 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Bob}})
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 
@@ -711,8 +711,8 @@ func TestService_ProposalStopIntroduceeSecond(t *testing.T) {
 		runtime.Goexit()
 	})
 
-	proposal1 := introduce.CreateProposal(&introduce.To{Name: Carol})
-	proposal2 := introduce.CreateProposal(&introduce.To{Name: Bob})
+	proposal1 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Carol}})
+	proposal2 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Bob}})
 
 	introduce.WrapWithMetadataPIID(proposal1, proposal2)
 

--- a/test/bdd/agent/agent_sdk_steps.go
+++ b/test/bdd/agent/agent_sdk_steps.go
@@ -50,7 +50,8 @@ func NewSDKSteps() *SDKSteps {
 	return &SDKSteps{}
 }
 
-func (a *SDKSteps) createAgent(agentID, inboundHost, inboundPort, scheme string) error {
+// CreateAgent with the given parameters.
+func (a *SDKSteps) CreateAgent(agentID, inboundHost, inboundPort, scheme string) error {
 	opts := append([]aries.Option{}, aries.WithStoreProvider(a.getStoreProvider(agentID)))
 
 	return a.create(agentID, inboundHost, inboundPort, scheme, opts...)
@@ -234,7 +235,7 @@ func (a *SDKSteps) SetContext(ctx *context.BDDContext) {
 // RegisterSteps registers agent steps
 func (a *SDKSteps) RegisterSteps(s *godog.Suite) {
 	s.Step(`^"([^"]*)" agent is running on "([^"]*)" port "([^"]*)" with "([^"]*)" as the transport provider$`,
-		a.createAgent)
+		a.CreateAgent)
 	s.Step(`^"([^"]*)" edge agent is running with "([^"]*)" as the outbound transport provider `+
 		`and "([^"]*)" as the transport return route option`, a.createEdgeAgent)
 	s.Step(`^"([^"]*)" agent is running on "([^"]*)" port "([^"]*)" `+

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/messaging"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/outofband"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/presentproof"
+	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/redeemableroutes"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/route"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/verifiable"
 )
@@ -190,5 +191,6 @@ func features() []feature {
 		verifiable.NewVerifiableCredentialSDKSteps(),
 		outofband.NewOutOfBandSDKSteps(),
 		presentproof.NewPresentProofSDKSteps(),
+		redeemableroutes.NewBDDSteps(),
 	}
 }

--- a/test/bdd/features/redeemable_routes.feature
+++ b/test/bdd/features/redeemable_routes.feature
@@ -1,0 +1,24 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+@all
+@redeemable_routes
+Feature: Redeemable routes after an introduction
+
+  Background:
+    Given "Alice" agent is running on "localhost" port "random" with "http" as the transport provider
+    And "Alice" is connected to "Alice-Router" with transport "http" on "localhost" port "random"
+    And "Alice" is connected to "Bob" with transport "http" on "localhost" port "random"
+
+  Scenario: Bob redeems a route in Alice's router after an introduction
+    Given "Alice" prepares an introduction proposal to "Bob" for "Alice-Router"
+    And "Alice" prepares an introduction proposal to "Alice-Router" for "Bob" with the goal code "FREEROUTES"
+    And "Alice" sends these proposals to "Alice-Router" and "Bob"
+    When "Bob" approves
+    And "Alice-Router" approves and responds with serviceEndpoint "http://routers-r-us.com" and routingKey "key1"
+    And "Bob" connects with "Alice-Router" and sends the embedded route registration request
+    And "Alice-Router" confirms redeemable code and approves
+    Then "Bob" is granted serviceEndpoint "http://routers-r-us.com" and routingKey "key1"

--- a/test/bdd/pkg/introduce/introduce_sdk_steps.go
+++ b/test/bdd/pkg/introduce/introduce_sdk_steps.go
@@ -304,7 +304,7 @@ func (a *SDKSteps) checkAndContinue(agentID, introduceeID string) error {
 
 		e.Continue(nil)
 
-		go a.outofbandSDKS.ApproveRequest(agentID)
+		go a.outofbandSDKS.ApproveOOBRequest(agentID)
 	case <-time.After(timeout):
 		return fmt.Errorf("timeout checkAndContinue %s", agentID)
 	}
@@ -331,7 +331,7 @@ func (a *SDKSteps) checkAndContinueWithInvitation(agentID, introduceeID string) 
 
 		e.Continue(introduce.WithOOBRequest(req))
 
-		go a.outofbandSDKS.ApproveRequest(agentID)
+		go a.outofbandSDKS.ApproveOOBRequest(agentID)
 	case <-time.After(timeout):
 		return fmt.Errorf("timeout checkAndContinue %s", agentID)
 	}
@@ -358,7 +358,7 @@ func (a *SDKSteps) checkAndContinueWithInvitationAndEmbeddedRequest(agentID, int
 
 		e.Continue(introduce.WithOOBRequest(req))
 
-		go a.outofbandSDKS.ApproveRequest(agentID)
+		go a.outofbandSDKS.ApproveOOBRequest(agentID)
 	case <-time.After(timeout):
 		return fmt.Errorf("timeout checkAndContinue %s", agentID)
 	}

--- a/test/bdd/pkg/redeemableroutes/redeemable_routes.go
+++ b/test/bdd/pkg/redeemableroutes/redeemable_routes.go
@@ -1,0 +1,338 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package redeemableroutes
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
+	introClient "github.com/hyperledger/aries-framework-go/pkg/client/introduce"
+	"github.com/hyperledger/aries-framework-go/pkg/client/outofband"
+	routeClient "github.com/hyperledger/aries-framework-go/pkg/client/route"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/introduce"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/route"
+	agentSteps "github.com/hyperledger/aries-framework-go/test/bdd/agent"
+	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/context"
+	oobSteps "github.com/hyperledger/aries-framework-go/test/bdd/pkg/outofband"
+	bddroute "github.com/hyperledger/aries-framework-go/test/bdd/pkg/route"
+)
+
+const timeout = 2 * time.Second
+
+// BDDSteps for this feature.
+type BDDSteps struct {
+	context        *context.BDDContext
+	agentSdk       *agentSteps.SDKSteps
+	oobSdk         *oobSteps.SDKSteps
+	routeSdk       *bddroute.SDKSteps
+	proposals      map[string]*introduce.Recipient
+	goalCode       string
+	redeemableCode string
+	redeemableOpts *route.Options
+	introClients   map[string]*introClient.Client
+	introEvents    map[string]chan service.DIDCommAction
+	introApprovals map[string]chan interface{}
+}
+
+// NewBDDSteps this feature's test steps.
+func NewBDDSteps() *BDDSteps {
+	return &BDDSteps{
+		agentSdk:       agentSteps.NewSDKSteps(),
+		oobSdk:         oobSteps.NewOutOfBandSDKSteps(),
+		routeSdk:       bddroute.NewRouteSDKSteps(),
+		proposals:      make(map[string]*introduce.Recipient),
+		introClients:   make(map[string]*introClient.Client),
+		introEvents:    make(map[string]chan service.DIDCommAction),
+		introApprovals: make(map[string]chan interface{}),
+	}
+}
+
+// RegisterSteps registers agent steps
+func (b *BDDSteps) RegisterSteps(s *godog.Suite) {
+	s.Step(
+		`^"([^"]*)" is connected to "([^"]*)" with transport "([^"]*)" on "([^"]*)" port "([^"]*)"$`,
+		b.createIntroduceeAndConnect)
+	s.Step(
+		`^"([^"]*)" prepares an introduction proposal to "([^"]*)" for "([^"]*)"$`,
+		b.alicePreparesProposalToBobForRouter)
+	s.Step(
+		`^"([^"]*)" prepares an introduction proposal to "([^"]*)" for "([^"]*)" with the goal code "([^"]*)"$`,
+		b.alicePreparesProposalToRouterForBob)
+	s.Step(`^"([^"]*)" sends these proposals to "([^"]*)" and "([^"]*)"$`, b.sendProposals)
+	s.Step(`^"([^"]*)" approves$`, b.bobApprovesIntroduction)
+	s.Step(
+		`^"([^"]*)" approves and responds with serviceEndpoint "([^"]*)" and routingKey "([^"]*)"`,
+		b.routerApprovesIntroduction)
+	s.Step(
+		`^"([^"]*)" connects with "([^"]*)" and sends the embedded route registration request$`,
+		b.bobConnectsWithRouterAndRequestsRoute)
+	s.Step(
+		`^"([^"]*)" confirms redeemable code and approves`, b.routerConfirmsCodeAndApprovesRequest)
+	s.Step(`^"([^"]*)" is granted serviceEndpoint "([^"]*)" and routingKey "([^"]*)"`, b.bobConfirmsGrant)
+}
+
+// SetContext for these BDD test steps.
+func (b *BDDSteps) SetContext(c *context.BDDContext) {
+	b.context = c
+	b.agentSdk.SetContext(c)
+	b.oobSdk.SetContext(c)
+	b.routeSdk.SetContext(c)
+}
+
+func (b *BDDSteps) createIntroduceeAndConnect(introducer, introducee, protocolScheme, host, port string) error {
+	err := b.agentSdk.CreateAgent(introducee, host, port, protocolScheme)
+	if err != nil {
+		return fmt.Errorf("failed to create router %s : %w", introducee, err)
+	}
+
+	err = b.routeSdk.CreateRouteClient(introducee)
+	if err != nil {
+		return fmt.Errorf("%s failed to create a routing client : %w", introducee, err)
+	}
+
+	err = b.oobSdk.ConnectAll(introducer + "," + introducee)
+	if err != nil {
+		return fmt.Errorf("failed to connect %s to %s : %w", introducer, introducee, err)
+	}
+
+	return nil
+}
+
+func (b *BDDSteps) alicePreparesProposalToBobForRouter(alice, bob, router string) error {
+	err := b.createIntroduceClients(alice, bob, router)
+	if err != nil {
+		return err
+	}
+
+	conn, err := b.getConnection(alice, bob)
+	if err != nil {
+		return err
+	}
+
+	b.proposals[bob] = &introduce.Recipient{
+		To:       &introduce.To{Name: router},
+		MyDID:    conn.MyDID,
+		TheirDID: conn.TheirDID,
+	}
+
+	return nil
+}
+
+func (b *BDDSteps) alicePreparesProposalToRouterForBob(alice, router, bob, goalCode string) error {
+	b.goalCode = goalCode
+
+	conn, err := b.getConnection(alice, router)
+	if err != nil {
+		return err
+	}
+
+	b.proposals[router] = &introduce.Recipient{
+		To:       &introduce.To{Name: bob},
+		Goal:     "test",
+		GoalCode: goalCode,
+		MyDID:    conn.MyDID,
+		TheirDID: conn.TheirDID,
+	}
+
+	return nil
+}
+
+func (b *BDDSteps) sendProposals(alice, bob, router string) error {
+	err := b.introClients[alice].SendProposal(
+		b.proposals[bob],
+		b.proposals[router],
+	)
+	if err != nil {
+		return fmt.Errorf("%s failed to send proposals to %s and %s : %w", alice, bob, router, err)
+	}
+
+	return nil
+}
+
+func (b *BDDSteps) bobApprovesIntroduction(bob string) error {
+	b.introApprovals[bob] <- &service.Empty{}
+
+	return nil
+}
+
+func (b *BDDSteps) routerApprovesIntroduction(router, serviceEndpoint, routingKey string) error {
+	select {
+	case event := <-b.introEvents[router]:
+		proposal := &introduce.Proposal{}
+
+		err := event.Message.Decode(proposal)
+		if err != nil {
+			return fmt.Errorf("%s failed to decode introduce proposal : %w", router, err)
+		}
+
+		if proposal.GoalCode != b.goalCode {
+			return fmt.Errorf(
+				"%s expected goal-code %s but got %s in the introduce proposal",
+				router, b.goalCode, proposal.GoalCode)
+		}
+	case <-time.After(timeout):
+		return fmt.Errorf("%s timed out waiting for proposal for introduction", router)
+	}
+
+	routeRequest := routeClient.NewRequest()
+	b.redeemableCode = routeRequest.ID
+	b.redeemableOpts = &route.Options{
+		ServiceEndpoint: serviceEndpoint,
+		RoutingKeys:     []string{routingKey},
+	}
+
+	bits, err := json.Marshal(routeRequest)
+	if err != nil {
+		return fmt.Errorf("failed to marshal route-request : %w", err)
+	}
+
+	req, err := b.context.OutOfBandClients[router].CreateRequest(
+		[]*decorator.Attachment{{
+			Description: "please redeem your route code",
+			Data: decorator.AttachmentData{
+				Base64: base64.StdEncoding.EncodeToString(bits),
+			},
+		}},
+		outofband.WithLabel(router),
+	)
+	if err != nil {
+		return fmt.Errorf("%s failed to create an oob request : %w", router, err)
+	}
+
+	b.introApprovals[router] <- introClient.WithOOBRequest(
+		req,
+		&decorator.Attachment{
+			Description: "pre-approved routing keys and service endpoints",
+			Data: decorator.AttachmentData{
+				JSON: map[string]interface{}{
+					"routingKeys":     []string{routingKey},
+					"serviceEndpoint": serviceEndpoint,
+				},
+			},
+		},
+	)
+
+	return nil
+}
+
+func (b *BDDSteps) bobConnectsWithRouterAndRequestsRoute(bob, router string) error {
+	// bob approves oob request received via the introducer
+	b.oobSdk.ApproveOOBRequest(bob)
+
+	// in order: make bob approve first, then the router
+	for _, agent := range []string{bob, router} {
+		err := b.oobSdk.ApproveDIDExchangeRequest(agent)
+		if err != nil {
+			return fmt.Errorf("%s failed to approve didexchange request : %w", agent, err)
+		}
+	}
+
+	err := b.oobSdk.ConfirmConnections(router, bob, "completed")
+	if err != nil {
+		return fmt.Errorf("failed to confirm connection status %s and %s", router, bob)
+	}
+
+	return nil
+}
+
+func (b *BDDSteps) routerConfirmsCodeAndApprovesRequest(router string) error {
+	event, err := b.routeSdk.GetEventReceived(b.redeemableCode, timeout)
+	if err != nil {
+		return err
+	}
+
+	request := &routeClient.Request{}
+
+	err = event.Message.Decode(request)
+	if err != nil {
+		return err
+	}
+
+	if request.ID != b.redeemableCode {
+		return fmt.Errorf("request received does not contain the redeemable routing code %s", b.redeemableCode)
+	}
+
+	b.routeSdk.ApproveRequest(router, b.redeemableOpts)
+
+	return nil
+}
+
+func (b *BDDSteps) bobConfirmsGrant(bob, serviceEndpoint, routingKey string) error {
+	config, err := b.routeSdk.GetRoutingConfig(bob, timeout)
+	if err != nil {
+		return err
+	}
+
+	if b.redeemableOpts.ServiceEndpoint != config.Endpoint() {
+		return fmt.Errorf(
+			"routing config mismatch: %s expected serviceEndpoint %s but got %s",
+			bob, b.redeemableOpts.ServiceEndpoint, config.Endpoint())
+	}
+
+	for i, k := range b.redeemableOpts.RoutingKeys {
+		if config.Keys()[i] != k {
+			return fmt.Errorf(
+				"routing config mismatch: %s expected routingKeys %+v but got %+v",
+				bob, b.redeemableOpts.RoutingKeys, config.Keys())
+		}
+	}
+
+	return nil
+}
+
+func (b *BDDSteps) createIntroduceClients(agents ...string) error {
+	for _, agent := range agents {
+		client, err := introClient.New(b.context.AgentCtx[agent])
+		if err != nil {
+			return fmt.Errorf("failed to create introduce client for %s : %w", agent, err)
+		}
+
+		actions := make(chan service.DIDCommAction)
+
+		err = client.RegisterActionEvent(actions)
+		if err != nil {
+			return fmt.Errorf("failed to register %s for introduce action events : %w", agent, err)
+		}
+
+		b.introClients[agent] = client
+		b.introEvents[agent] = make(chan service.DIDCommAction)
+		b.introApprovals[agent] = make(chan interface{})
+
+		go listenForIntroduceEvents(b.introApprovals[agent], actions, b.introEvents[agent])
+	}
+
+	return nil
+}
+
+func listenForIntroduceEvents(approvals chan interface{}, events, listen chan service.DIDCommAction) {
+	for event := range events {
+		go func() { listen <- event }()
+		event.Continue(<-approvals)
+	}
+}
+
+func (b *BDDSteps) getConnection(agentA, agentB string) (*didexchange.Connection, error) {
+	connections, err := b.context.DIDExchangeClients[agentA].QueryConnections(&didexchange.QueryConnectionsParams{})
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range connections {
+		if connections[i].TheirLabel == agentB {
+			return connections[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("no connection between %s and %s", agentA, agentB)
+}


### PR DESCRIPTION
closes #1741 

This PR demonstrates an application-level protocol on top of existing ones (introduce, routing, didexchange) where an introducer can request a "pre-approved" route from their router that an introducee may later redeem. The only change required at the protocol level was the addition of `goal` and `goal-code` to `introduce.Proposal`.



Signed-off-by: George Aristy <george.aristy@securekey.com>