### PR TITLE
test: Cache most commonly used VC contexts for tests

### DIFF
--- a/pkg/doc/verifiable/credential_extension_test.go
+++ b/pkg/doc/verifiable/credential_extension_test.go
@@ -38,7 +38,7 @@ type UniversityDegreeCredential struct {
 }
 
 func NewUniversityDegreeCredential(vcData []byte, opts ...CredentialOpt) (*UniversityDegreeCredential, error) {
-	cred, credBytes, err := NewCredential(vcData, opts...)
+	cred, credBytes, err := newTestCredential(vcData, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("new university degree credential: %w", err)
 	}
@@ -133,7 +133,7 @@ func TestCredentialExtensibility(t *testing.T) {
 }
 `
 
-	cred, _, err := NewCredential([]byte(udCredential))
+	cred, _, err := newTestCredential([]byte(udCredential))
 	require.NoError(t, err)
 	require.NotNil(t, cred)
 

--- a/pkg/doc/verifiable/credential_jws_test.go
+++ b/pkg/doc/verifiable/credential_jws_test.go
@@ -22,7 +22,7 @@ func TestJWTCredClaimsMarshalJWS(t *testing.T) {
 	privateKey, err := readPrivateKey(filepath.Join(certPrefix, "issuer_private.pem"))
 	require.NoError(t, err)
 
-	vc, _, err := NewCredential([]byte(validCredential))
+	vc, _, err := newTestCredential([]byte(validCredential))
 	require.NoError(t, err)
 
 	jwtClaims, err := vc.JWTClaims(true)
@@ -84,7 +84,7 @@ func TestCredJWSDecoderUnmarshal(t *testing.T) {
 		err = json.Unmarshal(vcBytes, &vcRaw)
 		require.NoError(t, err)
 
-		vc, _, err := NewCredential([]byte(jwtTestCredential))
+		vc, _, err := newTestCredential([]byte(jwtTestCredential))
 		require.NoError(t, err)
 		require.Equal(t, vc.stringJSON(t), vcRaw.stringJSON(t))
 	})

--- a/pkg/doc/verifiable/credential_jwt_unsecured_test.go
+++ b/pkg/doc/verifiable/credential_jwt_unsecured_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestCredentialJWTClaimsMarshallingToUnsecuredJWT(t *testing.T) {
-	vc, _, err := NewCredential([]byte(validCredential))
+	vc, _, err := newTestCredential([]byte(validCredential))
 	require.NoError(t, err)
 
 	jwtClaims, err := vc.JWTClaims(true)
@@ -39,7 +39,7 @@ func TestCredentialJWTClaimsMarshallingToUnsecuredJWT(t *testing.T) {
 
 func TestCredUnsecuredJWTDecoderParseJWTClaims(t *testing.T) {
 	t.Run("Successful unsecured JWT decoding", func(t *testing.T) {
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		jwtClaims, err := vc.JWTClaims(true)

--- a/pkg/doc/verifiable/credential_ldp_test.go
+++ b/pkg/doc/verifiable/credential_ldp_test.go
@@ -56,7 +56,7 @@ func TestNewCredentialFromLinkedDataProof_Ed25519Signature2018(t *testing.T) {
 		VerificationMethod:      "did:example:123456#key1",
 	}
 
-	vc, _, err := NewCredential([]byte(validCredential))
+	vc, _, err := newTestCredential([]byte(validCredential))
 	r.NoError(err)
 
 	err = vc.AddLinkedDataProof(ldpContext)
@@ -65,7 +65,7 @@ func TestNewCredentialFromLinkedDataProof_Ed25519Signature2018(t *testing.T) {
 	vcBytes, err := json.Marshal(vc)
 	r.NoError(err)
 
-	vcWithLdp, _, err := NewCredential(vcBytes,
+	vcWithLdp, _, err := newTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)))
 	r.NoError(err)
@@ -121,7 +121,7 @@ func TestNewCredentialFromLinkedDataProof_JSONLD_Validation(t *testing.T) {
 }
 `
 
-		vcWithLdp, _, err := NewCredential([]byte(vcJSON), vcOptions...)
+		vcWithLdp, _, err := newTestCredential([]byte(vcJSON), vcOptions...)
 		r.NoError(err)
 		r.NotNil(t, vcWithLdp)
 	})
@@ -162,7 +162,7 @@ func TestNewCredentialFromLinkedDataProof_JSONLD_Validation(t *testing.T) {
 }
 `
 
-		vcWithLdp, _, err := NewCredential([]byte(vcJSON), vcOptions...)
+		vcWithLdp, _, err := newTestCredential([]byte(vcJSON), vcOptions...)
 		r.Error(err)
 		r.EqualError(err, "JSON-LD doc has different structure after compaction")
 		r.Nil(vcWithLdp)
@@ -204,46 +204,40 @@ func TestNewCredentialFromLinkedDataProof_JSONLD_Validation(t *testing.T) {
 }
 `
 
