### PR TITLE
chore: Removes redundant docker env variables

### DIFF
--- a/test/bdd/fixtures/agent-rest/.env
+++ b/test/bdd/fixtures/agent-rest/.env
@@ -14,7 +14,7 @@ AGENT_REST_IMAGE=aries-framework-go/agent-rest
 AGENT_REST_IMAGE_TAG=latest
 
 # HTTP Resolver Configurations
-HTTP_DID_RESOLVER=sidetree@http://sidetree-mock:48326/sidetree/0.0.1/identifiers
+HTTP_DID_RESOLVER=sidetree@http://aries.bdd.sidetree.mock:48326/sidetree/0.0.1/identifiers
 
 # Transport Schemes
 HTTP_SCHEME=http
@@ -28,14 +28,12 @@ ALICE_HOST=0.0.0.0
 ALICE_INBOUND_PORT=8081
 ALICE_API_PORT=8082
 ALICE_DB_PATH=/tmp/db/aries
-ALICE_WEBHOOK_PORT=8083
 
 # Bob agent configurations
 BOB_HOST=0.0.0.0
 BOB_INBOUND_PORT=9081
 BOB_API_PORT=9082
 BOB_DB_PATH=/tmp/db/aries
-BOB_WEBHOOK_PORT=9083
 
 # Webhook configurations
 SAMPLE_WEBHOOK_IMAGE=aries-framework-go/sample-webhook
@@ -55,7 +53,6 @@ BOB_WEBHOOK_PORT=9083
 CARL_HOST=0.0.0.0
 CARL_API_PORT=10081
 CARL_DB_PATH=/tmp/db/aries
-CARL_WEBHOOK_PORT=10082
 
 # Carl router configurations
 CARL_ROUTER_HOST=0.0.0.0
@@ -63,7 +60,6 @@ CARL_ROUTER_HTTP_INBOUND_PORT=10091
 CARL_ROUTER_WS_INBOUND_PORT=10092
 CARL_ROUTER_API_PORT=10093
 CARL_ROUTER_DB_PATH=/tmp/db/aries
-CARL_ROUTER_WEBHOOK_PORT=10094
 
 # Carl webhook configurations
 CARL_WEBHOOK_CONTAINER_NAME=carl.webhook.example.com
@@ -79,7 +75,6 @@ CARL_ROUTER_WEBHOOK_PORT=10094
 DAVE_HOST=0.0.0.0
 DAVE_API_PORT=10061
 DAVE_DB_PATH=/tmp/db/aries
-DAVE_WEBHOOK_PORT=10062
 
 # Dave router configurations
 DAVE_ROUTER_HOST=0.0.0.0
@@ -87,7 +82,6 @@ DAVE_ROUTER_HTTP_INBOUND_PORT=10071
 DAVE_ROUTER_WS_INBOUND_PORT=10072
 DAVE_ROUTER_API_PORT=10073
 DAVE_ROUTER_DB_PATH=/tmp/db/aries
-DAVE_ROUTER_WEBHOOK_PORT=10074
 
 # Dave webhook configurations
 DAVE_WEBHOOK_CONTAINER_NAME=dave.webhook.example.com

--- a/test/bdd/fixtures/sidetree-mock/docker-compose.yml
+++ b/test/bdd/fixtures/sidetree-mock/docker-compose.yml
@@ -7,8 +7,8 @@ version: '2'
 
 services:
 
-  sidetree:
-    container_name: sidetree-mock
+  aries.bdd.sidetree.mock:
+    container_name: aries.bdd.sidetree.mock
     image: ${SIDETREE_MOCK_FIXTURE_IMAGE}:${SIDETREE_MOCK_FIXTURE_IMAGE_TAG}
     environment:
       - SIDETREE_MOCK_HOST=0.0.0.0


### PR DESCRIPTION
Removes redundant docker env variables.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>