### PR TITLE
fix: add missed license header for util/time.go

### DIFF
--- a/pkg/doc/util/time.go
+++ b/pkg/doc/util/time.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package util
 
 import (

--- a/pkg/doc/util/time_test.go
+++ b/pkg/doc/util/time_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package util
 
 import (


### PR DESCRIPTION
Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

https://github.com/hyperledger/aries-framework-go/issues/1772