### PR TITLE
fix: do not fire didexchange event after accepting oob message

### DIFF
--- a/pkg/client/outofband/client.go
+++ b/pkg/client/outofband/client.go
@@ -35,6 +35,18 @@ const (
 	InvitationMsgType = outofband.InvitationMsgType
 )
 
+// EventOptions are is a container of options that you can pass to an event's
+// Continue function to customize the reaction to incoming out-of-band messages.
+type EventOptions struct {
+	// Label will be shared with the other agent during the subsequent did-exchange.
+	Label string
+}
+
+// MyLabel will be shared with the other agent during the subsequent did-exchange.
+func (e *EventOptions) MyLabel() string {
+	return e.Label
+}
+
 // Event is a container of out-of-band protocol-specific properties for DIDCommActions and StateMsgs.
 type Event interface {
 	// ConnectionID of the connection record, once it's created.
@@ -56,10 +68,10 @@ type message struct {
 
 type oobService interface {
 	service.Event
-	AcceptRequest(request *outofband.Request) (string, error)
-	AcceptInvitation(inv *outofband.Invitation) (string, error)
-	SaveRequest(request *outofband.Request) error
-	SaveInvitation(inv *outofband.Invitation) error
+	AcceptRequest(*outofband.Request, string) (string, error)
+	AcceptInvitation(*outofband.Invitation, string) (string, error)
+	SaveRequest(*outofband.Request) error
+	SaveInvitation(*outofband.Invitation) error
 }
 
 // Provider provides the dependencies for the client.
@@ -192,10 +204,10 @@ func (c *Client) CreateInvitation(protocols []string, opts ...MessageOption) (*I
 }
 
 // AcceptRequest from another agent and return the ID of a new connection record.
-func (c *Client) AcceptRequest(r *Request) (string, error) {
+func (c *Client) AcceptRequest(r *Request, myLabel string) (string, error) {
 	cast := outofband.Request(*r)
 
-	connID, err := c.oobService.AcceptRequest(&cast)
+	connID, err := c.oobService.AcceptRequest(&cast, myLabel)
 	if err != nil {
 		return "", fmt.Errorf("out-of-band service failed to accept request : %w", err)
 	}
@@ -204,10 +216,10 @@ func (c *Client) AcceptRequest(r *Request) (string, error) {
 }
 
 // AcceptInvitation from another agent and return the ID of the new connection records.
-func (c *Client) AcceptInvitation(i *Invitation) (string, error) {
+func (c *Client) AcceptInvitation(i *Invitation, myLabel string) (string, error) {
 	cast := outofband.Invitation(*i)
 
-	connID, err := c.oobService.AcceptInvitation(&cast)
+	connID, err := c.oobService.AcceptInvitation(&cast, myLabel)
 	if err != nil {
 		return "", fmt.Errorf("out-of-band service failed to accept invitation : %w", err)
 	}

--- a/pkg/client/outofband/client_test.go
+++ b/pkg/client/outofband/client_test.go
@@ -339,14 +339,14 @@ func TestAcceptRequest(t *testing.T) {
 		provider := withTestProvider()
 		provider.ServiceMap = map[string]interface{}{
 			outofband.Name: &stubOOBService{
-				acceptReqFunc: func(*outofband.Request) (string, error) {
+				acceptReqFunc: func(*outofband.Request, string) (string, error) {
 					return expected, nil
 				},
 			},
 		}
 		c, err := New(provider)
 		require.NoError(t, err)
-		result, err := c.AcceptRequest(&Request{})
+		result, err := c.AcceptRequest(&Request{}, "")
 		require.NoError(t, err)
 		require.Equal(t, expected, result)
 	})
@@ -355,14 +355,14 @@ func TestAcceptRequest(t *testing.T) {
 		provider := withTestProvider()
 		provider.ServiceMap = map[string]interface{}{
 			outofband.Name: &stubOOBService{
-				acceptReqFunc: func(*outofband.Request) (string, error) {
+				acceptReqFunc: func(*outofband.Request, string) (string, error) {
 					return "", expected
 				},
 			},
 		}
 		c, err := New(provider)
 		require.NoError(t, err)
-		_, err = c.AcceptRequest(&Request{})
+		_, err = c.AcceptRequest(&Request{}, "")
 		require.Error(t, err)
 		require.True(t, errors.Is(err, expected))
 	})
@@ -374,14 +374,14 @@ func TestAcceptInvitation(t *testing.T) {
 		provider := withTestProvider()
 		provider.ServiceMap = map[string]interface{}{
 			outofband.Name: &stubOOBService{
-				acceptInvFunc: func(*outofband.Invitation) (string, error) {
+				acceptInvFunc: func(*outofband.Invitation, string) (string, error) {
 					return expected, nil
 				},
 			},
 		}
 		c, err := New(provider)
 		require.NoError(t, err)
-		result, err := c.AcceptInvitation(&Invitation{})
+		result, err := c.AcceptInvitation(&Invitation{}, "")
 		require.NoError(t, err)
 		require.Equal(t, expected, result)
 	})
@@ -390,14 +390,14 @@ func TestAcceptInvitation(t *testing.T) {
 		provider := withTestProvider()
 		provider.ServiceMap = map[string]interface{}{
 			outofband.Name: &stubOOBService{
-				acceptInvFunc: func(*outofband.Invitation) (string, error) {
+				acceptInvFunc: func(*outofband.Invitation, string) (string, error) {
 					return "", expected
 				},
 			},
 		}
 		c, err := New(provider)
 		require.NoError(t, err)
-		_, err = c.AcceptInvitation(&Invitation{})
+		_, err = c.AcceptInvitation(&Invitation{}, "")
 		require.Error(t, err)
 		require.True(t, errors.Is(err, expected))
 	})
@@ -447,23 +447,23 @@ func withTestProvider() *mockprovider.Provider {
 
 type stubOOBService struct {
 	service.Event
-	acceptReqFunc func(*outofband.Request) (string, error)
-	acceptInvFunc func(*outofband.Invitation) (string, error)
+	acceptReqFunc func(*outofband.Request, string) (string, error)
+	acceptInvFunc func(*outofband.Invitation, string) (string, error)
 	saveReqFunc   func(*outofband.Request) error
 	saveInvFunc   func(*outofband.Invitation) error
 }
 
-func (s *stubOOBService) AcceptRequest(request *outofband.Request) (string, error) {
+func (s *stubOOBService) AcceptRequest(request *outofband.Request, myLabel string) (string, error) {
 	if s.acceptReqFunc != nil {
-		return s.acceptReqFunc(request)
+		return s.acceptReqFunc(request, myLabel)
 	}
 
 	return "", nil
 }
 
-func (s *stubOOBService) AcceptInvitation(i *outofband.Invitation) (string, error) {
+func (s *stubOOBService) AcceptInvitation(i *outofband.Invitation, myLabel string) (string, error) {
 	if s.acceptInvFunc != nil {
-		return s.acceptInvFunc(i)
+		return s.acceptInvFunc(i, myLabel)
 	}
 
 	return "", nil

--- a/pkg/client/outofband/doc.go
+++ b/pkg/client/outofband/doc.go
@@ -51,7 +51,7 @@ SPDX-License-Identifier: Apache-2.0
 //             }
 //
 //             // accept the request:
-//             event.Continue(nil)
+//             event.Continue(&outofband.EventOptions{Label: "Bob"})
 //             // OR you may reject this request:
 //             // event.Stop(errors.New("rejected"))
 //         case outofband.InvitationMsgType:

--- a/pkg/didcomm/protocol/didexchange/models.go
+++ b/pkg/didcomm/protocol/didexchange/models.go
@@ -21,8 +21,10 @@ type OOBInvitation struct {
 	// ID of the thread from which this invitation originated.
 	// This will become the parent thread ID of the didexchange protocol instance.
 	ThreadID string
-	// Label of the connection invitation.
-	Label string
+	// TheirLabel is the label on the other party's connection invitation.
+	TheirLabel string
+	// MyLabel is the label we will use during the did-exchange.
+	MyLabel string
 	// Target destination.
 	// This can be any on of:
 	// - a string with a valid DID

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -1727,10 +1727,10 @@ func TestRespondTo(t *testing.T) {
 		s, err := New(testProvider())
 		require.NoError(t, err)
 		_, err = s.RespondTo(&OOBInvitation{
-			ID:       uuid.New().String(),
-			ThreadID: "",
-			Label:    "test",
-			Target:   "did:example:123",
+			ID:         uuid.New().String(),
+			ThreadID:   "",
+			TheirLabel: "test",
+			Target:     "did:example:123",
 		})
 		require.Error(t, err)
 	})
@@ -1738,10 +1738,10 @@ func TestRespondTo(t *testing.T) {
 		s, err := New(testProvider())
 		require.NoError(t, err)
 		_, err = s.RespondTo(&OOBInvitation{
-			ID:       uuid.New().String(),
-			ThreadID: uuid.New().String(),
-			Label:    "test",
-			Target:   nil,
+			ID:         uuid.New().String(),
+			ThreadID:   uuid.New().String(),
+			TheirLabel: "test",
+			Target:     nil,
 		})
 		require.Error(t, err)
 	})
@@ -1804,10 +1804,10 @@ func TestSave(t *testing.T) {
 
 func newInvitation(target interface{}) *OOBInvitation {
 	return &OOBInvitation{
-		ID:       uuid.New().String(),
-		ThreadID: uuid.New().String(),
-		Label:    "test",
-		Target:   target,
+		ID:         uuid.New().String(),
+		ThreadID:   uuid.New().String(),
+		TheirLabel: "test",
+		Target:     target,
 	}
 }
 

--- a/pkg/didcomm/protocol/didexchange/states_test.go
+++ b/pkg/didcomm/protocol/didexchange/states_test.go
@@ -257,7 +257,7 @@ func TestInvitedState_Execute(t *testing.T) {
 	t.Run("followup to 'requested' on inbound oobinvitations", func(t *testing.T) {
 		connRec, followup, action, err := (&invited{}).ExecuteInbound(
 			&stateMachineMsg{
-				DIDCommMsg: service.NewDIDCommMsgMap(&OOBInvitation{Type: OOBMsgType}),
+				DIDCommMsg: service.NewDIDCommMsgMap(&OOBInvitation{Type: oobMsgType}),
 				connRecord: &connection.Record{},
 			},
 			"",
@@ -312,10 +312,10 @@ func TestRequestedState_Execute(t *testing.T) {
 		ctx := getContext(t, &prov)
 		connRec, followup, action, err := (&requested{}).ExecuteInbound(&stateMachineMsg{
 			DIDCommMsg: service.NewDIDCommMsgMap(&OOBInvitation{
-				ID:       uuid.New().String(),
-				Type:     OOBMsgType,
-				ThreadID: uuid.New().String(),
-				Label:    "test",
+				ID:         uuid.New().String(),
+				Type:       oobMsgType,
+				ThreadID:   uuid.New().String(),
+				TheirLabel: "test",
 				Target: &diddoc.Service{
 					ID:              uuid.New().String(),
 					Type:            "did-communication",
@@ -344,10 +344,11 @@ func TestRequestedState_Execute(t *testing.T) {
 				return nil
 			},
 		}
+		inv := newOOBInvite(newServiceBlock())
+		inv.MyLabel = expected
 		_, _, action, err := (&requested{}).ExecuteInbound(&stateMachineMsg{
-			DIDCommMsg: service.NewDIDCommMsgMap(newOOBInvite(newServiceBlock())),
+			DIDCommMsg: service.NewDIDCommMsgMap(inv),
 			connRecord: &connection.Record{},
-			options:    &options{label: expected},
 		}, "", ctx)
 		require.NoError(t, err)
 		require.NotNil(t, action)
@@ -447,10 +448,10 @@ func TestRequestedState_Execute(t *testing.T) {
 		ctx.vdriRegistry = &mockvdri.MockVDRIRegistry{CreateValue: myDoc}
 		_, _, _, err := (&requested{}).ExecuteInbound(&stateMachineMsg{
 			DIDCommMsg: service.NewDIDCommMsgMap(&OOBInvitation{
-				ID:       uuid.New().String(),
-				Type:     OOBMsgType,
-				ThreadID: uuid.New().String(),
-				Label:    "test",
+				ID:         uuid.New().String(),
+				Type:       oobMsgType,
+				ThreadID:   uuid.New().String(),
+				TheirLabel: "test",
 				Target: &diddoc.Service{
 					ID:              uuid.New().String(),
 					Type:            "did-communication",
@@ -1553,11 +1554,11 @@ func newDidExchangeInvite(publicDID string, svc *diddoc.Service) *Invitation {
 
 func newOOBInvite(target interface{}) *OOBInvitation {
 	return &OOBInvitation{
-		ID:       uuid.New().String(),
-		Type:     OOBMsgType,
-		ThreadID: uuid.New().String(),
-		Label:    "test",
-		Target:   target,
+		ID:         uuid.New().String(),
+		Type:       oobMsgType,
+		ThreadID:   uuid.New().String(),
+		TheirLabel: "test",
+		Target:     target,
 	}
 }
 

--- a/pkg/didcomm/protocol/presentproof/service.go
+++ b/pkg/didcomm/protocol/presentproof/service.go
@@ -146,6 +146,8 @@ func New(p Provider) (*Service, error) {
 
 // HandleInbound handles inbound message (presentproof protocol)
 func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+	logger.Debugf("input: msg=%+v myDID=%s theirDID=%s", msg, myDID, theirDID)
+
 	msgMap, ok := msg.(service.DIDCommMsgMap)
 	if !ok {
 		return "", errors.New("bad assertion message is not DIDCommMsgMap")
@@ -249,6 +251,8 @@ func (s *Service) startInternalListener() {
 		if msg.err == nil {
 			continue
 		}
+
+		logger.Errorf("failed to handle msgID=%s : %s", msg.Msg.ID(), msg.err)
 
 		msg.state = &abandoning{Code: codeInternalError}
 

--- a/test/bdd/features/presentproof.feature
+++ b/test/bdd/features/presentproof.feature
@@ -11,7 +11,7 @@ Feature: Present Proof protocol
   Scenario: The Verifier begins with a request presentation
     Given "Alice" exchange DIDs with "Bob"
     Then "Alice" sends a request presentation to the "Bob"
-    And "Bob" accepts a request and sends a presentation to the Verifier
+    And "Bob" accepts a request and sends a presentation to the "Alice"
     And "Alice" accepts a presentation
     Then "Bob" checks the history of events "request-received,request-received,presentation-sent,presentation-sent,done,done"
     And "Alice" checks the history of events "request-sent,request-sent,presentation-received,presentation-received,done,done"
@@ -19,7 +19,7 @@ Feature: Present Proof protocol
   Scenario: The Verifier declines presentation
     Given "Thomas" exchange DIDs with "Paul"
     Then "Thomas" sends a request presentation to the "Paul"
-    And "Paul" accepts a request and sends a presentation to the Verifier
+    And "Paul" accepts a request and sends a presentation to the "Thomas"
     And "Thomas" declines presentation
     Then "Paul" checks the history of events "request-received,request-received,presentation-sent,presentation-sent,abandoning,abandoning,done,done"
     And "Thomas" checks the history of events "request-sent,request-sent,abandoning,abandoning,done,done"
@@ -35,7 +35,7 @@ Feature: Present Proof protocol
     Given "Carol" exchange DIDs with "Andrew"
     Then "Carol" sends a propose presentation to the "Andrew"
     And "Andrew" accepts a proposal and sends a request to the Prover
-    And "Carol" accepts a request and sends a presentation to the Verifier
+    And "Carol" accepts a request and sends a presentation to the "Andrew"
     And "Andrew" accepts a presentation
     Then "Carol" checks the history of events "proposal-sent,proposal-sent,request-received,request-received,presentation-sent,presentation-sent,done,done"
     And "Andrew" checks the history of events "proposal-received,proposal-received,request-sent,request-sent,presentation-received,presentation-received,done,done"
@@ -52,7 +52,7 @@ Feature: Present Proof protocol
     Then "William" sends a request presentation to the "Felix"
     Then "Felix" negotiates about the request presentation with a proposal
     And "William" accepts a proposal and sends a request to the Prover
-    And "Felix" accepts a request and sends a presentation to the Verifier
+    And "Felix" accepts a request and sends a presentation to the "William"
     And "William" accepts a presentation
     Then "Felix" checks the history of events "request-received,request-received,proposal-sent,proposal-sent,request-received,request-received,presentation-sent,presentation-sent,done,done"
     And "William" checks the history of events "request-sent,request-sent,proposal-received,proposal-received,request-sent,request-sent,presentation-received,presentation-received,done,done"
@@ -63,7 +63,7 @@ Feature: Present Proof protocol
     And "Jesse" accepts a proposal and sends a request to the Prover
     Then "Jason" negotiates about the request presentation with a proposal
     And "Jesse" accepts a proposal and sends a request to the Prover
-    And "Jason" accepts a request and sends a presentation to the Verifier
+    And "Jason" accepts a request and sends a presentation to the "Jesse"
     And "Jesse" accepts a presentation
     Then "Jason" checks the history of events "proposal-sent,proposal-sent,request-received,request-received,proposal-sent,proposal-sent,request-received,request-received,presentation-sent,presentation-sent,done,done"
     And "Jesse" checks the history of events "proposal-received,proposal-received,request-sent,request-sent,proposal-received,proposal-received,request-sent,request-sent,presentation-received,presentation-received,done,done"

--- a/test/bdd/pkg/introduce/introduce_sdk_steps.go
+++ b/test/bdd/pkg/introduce/introduce_sdk_steps.go
@@ -84,10 +84,6 @@ func (a *SDKSteps) RegisterSteps(s *godog.Suite) {
 }
 
 func (a *SDKSteps) connectionEstablished(agent1, agent2 string) error {
-	if err := a.didExchangeSDKS.ApproveRequest(agent1); err != nil {
-		return err
-	}
-
 	if err := a.didExchangeSDKS.ApproveRequest(agent2); err != nil {
 		return err
 	}
@@ -304,7 +300,7 @@ func (a *SDKSteps) checkAndContinue(agentID, introduceeID string) error {
 
 		e.Continue(nil)
 
-		go a.outofbandSDKS.ApproveOOBRequest(agentID)
+		go a.outofbandSDKS.ApproveOOBRequest(agentID, &outofband.EventOptions{Label: agentID})
 	case <-time.After(timeout):
 		return fmt.Errorf("timeout checkAndContinue %s", agentID)
 	}
@@ -331,7 +327,7 @@ func (a *SDKSteps) checkAndContinueWithInvitation(agentID, introduceeID string) 
 
 		e.Continue(introduce.WithOOBRequest(req))
 
-		go a.outofbandSDKS.ApproveOOBRequest(agentID)
+		go a.outofbandSDKS.ApproveOOBRequest(agentID, &outofband.EventOptions{Label: agentID})
 	case <-time.After(timeout):
 		return fmt.Errorf("timeout checkAndContinue %s", agentID)
 	}
@@ -358,7 +354,7 @@ func (a *SDKSteps) checkAndContinueWithInvitationAndEmbeddedRequest(agentID, int
 
 		e.Continue(introduce.WithOOBRequest(req))
 
-		go a.outofbandSDKS.ApproveOOBRequest(agentID)
+		go a.outofbandSDKS.ApproveOOBRequest(agentID, &outofband.EventOptions{Label: agentID})
 	case <-time.After(timeout):
 		return fmt.Errorf("timeout checkAndContinue %s", agentID)
 	}

--- a/test/bdd/pkg/redeemableroutes/redeemable_routes.go
+++ b/test/bdd/pkg/redeemableroutes/redeemable_routes.go
@@ -228,19 +228,16 @@ func (b *BDDSteps) routerApprovesIntroduction(router, serviceEndpoint, routingKe
 
 func (b *BDDSteps) bobConnectsWithRouterAndRequestsRoute(bob, router string) error {
 	// bob approves oob request received via the introducer
-	b.oobSdk.ApproveOOBRequest(bob)
+	b.oobSdk.ApproveOOBRequest(bob, &outofband.EventOptions{Label: bob})
 
-	// in order: make bob approve first, then the router
-	for _, agent := range []string{bob, router} {
-		err := b.oobSdk.ApproveDIDExchangeRequest(agent)
-		if err != nil {
-			return fmt.Errorf("%s failed to approve didexchange request : %w", agent, err)
-		}
+	err := b.oobSdk.ApproveDIDExchangeRequest(router)
+	if err != nil {
+		return fmt.Errorf("%s failed to approve didexchange request : %w", router, err)
 	}
 
-	err := b.oobSdk.ConfirmConnections(router, bob, "completed")
+	err = b.oobSdk.ConfirmConnections(router, bob, "completed")
 	if err != nil {
-		return fmt.Errorf("failed to confirm connection status %s and %s", router, bob)
+		return fmt.Errorf("failed to confirm connection status between %s and %s : %w", router, bob, err)
 	}
 
 	return nil


### PR DESCRIPTION
closes #1814

Note: `presentproof_sdk_steps.go#acceptRequestPresentation` was refactored because the JWS signature verification was failing for an as-yet unclear reason. Some of this method's assumptions[1] were strange to me, so I refactored and it started working. Please take a look.

[1]: it was assuming the first connection record retrieved from an agent's storage was the right one, and it was assuming consistency between these connection records and public DIDs registered in the BDD context by a different BDD package

Signed-off-by: George Aristy <george.aristy@securekey.com>