### PR TITLE
ci: enable publish in external repos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
 
   publish:
     name: Publish images and npm packages
-    if: github.event_name == 'push' && github.repository == 'hyperledger/aries-framework-go'
+    if: github.event_name == 'push' && ((github.repository == 'hyperledger/aries-framework-go' && github.ref == 'refs/heads/master') || (github.repository != 'hyperledger/aries-framework-go' && github.ref == 'refs/heads/afg-publish'))
     needs: [checks, unitTest, unitTestWasm, bddTest]
     runs-on: ubuntu-18.04
     timeout-minutes: 10
@@ -130,17 +130,23 @@ jobs:
               }
               trap logout EXIT
               source ci/version_var.sh
-              echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username $GITHUB_ACTOR --password-stdin
-              make agent-rest-docker
-              docker tag aries-framework-go/agent-rest:latest  docker.pkg.github.com/hyperledger/aries-framework-go/agent-rest:$AGENT_IMAGE_TAG
-              docker push docker.pkg.github.com/hyperledger/aries-framework-go/agent-rest:$AGENT_IMAGE_TAG
+              if [ "${IS_RELEASE}" = true ] || [ "${GITHUB_REF}" =  "refs/heads/afg-publish" ]; then
+                echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username $GITHUB_ACTOR --password-stdin
+                make agent-rest-docker
+                docker tag aries-framework-go/agent-rest:latest  docker.pkg.github.com/${GITHUB_REPOSITORY}/agent-rest:$AGENT_IMAGE_TAG
+                docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/agent-rest:$AGENT_IMAGE_TAG
+              fi
 
       - name: Publish npm packages
         working-directory: ./cmd/aries-js-worker
         run: |
           source ../../ci/version_var.sh
-          sed -i 's/"version": "0.0.1"/"version": "'$NPM_PKG_TAG'"/g' package.json
-          npm install
-          npm publish
+          if [ "${IS_RELEASE}" = true ] || [ "${GITHUB_REF}" =  "refs/heads/afg-publish" ]; then
+            sed -i 's/"version": "0.0.1"/"version": "'$NPM_PKG_TAG'"/g' package.json
+            sed -i 's#"name": "@hyperledger/aries-framework-go"#"name": "@'${GITHUB_REPOSITORY}'"#g' package.json
+            sed -i 's#"url": "git://github.com/hyperledger/aries-framework-go.git"#"url": "git://github.com/'${GITHUB_REPOSITORY}'.git"#g' package.json
+            npm install
+            npm publish
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/version_var.sh
+++ b/ci/version_var.sh
@@ -10,7 +10,7 @@ IS_RELEASE=false
 
 ARCH=$(go env GOARCH)
 
-if [ $IS_RELEASE == false ]
+if [ "${IS_RELEASE}" = false ]
 then
   EXTRA_VERSION=snapshot-$(git rev-parse --short=7 HEAD)
   PROJECT_VERSION=$BASE_VERSION-$EXTRA_VERSION
@@ -18,5 +18,6 @@ else
   PROJECT_VERSION=$BASE_VERSION
 fi
 
+export IS_RELEASE
 export AGENT_IMAGE_TAG=$ARCH-$PROJECT_VERSION
 export NPM_PKG_TAG=$PROJECT_VERSION


### PR DESCRIPTION
- the main repo will now only publish releases.
- external repo forks MAY publish snapshots by pushing to their own afg-publish branch.

Signed-off-by: Troy Ronda <troy@troyronda.com>
