### PR TITLE
feat: Credential and LDP dates to use custom object to avoid loss of data

### DIFF
--- a/pkg/didcomm/protocol/issuecredential/service_test.go
+++ b/pkg/didcomm/protocol/issuecredential/service_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	serviceMocks "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/didcomm/common/service"
 	issuecredentialMocks "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/didcomm/protocol/issuecredential"
@@ -626,7 +627,7 @@ func TestService_HandleInbound(t *testing.T) {
 						ID:           "did:example:76e12ec712ebc6f1c221ebfeb1f",
 						CustomFields: verifiable.CustomFields{"name": "Example University"},
 					},
-					Issued:  &issued,
+					Issued:  util.NewTime(issued),
 					Schemas: []verifiable.TypedID{},
 					CustomFields: map[string]interface{}{
 						"referenceNumber": 83294847,

--- a/pkg/didcomm/protocol/issuecredential/states_test.go
+++ b/pkg/didcomm/protocol/issuecredential/states_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	serviceMocks "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/didcomm/common/service"
 	issuecredentialMocks "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/didcomm/protocol/issuecredential"
@@ -690,7 +691,7 @@ func TestCredentialReceived_ExecuteInbound(t *testing.T) {
 								ID:           "did:example:76e12ec712ebc6f1c221ebfeb1f",
 								CustomFields: verifiable.CustomFields{"name": "Example University"},
 							},
-							Issued:  &issued,
+							Issued:  util.NewTime(issued),
 							Schemas: []verifiable.TypedID{},
 							CustomFields: map[string]interface{}{
 								"referenceNumber": 83294847,

--- a/pkg/doc/signature/proof/data_test.go
+++ b/pkg/doc/signature/proof/data_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 )
 
 func TestCreateVerifyHashAlgorithm(t *testing.T) {
@@ -78,7 +79,7 @@ func TestCreateVerifyData(t *testing.T) {
 
 	p := &Proof{
 		Type:    "type",
-		Created: &created,
+		Created: util.NewTime(created),
 		Creator: "key1",
 	}
 
@@ -113,7 +114,7 @@ type mockSignatureSuite struct {
 // GetCanonicalDocument will return normalized/canonical version of the document
 func (s *mockSignatureSuite) GetCanonicalDocument(doc map[string]interface{},
 	opts ...jsonld.ProcessorOpts) ([]byte, error) {
-	return jsonld.Default().GetCanonicalDocument(doc)
+	return jsonld.Default().GetCanonicalDocument(doc, opts...)
 }
 
 // GetDigest returns document digest

--- a/pkg/doc/signature/proof/jws_test.go
+++ b/pkg/doc/signature/proof/jws_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 )
 
 func Test_getJWTHeader(t *testing.T) {
@@ -31,7 +33,7 @@ func Test_createVerifyJWS(t *testing.T) {
 
 	p := &Proof{
 		Type:         "Ed25519Signature2018",
-		Created:      &created,
+		Created:      util.NewTime(created),
 		JWS:          "eyJ0eXAiOiJK..gFWFOEjXk",
 		ProofPurpose: "assertionMethod",
 	}

--- a/pkg/doc/signature/proof/proof.go
+++ b/pkg/doc/signature/proof/proof.go
@@ -8,7 +8,8 @@ package proof
 import (
 	"encoding/base64"
 	"errors"
-	"time"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 )
 
 const (
@@ -37,7 +38,7 @@ const (
 // Proof is cryptographic proof of the integrity of the DID Document
 type Proof struct {
 	Type                    string
-	Created                 *time.Time
+	Created                 *util.TimeWithTrailingZeroMsec
 	Creator                 string
 	VerificationMethod      string
 	ProofValue              []byte
@@ -53,7 +54,7 @@ type Proof struct {
 func NewProof(emap map[string]interface{}) (*Proof, error) {
 	created := stringEntry(emap[jsonldCreated])
 
-	timeValue, err := time.Parse(time.RFC3339Nano, created)
+	timeValue, err := util.ParseTimeWithTrailingZeroMsec(created)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +88,7 @@ func NewProof(emap map[string]interface{}) (*Proof, error) {
 
 	return &Proof{
 		Type:                    stringEntry(emap[jsonldType]),
-		Created:                 &timeValue,
+		Created:                 timeValue,
 		Creator:                 stringEntry(emap[jsonldCreator]),
 		VerificationMethod:      stringEntry(emap[jsonldVerificationMethod]),
 		ProofValue:              proofValue,
@@ -123,7 +124,7 @@ func (p *Proof) JSONLdObject() map[string]interface{} {
 	}
 
 	if p.Created != nil {
-		emap[jsonldCreated] = p.Created.Format(time.RFC3339Nano)
+		emap[jsonldCreated] = p.Created.Format(p.Created.GetFormat())
 	}
 
 	if len(p.ProofValue) > 0 {

--- a/pkg/doc/signature/proof/utils_test.go
+++ b/pkg/doc/signature/proof/utils_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 )
 
 func TestAddManyProofs(t *testing.T) {
@@ -21,7 +23,7 @@ func TestAddManyProofs(t *testing.T) {
 
 	now := time.Now()
 	proof1 := Proof{Creator: "creator-1",
-		Created:    &now,
+		Created:    util.NewTime(now),
 		ProofValue: []byte("proof"),
 		Type:       "Ed25519Signature2018"}
 
@@ -33,7 +35,7 @@ func TestAddManyProofs(t *testing.T) {
 	require.Equal(t, 1, len(proofs))
 
 	proof2 := Proof{Creator: "creator-2",
-		Created:    &now,
+		Created:    util.NewTime(now),
 		ProofValue: []byte("proof"),
 		Type:       "Ed25519Signature2018"}
 	err = AddProof(doc, &proof2)
@@ -79,7 +81,7 @@ func TestAddSingleProof(t *testing.T) {
 
 	now := time.Now()
 	proof := Proof{Creator: "creator-2",
-		Created:    &now,
+		Created:    util.NewTime(now),
 		ProofValue: []byte("proof #2"),
 		Type:       "Ed25519Signature2018"}
 

--- a/pkg/doc/signature/signer/signer.go
+++ b/pkg/doc/signature/signer/signer.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
-
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/proof"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 )
 
 const defaultProofPurpose = "assertionMethod"
@@ -103,7 +103,7 @@ func (signer *DocumentSigner) signObject(context *Context, jsonLdObject map[stri
 		Type:                    context.SignatureType,
 		SignatureRepresentation: context.SignatureRepresentation,
 		Creator:                 context.Creator,
-		Created:                 created,
+		Created:                 &util.TimeWithTrailingZeroMsec{Time: *created},
 		Domain:                  context.Domain,
 		Nonce:                   context.Nonce,
 		VerificationMethod:      context.VerificationMethod,

--- a/pkg/doc/util/time.go
+++ b/pkg/doc/util/time.go
@@ -1,0 +1,140 @@
+package util
+
+import (
+	"time"
+)
+
+// TimeWithTrailingZeroMsec overrides marshalling of time.Time. It keeps a format of initial unmarshalling
+// in case when date has zero a fractional second (e.g. ".000").
+// For example, time.Time marshals 2018-03-15T00:00:00.000Z to 2018-03-15T00:00:00Z
+// while TimeWithTrailingZeroMsec marshals to the initial 2018-03-15T00:00:00.000Z value.
+type TimeWithTrailingZeroMsec struct {
+	time.Time
+
+	trailingZerosMsecCount int
+}
+
+// NewTime creates TimeWithTrailingZeroMsec without zero sub-second precision.
+// It functions as a normal time.Time object.
+func NewTime(t time.Time) *TimeWithTrailingZeroMsec {
+	return &TimeWithTrailingZeroMsec{Time: t}
+}
+
+// NewTimeWithTrailingZeroMsec creates TimeWithTrailingZeroMsec with certain zero sub-second precision.
+func NewTimeWithTrailingZeroMsec(t time.Time, trailingZerosMsecCount int) *TimeWithTrailingZeroMsec {
+	return &TimeWithTrailingZeroMsec{
+		Time:                   t,
+		trailingZerosMsecCount: trailingZerosMsecCount,
+	}
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+// The time is a quoted string in RFC 3339 format, with sub-second precision added if present.
+// In case of zero sub-second precision presence, trailing zeros are included.
+func (tm TimeWithTrailingZeroMsec) MarshalJSON() ([]byte, error) {
+	timeBytes, err := tm.Time.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	if tm.trailingZerosMsecCount == 0 {
+		return timeBytes, nil
+	}
+
+	return tm.marshalJSONWithTrailingZeroMsec()
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// The time is expected to be a quoted string in RFC 3339 format.
+// In case of zero sub-second precision, it's kept and applied when e.g. unmarshal the time to JSON.
+func (tm *TimeWithTrailingZeroMsec) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+
+	err := (&tm.Time).UnmarshalJSON(data)
+	if err != nil {
+		return err
+	}
+
+	tm.keepTrailingZerosMsecFormat(string(data))
+
+	return nil
+}
+
+// GetFormat returns customized time.RFC3339Nano with trailing zeros included in case of
+// zero sub-second precision presence. Otherwise it returns time.RFC3339Nano.
+func (tm TimeWithTrailingZeroMsec) GetFormat() string {
+	if tm.trailingZerosMsecCount > 0 {
+		return tm.getTrailingZeroIncludedFormat()
+	}
+
+	return time.RFC3339Nano
+}
+
+// ParseTimeWithTrailingZeroMsec parses a formatted string and returns the time value it represents.
+// In case of zero sub-second precision, it's kept and applied when e.g. unmarshal the time to JSON.
+func ParseTimeWithTrailingZeroMsec(timeStr string) (*TimeWithTrailingZeroMsec, error) {
+	t, err := time.Parse(time.RFC3339, timeStr)
+	if err != nil {
+		return nil, err
+	}
+
+	tWithTrailingZeroMsec := &TimeWithTrailingZeroMsec{Time: t}
+	tWithTrailingZeroMsec.keepTrailingZerosMsecFormat(timeStr)
+
+	return tWithTrailingZeroMsec, nil
+}
+
+func (tm TimeWithTrailingZeroMsec) marshalJSONWithTrailingZeroMsec() ([]byte, error) {
+	format := tm.getTrailingZeroIncludedFormat()
+
+	b := make([]byte, 0, len(format)+len(`""`))
+	b = append(b, '"')
+	b = tm.AppendFormat(b, format)
+	b = append(b, '"')
+
+	return b, nil
+}
+
+func (tm TimeWithTrailingZeroMsec) getTrailingZeroIncludedFormat() string {
+	format := "2006-01-02T15:04:05."
+
+	for i := 0; i < tm.trailingZerosMsecCount; i++ {
+		format += "0"
+	}
+
+	format += "Z07:00"
+
+	return format
+}
+
+func (tm *TimeWithTrailingZeroMsec) keepTrailingZerosMsecFormat(timeStr string) {
+	msecFraction := false
+	zerosCount := 0
+
+	for i := 0; i < len(timeStr); i++ {
+		c := int(timeStr[i])
+		if !msecFraction {
+			if c == '.' {
+				msecFraction = true
+			}
+
+			continue
+		}
+
+		if c == 'Z' {
+			if zerosCount > 0 {
+				tm.trailingZerosMsecCount = zerosCount
+			}
+
+			break
+		}
+
+		if c != '0' {
+			break
+		}
+
+		zerosCount++
+	}
+}

--- a/pkg/doc/util/time_test.go
+++ b/pkg/doc/util/time_test.go
@@ -1,0 +1,82 @@
+package util
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeWithTrailingZeroMsec(t *testing.T) {
+	var timeTests = []struct {
+		in  string
+		out string
+	}{
+		{"2018-03-15T00:00:00Z", "2018-03-15T00:00:00Z"},
+		{"2018-03-15T00:00:00.9724Z", "2018-03-15T00:00:00.9724Z"},
+		{"2018-03-15T00:00:00.000Z", "2018-03-15T00:00:00.000Z"},
+		{"2018-03-15T00:00:00.00000Z", "2018-03-15T00:00:00.00000Z"},
+		{"2018-03-15T00:00:00.0000100Z", "2018-03-15T00:00:00.00001Z"},
+	}
+
+	for _, tt := range timeTests {
+		tt := tt
+		t.Run(tt.in, func(t *testing.T) {
+			var timeMsec TimeWithTrailingZeroMsec
+			err := json.Unmarshal([]byte(quote(tt.in)), &timeMsec)
+			require.NoError(t, err)
+
+			timeMsecBytes, err := json.Marshal(timeMsec)
+			require.NoError(t, err)
+			require.Equal(t, quote(tt.out), string(timeMsecBytes))
+		})
+	}
+
+	// Marshal corner cases.
+	timeMsec := TimeWithTrailingZeroMsec{Time: time.Date(10001, time.January, 1, 0, 0, 0, 0, time.UTC)}
+	bytes, err := timeMsec.MarshalJSON()
+	require.Error(t, err)
+	require.Nil(t, bytes)
+
+	// Unmarshal corner cases.
+	newTimeMsec := &TimeWithTrailingZeroMsec{}
+	err = newTimeMsec.UnmarshalJSON([]byte(quote("not_date")))
+	require.Error(t, err)
+
+	err = newTimeMsec.UnmarshalJSON([]byte("null"))
+	require.NoError(t, err)
+}
+
+func TestTimeWithTrailingZeroMsec_GetFormat(t *testing.T) {
+	timeMsec, err := ParseTimeWithTrailingZeroMsec("2018-03-15T00:00:00Z")
+	require.NoError(t, err)
+	require.Equal(t, time.RFC3339Nano, timeMsec.GetFormat())
+
+	timeMsec, err = ParseTimeWithTrailingZeroMsec("2018-03-15T00:00:00.972Z")
+	require.NoError(t, err)
+	require.Equal(t, time.RFC3339Nano, timeMsec.GetFormat())
+
+	timeMsec, err = ParseTimeWithTrailingZeroMsec("2018-03-15T00:00:00.000Z")
+	require.NoError(t, err)
+	require.Equal(t, "2006-01-02T15:04:05.000Z07:00", timeMsec.GetFormat())
+}
+
+func TestParse(t *testing.T) {
+	timeMsec, err := ParseTimeWithTrailingZeroMsec("2018-03-15T00:00:00.000Z")
+	require.NoError(t, err)
+	require.Equal(t, "2018-03-15T00:00:00.000Z", timeMsec.Format(timeMsec.GetFormat()))
+
+	timeMsec, err = ParseTimeWithTrailingZeroMsec("2018-03-15T00:00:00.123Z")
+	require.NoError(t, err)
+	require.Equal(t, "2018-03-15T00:00:00.123Z", timeMsec.Format(timeMsec.GetFormat()))
+
+	// error case
+	timeMsec, err = ParseTimeWithTrailingZeroMsec("invalid")
+	require.Error(t, err)
+	require.Nil(t, timeMsec)
+}
+
+func quote(str string) string {
+	return `"` + str + `"`
+}

--- a/pkg/doc/verifiable/common.go
+++ b/pkg/doc/verifiable/common.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/piprate/json-gold/ld"
 	"github.com/xeipuuv/gojsonschema"
@@ -118,59 +117,6 @@ type Proof map[string]interface{}
 // CustomFields is a map of extra fields of struct build when unmarshalling JSON which are not
 // mapped to the struct fields.
 type CustomFields map[string]interface{}
-
-// rememberedFields is a map of raw fields used to preserve actual values of fields which pose risk of losing
-// information during parsing, such as dates.
-// TODO currently this is used only for date parsing issues, to be removed as part of [Issue#1772]
-type rememberedFields map[string]interface{}
-
-// fields to be remembered
-const (
-	issuanceDate   = "issuanceDate"
-	expirationDate = "expirationDate"
-)
-
-func (r rememberedFields) GetIssuanceDate(vcDate *time.Time) interface{} {
-	if issueDate, ok := r[issuanceDate]; ok && issueDate != nil {
-		if issueDate != nil && vcDate != nil {
-			t, err := time.Parse(time.RFC3339, issueDate.(string))
-			if err != nil {
-				return vcDate
-			}
-
-			if t.Equal(*vcDate) {
-				return issueDate
-			}
-		}
-	}
-
-	return vcDate
-}
-
-func (r rememberedFields) GetExpirationDate(vcDate *time.Time) interface{} {
-	if expiryDate, ok := r[expirationDate]; ok {
-		if expiryDate != nil && vcDate != nil {
-			t, err := time.Parse(time.RFC3339, expiryDate.(string))
-			if err != nil {
-				return vcDate
-			}
-
-			if t.Equal(*vcDate) {
-				return expiryDate
-			}
-		}
-	}
-
-	return vcDate
-}
-
-func (r rememberedFields) PushIssuanceDate(val interface{}) {
-	r[issuanceDate] = val
-}
-
-func (r rememberedFields) PushExpirationDate(val interface{}) {
-	r[expirationDate] = val
-}
 
 // TypedID defines a flexible structure with id and name fields and arbitrary extra fields
 // kept in CustomFields.

--- a/pkg/doc/verifiable/credential_jwt.go
+++ b/pkg/doc/verifiable/credential_jwt.go
@@ -41,14 +41,14 @@ func newJWTCredClaims(vc *Credential, minimizeVC bool) (*JWTCredClaims, error) {
 
 	// currently jwt encoding supports only single subject (by the spec)
 	jwtClaims := &jwt.Claims{
-		Issuer:    vc.Issuer.ID,                       // iss
-		NotBefore: josejwt.NewNumericDate(*vc.Issued), // nbf
-		ID:        vc.ID,                              // jti
-		Subject:   subjectID,                          // sub
-		IssuedAt:  josejwt.NewNumericDate(*vc.Issued), // iat (not in spec, follow the interop project approach)
+		Issuer:    vc.Issuer.ID,                           // iss
+		NotBefore: josejwt.NewNumericDate(vc.Issued.Time), // nbf
+		ID:        vc.ID,                                  // jti
+		Subject:   subjectID,                              // sub
+		IssuedAt:  josejwt.NewNumericDate(vc.Issued.Time), // iat (not in spec, follow the interop project approach)
 	}
 	if vc.Expired != nil {
-		jwtClaims.Expiry = josejwt.NewNumericDate(*vc.Expired) // exp
+		jwtClaims.Expiry = josejwt.NewNumericDate(vc.Expired.Time) // exp
 	}
 
 	var raw *rawCredential

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -83,11 +83,11 @@ func TestNewCredential(t *testing.T) {
 
 		// check issued date
 		expectedIssued := time.Date(2010, time.January, 1, 19, 23, 24, 0, time.UTC)
-		require.Equal(t, &expectedIssued, vc.Issued)
+		require.Equal(t, expectedIssued, vc.Issued.Time)
 
 		// check issued date
 		expectedExpired := time.Date(2020, time.January, 1, 19, 23, 24, 0, time.UTC)
-		require.Equal(t, &expectedExpired, vc.Expired)
+		require.Equal(t, expectedExpired, vc.Expired.Time)
 
 		// check credential status
 		require.NotNil(t, vc.Status)
@@ -1495,10 +1495,17 @@ func TestNewCredentialFromRaw_PreserveDates(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, cred)
 
-	raw, err := cred.raw()
+	vcBytes, err := cred.MarshalJSON()
 	require.NoError(t, err)
-	require.Equal(t, raw.Issued.(string), "2020-01-01T00:00:00.000Z")
-	require.Equal(t, raw.Expired.(string), "2030-01-01T00:00:00.000Z")
+
+	// Check that the dates formatting is not corrupted.
+	rawMap, err := toMap(vcBytes)
+	require.NoError(t, err)
+
+	require.Contains(t, rawMap, "issuanceDate")
+	require.Equal(t, rawMap["issuanceDate"], "2020-01-01T00:00:00.000Z")
+	require.Contains(t, rawMap, "expirationDate")
+	require.Equal(t, rawMap["expirationDate"], "2030-01-01T00:00:00.000Z")
 }
 
 func TestCredential_CreatePresentation(t *testing.T) {

--- a/pkg/doc/verifiable/example_credential_test.go
+++ b/pkg/doc/verifiable/example_credential_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ed25519signature2018"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/jsonwebsignature2020"
 	sigverifier "github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
@@ -93,8 +94,8 @@ func ExampleCredential_embedding() {
 				ID:           "did:example:76e12ec712ebc6f1c221ebfeb1f",
 				CustomFields: verifiable.CustomFields{"name": "Example University"},
 			},
-			Issued:  &issued,
-			Expired: &expired,
+			Issued:  util.NewTime(issued),
+			Expired: util.NewTime(expired),
 			Schemas: []verifiable.TypedID{},
 		},
 		ReferenceNumber: 83294847,
@@ -161,8 +162,8 @@ func ExampleCredential_extraFields() {
 			ID:           "did:example:76e12ec712ebc6f1c221ebfeb1f",
 			CustomFields: verifiable.CustomFields{"name": "Example University"},
 		},
-		Issued:  &issued,
-		Expired: &expired,
+		Issued:  util.NewTime(issued),
+		Expired: util.NewTime(expired),
 		Schemas: []verifiable.TypedID{},
 		CustomFields: map[string]interface{}{
 			"referenceNumber": 83294847,
@@ -230,8 +231,8 @@ func ExampleNewCredential() {
 			ID:           "did:example:76e12ec712ebc6f1c221ebfeb1f",
 			CustomFields: verifiable.CustomFields{"name": "Example University"},
 		},
-		Issued:  &issued,
-		Expired: &expired,
+		Issued:  util.NewTime(issued),
+		Expired: util.NewTime(expired),
 		Schemas: []verifiable.TypedID{},
 		CustomFields: map[string]interface{}{
 			"referenceNumber": 83294847,

--- a/pkg/doc/verifiable/example_presentation_test.go
+++ b/pkg/doc/verifiable/example_presentation_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
@@ -216,8 +217,8 @@ func ExamplePresentation_SetCredentials() {
 			ID:           "did:example:76e12ec712ebc6f1c221ebfeb1f",
 			CustomFields: verifiable.CustomFields{"name": "Example University"},
 		},
-		Issued:  &issued,
-		Expired: &expired,
+		Issued:  util.NewTime(issued),
+		Expired: util.NewTime(expired),
 		Schemas: []verifiable.TypedID{},
 		CustomFields: map[string]interface{}{
 			"referenceNumber": 83294847,
@@ -350,8 +351,8 @@ func ExamplePresentation_MarshalJSON() {
 			ID:           "did:example:76e12ec712ebc6f1c221ebfeb1f",
 			CustomFields: verifiable.CustomFields{"name": "Example University"},
 		},
-		Issued:  &issued,
-		Expired: &expired,
+		Issued:  util.NewTime(issued),
+		Expired: util.NewTime(expired),
 		Schemas: []verifiable.TypedID{},
 		CustomFields: map[string]interface{}{
 			"referenceNumber": 83294847,
@@ -441,8 +442,8 @@ func ExamplePresentation_MarshalledCredentials() {
 			ID:           "did:example:76e12ec712ebc6f1c221ebfeb1f",
 			CustomFields: verifiable.CustomFields{"name": "Example University"},
 		},
-		Issued:  &issued,
-		Expired: &expired,
+		Issued:  util.NewTime(issued),
+		Expired: util.NewTime(expired),
 		Schemas: []verifiable.TypedID{},
 	}
 

--- a/pkg/doc/verifiable/presentation_jwt_proof_test.go
+++ b/pkg/doc/verifiable/presentation_jwt_proof_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
@@ -169,8 +170,8 @@ func TestNewPresentationWithVCJWT(t *testing.T) {
 			ID:           "did:example:76e12ec712ebc6f1c221ebfeb1f",
 			CustomFields: CustomFields{"name": "Example University"},
 		},
-		Issued:  &issued,
-		Expired: &expired,
+		Issued:  util.NewTime(issued),
+		Expired: util.NewTime(expired),
 		Schemas: []TypedID{},
 	}
 

--- a/test/bdd/pkg/issuecredential/issuecredential_sdk_steps.go
+++ b/test/bdd/pkg/issuecredential/issuecredential_sdk_steps.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/client/issuecredential"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	verifiableStore "github.com/hyperledger/aries-framework-go/pkg/store/verifiable"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/context"
@@ -43,7 +44,7 @@ func getVCredential() *verifiable.Credential {
 			ID:           "did:example:76e12ec712ebc6f1c221ebfeb1f",
 			CustomFields: verifiable.CustomFields{"name": "Example University"},
 		},
-		Issued:  &issued,
+		Issued:  util.NewTime(issued),
 		Schemas: []verifiable.TypedID{},
 		CustomFields: map[string]interface{}{
 			"referenceNumber": referenceNumber,

--- a/test/bdd/pkg/verifiable/verifiable_steps.go
+++ b/test/bdd/pkg/verifiable/verifiable_steps.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ed25519signature2018"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/hyperledger/aries-framework-go/test/bdd/agent"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/context"
@@ -95,7 +96,7 @@ func (s *SDKSteps) createVC(issuedAt, subject, issuer string) (*verifiable.Crede
 			ID:           s.getPublicDID(issuer).ID,
 			CustomFields: verifiable.CustomFields{"name": issuer},
 		},
-		Issued: &issued,
+		Issued: util.NewTime(issued),
 	}
 
 	return vcToIssue, nil
@@ -114,7 +115,7 @@ func (s *SDKSteps) addVCProof(vc *verifiable.Credential, issuer, proofType strin
 			SignatureType:           "Ed25519Signature2018",
 			Suite:                   ed25519signature2018.New(suite.WithSigner(signer)),
 			SignatureRepresentation: verifiable.SignatureJWS,
-			Created:                 vc.Issued,
+			Created:                 &vc.Issued.Time,
 			VerificationMethod:      doc.ID + pubKey.ID,
 		})
 		if err != nil {


### PR DESCRIPTION
closes #1772

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

This is a re-opened PR from accidentally closed https://github.com/hyperledger/aries-framework-go/pull/1793

> ".000" millisecond precision in expirationDate and issuanceDate of credentials are getting removed/truncated while parsing.

For example, `2020-01-01T00:00:00.000Z` gets truncated to `2020-01-01T00:00:00Z` when formatted (marshalled) to string. It results in interoperability issues with e.g. JS libraries which provide VC with linked data proofs to validate.

In this PR, `TimeWithTrailingZeroMsec` is added that extends `time.Time` to handle this use case.