-		vcWithLdp, _, err := NewCredential([]byte(vcJSON), vcOptions...)
+		vcWithLdp, _, err := newTestCredential([]byte(vcJSON), vcOptions...)
 		r.Error(err)
 		r.EqualError(err, "JSON-LD doc has different structure after compaction")
 		r.Nil(vcWithLdp)
 	})
 
 	t.Run("VC with different mapped field", func(t *testing.T) {
+		localJSONLDContext := `
+{
+  "@context":
+  {
+      "@version": 1.1,
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "schema": "http://schema.org/",
+      "comments": "schema:text"
+  }
+}
+`
+
+		docLoader := createTestJSONLDDocumentLoader()
+		addJSONLDCachedContext(docLoader, "http://localhost:9191/example.jsonld", localJSONLDContext)
+
 		vcJSON := `
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://schema.org/",
-    "https://mavennet.github.io/contexts/bill-of-lading-v1.0.jsonld"
+    "http://localhost:9191/example.jsonld"
   ],
   "id": "http://neo-flow.com/credentials/e94a16cb-35b2-4301-9fb6-7af3d8fe7b81",
   "type": ["VerifiableCredential", "BillOfLadingCredential"],
-  "name": "Bill of Lading",
-  "description": "Detailed shipment document provided by the carrier to the receiver of products.",
-  "issuer": "did:v1:test:nym:z6MkfG5HTrBXzsAP8AbayNpG3ZaoyM4PCqNPrdWQRSpHDV6J",
+  "issuer": "did:example:76e12ec712ebc6f1c221ebfeb1f",
   "issuanceDate": "2020-04-09T21:13:13Z",
   "credentialSubject": {
-    "productIdentifier": "3a185b8f-078a-4646-8343-76a45c2856a5",
-    "bolNumber": "BOL000104976",
-    "carrier": "did:v1:test:nym:z6MkhdmzFu659ZJ4XKj31vtEDmjvsi5yDZG5L7Caz63oP39k",
-    "recipient": "did:v1:test:nym:z6MknQLHcwKwopce5ji1Ftsurn8mNL58wTxZB238uEMsegUj",
-    "transportType": "Pipeline",
-    "originAddress": {
-      "address": "Quebec, CAN",
-      "latitude": "52.9399",
-      "longitude": "73.5491"
-    },
-    "deliveryAddress": {
-      "address": "Chicago, USA",
-      "latitude": "41.8781",
-      "longitude": "87.6298"
-    },
-    "valuePerItem": "46",
-    "totalOrderValue": "126500",
-    "freightChargeTerms": "Freight Prepaid",
-    "expectedDeliveryDates": "12-APR-2020",
+	"id": "https://example.edu/status/24",
     "comments": ""
   },
   "proof": {
@@ -256,9 +250,10 @@ func TestNewCredentialFromLinkedDataProof_JSONLD_Validation(t *testing.T) {
 }
 `
 
-		vc, _, err := NewCredential([]byte(vcJSON),
+		vc, _, err := newTestCredential([]byte(vcJSON),
 			WithDisabledProofCheck(),
 			WithStrictValidation(),
+			WithJSONLDDocumentLoader(docLoader),
 		)
 		require.NoError(t, err)
 		require.NotNil(t, vc)
@@ -308,7 +303,7 @@ func TestWithStrictValidationOfJsonWebSignature2020(t *testing.T) {
 	copy(publicKey[0:32], decoded)
 	rv := ed25519.PublicKey(publicKey)
 
-	vcWithLdp, _, err := NewCredential([]byte(vcJSON),
+	vcWithLdp, _, err := newTestCredential([]byte(vcJSON),
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(func(issuerID, keyID string) (*sigverifier.PublicKey, error) {
 			return &sigverifier.PublicKey{
@@ -366,7 +361,7 @@ func TestExtraContextWithLDP(t *testing.T) {
 		VerificationMethod:      "did:example:123456#key1",
 	}
 
-	vc, _, err := NewCredential([]byte(vcJSON))
+	vc, _, err := newTestCredential([]byte(vcJSON))
 	r.NoError(err)
 
 	err = vc.AddLinkedDataProof(ldpContext)
@@ -375,7 +370,7 @@ func TestExtraContextWithLDP(t *testing.T) {
 	vcBytes, err := json.Marshal(vc)
 	r.NoError(err)
 
-	vcWithLdp, _, err := NewCredential(vcBytes,
+	vcWithLdp, _, err := newTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)),
 		WithStrictValidation())
@@ -392,7 +387,7 @@ func TestExtraContextWithLDP(t *testing.T) {
 	vcBytes, err = json.Marshal(vcMap)
 	r.NoError(err)
 
-	vcWithLdp, _, err = NewCredential(vcBytes,
+	vcWithLdp, _, err = newTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)),
 		WithStrictValidation())
@@ -401,7 +396,7 @@ func TestExtraContextWithLDP(t *testing.T) {
 	r.Nil(vcWithLdp)
 
 	// Use extra context.
-	vcWithLdp, _, err = NewCredential(vcBytes,
+	vcWithLdp, _, err = newTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)),
 		WithExternalJSONLDContext("https://trustbloc.github.io/context/vc/examples-v1.jsonld"),
@@ -410,7 +405,7 @@ func TestExtraContextWithLDP(t *testing.T) {
 	r.NotNil(vcWithLdp)
 
 	// Use extra context.
-	vcWithLdp, _, err = NewCredential(vcBytes,
+	vcWithLdp, _, err = newTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)),
 		WithExternalJSONLDContext("https://trustbloc.github.io/context/vc/examples-v1.jsonld"),
@@ -467,7 +462,7 @@ func TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_Ed25519(t *testin
 		VerificationMethod:      "did:example:123456#key1",
 	}
 
-	vc, _, err := NewCredential([]byte(validCredential))
+	vc, _, err := newTestCredential([]byte(validCredential))
 	r.NoError(err)
 
 	err = vc.AddLinkedDataProof(ldpContext)
@@ -476,7 +471,7 @@ func TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_Ed25519(t *testin
 	vcBytes, err := json.Marshal(vc)
 	r.NoError(err)
 
-	vcWithLdp, _, err := NewCredential(vcBytes,
+	vcWithLdp, _, err := newTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(SingleKey(pubKey, "Ed25519Signature2018")))
 	r.NoError(err)
@@ -501,7 +496,7 @@ func TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_ecdsaP256(t *test
 		VerificationMethod:      "did:example:123456#key1",
 	}
 
-	vc, _, err := NewCredential([]byte(validCredential))
+	vc, _, err := newTestCredential([]byte(validCredential))
 	r.NoError(err)
 
 	err = vc.AddLinkedDataProof(ldpContext)
@@ -512,7 +507,7 @@ func TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_ecdsaP256(t *test
 
 	pubKeyBytes := elliptic.Marshal(privateKey.Curve, privateKey.X, privateKey.Y)
 
-	vcWithLdp, _, err := NewCredential(vcBytes,
+	vcWithLdp, _, err := newTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(func(issuerID, keyID string) (*sigverifier.PublicKey, error) {
 			return &sigverifier.PublicKey{
@@ -551,7 +546,7 @@ func TestNewCredentialFromLinkedDataProof_EcdsaSecp256k1Signature2019(t *testing
 		VerificationMethod:      "did:example:123456#key1",
 	}
 
-	vc, _, err := NewCredential([]byte(validCredential))
+	vc, _, err := newTestCredential([]byte(validCredential))
 	r.NoError(err)
 
 	err = vc.AddLinkedDataProof(ldpContext)
@@ -561,7 +556,7 @@ func TestNewCredentialFromLinkedDataProof_EcdsaSecp256k1Signature2019(t *testing
 	r.NoError(err)
 
 	// JWK encoded public key
-	vcWithLdp, _, err := NewCredential(vcBytes,
+	vcWithLdp, _, err := newTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(func(issuerID, keyID string) (*sigverifier.PublicKey, error) {
 			return &sigverifier.PublicKey{
@@ -581,7 +576,7 @@ func TestNewCredentialFromLinkedDataProof_EcdsaSecp256k1Signature2019(t *testing
 
 	// Bytes encoded public key (can come in e.g. publicKeyHex field)
 	pubKeyBytes := elliptic.Marshal(privateKey.Curve, privateKey.X, privateKey.Y)
-	vcWithLdp, _, err = NewCredential(vcBytes,
+	vcWithLdp, _, err = newTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(func(issuerID, keyID string) (*sigverifier.PublicKey, error) {
 			return &sigverifier.PublicKey{
@@ -595,230 +590,252 @@ func TestNewCredentialFromLinkedDataProof_EcdsaSecp256k1Signature2019(t *testing
 
 //nolint:lll
 func TestNewCredential_JSONLiteralsNotSupported(t *testing.T) {
-	vcJSON := `
+	cmtrJSONLD := `
 {
-    "@context": [
-      "https://www.w3.org/2018/credentials/v1",
-      "https://w3c-ccg.github.io/vc-examples/cmtr/examples/v0.2/cmtr-v0.2.jsonld"
-    ],
-    "id": "http://example.com/credentials/123",
-    "type": [
-      "VerifiableCredential",
-      "CertifiedMillTestReport"
-    ],
-    "issuer": "did:elem:ropsten:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg",
-    "issuanceDate": "2020-03-09T18:19:10.033Z",
-    "name": "Certified Mill Test Report",
-    "description": "A mill test report (MTR) and often also called a certified mill test report, certified material test report, mill test certificate (MTC), inspection certificate, certificate of test, or a host of other names, is a quality assurance document used in the metals industry that certifies a material's chemical and physical properties and states a product made of metal (steel, aluminum, brass or other alloys) complies with an international standards organization (such as ANSI, ASME, etc.) specific standards.",
-    "credentialSubject": {
-      "id": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
-      "cmtr": {
-        "companyName": "Steel Inc.",
-        "companyWebsite": "https://example.com",
-        "companyAddress": "3260 46 Ave SE #30, Calgary, AB T2B 3K7, Canada",
-        "companyPhoneNumber": "555 555 5555",
-        "companyBrandMark": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAACnWSURBVHhe7V0HmBRF2pa8bCAsu7CywJJzEliiiICwgCQDUQUUMRAlbI7AktlDwikIBhA9RUFO8czxP7lDQKICCiKCAcN5eoY70/e/X2912zPT09MzO8vOLt/7PO/T01VfVXdXfe90VXd11SUCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAIBAIBAL/sWHDhkoZGRmXZmVltcnOzu7jztzc3NZgHFhRJREIyh7YweHw3SCEW7FdmZOTswv8EL9/w5Yc8FfwJLgLeawAb4Gwum7btq2COoRAUKpQDk7cAQ49GyJ4BvxWOXpQqfJ9GpyF47Xj4xYeXiAIQWRmZjaBs86H457WndhMhH8GvgCuwf4MbEeAibjD1EtPT4/Ftgbnk5qaWp33kV8jvlPA+YfDLgV8AOl2g//S83TjhyCyyW2onZBAUNKYMWNGFTjlzeCbcODflaPqPIewTXDw8cF2WuTZDPnfjvwfB780H5fPA/Gv45gTuJ+jkggEFw6zZ8+uCkecCYf82OycvI/wxXDOjsr0QqAcjtcJx70bPG8+H+yfAaeykJWtQFB8gCOG4d85GU73qckRf8X+U+AAxJdXpiUCHL8iyE2y7Xxe+jli/yy2sxBXWZkKBMEF+gSD4GT8NEl3uv+C69Bn8Nl8gmPGcH8C9sMgMH6axXefXBO5Qz8VcWNxnIHog7QsqjNzMwx5Pgj+wufLxO/jYF9lIhAUHXDUunC2bbqTgXzHWI/wesrEBXDwBNhPANfC9u+wDegpFjs2+AF+78J2JfIbzUJTh3EMFjDS34d8fjblvQUirKNMBILAAKe8Ec70ne5Y4MsI40eqBvh9BBz3StjdjXjjDmPDL8Bz4FEzkf48aCsmxPODgINgAX4njRo1yvG7EJx3B6TZY8rrG2xHqWiBwDng8NzX2GBypq+xnaiiNfCdBeF5CGdnd3dk/rfmuweL5k7Y9kMTK14ltQVsw/mRMbZXIO3t4J+Rz1vgj5y3mQg7Cy7gR8IquS2QZ3nYTwVZHFoeuM61CJe+icAZ4CyN4UD7TU74rLk5ovoiOxFutO0V30PYcqQfBEYq86CBn0Qh/75gPnjAfGzs81v5FyHC7srcFjg/FvdrpjzeRpi8PxHYA07TG9T/XfkukArH0Z5MIbwP9vlFneGY4KcI/xNsOmkZXEBwRx7H5w6++6PmJ3E+LZWZV3DzDLYLcf76kJev8LuHihYIXAGnGgon0Zsx7Cza0x40QS7D7+dUuEbs7wWv86cPUFzAeVfEOY7H+Rh3FfzmDv7diAtXZl7BT81gy/0iTvs90gxUUQJBIeAYE9mplHMdg5M0nTt3bgQcbzX2zYMKX8Z+f5UsICDvysi3FfK5BuRHu8nINxe/1+D3QvV7Jn6PhW13MFoltQXsyiPtOPAjUBfKMbCzMvEKvl7Y8VAVTvMzjj1aRQkudsAh7gC1YSLYHoGz1Oa2PPbfNznaKXCYSuIXkBcPab8R+dyPPPg9hHvfxSeR5lPk8TS2GTi/nnYjeREfBrsFSKc/1uVtOqJsBzMiXV3YHeY0SP8b9ieoKMHFCjjCdewMyimO8JMmOOIy7OtvoX9EeBY7nUriCGlpabWQlgckGp19Ky7NzKBVqfMod/Ysmjp1Kk2bNo3mzJlD81NSaEFWpmUaRW4CbgGTvIkF58zDT47pafD7QV9js5AmGrb/VPbcTLtaRQkuNqDtfQUc4CflDHznaIntKyaHOsBhytwRYN8RaXkA4f/0fJh5Odm0LnMuPZl8M7088zraOyWJjt3Qk45f35mODe9IWa3qEpIbXNmwDh1u05D2dGlPL13enXZcPYQ2TpxIi9PTjTx14lifgFk8ApjPwQycTzXY7NBtIf7nEWb7hE2leUel+d7pkzFBGQIchb/i055WYXsE5K/4+K017/8O3u3PAD84UVek5TfexoheFsUDuTPp9axxdDwliU7edSWdnHoFfTClF70/sTudGNfVp0AONWtABxvG04H4ODoYfykdalCXdnfrRE9eP4IK5s4xRKLIDxhWcZOOz8mEcjivpbodfu/xJZJ58+bFwe6Usv+Sn5ipKEFZB/9DotJ1MXwGsdyC7b/V/n8QP1SZ+gT/ayPNQ6AhjGV5GfTsolvp+OKR9OGCQXQqayCdSukfNIEcblqfjrRKoKPtG9FbA3rS1lsnoDmW5SIUnA83C11e/iEsTbfB7xd8NbdQLjyWS3+6dXzFihURKkpQloFK36qc5L9wAn5ipDezuCN8mTLzCaSZjDT8hl1zumXzM+j5lbfRh2uupY9WDqfTS662FcihUV1oeWIC9a9TjcLKl3MRSDj2k6LCaVmdaHo7oa5XgbzXpSkd69GMDg3oRNtuHU/5rv2W9yCSy/lcdeB8s/R4/H4IQbYdd9h0A7XmIrYPqmBBWQUqerLuIOATqHSjD5KamtpAmdmCmyewf0zPJy83m7avmkmnN42lj9dfR2fWjrQVyPsQyOormlJ8eGUXUXhjg4oVaG10DVuBHL+iJZ24qjUdHZ5ID0+/Rb8+vi5uLm40//vjT4AHUerxaSrYK2AzT7dHWnmyVVaBym2FSv5eOQZ/WKT/5g66o3cNyIP7Lsc5HXPd0jQ6suUWOrt1LJ19YLRPgRy7ozeNa1nbUgi+OCkinN7xIZAPBrelk8Pb054JA2h16h99FJzzIVxjY+SjDa5E2Ksq7mfEJXK4DcrB7m/K/jvk01yFC8oQuKP6hqpks+O8zx1SZWML9dRL66swH183h84+NYHObbvBkUCOz+xDverXsHR+pxwSHkaHHAjk1PWX0cnxXemJuyaZr/VrOLf2llz1nT5Rce/zXZHDvUHZ6x+JvayCBWUFqNQbVOWaHeYjOH2CMrEFbIeBWnNsfl42vbl1On367ET6ZOdNjgVyZ5f6lk7vL++Kru5IIB+O60ynJyTS7mnDaUmW8XiY3+/MQj7cVOQhJvoL0ns4zA64e45UeRDSXq+CBaUdycnJUahU9yHp3+Nfsb0ysQWch2cf0d5+58/Ppv1PTafPXrrFL4E8Pr6TpbMzG6Evkt2qLnWoVpW6V69K6QmxVLtSRUtbndsbXepYIGdu7U7vTh9AqzKTjevH9cxEPnxt/CEVh/3qpDxgr41Jw/asPNUqI0CFrlBOYBD/hjeqaFvAEXrBXhvAuDg/m448N50+f2OKXwI5mTmQEutV93DyapUqUI/YSFrYvj69N6g9vduvDY2MjaIZ8bUos14MdQ+vQhHlXJ9u6ewbGeaXQD6+syednNWP1mfepQvkd9w9py1evJjf+H/FYeCryNsWaWlpzZFWfwm6SAULSiv4pRkq0uVDI1TwGhVtC+7Uw1Z7jLsAd47DL86i87tv91sgT07qaunkm/s2196DPHFFM+oHYYytW4MqlruEqlcoT7fUrk49IZAltWtapmU+1yLeL4GcnXk5nZnXj+7LMkTyG65xErZT9bLB/nDkbQvYLVL2P+KuI5/tlmagEgtUZepOwU9zfH49xyN5Yc+fwqK9nUN7nptDX+ybGpBAZvZubOng2wa00gSypnOCtt8nOoI2tI6nhY3rUKMqlbSwzBjvnfrUS6P9Fsi5eX3oTPoAujfbeML1M8qjH8pFm+wO273I2xbcZIWd9seBbb4KFpQ2oOKjUYHmb7x5soVuKtoWsNuop3txRwp9eXhGwAJJtHhytX1Ia+1N+v4RHWlWizrUNKIKHe7bmo72bklHuzWnV9okUBiaV2viatHjcTEe6Zm9oqoGJJBP0/vSmZxBtDqnsE+Ca9XGcunXi999kL8tYJOvbL9FOWszQgpKGVB5PORbFwc3H1arKFugwkfrae5fn0lfHptVJIHEV6vi4ti1wyrSkRu7agLJ7Fj4ZGtyQi2tD6IL5MhlTegyNLE47qHa0ZRQvrxLHsw2VSsFLJDPcvrTiQXDaVFO4Zt3lBV/864PK3ka+dtC/fno75EyVLCgtAAVWBkVZ56S81OE+fxOnOfFRbrPOc3SJdl09t25RRLIidyBHo7NXNqrsSaQFwa1paH1alKPmuEuAtnboRHVQl9kWs1qNKtGlGUeUeXLFUkgny8cQHvzx1GuKiNc9w9qyx14n5NAwHaVsj+PspUlGkoTUGnXcOXpxP5tKsoWsONZSLQ0/3g9jb46NadIAjk5P8nDseMjK9M747sYgxU3dW+khU+qF02vdW1Cz3doSJdXC9fC3mxcl/6v/qUUD7GY82DGIqyoAjm/dBDtzL/DKCeduNtm4hi2YBGxmNgeW/lupDQBlcZTb2qVjco77WQSZzhFO9hq7zs2bsiirz5OLrJAuInVNKbQ2XWGVShHb8KBdYGsTWxIsZUrUvuoMC0ef8XULTKMakMAOxMupWfjrYemdKhaOSgC+XTlMCqYn+YiEJTDERzDJ2D7prJ/TAUJQh1LliypiQozf7DkMp+VNyDNI2yfl5tDHxxJDZpAutT3fAfCfHJga2O4++GB7egomlgt0a8YFh2p9UH2t06gTfGxlmmZg6uHB0UgXxQMoYMF442mlk7+w8BxbAE7nreLBfIjN09VsCCUoVeaqrizTlZiQhu6Key1z2wf2ZJJX3+SEhSBnIJA6rp10nU+lfSHQPQXheZOOn8Pcr+NQFIurRk0gXy1dihtXVz4fkQnBJKN49hC/Rn9V6W5WQULQhmosKdMFb1QBdsCzmDMonjicFrQBLIvtZ+lczNjwirRVXWrU0GnBh4CyWsQS/3QzKpu8fRK51jcaYIpkA/WjqG8P8qN/1xew3F8Ara8yhXbP66CBKEKvlugovRPaXlmDp+zBfJLQdhqjywf2JiliSNYAtl4g/cxWDobR1ShhW3r0dW1o2hEbBQtaPTHi0I7BqsPogvk6/XD6bFlM80C+Qnl53NeLdhOU2m+gH2JLv8g8AFUaqJeweCLKtgWuHvwlDxamn/+X3pQBZI6sLmlcweD3Jk/0KlxUAXywfrxetlpRHkOwLFsAVG01u1Rlh1UsCAUgQriSdj0Cr5dBdsCdtrHQIvyc+j8x4XiCJZA+jb33ocIBne0ig+qQP71wEhav8hl1K+Tl4D8QZX27gjUhtILQhSoIK09zHS4sA1P4KA92t32l8LOebAE8iEEUrd64aPb4mJeQmzQBbJ73a1mgTh6fAu7x1WaJ1WQIBSBCtLW50CFHVNBtoDdMFWx9PbfCzvnwRLI/swBlk4dTF5fKyroAvli82jtO3tVLkdxHJ9AOerfrR9XQYJQA+4GYaggfUbEVSrYFmzH9vwO4JMPU4MqkE0Tulg6dTDZLrxy0AXyzcPX0aal83SB8Ghfn6Of0bQdbrKXYSehCFRSG1VJ3Fkcr4JtAVttBsF1a7JdxBEMgaQMamHp1DqbVwujlwe1oeRWl1LvmEjqEBVGzatWog4RVah3tXBKrVOTUmpZv2Q080C3pkEXyCvr7tQFQpmZmU1wHFugvFvo9hCITOoQisBt3hh/hQrz+TSFly5AGu2Nu3v/IxgCubKFfQf9rnbxPl8U/qNJPQr38lWhzsfa1gu6QN5/cIIhEJSRz+Hvt912WyXYapNlc7NVBQtCCaicVFWpv3JzSwV7Bf8zKnt6+bmMoArkNAQS5+UNus6Xh7bzKRCeWXFwRFXL9DpzGsUGXSBfPTrGGHqCPxunnyefYHts71JBglACKmalqqATKsgWsBusC2TfbtcOelEFsj/Pepi7zstiIozBir4Eck/tWpZ56BweGxV0gXz72ChavciYCSUVx/EJlOdbqvwXqyBBKAEV86CqIEdDJGBnfIv94THXDnpRBbLx5kRLZ9aZlZjgWCD7EupSLbepSc1shY56cQhk88q5ukCW4Dg+gfJ8QZX/fSpIEEpAxTyhKnSnCrIF7NKVPZ07FVyBpAxuaenMzErlLqF/jOnkWCA8efW4CNch8+58p1fzoAtk26pZWtmgXNfgGD4B2yeVvYzJCkWgcnapCtqsgmwBW312Djp/xlUcRRXIla28Ty96RXx1j9ndfQlkS0y0ZV46H+lQP+gC2bV2hi6Q+3EMn2A7Zb9dBQlCCagY7RaPTqWjb89hu5rtmV+dC55APoJA4qp776Cv7NPUb4G8Ex9HDSpUsMyPmdWkdtAF8uI903SBOH2bvk6V5y4VJAgloIK0Wf/8EIj2gdTa1X+M4A2GQPYvHmTpxMywCuXp4KRulgJ5qUdTeqZTQ3q1YyMPgfDyB3dGRljmybwaHfVgC+TpNcbI3m04hk+g/LVZGrF9SgUJQgmoGG08ELa87oVPwG5zoUA8XxIWRSCbbutm6cTMIU1iLBfQYYF0qVHYzxiovih0F8hfa1tP/8NsVrVS0AXy2J+MCeYcrQsCu0fZHn9QW1SQIJSACnqAKwjcoYJsAftNbF+wIrgCmTe0laUTM+8dBCcOUCC8Pkhbmzl79/dpEVSBPFxgTC7n9I6sDxR1ZC+4wEDFaHPwwvFfUkG2gN0ats9fGLhAHpt/FXVHh7xby1jq1jyGujWLoegI7wvjdKoTRYlx1SiRt7GRlBgTSV2iI6hLzXCKqlj49WDNihWoc0QYdQ6vQp3DKlPnKpWpU+VK1BmMs/nCsF1UFUpEPl2jwZgI6or8tw5oHrBAHlhujMdyNAcvyvM1Vf4y22IoArd27VsQVJDP6TMZXJHKAQJ+zPvnOZdbOmuocHXvxgELZI16UYhy0maC9wXYaWuscz2oIEEoAZWjrQGCivpSBdkCtrPYnnlob2Bv0suqQL75y2iar4a8ozyTkJctcnNzy8PuJ2V/jQoWhBJQMZ11h0eFxahgr4DdTbr9ay/+8amtPwLZuSSJhvZoQEO71aehifWpfYL1bOzR6EQPbhZLg5uAjWNocMNaNKhBNA2qV5MG1a1BSXHVqWalwse4dSpXpIE1ImlgtQgaGBlOAyKq0oCqYRoHhlelrmHWj5D5BeRg5DO4bnUaUq8GDWlQk54Y1DIggZzZcqNWLqostaXb7MCTyOn2uIP4nC5IUAJQky/8xpWECrtCBXsFbPrplfqXrcEZzZs8orWl897apb7tMtBOO+m8iOeexvFeR/juu6pVUDrp+zZM1soF5fkjj3pG3raAnTaujcvfyUBRQQkBFfShqiifU42aR/MuW5rt8bIwEIFc2aaOpeM+DUf1JZCpjWIpKSaKkhvE2gqEF/EcEmU9wvehLglBEcjOVcZbdKdT/2Qq+49UkCAUgUrSJmBARa1RQV4xY8aMKrDT7jjM44eK9sntx/ePpjoW36A3jg6nk8me66S7C8TuTbq7QNbXs/7WJK1lnaAIZE2+MZI3F/n6BAtJlfszKkgQikAF6U+mDqogW8D+Y2VPz/7V9ZsQfwXyzqphlk4754rGLuukB0MgB1o20GZ/dz/WlbWjiiyQTx4cq4uD+x89ka8tYBOOctQ66Oh/OBoaLyghoKL6ckVh+zsqrrYK9grYagMcmStXuDaz/BXIxuk9PRyW+frUXkEXCK9ye0O057II8WEViyyQV9bcrpUHyvBLJ5N+o6k6UC9DJ4ISlCC4g4iK0mZJxL+Zz6WK4QTGuxDmO//8o5nlr0Dmjmzj4bAd46sZy0AHWyCPNonzOB7z7aTWRRLIn/NTdIGsQ34+ATt9DNYPTgQlKGGgsrR+CARyrwryCtgYq0kxNz8Y+NSjfdp6OmzGwObFJpAj7RtRQmXPoSf3dW0YsEBOrh9nlAUc3udydQUFBVVh92+VxucquYIQACpsjqqwc74eUfLkcspWI3+H/d7BwruIPwL5+OExFGsxxD2qSkV6dkqPYhHI7tYNqJnFHL7JreoELBB9bl6U4bvIqxxoC/zBjNfLDmkcvXEXlDDQzGqIytJXPvL5Fhg22mQDOh+8v/Au4o9A9q8b4eGoOrMH4C5SDAKZV8f6pWSfOlEBCeTMuuspL8eYMG4K8vIJ2L2i7H9NTk6uq4IFoQ44vf7YcasK8gpuiqlKNnhkX5pfAvloyxg6tHo49TRN9VOlYnmKDq9EL91RPJ301Q08H/XObBpLBwe3CUgg25dO164dZXbWSV8Cdj308uLyVsGC0gBU2kRVcT/gjlJNBVuCO/N6RetcVZBN50/71wfhF4W6QOpHV6WjeUl0PAf9j2LqgxxFH+TepnG0uPEfn/eyQAJ5inVi1Wjz3cPRBNQoW/M6LI4mCheECHC758XutadZvirPvD4ItkZz65nt6X4LpH1C4Zro47rW12Z35yXYilMg+vogHSML+z9j6tUISCAbFhTOYMLXjz8Un1ONwqYjbLVmLPgd9qNVlKC0ABWoTwPkcxFP2Oizk/8dPMi/ea3CI/9M9ksgdWsWvkm/e9xlF1QgU+ILJ3W4qk41vwXyxpJJmjiY/E5DKxAfQHm9pKcB5QOp0gg0nXi+WG0ya/y2nR0Q8SPZjv8V8fta/NbW3Vu2JJvOHJjtSCCnN43SnJS5L2/gBRXIA23racftHRvpl0COL76W8nOzdEd/gsvCF3C3MDdJeRZLn8tMCEIUcPitXJHYHrN75MvjsmD3har0VbCfrn7ThrWZdP6gb4Ecu+cazUlb1Y3S5ua9kAI52Ks5VSl3ifZlolOBfLIwidbmFi6Wg+s9l56eHltYGt6xYsUKbo6e1csGv2UOrNIM/Lu1RCXqbeUbVLAlEJ+rKv3fSFctN7dwEgLmIxvT6Pxee4HsV2OxJvdpfMEFwjMrdqsRTq2jqjgSyKc5V9EjuYXT+oC/4pr7FpaCPWD7Z71MOB3utrLkWmkHKnIHVyj/88HxI1WwB9LS0mrB7kdlmwPbsJyc7D28z3x8Uwp9biOQ1/KTNIFsvLVriQgkuUksxVWu4EggO7On6E7O9LncMwPloTVDdaKMHlBRgtIMVGxjVKjm+OAKFWwJxGv/kKj8b5EueuXK3Ji83OzjKi1t35RMn71uLZCH7uqtCeTdFVeXiEC2dWmoHf/EMHuBPJ8x0d3Jfb4xR+e9Pmy/1tOB36N85MVgWQGaAvoHPT+jrd1WBXuAKx123ykn2MBhS3NT6s3PK/wQi7l5bQqdfWGyh0BWT+lGnRtHa1OPloRA3u3XiiIqlKfDQ9p6FciutD+eWKEsnuFls7ULtwHKhIezG3dSRUffiQhKCVDJlVHJ+p3g73aOATHpk1r/mpGR0Z3D1i2fF7dwQfYBFU73rEyjUztvcRHIkomdadaQFiUmEJ44rn9sJO0d5Dma98ydvejJVJfFOV/g9z/aBdtALTJkfiHIaU84SSsoZUDF9gf1MVpe526CmHjIvLEYqO4M29blRi5dkKXN/8tcujCT3t5yuyGQrDEd6PHZl5eoQLJbxtHrV7VwEciJ2/rQfWmFn9Cqa3rM6bB02Gpzh5nS/gL6HOUrKKVAJWuLdqKSf7N7KYb4waAupo0q+JJt20ZVWL4oc6PuMMwdq2fSRw+PpzkjWtH7a0aWqEBe7N2UdvVpaghkz22DaVlmmnGu4Cr8AZRXl2MLXLfLtzJMDlPRgrII1dTS2tPYfo79OBXlAcQvNzmGyyQQyxdl3ZiXYwxloZULMyj/jmHG8gclJZATg9rSU72b0LEx3emRuyYby6iB36HpOFadvi+Ug732R2ImymC/fBB1EQCi4OHw/1KVvsdbexp2FRGvLSsG/ux+x1m9PLNJfl7WG7oDMe9bNJf2/+mGkhPIkA60Y8IIWpJpTLrA13ggPT29pTptW3DfDPYud0jFL3D9jZSZoKwDTjAC1GY0wfZZFoOKcgE/3oTNOeUk32P/ShVlYHFe5s24m+hv4TXy4L/d+eMvmEDe7duWdk0YScvTU41zAL/Dtc3xdm3u4PdAsDePsdKIMF773Oc8Y4IyBlT8TJMT8BT/lu8D4BytEX9e2fLz/34qysCyZclR83Mz83JzsvVHxBoLclLpqezJdCh1aLEI5K0BPemRyTfSoowM45ggvxnfivOsp07PJ9D8aod02oMJCzr6eEpQBgFHMndEVyHIUiQ8pAK22osybH8GLSemW7o0tfqCnKz03OzsT035alyTOY+2JU+mN6aPpPdu7h2QQPa1ak7P9+9DD980jlYmG7Ova8Q58ROmB3GuLdTpOEE5vhbwPyoPvrYfTHkuVXaCixTsINqsHMohNntrkiC8E+L1Ownb3uOt/8Jt+dysrJHoJO+E3S96GjNXZqTS+rnT6C9TJ9COyWPo6Zuuob+NGkTPjehPu0YMpJ3XDKNto66lzePH0ro776BlqS7NJ4PI/wREkenPHYOB5mIC0pqbVB9j/z19H3najjoQXCRQHVNtMR0mfj/jzfG5owobbZp/ZXssIyOji4q2BBy3GpxtLGy3gGf0tIESefCd4h9gPs7H73mocD5hSDsPNDcH/4Zz5G9h9P21MPU5BEVw8YDvJItNDrIbjmQ51ojFA1vtYyxFHtV6b3p6eh1lYgv1z30N0mGTzeskvo7tB+B5kJtx3Ifg3x/h91HwZfzmBTJnIO1VLDiVlV9AuvLI4ybkZYgUvz8H78JvszgKYC7iEHgCzjIT1J9u8aNNry8TYTMKNp/pjoXf30Io8518V3EhwXcMnN9knB+LTT/X30C+a/I1aE/gsP0F13unSiYQWEM5jdb8UI60wNvHVnC+Goi/G/yZ7RV/xP56xHVSZiUCOHt9CDYX52L0mxR3IrwDthyn/xnwNzCOPrcVCPipVTM4jTE4Eb/fYqdS0R6AMzaBzWbQLBROx5NA5HI/xck6G0UFnJxHI8/g8wX1D8WY/OnxXxHWDXe49vhtNKkQdgjpWqssBAJngNOEQRTmObN+xn4Bz5iiTDyANA3gcEth6/GYF+HfgDwyNpmbbhDNpSpZQMCxyrMwkd9NOK8N2BpPoHTieF8ibhnsGsE+EvsrEa6JGL/57lHA16myFAj8BxxpGGh8D4LfZ+F0k+yGzGuPeXNzh8D2fqRxecvuxq/AfeAu2N4H5iHvTGynmol4HoKfi7i12H8Gv9/DVptYwp0I/zf4MGyH87f2fC4I53nCjKUe+DdE4/HCUyAICHD2cDjcIjje/3Qnw+8PsJ3sawCfeoyciPTJ4NP4/YmeRzCI/PjFHj8JyweT9PPhLcKngOY35Nw/WsB3E+3kBIJgAg7OUwk9Aycz2vf4fRqcCafzuXCoDn7ShTS8lsnNSngPgZwvD448iu0xkB/1Mk9xGMj9hhexvwlMQbrR4GXuAsV5xCF8LmyMOwZ+/w4+irgGykwgKD7A0TrC8bbB6Ywl3EBu2/Ob8+sQ73N2wmCCm1JoMvHTNxaZ+c09v1N5HOdTok/UBBcp4Hg8rRC/NDS+DWEi7Btsd2A7nW2UeVChjs3zd7Eo9TU69OP/AK7jzrkyFwhKDnDWSDRrJsApXwHNdxXdYbnfsRNcBttJ2O+BraP5bNkO7I603NFeArLwjMnbTOS7xUs4j1tgX0MlFwhCC3DOenDU6eB20DxVjiVh8y34OX5zP0Mj74MudwUrwoYfHfNTrRk4rtevIwWCkASctjzYCQ7MnWbuiO9x4vhW5HS4O7yNLU+nOgO/O1yIl48CwQUH/9uDPeHk12PL32Pwx1s89SlzNvanIm404kbiN7/91sZ3YZ9H4epPtzSin1Ffy1QQ+kAFRnJlBkqk9znjxuzZs6u6p7tYJhNQAnK5s/A6iyq6yODPbs3liryrqyhBIFCzffPbXl7yzOVJTiDkSlFZewUfzz0dwvqo6DINXGuxCoTvSG7571JRAn+BwuwF8jcL5gItEkUg9sC1ikBKA1gcKLwi3zHcKQKxB65VBBLqUM2q024FGRSKQOyBaxWBhDpQaHe6FSI7KI9N4k9D7wHXBUru5KvDeAXsRCAmikBCDFlZWa+6FaLPNQCDCRGI67WLQEIMKDSXjjkKda+KCiqQbxL4mgXfNx9fncMBNxt3Ws5IjvAeIH9ExMPQrdK5EHY8QHGmk6Yg7oaVwethz6NvX9Dz8Ebk/Sq2G9X7D8vBjrAJCYFkZmYOhC1/oWh5Le5EPty62IprS/b3fNX3LGPAR9zzdcgkldWFAQ7oMnsg9otlIUfkzWOPzJUVMFExQ1S2GtTMJMYahAHwe6SfqrLzABycZ2N81yKdIyItz3KSqLIzgLgSFwiurTnsXD4tDoB/RT6NVZZegXrjb+c9/hD95ESV3YUBCsf90e47Kiqo4AtzO07AdBNIOew/b2XnL1EW81SeBvjNtoWj+U3k8W1GRkZHla0GhJe4QFB2t7rZBEQci+cOHqCy9QCO0wLxPseyOeAFF4jHBMdwittVdNDAF+Z+nEBpFgj+uSZY2QRClMX/kF9TlbUGhD/hbhcokf9+ZGnMUYWwEhcIbDz6gIESef2A8muvsnYB4l90tw+QF1YgOCB/xml1Ijzj4HZwmxOicHia/blw3mYqaxcgfgTijRGuJlpNiMCPna1sNULAxuzksNWXNDCT2/+WT9ZM5PO1ut0vUllfMm/evDjs8wwiRjzS8bcZj5ry8UYehOjSfGXiLtJVZR+yAkEYf35sWfZMxB8HvTXL3ka2LhPVpaWlNbew4+PwpHeWx/BGpBmhsr0wgOLDceCitgtdiIt4Dk7cRB3CFrAN+CkWf3kHe/eKWq2ifYLT41gH3dK/qqL53K5zi+Nz66+ifQKd/7awd5nLF+UyQ0WHrEDgEz6nDYINz6rC00l6zFVs/gNjWB0DYTNVdOgDJ5sIfut+EUUkLy1wuTqEV3gpPEcCSUlJqWeR1ms72Aqwv9stj8MqiuOMJRWY2P8Pgv2axhNpXF7CYt9Y9gz7pVYgOtBi0FYcNhN5LlfRGnjf3YYHUqro0gG+9eNC+NbqciFFIfLjbx4sm1w6rCoIYY4Ews4UaFoGHIHnt33bLY83VDRXfrI5DnmfV1GOwOeHNO53uLkqukwIRD1B/MmcHvvPqWgN2Oe5iN2PEa6iSw9w0jzv60RcEH/Vdg5by6n+/eSTKntL4BjFIhDc5rlvxQ5oSdgtAF2WXGMizFhDw5tAUE41sG+Zr07OB/SY/R1ptaWoGWznHl/aBMJAGn1Jbo0ot90qSgOOUTYEUhTggqNREPxpqss/JvZ/4Thl5gGrCkJYkQWCSnK/M/gkn6v5judNIFbHdUKkP4LkIf8UKwCBcAfaSM9lr6I04BgiEB0onBXuhYEC8vr206qCEFZSAlmgZawQTIEgLS8c6rL+B8JFIBcbUBgDLArD69guqwpC2AUVCNLwrO/ctHLpgAdLIEj3L3CYlqkJiBOBXGxA4Qx3LwyEjVfRHrCqIIQVWSDY8ngpl++93chz8vKkCfegsixXlfImENwJtLfrPngKfAN58HJqtbUM3YB4ZOt6/mVRIAhba45nXrQCQYF7jIlCWG8V7QGrCkKYI4Hwo0L3tCj40Sq6yEBF3+KW/6/BrFgIbZpb/vwO4SoVXWSgHEPlDpJnjmfiGMUyAV/QgRPlxSz7FJUoFB7p+ph7QYBfFRQUVFWH8wDSBCwQBuzdB1seATvzCF07OnF05OPRXETYQ/wvb5Wnmcjf53rmyOtq9/zBkyjLsYjTyrUoUwEhfUgIBPuTzPGKuxE+XL9Op8S5ucwXxqODkU+HYnuvwhdjcfLB5EJ1KEvgooskENhaidIJc1UWXqHetAf0AhXpPEbvuoNndIGd7bxaToTsDcg7JASC/GJwnKKOGNZpjMVCvvw2fy+HY/sTjnu9igoeilMgOOmPcBG202ZaVRDCHAuEKxP2lmtr+KBPgTBQPi79EKfEOfkUCAP5z7ZKrxPXV+oFwsBxzIuqFoWGQPB7hlvcORUVPBSjQHhQoc/xWFYVhDDHAmHgGrhJ4u9LTUcC4SYO8vf7WxOcjyOBwBnLw9ZYttqdZUUgan2THWa7AGkIBMdxf4jypYoKHoItEJzkaeQ51+nkb1YVhDC/BMLIyMjojnQeb8Zt6EggDHZi2E/ha3PLwyth60ggOlBmPGzfY9BoWREIg8uRjweaV8fyl+YmVgz29TLjUddB/0yDC6g/Mh5VVKJQhoLtVLaOwXcZ97y4k6ui/QavFYhr4s6vS57u9NcJGFzBYFvwWqs8zYSNo9ne3cAff7UCR+r5cCdUxfkN5MOP3M3n5DF41Kr8YefX2u0o7yRzevYpFWUJdVdu56Qc3Yk0Lo/BsR8OXumktSIQCAQCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoGgrOGSS/4foGS8YOq1ZfQAAAAASUVORK5CYII=",
-        "companyContactPersonName": "Test Test",
-        "companyEmail": "stacy@example.com",
-        "certificateNumber": "CT 001",
-        "purchaseOrder": "PO 123",
-        "invoiceNumber": "IN 456",
-        "authorizingPartyName": "Stacy Slater",
-        "authorizingPartyTitle": "Chief Quality Assurance Officer",
-        "authorizingPartyDate": "February 19, 2020",
-        "manufacturerLocationCompanyName": "Steel Inc.",
-        "manufacturerLocationStreetAddress": "3260 46 Ave SE #30",
-        "manufacturerLocationAddressLocality": "Calgary",
-        "manufacturerLocationAddressRegion": "AB T2B 3K7",
-        "manufacturerLocationPostalCode": "",
-        "manufacturerLocationAddressCountry": "Canada",
-        "customerLocationCompanyName": "Nucor Steel Jewett",
-        "customerLocationStreetAddress": "U.S. 79",
-        "customerLocationAddressLocality": "Jewett",
-        "customerLocationAddressRegion": "TX",
-        "customerLocationPostalCode": "",
-        "customerLocationAddressCountry": "USA",
-        "additionalRemarks": "Product is coated for high temperatures. STEEL-IT High Temp coatings are intended for use where surface temperatures reach above 200°F, such as the external surfaces of industrial ovens, certain types of piping used in chemical and other manufacturing, and more. Customers choose which high temp coating is right for them based on whether USDA approval is required; whether the surface will be exposed to corrosive chemicals; or whether the surface will be exposed to sunlight or other sources of ultraviolet radiation.",
-        "productDescription": "SS490 steel is a structural hot Rolled steel in the form of plates, sheets & strips for general structural applications. SS490 is a material grade and designation defined in JIS G 3101 standard. JIS G 3101 is a Japanese material standard for hot Rolled steel plates, sheets, strips for general structural usage. The structural quality hot rolled SS490 steel is more reliable in its tensile strength than SS400 steel...",
-        "chemicalProperties": {
-          "columns": [
-            {
-              "title": "Heat Number",
-              "field": "heatNumber"
-            },
-            {
-              "title": "C",
-              "field": "C"
-            },
-            {
-              "title": "Si",
-              "field": "Si"
-            },
-            {
-              "title": "P",
-              "field": "P"
-            },
-            {
-              "title": "S",
-              "field": "S"
-            },
-            {
-              "title": "V",
-              "field": "V"
-            },
-            {
-              "title": "Cr",
-              "field": "Cr"
-            },
-            {
-              "title": "Mn",
-              "field": "Mn"
-            },
-            {
-              "title": "Ni",
-              "field": "Ni"
-            },
-            {
-              "title": "Cu",
-              "field": "Cu"
-            },
-            {
-              "title": "Mo",
-              "field": "Mo"
-            },
-            {
-              "title": "Sn",
-              "field": "Sn"
-            }
-          ],
-          "rows": [
-            {
-              "heatNumber": "404012",
-              "C": ".1"
-            },
-            {
-              "heatNumber": "387230",
-              "C": ".4"
-            }
-          ]
-        },
-        "mechanicalProperties": {
-          "columns": [
-            {
-              "title": "Heat Number",
-              "field": "heatNumber"
-            },
-            {
-              "title": "Item Description",
-              "field": "description"
-            },
-            {
-              "title": "Quantity",
-              "field": "quantity"
-            },
-            {
-              "title": "Dimension",
-              "field": "dimension"
-            },
-            {
-              "title": "Net Weight (Kg)",
-              "field": "weight"
-            },
-            {
-              "title": "Yield to Tensile Ratio",
-              "field": "yieldToTensileRatio"
-            },
-            {
-              "title": "Yield Strength (PSI)",
-              "field": "yieldStrength"
-            },
-            {
-              "title": "Tensile Strength (PSI)",
-              "field": "tensileStrength"
-            },
-            {
-              "title": "Elongation (%)",
-              "field": "elongation"
-            },
-            {
-              "title": "CHARPY IMPACT Temp (C)",
-              "field": "charpyImpactTempDegreesC"
-            },
-            {
-              "title": "CHARPY IMPACT Energy (J)",
-              "field": "charpyImpactEnergyJoules"
-            }
-          ],
-          "rows": [
-            {
-              "description": "Hot Rolled Steel Pipe",
-              "quantity": "2",
-              "heatNumber": "404012",
-              "dimension": "203.2 mm dia. x 5609 + 5663 mm (8\" dia.)",
-              "weight": "2900.27",
-              "yieldToTensileRatio": "0.73",
-              "yieldStrength": "52000",
-              "tensileStrength": "71000",
-              "elongation": "27"
-            },
-            {
-              "description": "Cold Rolled Steel Bar",
-              "quantity": "500",
-              "heatNumber": "387230",
-              "dimension": "203.2 mm dia. x 5609 + 5663 mm",
-              "weight": "2900.27",
-              "yieldToTensileRatio": "0.72",
-              "yieldStrength": "55000",
-              "tensileStrength": "76000",
-              "elongation": "27"
-            }
-          ]
-        },
-        "standardSpecifications": [
-          {
-            "title": "JIS G 3101",
-            "description": "Rolled steels for general structure",
-            "isoCode": "JIS G 3101"
-          }
-        ],
-        "standardGrades": [
-          {
-            "title": "SUS201",
-            "description": "SUS201"
-          }
-        ],
-        "proprietarySpecifications": [
-          {
-            "title": "ASTM-51",
-            "description": "ASTM-51"
-          }
-        ],
-        "proprietaryGrades": [
-          {
-            "title": "BF-4122",
-            "description": "BF-4122"
-          }
-        ]
-      }
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "name": "http://schema.org/name",
+    "description": "http://schema.org/description",
+    "image": {
+      "@id": "http://schema.org/image",
+      "@type": "@id"
     },
-    "proof": {
-      "type": "Ed25519Signature2018",
-      "created": "2020-04-27T16:33:36Z",
-      "verificationMethod": "did:elem:ropsten:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg#xqc3gS1gz1vch7R3RvNebWMjLvBOY-n_14feCYRPsUo",
-      "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..W98hFRglzPdcFGG2kx4wL68IcPjSemwWLyeYhcUo6-e5ZAwkBgNoX7gUGg4_xvZnhscGv4fTBzJYkxRv1GdpAQ"
+    "hetc": "http://localhost:9393/cmtr#",
+    "cmtr": {
+      "@id": "hetc:cmtr",
+      "@type": "@json"
     }
   }
+}
 `
 
-	publicKeyBytes := base58.Decode("kw41Mbj9jVnNDrrQPMEK6iZzG5cjSjkxmr9u2V6igxL")
+	docLoader := createTestJSONLDDocumentLoader()
+	addJSONLDCachedContext(docLoader, "http://127.0.0.1:53401/cmtr.jsonld", cmtrJSONLD)
+
+	vcJSON := `{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "http://127.0.0.1:53401/cmtr.jsonld"
+  ],
+  "id": "http://example.com/credentials/123",
+  "type": [
+    "VerifiableCredential",
+    "CertifiedMillTestReport"
+  ],
+  "issuer": "did:elem:ropsten:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg",
+  "issuanceDate": "2020-03-09T18:19:10.033Z",
+  "name": "Certified Mill Test Report",
+  "description": "A mill test report (MTR) and often also called a certified mill test report, certified material test report, mill test certificate (MTC), inspection certificate, certificate of test, or a host of other names, is a quality assurance document used in the metals industry that certifies a material's chemical and physical properties and states a product made of metal (steel, aluminum, brass or other alloys) complies with an international standards organization (such as ANSI, ASME, etc.) specific standards.",
+  "credentialSubject": {
+    "cmtr": {
+      "additionalRemarks": "Product is coated for high temperatures. STEEL-IT High Temp coatings are intended for use where surface temperatures reach above 200°F, such as the external surfaces of industrial ovens, certain types of piping used in chemical and other manufacturing, and more. Customers choose which high temp coating is right for them based on whether USDA approval is required; whether the surface will be exposed to corrosive chemicals; or whether the surface will be exposed to sunlight or other sources of ultraviolet radiation.",
+      "authorizingPartyDate": "February 19, 2020",
+      "authorizingPartyName": "Stacy Slater",
+      "authorizingPartyTitle": "Chief Quality Assurance Officer",
+      "certificateNumber": "CT 001",
+      "chemicalProperties": {
+        "columns": [
+          {
+            "field": "heatNumber",
+            "title": "Heat Number"
+          },
+          {
+            "field": "C",
+            "title": "C"
+          },
+          {
+            "field": "Si",
+            "title": "Si"
+          },
+          {
+            "field": "P",
+            "title": "P"
+          },
+          {
+            "field": "S",
+            "title": "S"
+          },
+          {
+            "field": "V",
+            "title": "V"
+          },
+          {
+            "field": "Cr",
+            "title": "Cr"
+          },
+          {
+            "field": "Mn",
+            "title": "Mn"
+          },
+          {
+            "field": "Ni",
+            "title": "Ni"
+          },
+          {
+            "field": "Cu",
+            "title": "Cu"
+          },
+          {
+            "field": "Mo",
+            "title": "Mo"
+          },
+          {
+            "field": "Sn",
+            "title": "Sn"
+          }
+        ],
+        "rows": [
+          {
+            "C": ".1",
+            "heatNumber": "404012"
+          },
+          {
+            "C": ".4",
+            "heatNumber": "387230"
+          }
+        ]
+      },
+      "companyAddress": "3260 46 Ave SE #30, Calgary, AB T2B 3K7, Canada",
+      "companyBrandMark": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAACnWSURBVHhe7V0HmBRF2pa8bCAsu7CywJJzEliiiICwgCQDUQUUMRAlbI7AktlDwikIBhA9RUFO8czxP7lDQKICCiKCAcN5eoY70/e/X2912zPT09MzO8vOLt/7PO/T01VfVXdXfe90VXd11SUCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAIBAIBAL/sWHDhkoZGRmXZmVltcnOzu7jztzc3NZgHFhRJREIyh7YweHw3SCEW7FdmZOTswv8EL9/w5Yc8FfwJLgLeawAb4Gwum7btq2COoRAUKpQDk7cAQ49GyJ4BvxWOXpQqfJ9GpyF47Xj4xYeXiAIQWRmZjaBs86H457WndhMhH8GvgCuwf4MbEeAibjD1EtPT4/Ftgbnk5qaWp33kV8jvlPA+YfDLgV8AOl2g//S83TjhyCyyW2onZBAUNKYMWNGFTjlzeCbcODflaPqPIewTXDw8cF2WuTZDPnfjvwfB780H5fPA/Gv45gTuJ+jkggEFw6zZ8+uCkecCYf82OycvI/wxXDOjsr0QqAcjtcJx70bPG8+H+yfAaeykJWtQFB8gCOG4d85GU73qckRf8X+U+AAxJdXpiUCHL8iyE2y7Xxe+jli/yy2sxBXWZkKBMEF+gSD4GT8NEl3uv+C69Bn8Nl8gmPGcH8C9sMgMH6axXefXBO5Qz8VcWNxnIHog7QsqjNzMwx5Pgj+wufLxO/jYF9lIhAUHXDUunC2bbqTgXzHWI/wesrEBXDwBNhPANfC9u+wDegpFjs2+AF+78J2JfIbzUJTh3EMFjDS34d8fjblvQUirKNMBILAAKe8Ec70ne5Y4MsI40eqBvh9BBz3StjdjXjjDmPDL8Bz4FEzkf48aCsmxPODgINgAX4njRo1yvG7EJx3B6TZY8rrG2xHqWiBwDng8NzX2GBypq+xnaiiNfCdBeF5CGdnd3dk/rfmuweL5k7Y9kMTK14ltQVsw/mRMbZXIO3t4J+Rz1vgj5y3mQg7Cy7gR8IquS2QZ3nYTwVZHFoeuM61CJe+icAZ4CyN4UD7TU74rLk5ovoiOxFutO0V30PYcqQfBEYq86CBn0Qh/75gPnjAfGzs81v5FyHC7srcFjg/FvdrpjzeRpi8PxHYA07TG9T/XfkukArH0Z5MIbwP9vlFneGY4KcI/xNsOmkZXEBwRx7H5w6++6PmJ3E+LZWZV3DzDLYLcf76kJev8LuHihYIXAGnGgon0Zsx7Cza0x40QS7D7+dUuEbs7wWv86cPUFzAeVfEOY7H+Rh3FfzmDv7diAtXZl7BT81gy/0iTvs90gxUUQJBIeAYE9mplHMdg5M0nTt3bgQcbzX2zYMKX8Z+f5UsICDvysi3FfK5BuRHu8nINxe/1+D3QvV7Jn6PhW13MFoltQXsyiPtOPAjUBfKMbCzMvEKvl7Y8VAVTvMzjj1aRQkudsAh7gC1YSLYHoGz1Oa2PPbfNznaKXCYSuIXkBcPab8R+dyPPPg9hHvfxSeR5lPk8TS2GTi/nnYjeREfBrsFSKc/1uVtOqJsBzMiXV3YHeY0SP8b9ieoKMHFCjjCdewMyimO8JMmOOIy7OtvoX9EeBY7nUriCGlpabWQlgckGp19Ky7NzKBVqfMod/Ysmjp1Kk2bNo3mzJlD81NSaEFWpmUaRW4CbgGTvIkF58zDT47pafD7QV9js5AmGrb/VPbcTLtaRQkuNqDtfQUc4CflDHznaIntKyaHOsBhytwRYN8RaXkA4f/0fJh5Odm0LnMuPZl8M7088zraOyWJjt3Qk45f35mODe9IWa3qEpIbXNmwDh1u05D2dGlPL13enXZcPYQ2TpxIi9PTjTx14lifgFk8ApjPwQycTzXY7NBtIf7nEWb7hE2leUel+d7pkzFBGQIchb/i055WYXsE5K/4+K017/8O3u3PAD84UVek5TfexoheFsUDuTPp9axxdDwliU7edSWdnHoFfTClF70/sTudGNfVp0AONWtABxvG04H4ODoYfykdalCXdnfrRE9eP4IK5s4xRKLIDxhWcZOOz8mEcjivpbodfu/xJZJ58+bFwe6Usv+Sn5ipKEFZB/9DotJ1MXwGsdyC7b/V/n8QP1SZ+gT/ayPNQ6AhjGV5GfTsolvp+OKR9OGCQXQqayCdSukfNIEcblqfjrRKoKPtG9FbA3rS1lsnoDmW5SIUnA83C11e/iEsTbfB7xd8NbdQLjyWS3+6dXzFihURKkpQloFK36qc5L9wAn5ipDezuCN8mTLzCaSZjDT8hl1zumXzM+j5lbfRh2uupY9WDqfTS662FcihUV1oeWIC9a9TjcLKl3MRSDj2k6LCaVmdaHo7oa5XgbzXpSkd69GMDg3oRNtuHU/5rv2W9yCSy/lcdeB8s/R4/H4IQbYdd9h0A7XmIrYPqmBBWQUqerLuIOATqHSjD5KamtpAmdmCmyewf0zPJy83m7avmkmnN42lj9dfR2fWjrQVyPsQyOormlJ8eGUXUXhjg4oVaG10DVuBHL+iJZ24qjUdHZ5ID0+/Rb8+vi5uLm40//vjT4AHUerxaSrYK2AzT7dHWnmyVVaBym2FSv5eOQZ/WKT/5g66o3cNyIP7Lsc5HXPd0jQ6suUWOrt1LJ19YLRPgRy7ozeNa1nbUgi+OCkinN7xIZAPBrelk8Pb054JA2h16h99FJzzIVxjY+SjDa5E2Ksq7mfEJXK4DcrB7m/K/jvk01yFC8oQuKP6hqpks+O8zx1SZWML9dRL66swH183h84+NYHObbvBkUCOz+xDverXsHR+pxwSHkaHHAjk1PWX0cnxXemJuyaZr/VrOLf2llz1nT5Rce/zXZHDvUHZ6x+JvayCBWUFqNQbVOWaHeYjOH2CMrEFbIeBWnNsfl42vbl1On367ET6ZOdNjgVyZ5f6lk7vL++Kru5IIB+O60ynJyTS7mnDaUmW8XiY3+/MQj7cVOQhJvoL0ns4zA64e45UeRDSXq+CBaUdycnJUahU9yHp3+Nfsb0ysQWch2cf0d5+58/Ppv1PTafPXrrFL4E8Pr6TpbMzG6Evkt2qLnWoVpW6V69K6QmxVLtSRUtbndsbXepYIGdu7U7vTh9AqzKTjevH9cxEPnxt/CEVh/3qpDxgr41Jw/asPNUqI0CFrlBOYBD/hjeqaFvAEXrBXhvAuDg/m448N50+f2OKXwI5mTmQEutV93DyapUqUI/YSFrYvj69N6g9vduvDY2MjaIZ8bUos14MdQ+vQhHlXJ9u6ewbGeaXQD6+syednNWP1mfepQvkd9w9py1evJjf+H/FYeCryNsWaWlpzZFWfwm6SAULSiv4pRkq0uVDI1TwGhVtC+7Uw1Z7jLsAd47DL86i87tv91sgT07qaunkm/s2196DPHFFM+oHYYytW4MqlruEqlcoT7fUrk49IZAltWtapmU+1yLeL4GcnXk5nZnXj+7LMkTyG65xErZT9bLB/nDkbQvYLVL2P+KuI5/tlmagEgtUZepOwU9zfH49xyN5Yc+fwqK9nUN7nptDX+ybGpBAZvZubOng2wa00gSypnOCtt8nOoI2tI6nhY3rUKMqlbSwzBjvnfrUS6P9Fsi5eX3oTPoAujfbeML1M8qjH8pFm+wO273I2xbcZIWd9seBbb4KFpQ2oOKjUYHmb7x5soVuKtoWsNuop3txRwp9eXhGwAJJtHhytX1Ia+1N+v4RHWlWizrUNKIKHe7bmo72bklHuzWnV9okUBiaV2viatHjcTEe6Zm9oqoGJJBP0/vSmZxBtDqnsE+Ca9XGcunXi999kL8tYJOvbL9FOWszQgpKGVB5PORbFwc3H1arKFugwkfrae5fn0lfHptVJIHEV6vi4ti1wyrSkRu7agLJ7Fj4ZGtyQi2tD6IL5MhlTegyNLE47qHa0ZRQvrxLHsw2VSsFLJDPcvrTiQXDaVFO4Zt3lBV/864PK3ka+dtC/fno75EyVLCgtAAVWBkVZ56S81OE+fxOnOfFRbrPOc3SJdl09t25RRLIidyBHo7NXNqrsSaQFwa1paH1alKPmuEuAtnboRHVQl9kWs1qNKtGlGUeUeXLFUkgny8cQHvzx1GuKiNc9w9qyx14n5NAwHaVsj+PspUlGkoTUGnXcOXpxP5tKsoWsONZSLQ0/3g9jb46NadIAjk5P8nDseMjK9M747sYgxU3dW+khU+qF02vdW1Cz3doSJdXC9fC3mxcl/6v/qUUD7GY82DGIqyoAjm/dBDtzL/DKCeduNtm4hi2YBGxmNgeW/lupDQBlcZTb2qVjco77WQSZzhFO9hq7zs2bsiirz5OLrJAuInVNKbQ2XWGVShHb8KBdYGsTWxIsZUrUvuoMC0ef8XULTKMakMAOxMupWfjrYemdKhaOSgC+XTlMCqYn+YiEJTDERzDJ2D7prJ/TAUJQh1LliypiQozf7DkMp+VNyDNI2yfl5tDHxxJDZpAutT3fAfCfHJga2O4++GB7egomlgt0a8YFh2p9UH2t06gTfGxlmmZg6uHB0UgXxQMoYMF442mlk7+w8BxbAE7nreLBfIjN09VsCCUoVeaqrizTlZiQhu6Key1z2wf2ZJJX3+SEhSBnIJA6rp10nU+lfSHQPQXheZOOn8Pcr+NQFIurRk0gXy1dihtXVz4fkQnBJKN49hC/Rn9V6W5WQULQhmosKdMFb1QBdsCzmDMonjicFrQBLIvtZ+lczNjwirRVXWrU0GnBh4CyWsQS/3QzKpu8fRK51jcaYIpkA/WjqG8P8qN/1xew3F8Ara8yhXbP66CBKEKvlugovRPaXlmDp+zBfJLQdhqjywf2JiliSNYAtl4g/cxWDobR1ShhW3r0dW1o2hEbBQtaPTHi0I7BqsPogvk6/XD6bFlM80C+Qnl53NeLdhOU2m+gH2JLv8g8AFUaqJeweCLKtgWuHvwlDxamn/+X3pQBZI6sLmlcweD3Jk/0KlxUAXywfrxetlpRHkOwLFsAVG01u1Rlh1UsCAUgQriSdj0Cr5dBdsCdtrHQIvyc+j8x4XiCJZA+jb33ocIBne0ig+qQP71wEhav8hl1K+Tl4D8QZX27gjUhtILQhSoIK09zHS4sA1P4KA92t32l8LOebAE8iEEUrd64aPb4mJeQmzQBbJ73a1mgTh6fAu7x1WaJ1WQIBSBCtLW50CFHVNBtoDdMFWx9PbfCzvnwRLI/swBlk4dTF5fKyroAvli82jtO3tVLkdxHJ9AOerfrR9XQYJQA+4GYaggfUbEVSrYFmzH9vwO4JMPU4MqkE0Tulg6dTDZLrxy0AXyzcPX0aal83SB8Ghfn6Of0bQdbrKXYSehCFRSG1VJ3Fkcr4JtAVttBsF1a7JdxBEMgaQMamHp1DqbVwujlwe1oeRWl1LvmEjqEBVGzatWog4RVah3tXBKrVOTUmpZv2Q080C3pkEXyCvr7tQFQpmZmU1wHFugvFvo9hCITOoQisBt3hh/hQrz+TSFly5AGu2Nu3v/IxgCubKFfQf9rnbxPl8U/qNJPQr38lWhzsfa1gu6QN5/cIIhEJSRz+Hvt912WyXYapNlc7NVBQtCCaicVFWpv3JzSwV7Bf8zKnt6+bmMoArkNAQS5+UNus6Xh7bzKRCeWXFwRFXL9DpzGsUGXSBfPTrGGHqCPxunnyefYHts71JBglACKmalqqATKsgWsBusC2TfbtcOelEFsj/Pepi7zstiIozBir4Eck/tWpZ56BweGxV0gXz72ChavciYCSUVx/EJlOdbqvwXqyBBKAEV86CqIEdDJGBnfIv94THXDnpRBbLx5kRLZ9aZlZjgWCD7EupSLbepSc1shY56cQhk88q5ukCW4Dg+gfJ8QZX/fSpIEEpAxTyhKnSnCrIF7NKVPZ07FVyBpAxuaenMzErlLqF/jOnkWCA8efW4CNch8+58p1fzoAtk26pZWtmgXNfgGD4B2yeVvYzJCkWgcnapCtqsgmwBW312Djp/xlUcRRXIla28Ty96RXx1j9ndfQlkS0y0ZV46H+lQP+gC2bV2hi6Q+3EMn2A7Zb9dBQlCCagY7RaPTqWjb89hu5rtmV+dC55APoJA4qp776Cv7NPUb4G8Ex9HDSpUsMyPmdWkdtAF8uI903SBOH2bvk6V5y4VJAgloIK0Wf/8EIj2gdTa1X+M4A2GQPYvHmTpxMywCuXp4KRulgJ5qUdTeqZTQ3q1YyMPgfDyB3dGRljmybwaHfVgC+TpNcbI3m04hk+g/LVZGrF9SgUJQgmoGG08ELa87oVPwG5zoUA8XxIWRSCbbutm6cTMIU1iLBfQYYF0qVHYzxiovih0F8hfa1tP/8NsVrVS0AXy2J+MCeYcrQsCu0fZHn9QW1SQIJSACnqAKwjcoYJsAftNbF+wIrgCmTe0laUTM+8dBCcOUCC8Pkhbmzl79/dpEVSBPFxgTC7n9I6sDxR1ZC+4wEDFaHPwwvFfUkG2gN0ats9fGLhAHpt/FXVHh7xby1jq1jyGujWLoegI7wvjdKoTRYlx1SiRt7GRlBgTSV2iI6hLzXCKqlj49WDNihWoc0QYdQ6vQp3DKlPnKpWpU+VK1BmMs/nCsF1UFUpEPl2jwZgI6or8tw5oHrBAHlhujMdyNAcvyvM1Vf4y22IoArd27VsQVJDP6TMZXJHKAQJ+zPvnOZdbOmuocHXvxgELZI16UYhy0maC9wXYaWuscz2oIEEoAZWjrQGCivpSBdkCtrPYnnlob2Bv0suqQL75y2iar4a8ozyTkJctcnNzy8PuJ2V/jQoWhBJQMZ11h0eFxahgr4DdTbr9ay/+8amtPwLZuSSJhvZoQEO71aehifWpfYL1bOzR6EQPbhZLg5uAjWNocMNaNKhBNA2qV5MG1a1BSXHVqWalwse4dSpXpIE1ImlgtQgaGBlOAyKq0oCqYRoHhlelrmHWj5D5BeRg5DO4bnUaUq8GDWlQk54Y1DIggZzZcqNWLqostaXb7MCTyOn2uIP4nC5IUAJQky/8xpWECrtCBXsFbPrplfqXrcEZzZs8orWl897apb7tMtBOO+m8iOeexvFeR/juu6pVUDrp+zZM1soF5fkjj3pG3raAnTaujcvfyUBRQQkBFfShqiifU42aR/MuW5rt8bIwEIFc2aaOpeM+DUf1JZCpjWIpKSaKkhvE2gqEF/EcEmU9wvehLglBEcjOVcZbdKdT/2Qq+49UkCAUgUrSJmBARa1RQV4xY8aMKrDT7jjM44eK9sntx/ePpjoW36A3jg6nk8me66S7C8TuTbq7QNbXs/7WJK1lnaAIZE2+MZI3F/n6BAtJlfszKkgQikAF6U+mDqogW8D+Y2VPz/7V9ZsQfwXyzqphlk4754rGLuukB0MgB1o20GZ/dz/WlbWjiiyQTx4cq4uD+x89ka8tYBOOctQ66Oh/OBoaLyghoKL6ckVh+zsqrrYK9grYagMcmStXuDaz/BXIxuk9PRyW+frUXkEXCK9ye0O057II8WEViyyQV9bcrpUHyvBLJ5N+o6k6UC9DJ4ISlCC4g4iK0mZJxL+Zz6WK4QTGuxDmO//8o5nlr0Dmjmzj4bAd46sZy0AHWyCPNonzOB7z7aTWRRLIn/NTdIGsQ34+ATt9DNYPTgQlKGGgsrR+CARyrwryCtgYq0kxNz8Y+NSjfdp6OmzGwObFJpAj7RtRQmXPoSf3dW0YsEBOrh9nlAUc3udydQUFBVVh92+VxucquYIQACpsjqqwc74eUfLkcspWI3+H/d7BwruIPwL5+OExFGsxxD2qSkV6dkqPYhHI7tYNqJnFHL7JreoELBB9bl6U4bvIqxxoC/zBjNfLDmkcvXEXlDDQzGqIytJXPvL5Fhg22mQDOh+8v/Au4o9A9q8b4eGoOrMH4C5SDAKZV8f6pWSfOlEBCeTMuuspL8eYMG4K8vIJ2L2i7H9NTk6uq4IFoQ44vf7YcasK8gpuiqlKNnhkX5pfAvloyxg6tHo49TRN9VOlYnmKDq9EL91RPJ301Q08H/XObBpLBwe3CUgg25dO164dZXbWSV8Cdj308uLyVsGC0gBU2kRVcT/gjlJNBVuCO/N6RetcVZBN50/71wfhF4W6QOpHV6WjeUl0PAf9j2LqgxxFH+TepnG0uPEfn/eyQAJ5inVi1Wjz3cPRBNQoW/M6LI4mCheECHC758XutadZvirPvD4ItkZz65nt6X4LpH1C4Zro47rW12Z35yXYilMg+vogHSML+z9j6tUISCAbFhTOYMLXjz8Un1ONwqYjbLVmLPgd9qNVlKC0ABWoTwPkcxFP2Oizk/8dPMi/ea3CI/9M9ksgdWsWvkm/e9xlF1QgU+ILJ3W4qk41vwXyxpJJmjiY/E5DKxAfQHm9pKcB5QOp0gg0nXi+WG0ya/y2nR0Q8SPZjv8V8fta/NbW3Vu2JJvOHJjtSCCnN43SnJS5L2/gBRXIA23racftHRvpl0COL76W8nOzdEd/gsvCF3C3MDdJeRZLn8tMCEIUcPitXJHYHrN75MvjsmD3har0VbCfrn7ThrWZdP6gb4Ecu+cazUlb1Y3S5ua9kAI52Ks5VSl3ifZlolOBfLIwidbmFi6Wg+s9l56eHltYGt6xYsUKbo6e1csGv2UOrNIM/Lu1RCXqbeUbVLAlEJ+rKv3fSFctN7dwEgLmIxvT6Pxee4HsV2OxJvdpfMEFwjMrdqsRTq2jqjgSyKc5V9EjuYXT+oC/4pr7FpaCPWD7Z71MOB3utrLkWmkHKnIHVyj/88HxI1WwB9LS0mrB7kdlmwPbsJyc7D28z3x8Uwp9biOQ1/KTNIFsvLVriQgkuUksxVWu4EggO7On6E7O9LncMwPloTVDdaKMHlBRgtIMVGxjVKjm+OAKFWwJxGv/kKj8b5EueuXK3Ji83OzjKi1t35RMn71uLZCH7uqtCeTdFVeXiEC2dWmoHf/EMHuBPJ8x0d3Jfb4xR+e9Pmy/1tOB36N85MVgWQGaAvoHPT+jrd1WBXuAKx123ykn2MBhS3NT6s3PK/wQi7l5bQqdfWGyh0BWT+lGnRtHa1OPloRA3u3XiiIqlKfDQ9p6FciutD+eWKEsnuFls7ULtwHKhIezG3dSRUffiQhKCVDJlVHJ+p3g73aOATHpk1r/mpGR0Z3D1i2fF7dwQfYBFU73rEyjUztvcRHIkomdadaQFiUmEJ44rn9sJO0d5Dma98ydvejJVJfFOV/g9z/aBdtALTJkfiHIaU84SSsoZUDF9gf1MVpe526CmHjIvLEYqO4M29blRi5dkKXN/8tcujCT3t5yuyGQrDEd6PHZl5eoQLJbxtHrV7VwEciJ2/rQfWmFn9Cqa3rM6bB02Gpzh5nS/gL6HOUrKKVAJWuLdqKSf7N7KYb4waAupo0q+JJt20ZVWL4oc6PuMMwdq2fSRw+PpzkjWtH7a0aWqEBe7N2UdvVpaghkz22DaVlmmnGu4Cr8AZRXl2MLXLfLtzJMDlPRgrII1dTS2tPYfo79OBXlAcQvNzmGyyQQyxdl3ZiXYwxloZULMyj/jmHG8gclJZATg9rSU72b0LEx3emRuyYby6iB36HpOFadvi+Ug732R2ImymC/fBB1EQCi4OHw/1KVvsdbexp2FRGvLSsG/ux+x1m9PLNJfl7WG7oDMe9bNJf2/+mGkhPIkA60Y8IIWpJpTLrA13ggPT29pTptW3DfDPYud0jFL3D9jZSZoKwDTjAC1GY0wfZZFoOKcgE/3oTNOeUk32P/ShVlYHFe5s24m+hv4TXy4L/d+eMvmEDe7duWdk0YScvTU41zAL/Dtc3xdm3u4PdAsDePsdKIMF773Oc8Y4IyBlT8TJMT8BT/lu8D4BytEX9e2fLz/34qysCyZclR83Mz83JzsvVHxBoLclLpqezJdCh1aLEI5K0BPemRyTfSoowM45ggvxnfivOsp07PJ9D8aod02oMJCzr6eEpQBgFHMndEVyHIUiQ8pAK22osybH8GLSemW7o0tfqCnKz03OzsT035alyTOY+2JU+mN6aPpPdu7h2QQPa1ak7P9+9DD980jlYmG7Ova8Q58ROmB3GuLdTpOEE5vhbwPyoPvrYfTHkuVXaCixTsINqsHMohNntrkiC8E+L1Ownb3uOt/8Jt+dysrJHoJO+E3S96GjNXZqTS+rnT6C9TJ9COyWPo6Zuuob+NGkTPjehPu0YMpJ3XDKNto66lzePH0ro776BlqS7NJ4PI/wREkenPHYOB5mIC0pqbVB9j/z19H3najjoQXCRQHVNtMR0mfj/jzfG5owobbZp/ZXssIyOji4q2BBy3GpxtLGy3gGf0tIESefCd4h9gPs7H73mocD5hSDsPNDcH/4Zz5G9h9P21MPU5BEVw8YDvJItNDrIbjmQ51ojFA1vtYyxFHtV6b3p6eh1lYgv1z30N0mGTzeskvo7tB+B5kJtx3Ifg3x/h91HwZfzmBTJnIO1VLDiVlV9AuvLI4ybkZYgUvz8H78JvszgKYC7iEHgCzjIT1J9u8aNNry8TYTMKNp/pjoXf30Io8518V3EhwXcMnN9knB+LTT/X30C+a/I1aE/gsP0F13unSiYQWEM5jdb8UI60wNvHVnC+Goi/G/yZ7RV/xP56xHVSZiUCOHt9CDYX52L0mxR3IrwDthyn/xnwNzCOPrcVCPipVTM4jTE4Eb/fYqdS0R6AMzaBzWbQLBROx5NA5HI/xck6G0UFnJxHI8/g8wX1D8WY/OnxXxHWDXe49vhtNKkQdgjpWqssBAJngNOEQRTmObN+xn4Bz5iiTDyANA3gcEth6/GYF+HfgDwyNpmbbhDNpSpZQMCxyrMwkd9NOK8N2BpPoHTieF8ibhnsGsE+EvsrEa6JGL/57lHA16myFAj8BxxpGGh8D4LfZ+F0k+yGzGuPeXNzh8D2fqRxecvuxq/AfeAu2N4H5iHvTGynmol4HoKfi7i12H8Gv9/DVptYwp0I/zf4MGyH87f2fC4I53nCjKUe+DdE4/HCUyAICHD2cDjcIjje/3Qnw+8PsJ3sawCfeoyciPTJ4NP4/YmeRzCI/PjFHj8JyweT9PPhLcKngOY35Nw/WsB3E+3kBIJgAg7OUwk9Aycz2vf4fRqcCafzuXCoDn7ShTS8lsnNSngPgZwvD448iu0xkB/1Mk9xGMj9hhexvwlMQbrR4GXuAsV5xCF8LmyMOwZ+/w4+irgGykwgKD7A0TrC8bbB6Ywl3EBu2/Ob8+sQ73N2wmCCm1JoMvHTNxaZ+c09v1N5HOdTok/UBBcp4Hg8rRC/NDS+DWEi7Btsd2A7nW2UeVChjs3zd7Eo9TU69OP/AK7jzrkyFwhKDnDWSDRrJsApXwHNdxXdYbnfsRNcBttJ2O+BraP5bNkO7I603NFeArLwjMnbTOS7xUs4j1tgX0MlFwhCC3DOenDU6eB20DxVjiVh8y34OX5zP0Mj74MudwUrwoYfHfNTrRk4rtevIwWCkASctjzYCQ7MnWbuiO9x4vhW5HS4O7yNLU+nOgO/O1yIl48CwQUH/9uDPeHk12PL32Pwx1s89SlzNvanIm404kbiN7/91sZ3YZ9H4epPtzSin1Ffy1QQ+kAFRnJlBkqk9znjxuzZs6u6p7tYJhNQAnK5s/A6iyq6yODPbs3liryrqyhBIFCzffPbXl7yzOVJTiDkSlFZewUfzz0dwvqo6DINXGuxCoTvSG7571JRAn+BwuwF8jcL5gItEkUg9sC1ikBKA1gcKLwi3zHcKQKxB65VBBLqUM2q024FGRSKQOyBaxWBhDpQaHe6FSI7KI9N4k9D7wHXBUru5KvDeAXsRCAmikBCDFlZWa+6FaLPNQCDCRGI67WLQEIMKDSXjjkKda+KCiqQbxL4mgXfNx9fncMBNxt3Ws5IjvAeIH9ExMPQrdK5EHY8QHGmk6Yg7oaVwethz6NvX9Dz8Ebk/Sq2G9X7D8vBjrAJCYFkZmYOhC1/oWh5Le5EPty62IprS/b3fNX3LGPAR9zzdcgkldWFAQ7oMnsg9otlIUfkzWOPzJUVMFExQ1S2GtTMJMYahAHwe6SfqrLzABycZ2N81yKdIyItz3KSqLIzgLgSFwiurTnsXD4tDoB/RT6NVZZegXrjb+c9/hD95ESV3YUBCsf90e47Kiqo4AtzO07AdBNIOew/b2XnL1EW81SeBvjNtoWj+U3k8W1GRkZHla0GhJe4QFB2t7rZBEQci+cOHqCy9QCO0wLxPseyOeAFF4jHBMdwittVdNDAF+Z+nEBpFgj+uSZY2QRClMX/kF9TlbUGhD/hbhcokf9+ZGnMUYWwEhcIbDz6gIESef2A8muvsnYB4l90tw+QF1YgOCB/xml1Ijzj4HZwmxOicHia/blw3mYqaxcgfgTijRGuJlpNiMCPna1sNULAxuzksNWXNDCT2/+WT9ZM5PO1ut0vUllfMm/evDjs8wwiRjzS8bcZj5ry8UYehOjSfGXiLtJVZR+yAkEYf35sWfZMxB8HvTXL3ka2LhPVpaWlNbew4+PwpHeWx/BGpBmhsr0wgOLDceCitgtdiIt4Dk7cRB3CFrAN+CkWf3kHe/eKWq2ifYLT41gH3dK/qqL53K5zi+Nz66+ifQKd/7awd5nLF+UyQ0WHrEDgEz6nDYINz6rC00l6zFVs/gNjWB0DYTNVdOgDJ5sIfut+EUUkLy1wuTqEV3gpPEcCSUlJqWeR1ms72Aqwv9stj8MqiuOMJRWY2P8Pgv2axhNpXF7CYt9Y9gz7pVYgOtBi0FYcNhN5LlfRGnjf3YYHUqro0gG+9eNC+NbqciFFIfLjbx4sm1w6rCoIYY4Ews4UaFoGHIHnt33bLY83VDRXfrI5DnmfV1GOwOeHNO53uLkqukwIRD1B/MmcHvvPqWgN2Oe5iN2PEa6iSw9w0jzv60RcEH/Vdg5by6n+/eSTKntL4BjFIhDc5rlvxQ5oSdgtAF2WXGMizFhDw5tAUE41sG+Zr07OB/SY/R1ptaWoGWznHl/aBMJAGn1Jbo0ot90qSgOOUTYEUhTggqNREPxpqss/JvZ/4Thl5gGrCkJYkQWCSnK/M/gkn6v5judNIFbHdUKkP4LkIf8UKwCBcAfaSM9lr6I04BgiEB0onBXuhYEC8vr206qCEFZSAlmgZawQTIEgLS8c6rL+B8JFIBcbUBgDLArD69guqwpC2AUVCNLwrO/ctHLpgAdLIEj3L3CYlqkJiBOBXGxA4Qx3LwyEjVfRHrCqIIQVWSDY8ngpl++93chz8vKkCfegsixXlfImENwJtLfrPngKfAN58HJqtbUM3YB4ZOt6/mVRIAhba45nXrQCQYF7jIlCWG8V7QGrCkKYI4Hwo0L3tCj40Sq6yEBF3+KW/6/BrFgIbZpb/vwO4SoVXWSgHEPlDpJnjmfiGMUyAV/QgRPlxSz7FJUoFB7p+ph7QYBfFRQUVFWH8wDSBCwQBuzdB1seATvzCF07OnF05OPRXETYQ/wvb5Wnmcjf53rmyOtq9/zBkyjLsYjTyrUoUwEhfUgIBPuTzPGKuxE+XL9Op8S5ucwXxqODkU+HYnuvwhdjcfLB5EJ1KEvgooskENhaidIJc1UWXqHetAf0AhXpPEbvuoNndIGd7bxaToTsDcg7JASC/GJwnKKOGNZpjMVCvvw2fy+HY/sTjnu9igoeilMgOOmPcBG202ZaVRDCHAuEKxP2lmtr+KBPgTBQPi79EKfEOfkUCAP5z7ZKrxPXV+oFwsBxzIuqFoWGQPB7hlvcORUVPBSjQHhQoc/xWFYVhDDHAmHgGrhJ4u9LTUcC4SYO8vf7WxOcjyOBwBnLw9ZYttqdZUUgan2THWa7AGkIBMdxf4jypYoKHoItEJzkaeQ51+nkb1YVhDC/BMLIyMjojnQeb8Zt6EggDHZi2E/ha3PLwyth60ggOlBmPGzfY9BoWREIg8uRjweaV8fyl+YmVgz29TLjUddB/0yDC6g/Mh5VVKJQhoLtVLaOwXcZ97y4k6ui/QavFYhr4s6vS57u9NcJGFzBYFvwWqs8zYSNo9ne3cAff7UCR+r5cCdUxfkN5MOP3M3n5DF41Kr8YefX2u0o7yRzevYpFWUJdVdu56Qc3Yk0Lo/BsR8OXumktSIQCAQCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoGgrOGSS/4foGS8YOq1ZfQAAAAASUVORK5CYII=",
+      "companyContactPersonName": "Test Test",
+      "companyEmail": "stacy@example.com",
+      "companyName": "Steel Inc.",
+      "companyPhoneNumber": "555 555 5555",
+      "companyWebsite": "https://example.com",
+      "customerLocationAddressCountry": "USA",
+      "customerLocationAddressLocality": "Jewett",
+      "customerLocationAddressRegion": "TX",
+      "customerLocationCompanyName": "Nucor Steel Jewett",
+      "customerLocationPostalCode": "",
+      "customerLocationStreetAddress": "U.S. 79",
+      "invoiceNumber": "IN 456",
+      "manufacturerLocationAddressCountry": "Canada",
+      "manufacturerLocationAddressLocality": "Calgary",
+      "manufacturerLocationAddressRegion": "AB T2B 3K7",
+      "manufacturerLocationCompanyName": "Steel Inc.",
+      "manufacturerLocationPostalCode": "",
+      "manufacturerLocationStreetAddress": "3260 46 Ave SE #30",
+      "mechanicalProperties": {
+        "columns": [
+          {
+            "field": "heatNumber",
+            "title": "Heat Number"
+          },
+          {
+            "field": "description",
+            "title": "Item Description"
+          },
+          {
+            "field": "quantity",
+            "title": "Quantity"
+          },
+          {
+            "field": "dimension",
+            "title": "Dimension"
+          },
+          {
+            "field": "weight",
+            "title": "Net Weight (Kg)"
+          },
+          {
+            "field": "yieldToTensileRatio",
+            "title": "Yield to Tensile Ratio"
+          },
+          {
+            "field": "yieldStrength",
+            "title": "Yield Strength (PSI)"
+          },
+          {
+            "field": "tensileStrength",
+            "title": "Tensile Strength (PSI)"
+          },
+          {
+            "field": "elongation",
+            "title": "Elongation (%)"
+          },
+          {
+            "field": "charpyImpactTempDegreesC",
+            "title": "CHARPY IMPACT Temp (C)"
+          },
+          {
+            "field": "charpyImpactEnergyJoules",
+            "title": "CHARPY IMPACT Energy (J)"
+          }
+        ],
+        "rows": [
+          {
+            "description": "Hot Rolled Steel Pipe",
+            "dimension": "203.2 mm dia. x 5609 + 5663 mm (8\" dia.)",
+            "elongation": "27",
+            "heatNumber": "404012",
+            "quantity": "2",
+            "tensileStrength": "71000",
+            "weight": "2900.27",
+            "yieldStrength": "52000",
+            "yieldToTensileRatio": "0.73"
+          },
+          {
+            "description": "Cold Rolled Steel Bar",
+            "dimension": "203.2 mm dia. x 5609 + 5663 mm",
+            "elongation": "27",
+            "heatNumber": "387230",
+            "quantity": "500",
+            "tensileStrength": "76000",
+            "weight": "2900.27",
+            "yieldStrength": "55000",
+            "yieldToTensileRatio": "0.72"
+          }
+        ]
+      },
+      "productDescription": "SS490 steel is a structural hot Rolled steel in the form of plates, sheets \u0026 strips for general structural applications. SS490 is a material grade and designation defined in JIS G 3101 standard. JIS G 3101 is a Japanese material standard for hot Rolled steel plates, sheets, strips for general structural usage. The structural quality hot rolled SS490 steel is more reliable in its tensile strength than SS400 steel...",
+      "proprietaryGrades": [
+        {
+          "description": "BF-4122",
+          "title": "BF-4122"
+        }
+      ],
+      "proprietarySpecifications": [
+        {
+          "description": "ASTM-51",
+          "title": "ASTM-51"
+        }
+      ],
+      "purchaseOrder": "PO 123",
+      "standardGrades": [
+        {
+          "description": "SUS201",
+          "title": "SUS201"
+        }
+      ],
+      "standardSpecifications": [
+        {
+          "description": "Rolled steels for general structure",
+          "isoCode": "JIS G 3101",
+          "title": "JIS G 3101"
+        }
+      ]
+    },
+    "id": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd"
+  },
+  "proof": {
+    "type": "Ed25519Signature2018",
+    "created": "2020-05-14T15:22:26.065935+03:00",
+    "verificationMethod": "did:example:123456#key1",
+    "proofPurpose": "assertionMethod",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..dmLYprMM4-E9XnEsd6iQHvmrgeC8pKe2liEKcSAu53A7Ok6LjognKQKLNdJSLsJd8cGh2g15ZTu6BKAnp2v7AQ"
+  }
+}`
+
+	publicKeyBytes := base58.Decode("At4yQndGdrJs5AVFjYXqwDRALfm3ghLAmzhLux5eJkhh")
 
 	vc, _, err := NewCredential([]byte(vcJSON),
 		WithPublicKeyFetcher(SingleKey(publicKeyBytes, "Ed25519Signature2018")),
 		WithEmbeddedSignatureSuites(ed25519signature2018.New(
 			suite.WithVerifier(suite.NewCryptoVerifier(createLocalCrypto())))),
 		WithJSONLDOnlyValidRDF(),
-		WithStrictValidation())
+		WithStrictValidation(),
+		WithJSONLDDocumentLoader(docLoader))
 
 	require.NoError(t, err)
 	require.NotNil(t, vc)
@@ -860,7 +877,7 @@ func TestNewCredential_ProofCreatedWithMillisec(t *testing.T) {
 
 	publicKeyBytes := base58.Decode("DNwKNoq5MnZ185AyatKe3kT7MMCDD7R2PeNDV6FndMkz")
 
-	vc, _, err := NewCredential([]byte(vcJSON),
+	vc, _, err := newTestCredential([]byte(vcJSON),
 		WithPublicKeyFetcher(SingleKey(publicKeyBytes, "Ed25519Signature2018")),
 		WithEmbeddedSignatureSuites(ed25519signature2018.New(
 			suite.WithVerifier(suite.NewCryptoVerifier(createLocalCrypto())))),
@@ -881,7 +898,7 @@ func TestNewCredentialWithSeveralLinkedDataProofs(t *testing.T) {
 		suite.WithSigner(getEd25519TestSigner(ed25519PrivKey)),
 		suite.WithVerifier(ed25519signature2018.NewPublicKeyVerifier()))
 
-	vc, _, err := NewCredential([]byte(validCredential))
+	vc, _, err := newTestCredential([]byte(validCredential))
 	r.NoError(err)
 
 	err = vc.AddLinkedDataProof(&LinkedDataProofContext{
@@ -911,7 +928,7 @@ func TestNewCredentialWithSeveralLinkedDataProofs(t *testing.T) {
 	r.NoError(err)
 	r.NotEmpty(vcBytes)
 
-	vcWithLdp, _, err := NewCredential(vcBytes,
+	vcWithLdp, _, err := newTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(ed25519SigSuite, ecdsaSigSuite),
 		WithPublicKeyFetcher(func(issuerID, keyID string) (*sigverifier.PublicKey, error) {
 			switch keyID {
@@ -1029,7 +1046,7 @@ func TestCredential_AddLinkedDataProof(t *testing.T) {
 	r.NoError(err)
 
 	t.Run("Add a valid JWS Linked Data proof to VC", func(t *testing.T) {
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		r.NoError(err)
 
 		originalVCMap, err := toMap(vc)
@@ -1068,7 +1085,7 @@ func TestCredential_AddLinkedDataProof(t *testing.T) {
 	})
 
 	t.Run("Add invalid Linked Data proof to VC", func(t *testing.T) {
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		vc.CustomFields = map[string]interface{}{

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -54,43 +54,9 @@ const issuerAsObject = `
 }
 `
 
-const credentialWithPreciseDate = `{
-      "@context": [
-        "https://www.w3.org/2018/credentials/v1",
-        "https://w3id.org/citizenship/v1"
-      ],
-      "id": "https://prc.uscis.gov/credentials/3dbd30a1-114b-4889-90b2-b37b07866125",
-      "type": [
-        "VerifiableCredential",
-        "PermanentResidentCard"
-      ],
-      "issuer": {"id": "did:v1:test:nym:z6MkqaFQ7SZdWMgUkiQLvxZBpmkmYmbgAcAvXftU7jfmMWLa"},
-      "issuanceDate": "2020-01-01T00:00:00.000Z",
-      "expirationDate": "2030-01-01T00:00:00.000Z",
-      "name": "Permanent Resident Card",
-      "description": "Permanent Resident Card of Mr.Louis Pasteur",
-      "credentialSubject": {
-        "id": "did:v1:test:nym:z6Mkoi4q6txuz3rJ3XeqJauhrHcKDWbTwHepfcewDm5BVN4N",
-        "type": [
-          "Person",
-          "PermanentResident"
-        ],
-        "givenName": "Louis",
-        "familyName": "Pasteur",
-        "gender": "Male",
-        "image": "data:image/png;base64,Jtvf7y4+Pjdxw/UiREBZDlwUAwoALFcm9QPcSTMzX2Rqsyr26dfDeBflf6uKaaRK5CYII=",
-        "residentSince": "2015-01-01T00:00:00.000Z",
-        "lprCategory": "C09",
-        "lprNumber": "999-999-999",
-        "birthCountry": "Mexico",
-        "birthDate": "1958-07-17T00:00:00.000Z"
-      }
-}
-`
-
 func TestNewCredential(t *testing.T) {
 	t.Run("test creation of new Verifiable Credential from JSON with valid structure", func(t *testing.T) {
-		vc, vcData, err := NewCredential([]byte(validCredential), WithStrictValidation())
+		vc, vcData, err := newTestCredential([]byte(validCredential), WithStrictValidation())
 		require.NoError(t, err)
 		require.NotNil(t, vc)
 		require.NotEmpty(t, vcData)
@@ -141,7 +107,7 @@ func TestNewCredential(t *testing.T) {
 
 	t.Run("test a try to create a new Verifiable Credential from JSON with invalid structure", func(t *testing.T) {
 		emptyJSONDoc := "{}"
-		vc, vcBytes, err := NewCredential([]byte(emptyJSONDoc))
+		vc, vcBytes, err := newTestCredential([]byte(emptyJSONDoc))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "credential type of unknown structure")
 		require.Nil(t, vc)
@@ -149,7 +115,7 @@ func TestNewCredential(t *testing.T) {
 	})
 
 	t.Run("test a try to create a new Verifiable Credential from non-JSON doc", func(t *testing.T) {
-		vc, vcBytes, err := NewCredential([]byte("non json"))
+		vc, vcBytes, err := newTestCredential([]byte("non json"))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "new credential")
 		require.Nil(t, vc)
@@ -663,7 +629,7 @@ func TestValidateVerCredRefreshService(t *testing.T) {
 	})
 
 	t.Run("test verifiable credential with undefined id of refresh service", func(t *testing.T) {
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		vc.RefreshService = []TypedID{{Type: "ManualRefreshService2018"}}
@@ -675,7 +641,7 @@ func TestValidateVerCredRefreshService(t *testing.T) {
 	})
 
 	t.Run("test verifiable credential with undefined type of refresh service", func(t *testing.T) {
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		vc.RefreshService = []TypedID{{ID: "https://example.edu/refresh/3732"}}
@@ -687,7 +653,7 @@ func TestValidateVerCredRefreshService(t *testing.T) {
 	})
 
 	t.Run("test verifiable credential with invalid URL of id of credential schema", func(t *testing.T) {
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		vc.RefreshService = []TypedID{{ID: "invalid URL", Type: "ManualRefreshService2018"}}
@@ -702,7 +668,7 @@ func TestValidateVerCredRefreshService(t *testing.T) {
 func TestCredential_MarshalJSON(t *testing.T) {
 	t.Run("round trip conversion of credential with plain issuer", func(t *testing.T) {
 		// setup -> create verifiable credential from json byte data
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 		require.NotEmpty(t, vc)
 
@@ -712,7 +678,7 @@ func TestCredential_MarshalJSON(t *testing.T) {
 		require.NotEmpty(t, byteCred)
 
 		// convert json byte data to verifiable credential
-		cred2, _, err := NewCredential(byteCred)
+		cred2, _, err := newTestCredential(byteCred)
 		require.NoError(t, err)
 		require.NotEmpty(t, cred2)
 
@@ -722,7 +688,7 @@ func TestCredential_MarshalJSON(t *testing.T) {
 
 	t.Run("round trip conversion of credential with composite issuer", func(t *testing.T) {
 		// setup -> create verifiable credential from json byte data
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 		require.NotEmpty(t, vc)
 
@@ -736,7 +702,7 @@ func TestCredential_MarshalJSON(t *testing.T) {
 		require.NotEmpty(t, byteCred)
 
 		// convert json byte data to verifiable credential
-		cred2, _, err := NewCredential(byteCred)
+		cred2, _, err := newTestCredential(byteCred)
 		require.NoError(t, err)
 		require.NotEmpty(t, cred2)
 
@@ -745,7 +711,7 @@ func TestCredential_MarshalJSON(t *testing.T) {
 	})
 
 	t.Run("Failure in VC marshalling", func(t *testing.T) {
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		vc.CustomFields = map[string]interface{}{
@@ -935,7 +901,7 @@ func TestCustomCredentialJsonSchemaValidator2018(t *testing.T) {
 	require.NoError(t, mErr)
 
 	t.Run("Applies custom JSON Schema and detects data inconsistency due to missing new required field", func(t *testing.T) { //nolint:lll
-		vc, vcBytes, err := NewCredential(missingReqFieldSchema)
+		vc, vcBytes, err := newTestCredential(missingReqFieldSchema)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "referenceNumber is required")
 		require.Nil(t, vc)
@@ -952,7 +918,7 @@ func TestCustomCredentialJsonSchemaValidator2018(t *testing.T) {
 		customValidSchema, err := json.Marshal(raw)
 		require.NoError(t, err)
 
-		vc, _, err := NewCredential(customValidSchema, WithBaseContextExtendedValidation([]string{
+		vc, _, err := newTestCredential(customValidSchema, WithBaseContextExtendedValidation([]string{
 			"https://www.w3.org/2018/credentials/v1",
 			"https://www.w3.org/2018/credentials/examples/v1",
 			"https://trustbloc.github.io/context/vc/examples-v1.jsonld",
@@ -980,7 +946,7 @@ func TestCustomCredentialJsonSchemaValidator2018(t *testing.T) {
 		schemaWithInvalidURLToCredentialSchema, err := json.Marshal(raw)
 		require.NoError(t, err)
 
-		vc, vcBytes, err := NewCredential(schemaWithInvalidURLToCredentialSchema)
+		vc, vcBytes, err := newTestCredential(schemaWithInvalidURLToCredentialSchema)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "load of custom credential schema")
 		require.Nil(t, vc)
@@ -998,7 +964,7 @@ func TestCustomCredentialJsonSchemaValidator2018(t *testing.T) {
 		unsupportedCredentialTypeOfSchema, err := json.Marshal(raw)
 		require.NoError(t, err)
 
-		vc, _, err := NewCredential(unsupportedCredentialTypeOfSchema)
+		vc, _, err := newTestCredential(unsupportedCredentialTypeOfSchema)
 		require.NoError(t, err)
 
 		// check credential schema
@@ -1008,7 +974,7 @@ func TestCustomCredentialJsonSchemaValidator2018(t *testing.T) {
 	})
 
 	t.Run("Fallback to default schema validation when custom schemas usage is disabled", func(t *testing.T) {
-		_, _, err := NewCredential(missingReqFieldSchema, WithNoCustomSchemaCheck())
+		_, _, err := newTestCredential(missingReqFieldSchema, WithNoCustomSchemaCheck())
 
 		// without disabling external schema check we would get an error here
 		require.NoError(t, err)
@@ -1516,7 +1482,16 @@ func TestNewCredentialFromRaw(t *testing.T) {
 }
 
 func TestNewCredentialFromRaw_PreserveDates(t *testing.T) {
-	cred, _, err := NewCredential([]byte(credentialWithPreciseDate), WithDisabledProofCheck())
+	vcMap, err := toMap(validCredential)
+	require.NoError(t, err)
+
+	vcMap["issuanceDate"] = "2020-01-01T00:00:00.000Z"
+	vcMap["expirationDate"] = "2030-01-01T00:00:00.000Z"
+
+	credentialWithPreciseDate, err := json.Marshal(vcMap)
+	require.NoError(t, err)
+
+	cred, _, err := newTestCredential(credentialWithPreciseDate, WithDisabledProofCheck())
 	require.NoError(t, err)
 	require.NotEmpty(t, cred)
 
@@ -1527,7 +1502,7 @@ func TestNewCredentialFromRaw_PreserveDates(t *testing.T) {
 }
 
 func TestCredential_CreatePresentation(t *testing.T) {
-	vc, _, err := NewCredential([]byte(validCredential))
+	vc, _, err := newTestCredential([]byte(validCredential))
 	require.NoError(t, err)
 
 	vp, err := vc.Presentation()
@@ -1544,17 +1519,16 @@ func TestCredential_validateCredential(t *testing.T) {
 	r := require.New(t)
 
 	t.Run("test jsonldValidation constraint", func(t *testing.T) {
-		vc, _, err := NewCredential([]byte(validCredential))
-		require.NoError(t, err)
+		vc, _, err := newTestCredential([]byte(validCredential))
+		r.NoError(err)
 
 		vcOpts := &credentialOpts{
 			modelValidationMode: jsonldValidation,
 			jsonldCredentialOpts: jsonldCredentialOpts{
-				jsonldDocumentLoader: ld.NewDefaultDocumentLoader(nil),
+				jsonldDocumentLoader: testDocumentLoader,
 			},
 			strictValidation: true,
 		}
-
 		r.NoError(validateCredential(vc, vc.byteJSON(t), vcOpts))
 
 		// add a field which is not defined in the schema
@@ -1565,7 +1539,7 @@ func TestCredential_validateCredential(t *testing.T) {
 	})
 
 	t.Run("test baseContextValidation constraint", func(t *testing.T) {
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		vc.Types = []string{"VerifiableCredential"}
@@ -1608,7 +1582,7 @@ func TestCredential_validateCredential(t *testing.T) {
 	})
 
 	t.Run("test baseContextExtendedValidation constraint", func(t *testing.T) {
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		vc.Types = []string{"VerifiableCredential", "AlumniCredential"}
@@ -1694,14 +1668,14 @@ func TestDecodeWithNullValues(t *testing.T) {
 }
 `
 
-	vc, _, err := NewCredential([]byte(vcJSON))
+	vc, _, err := newTestCredential([]byte(vcJSON))
 	require.NoError(t, err)
 	require.NotNil(t, vc)
 }
 
 func TestCredential_raw(t *testing.T) {
 	t.Run("Serialize with invalid refresh service", func(t *testing.T) {
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		vc.RefreshService = []TypedID{{CustomFields: map[string]interface{}{
@@ -1713,7 +1687,7 @@ func TestCredential_raw(t *testing.T) {
 	})
 
 	t.Run("Serialize with invalid terms of use", func(t *testing.T) {
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		vc.TermsOfUse = []TypedID{{CustomFields: map[string]interface{}{
@@ -1726,7 +1700,7 @@ func TestCredential_raw(t *testing.T) {
 	})
 
 	t.Run("Serialize with invalid proof", func(t *testing.T) {
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		vc.Proofs = []Proof{{
@@ -1745,7 +1719,7 @@ func TestNewUnverifiedCredential(t *testing.T) {
 
 	t.Run("NewUnverifiedCredential() for JWS", func(t *testing.T) {
 		// Prepare JWS.
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		credClaims, err := vc.JWTClaims(true)
@@ -1763,7 +1737,7 @@ func TestNewUnverifiedCredential(t *testing.T) {
 
 	t.Run("NewUnverifiedCredential() for Linked Data proof", func(t *testing.T) {
 		// Prepare JWS.
-		vc, _, err := NewCredential([]byte(validCredential))
+		vc, _, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		created := time.Now()
@@ -1825,7 +1799,7 @@ func TestNewUnverifiedCredential(t *testing.T) {
 
 func TestMarshalCredential(t *testing.T) {
 	t.Run("test marshalling VC to JSON bytes", func(t *testing.T) {
-		vc, vcData, err := NewCredential([]byte(validCredential))
+		vc, vcData, err := newTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 		require.NotNil(t, vc)
 		require.NotEmpty(t, vcData)

--- a/pkg/doc/verifiable/linked_data_proof_test.go
+++ b/pkg/doc/verifiable/linked_data_proof_test.go
@@ -104,7 +104,7 @@ func TestLinkedDataProofSignerAndVerifier(t *testing.T) {
 		verifierSuite := ed25519signature2018.New(
 			suite.WithVerifier(ed25519signature2018.NewPublicKeyVerifier()),
 			suite.WithCompactProof())
-		vcDecoded, _, err := NewCredential(vcWithEd25519ProofBytes,
+		vcDecoded, _, err := newTestCredential(vcWithEd25519ProofBytes,
 			WithEmbeddedSignatureSuites(verifierSuite),
 			WithPublicKeyFetcher(SingleKey(ed25519PubKey, kms.ED25519)))
 		require.NoError(t, err)
@@ -120,14 +120,14 @@ func TestLinkedDataProofSignerAndVerifier(t *testing.T) {
 				suite.WithVerifier(ecdsasecp256k1signature2019.NewPublicKeyVerifier())),
 		}
 
-		vcDecoded, _, err := NewCredential(vcWithEd25519ProofBytes,
+		vcDecoded, _, err := newTestCredential(vcWithEd25519ProofBytes,
 			WithEmbeddedSignatureSuites(verifierSuites...),
 			WithPublicKeyFetcher(SingleKey(ed25519PubKey, kms.ED25519)))
 		require.NoError(t, err)
 		require.Equal(t, vcWithEd25519Proof, vcDecoded)
 
 		pubKeyBytes := elliptic.Marshal(ecdsaPrivKey.Curve, ecdsaPrivKey.X, ecdsaPrivKey.Y)
-		vcDecoded, _, err = NewCredential(vcWithSecp256k1ProofBytes,
+		vcDecoded, _, err = newTestCredential(vcWithSecp256k1ProofBytes,
 			WithEmbeddedSignatureSuites(verifierSuites...),
 			WithPublicKeyFetcher(func(issuerID, keyID string) (*verifier.PublicKey, error) {
 				return &verifier.PublicKey{
@@ -148,7 +148,7 @@ func TestLinkedDataProofSignerAndVerifier(t *testing.T) {
 	})
 
 	t.Run("no signature suite defined", func(t *testing.T) {
-		vcDecoded, _, err := NewCredential(vcWithEd25519ProofBytes,
+		vcDecoded, _, err := newTestCredential(vcWithEd25519ProofBytes,
 			WithPublicKeyFetcher(SingleKey(ed25519PubKey, kms.ED25519)))
 		require.NoError(t, err)
 		require.NotNil(t, vcDecoded)

--- a/pkg/doc/verifiable/presentation.go
+++ b/pkg/doc/verifiable/presentation.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/piprate/json-gold/ld"
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
@@ -355,6 +356,14 @@ func WithPresStrictValidation() PresentationOpt {
 func WithPresRequireVC() PresentationOpt {
 	return func(opts *presentationOpts) {
 		opts.requireVC = true
+	}
+}
+
+// WithPresJSONLDDocumentLoader defines custom JSON-LD document loader. If not defined, when decoding VP
+// a new document loader will be created using CachingJSONLDLoader() if JSON-LD validation is made.
+func WithPresJSONLDDocumentLoader(documentLoader ld.DocumentLoader) PresentationOpt {
+	return func(opts *presentationOpts) {
+		opts.jsonldDocumentLoader = documentLoader
 	}
 }
 

--- a/pkg/doc/verifiable/presentation_jws_test.go
+++ b/pkg/doc/verifiable/presentation_jws_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestJWTPresClaims_MarshalJWS(t *testing.T) {
-	vp, err := NewPresentation([]byte(validPresentation))
+	vp, err := newTestPresentation([]byte(validPresentation))
 	require.NoError(t, err)
 
 	jws := createCredJWS(t, vp)
@@ -39,7 +39,7 @@ func TestUnmarshalPresJWSClaims(t *testing.T) {
 	testFetcher := holderPublicKeyFetcher(t)
 
 	t.Run("Successful JWS decoding", func(t *testing.T) {
-		vp, err := NewPresentation([]byte(validPresentation))
+		vp, err := newTestPresentation([]byte(validPresentation))
 		require.NoError(t, err)
 
 		jws := createCredJWS(t, vp)
@@ -80,7 +80,7 @@ func TestUnmarshalPresJWSClaims(t *testing.T) {
 	})
 
 	t.Run("Invalid signature of JWS", func(t *testing.T) {
-		vp, err := NewPresentation([]byte(validPresentation))
+		vp, err := newTestPresentation([]byte(validPresentation))
 		require.NoError(t, err)
 
 		jws := createCredJWS(t, vp)

--- a/pkg/doc/verifiable/presentation_jwt_test.go
+++ b/pkg/doc/verifiable/presentation_jwt_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNewJWTPresClaims(t *testing.T) {
-	vp, err := NewPresentation([]byte(validPresentation))
+	vp, err := newTestPresentation([]byte(validPresentation))
 	require.NoError(t, err)
 
 	audience := []string{"did:example:4a57546973436f6f6c4a4a57573"}

--- a/pkg/doc/verifiable/presentation_jwt_unsecured_test.go
+++ b/pkg/doc/verifiable/presentation_jwt_unsecured_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestJWTPresClaims_MarshalUnsecuredJWT(t *testing.T) {
-	vp, err := NewPresentation([]byte(validPresentation))
+	vp, err := newTestPresentation([]byte(validPresentation))
 	require.NoError(t, err)
 
 	jws := createCredUnsecuredJWT(t, vp)
@@ -28,7 +28,7 @@ func TestJWTPresClaims_MarshalUnsecuredJWT(t *testing.T) {
 
 func TestDecodeVPFromUnsecuredJWT(t *testing.T) {
 	t.Run("Successful unsecured JWT decoding", func(t *testing.T) {
-		vp, err := NewPresentation([]byte(validPresentation))
+		vp, err := newTestPresentation([]byte(validPresentation))
 		require.NoError(t, err)
 
 		jws := createCredUnsecuredJWT(t, vp)

--- a/pkg/doc/verifiable/presentation_ldp_test.go
+++ b/pkg/doc/verifiable/presentation_ldp_test.go
@@ -32,7 +32,7 @@ func TestNewPresentationFromLinkedDataProof(t *testing.T) {
 		Suite:                   ss,
 	}
 
-	vc, err := NewPresentation([]byte(validPresentation))
+	vc, err := newTestPresentation([]byte(validPresentation))
 	r.NoError(err)
 
 	err = vc.AddLinkedDataProof(ldpContext)
@@ -41,7 +41,7 @@ func TestNewPresentationFromLinkedDataProof(t *testing.T) {
 	vcBytes, err := json.Marshal(vc)
 	r.NoError(err)
 
-	vcWithLdp, err := NewPresentation(vcBytes,
+	vcWithLdp, err := newTestPresentation(vcBytes,
 		WithPresEmbeddedSignatureSuites(ss),
 		WithPresPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)))
 	r.NoError(err)
@@ -63,7 +63,7 @@ func TestPresentation_AddLinkedDataProof(t *testing.T) {
 	}
 
 	t.Run("Add a valid Linked Data proof to VC", func(t *testing.T) {
-		vp, err := NewPresentation([]byte(validPresentation))
+		vp, err := newTestPresentation([]byte(validPresentation))
 		r.NoError(err)
 
 		err = vp.AddLinkedDataProof(ldpContext)

--- a/pkg/doc/verifiable/testdata/context/trustbloc_example.jsonld
+++ b/pkg/doc/verifiable/testdata/context/trustbloc_example.jsonld
@@ -1,0 +1,16 @@
+{
+    "@context": {
+      "@version": 1.1,
+
+      "id": "@id",
+      "type": "@type",
+
+      "ex": "https://example.org/examples#",
+
+      "image": {"@id": "http://schema.org/image", "@type": "@id"},
+
+      "CredentialStatusList2017": "ex:CredentialStatusList2017",
+      "DocumentVerification": "ex:DocumentVerification",
+      "SupportingActivity": "ex:SupportingActivity"
+    }
+}

--- a/pkg/doc/verifiable/testdata/context/vc_example.jsonld
+++ b/pkg/doc/verifiable/testdata/context/vc_example.jsonld
@@ -1,0 +1,47 @@
+{
+  "@context": [{
+    "@version": 1.1
+  },"https://www.w3.org/ns/odrl.jsonld", {
+    "ex": "https://example.org/examples#",
+    "schema": "http://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+
+    "3rdPartyCorrelation": "ex:3rdPartyCorrelation",
+    "AllVerifiers": "ex:AllVerifiers",
+    "Archival": "ex:Archival",
+    "BachelorDegree": "ex:BachelorDegree",
+    "Child": "ex:Child",
+    "CLCredentialDefinition2019": "ex:CLCredentialDefinition2019",
+    "CLSignature2019": "ex:CLSignature2019",
+    "IssuerPolicy": "ex:IssuerPolicy",
+    "HolderPolicy": "ex:HolderPolicy",
+    "Mother": "ex:Mother",
+    "RelationshipCredential": "ex:RelationshipCredential",
+    "UniversityDegreeCredential": "ex:UniversityDegreeCredential",
+    "ZkpExampleSchema2018": "ex:ZkpExampleSchema2018",
+
+    "issuerData": "ex:issuerData",
+    "attributes": "ex:attributes",
+    "signature": "ex:signature",
+    "signatureCorrectnessProof": "ex:signatureCorrectnessProof",
+    "primaryProof": "ex:primaryProof",
+    "nonRevocationProof": "ex:nonRevocationProof",
+
+    "alumniOf": {"@id": "schema:alumniOf", "@type": "rdf:HTML"},
+    "child": {"@id": "ex:child", "@type": "@id"},
+    "degree": "ex:degree",
+    "degreeType": "ex:degreeType",
+    "degreeSchool": "ex:degreeSchool",
+    "college": "ex:college",
+    "name": {"@id": "schema:name", "@type": "rdf:HTML"},
+    "givenName": "schema:givenName",
+    "familyName": "schema:familyName",
+    "parent": {"@id": "ex:parent", "@type": "@id"},
+    "referenceId": "ex:referenceId",
+    "documentPresence": "ex:documentPresence",
+    "evidenceDocument": "ex:evidenceDocument",
+    "spouse": "schema:spouse",
+    "subjectPresence": "ex:subjectPresence",
+    "verifier": {"@id": "ex:verifier", "@type": "@id"}
+  }]
+}


### PR DESCRIPTION
closes #1753

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

In a follow-up PR, the same will be done for linked data proofs (`signature` package).