### PR TITLE
refactor: new VC/VP functions refactoring

### DIFF
--- a/pkg/controller/command/verifiable/command.go
+++ b/pkg/controller/command/verifiable/command.go
@@ -213,7 +213,7 @@ func (o *Command) ValidateCredential(rw io.Writer, req io.Reader) command.Error 
 	// we are only validating the VerifiableCredential here, hence ignoring other return values
 	// TODO https://github.com/hyperledger/aries-framework-go/issues/1316 VC Validate Command - Add keys for proof
 	//  verification as options to the function.
-	_, _, err = verifiable.NewCredential([]byte(request.VerifiableCredential))
+	_, err = verifiable.ParseCredential([]byte(request.VerifiableCredential))
 	if err != nil {
 		logutil.LogInfo(logger, commandName, validateCredentialCommandMethod, "validate vc : "+err.Error())
 
@@ -243,7 +243,7 @@ func (o *Command) SaveCredential(rw io.Writer, req io.Reader) command.Error {
 		return command.NewValidationError(SaveCredentialErrorCode, fmt.Errorf(errEmptyCredentialName))
 	}
 
-	vc, err := verifiable.NewUnverifiedCredential([]byte(request.VerifiableCredential))
+	vc, err := verifiable.ParseUnverifiedCredential([]byte(request.VerifiableCredential))
 	if err != nil {
 		logutil.LogError(logger, commandName, saveCredentialCommandMethod, "parse vc : "+err.Error())
 
@@ -280,7 +280,7 @@ func (o *Command) SavePresentation(rw io.Writer, req io.Reader) command.Error {
 		return command.NewValidationError(SavePresentationErrorCode, fmt.Errorf(errEmptyPresentationName))
 	}
 
-	vp, err := verifiable.NewPresentation([]byte(request.VerifiablePresentation),
+	vp, err := verifiable.ParsePresentation([]byte(request.VerifiablePresentation),
 		verifiable.WithDisabledPresentationProofCheck())
 	if err != nil {
 		logutil.LogError(logger, commandName, savePresentationCommandMethod, "parse vp : "+err.Error())
@@ -682,7 +682,7 @@ func (o *Command) parsePresentationRequest(request *PresentationRequest,
 				))
 			}
 
-			vc, _, e := verifiable.NewCredential(vcRaw, credOpts...)
+			vc, e := verifiable.ParseCredential(vcRaw, credOpts...)
 			if e != nil {
 				logutil.LogError(logger, commandName, generatePresentationCommandMethod,
 					"failed to parse credential from request, invalid credential: "+e.Error())
@@ -692,7 +692,7 @@ func (o *Command) parsePresentationRequest(request *PresentationRequest,
 			vcs = append(vcs, vc)
 		}
 	} else {
-		presentation, err = verifiable.NewUnverifiedPresentation(request.Presentation)
+		presentation, err = verifiable.ParseUnverifiedPresentation(request.Presentation)
 		if err != nil {
 			logutil.LogError(logger, commandName, generatePresentationCommandMethod,
 				"failed to parse presentation from request: "+err.Error())

--- a/pkg/controller/command/verifiable/command_test.go
+++ b/pkg/controller/command/verifiable/command_test.go
@@ -792,7 +792,7 @@ func TestGeneratePresentation(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, response)
 
-		vp, err := verifiable.NewPresentation([]byte(response.VerifiablePresentation))
+		vp, err := verifiable.ParsePresentation(response.VerifiablePresentation)
 
 		require.NoError(t, err)
 		require.NotNil(t, vp)
@@ -833,7 +833,7 @@ func TestGeneratePresentation(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, response)
 
-		vp, err := verifiable.NewPresentation([]byte(response.VerifiablePresentation))
+		vp, err := verifiable.ParsePresentation(response.VerifiablePresentation)
 
 		require.NoError(t, err)
 		require.NotNil(t, vp)
@@ -877,7 +877,7 @@ func TestGeneratePresentation(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, response)
 
-		vp, err := verifiable.NewPresentation([]byte(response.VerifiablePresentation))
+		vp, err := verifiable.ParsePresentation(response.VerifiablePresentation)
 
 		require.NoError(t, err)
 		require.NotNil(t, vp)
@@ -920,7 +920,7 @@ func TestGeneratePresentation(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, response)
 
-		vp, err := verifiable.NewPresentation([]byte(response.VerifiablePresentation))
+		vp, err := verifiable.ParsePresentation(response.VerifiablePresentation)
 
 		require.NoError(t, err)
 		require.NotNil(t, vp)
@@ -973,8 +973,8 @@ func TestGeneratePresentation(t *testing.T) {
 	})
 
 	t.Run("test generate verifiable presentation with proof options & presentation - success", func(t *testing.T) {
-		pRaw := json.RawMessage([]byte(`{"@context": "https://www.w3.org/2018/credentials/v1",
-		"type": "VerifiablePresentation"}`))
+		pRaw := json.RawMessage(`{"@context": "https://www.w3.org/2018/credentials/v1",
+		"type": "VerifiablePresentation"}`)
 
 		createdTime := time.Now().AddDate(-1, 0, 0)
 		presReq := PresentationRequest{
@@ -1002,7 +1002,7 @@ func TestGeneratePresentation(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, response)
 
-		vp, err := verifiable.NewPresentation([]byte(response.VerifiablePresentation))
+		vp, err := verifiable.ParsePresentation(response.VerifiablePresentation)
 
 		require.NoError(t, err)
 		require.NotNil(t, vp)
@@ -1758,5 +1758,5 @@ func TestGeneratePresentation_prepareOpts(t *testing.T) {
 }
 
 func stringToJSONRaw(jsonStr string) json.RawMessage {
-	return json.RawMessage([]byte(jsonStr))
+	return []byte(jsonStr)
 }

--- a/pkg/controller/rest/verifiable/operation_test.go
+++ b/pkg/controller/rest/verifiable/operation_test.go
@@ -565,7 +565,7 @@ func TestGeneratePresentation(t *testing.T) {
 		require.NotEmpty(t, response)
 		require.NotEmpty(t, response.VerifiablePresentation)
 
-		vp, err := verifiableapi.NewPresentation([]byte(response.VerifiablePresentation))
+		vp, err := verifiableapi.ParsePresentation([]byte(response.VerifiablePresentation))
 
 		require.NoError(t, err)
 		require.NotNil(t, vp)
@@ -608,7 +608,7 @@ func TestGeneratePresentation(t *testing.T) {
 		require.NotEmpty(t, response)
 		require.NotEmpty(t, response.VerifiablePresentation)
 
-		vp, err := verifiableapi.NewPresentation([]byte(response.VerifiablePresentation))
+		vp, err := verifiableapi.ParsePresentation([]byte(response.VerifiablePresentation))
 
 		require.NoError(t, err)
 		require.NotNil(t, vp)

--- a/pkg/didcomm/protocol/issuecredential/states.go
+++ b/pkg/didcomm/protocol/issuecredential/states.go
@@ -393,7 +393,7 @@ func toVerifiableCredentials(attachments []decorator.Attachment) ([]*verifiable.
 			return nil, fmt.Errorf("marshal: %w", err)
 		}
 
-		vc, _, err := verifiable.NewCredential(rawVC)
+		vc, err := verifiable.ParseCredential(rawVC)
 		if err != nil {
 			return nil, fmt.Errorf("new credential: %w", err)
 		}

--- a/pkg/didcomm/protocol/presentproof/states.go
+++ b/pkg/didcomm/protocol/presentproof/states.go
@@ -256,7 +256,7 @@ func verifyPresentation(registryVDRI vdri.Registry, attachments []decorator.Atta
 			return fmt.Errorf("decode string: %w", err)
 		}
 
-		_, err = verifiable.NewPresentation(raw, verifiable.WithPresPublicKeyFetcher(
+		_, err = verifiable.ParsePresentation(raw, verifiable.WithPresPublicKeyFetcher(
 			verifiable.NewDIDKeyResolver(registryVDRI).PublicKeyFetcher(),
 		))
 		if err != nil {

--- a/pkg/doc/verifiable/common.go
+++ b/pkg/doc/verifiable/common.go
@@ -262,7 +262,7 @@ func proofsToRaw(proofs []Proof) ([]byte, error) {
 	}
 }
 
-func decodeProof(proofBytes json.RawMessage) ([]Proof, error) {
+func parseProof(proofBytes json.RawMessage) ([]Proof, error) {
 	if len(proofBytes) == 0 {
 		return nil, nil
 	}

--- a/pkg/doc/verifiable/credential_extension_test.go
+++ b/pkg/doc/verifiable/credential_extension_test.go
@@ -38,13 +38,18 @@ type UniversityDegreeCredential struct {
 }
 
 func NewUniversityDegreeCredential(vcData []byte, opts ...CredentialOpt) (*UniversityDegreeCredential, error) {
-	cred, credBytes, err := newTestCredential(vcData, opts...)
+	cred, err := parseTestCredential(vcData, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("new university degree credential: %w", err)
 	}
 
 	udc := UniversityDegreeCredential{
 		Base: *cred,
+	}
+
+	credBytes, err := json.Marshal(cred)
+	if err != nil {
+		return nil, fmt.Errorf("new university degree credential: %w", err)
 	}
 
 	err = json.Unmarshal(credBytes, &udc)
@@ -133,7 +138,7 @@ func TestCredentialExtensibility(t *testing.T) {
 }
 `
 
-	cred, _, err := newTestCredential([]byte(udCredential))
+	cred, err := parseTestCredential([]byte(udCredential))
 	require.NoError(t, err)
 	require.NotNil(t, cred)
 

--- a/pkg/doc/verifiable/credential_jws_test.go
+++ b/pkg/doc/verifiable/credential_jws_test.go
@@ -22,7 +22,7 @@ func TestJWTCredClaimsMarshalJWS(t *testing.T) {
 	privateKey, err := readPrivateKey(filepath.Join(certPrefix, "issuer_private.pem"))
 	require.NoError(t, err)
 
-	vc, _, err := newTestCredential([]byte(validCredential))
+	vc, err := parseTestCredential([]byte(validCredential))
 	require.NoError(t, err)
 
 	jwtClaims, err := vc.JWTClaims(true)
@@ -84,7 +84,7 @@ func TestCredJWSDecoderUnmarshal(t *testing.T) {
 		err = json.Unmarshal(vcBytes, &vcRaw)
 		require.NoError(t, err)
 
-		vc, _, err := newTestCredential([]byte(jwtTestCredential))
+		vc, err := parseTestCredential([]byte(jwtTestCredential))
 		require.NoError(t, err)
 		require.Equal(t, vc.stringJSON(t), vcRaw.stringJSON(t))
 	})

--- a/pkg/doc/verifiable/credential_jwt_unsecured_test.go
+++ b/pkg/doc/verifiable/credential_jwt_unsecured_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestCredentialJWTClaimsMarshallingToUnsecuredJWT(t *testing.T) {
-	vc, _, err := newTestCredential([]byte(validCredential))
+	vc, err := parseTestCredential([]byte(validCredential))
 	require.NoError(t, err)
 
 	jwtClaims, err := vc.JWTClaims(true)
@@ -39,7 +39,7 @@ func TestCredentialJWTClaimsMarshallingToUnsecuredJWT(t *testing.T) {
 
 func TestCredUnsecuredJWTDecoderParseJWTClaims(t *testing.T) {
 	t.Run("Successful unsecured JWT decoding", func(t *testing.T) {
-		vc, _, err := newTestCredential([]byte(validCredential))
+		vc, err := parseTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		jwtClaims, err := vc.JWTClaims(true)

--- a/pkg/doc/verifiable/credential_ldp_test.go
+++ b/pkg/doc/verifiable/credential_ldp_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
 )
 
-func TestNewCredentialFromLinkedDataProof_Ed25519Signature2018(t *testing.T) {
+func TestParseCredentialFromLinkedDataProof_Ed25519Signature2018(t *testing.T) {
 	r := require.New(t)
 
 	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
@@ -56,7 +56,7 @@ func TestNewCredentialFromLinkedDataProof_Ed25519Signature2018(t *testing.T) {
 		VerificationMethod:      "did:example:123456#key1",
 	}
 
-	vc, _, err := newTestCredential([]byte(validCredential))
+	vc, err := parseTestCredential([]byte(validCredential))
 	r.NoError(err)
 
 	err = vc.AddLinkedDataProof(ldpContext)
@@ -65,7 +65,7 @@ func TestNewCredentialFromLinkedDataProof_Ed25519Signature2018(t *testing.T) {
 	vcBytes, err := json.Marshal(vc)
 	r.NoError(err)
 
-	vcWithLdp, _, err := newTestCredential(vcBytes,
+	vcWithLdp, err := parseTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)))
 	r.NoError(err)
@@ -73,7 +73,7 @@ func TestNewCredentialFromLinkedDataProof_Ed25519Signature2018(t *testing.T) {
 }
 
 //nolint:lll
-func TestNewCredentialFromLinkedDataProof_JSONLD_Validation(t *testing.T) {
+func TestParseCredentialFromLinkedDataProof_JSONLD_Validation(t *testing.T) {
 	r := require.New(t)
 
 	pubKeyBytes := base58.Decode("DqS5F3GVe3rCxucgi4JBNagjv4dKoHc8TDLDw9kR58Pz")
@@ -121,7 +121,7 @@ func TestNewCredentialFromLinkedDataProof_JSONLD_Validation(t *testing.T) {
 }
 `
 
-		vcWithLdp, _, err := newTestCredential([]byte(vcJSON), vcOptions...)
+		vcWithLdp, err := parseTestCredential([]byte(vcJSON), vcOptions...)
 		r.NoError(err)
 		r.NotNil(t, vcWithLdp)
 	})
@@ -162,7 +162,7 @@ func TestNewCredentialFromLinkedDataProof_JSONLD_Validation(t *testing.T) {
 }
 `
 
-		vcWithLdp, _, err := newTestCredential([]byte(vcJSON), vcOptions...)
+		vcWithLdp, err := parseTestCredential([]byte(vcJSON), vcOptions...)
 		r.Error(err)
 		r.EqualError(err, "JSON-LD doc has different structure after compaction")
 		r.Nil(vcWithLdp)
@@ -204,7 +204,7 @@ func TestNewCredentialFromLinkedDataProof_JSONLD_Validation(t *testing.T) {
 }
 `
 
-		vcWithLdp, _, err := newTestCredential([]byte(vcJSON), vcOptions...)
+		vcWithLdp, err := parseTestCredential([]byte(vcJSON), vcOptions...)
 		r.Error(err)
 		r.EqualError(err, "JSON-LD doc has different structure after compaction")
 		r.Nil(vcWithLdp)
@@ -250,7 +250,7 @@ func TestNewCredentialFromLinkedDataProof_JSONLD_Validation(t *testing.T) {
 }
 `
 
-		vc, _, err := newTestCredential([]byte(vcJSON),
+		vc, err := parseTestCredential([]byte(vcJSON),
 			WithDisabledProofCheck(),
 			WithStrictValidation(),
 			WithJSONLDDocumentLoader(docLoader),
@@ -311,7 +311,7 @@ func TestWithStrictValidationOfJsonWebSignature2020(t *testing.T) {
 	copy(publicKey[0:32], decoded)
 	rv := ed25519.PublicKey(publicKey)
 
-	vcWithLdp, _, err := newTestCredential([]byte(vcJSON),
+	vcWithLdp, err := parseTestCredential([]byte(vcJSON),
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(func(issuerID, keyID string) (*sigverifier.PublicKey, error) {
 			return &sigverifier.PublicKey{
@@ -369,7 +369,7 @@ func TestExtraContextWithLDP(t *testing.T) {
 		VerificationMethod:      "did:example:123456#key1",
 	}
 
-	vc, _, err := newTestCredential([]byte(vcJSON))
+	vc, err := parseTestCredential([]byte(vcJSON))
 	r.NoError(err)
 
 	err = vc.AddLinkedDataProof(ldpContext)
@@ -378,7 +378,7 @@ func TestExtraContextWithLDP(t *testing.T) {
 	vcBytes, err := json.Marshal(vc)
 	r.NoError(err)
 
-	vcWithLdp, _, err := newTestCredential(vcBytes,
+	vcWithLdp, err := parseTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)),
 		WithStrictValidation())
@@ -395,7 +395,7 @@ func TestExtraContextWithLDP(t *testing.T) {
 	vcBytes, err = json.Marshal(vcMap)
 	r.NoError(err)
 
-	vcWithLdp, _, err = newTestCredential(vcBytes,
+	vcWithLdp, err = parseTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)),
 		WithStrictValidation())
@@ -404,7 +404,7 @@ func TestExtraContextWithLDP(t *testing.T) {
 	r.Nil(vcWithLdp)
 
 	// Use extra context.
-	vcWithLdp, _, err = newTestCredential(vcBytes,
+	vcWithLdp, err = parseTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)),
 		WithExternalJSONLDContext("https://trustbloc.github.io/context/vc/examples-v1.jsonld"),
@@ -413,7 +413,7 @@ func TestExtraContextWithLDP(t *testing.T) {
 	r.NotNil(vcWithLdp)
 
 	// Use extra context.
-	vcWithLdp, _, err = newTestCredential(vcBytes,
+	vcWithLdp, err = parseTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)),
 		WithExternalJSONLDContext("https://trustbloc.github.io/context/vc/examples-v1.jsonld"),
@@ -443,7 +443,7 @@ func TestExtraContextWithLDP(t *testing.T) {
 	loader := CachingJSONLDLoader()
 	loader.AddDocument("http://localhost:8652/dummy.jsonld", reader)
 
-	vcWithLdp, _, err = NewCredential(vcBytes,
+	vcWithLdp, err = ParseCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(SingleKey(pubKey, kms.ED25519)),
 		WithExternalJSONLDContext("http://localhost:8652/dummy.jsonld"),
@@ -453,7 +453,7 @@ func TestExtraContextWithLDP(t *testing.T) {
 	r.NotNil(vcWithLdp)
 }
 
-func TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_Ed25519(t *testing.T) {
+func TestParseCredentialFromLinkedDataProof_JsonWebSignature2020_Ed25519(t *testing.T) {
 	r := require.New(t)
 
 	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
@@ -470,7 +470,7 @@ func TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_Ed25519(t *testin
 		VerificationMethod:      "did:example:123456#key1",
 	}
 
-	vc, _, err := newTestCredential([]byte(validCredential))
+	vc, err := parseTestCredential([]byte(validCredential))
 	r.NoError(err)
 
 	err = vc.AddLinkedDataProof(ldpContext)
@@ -479,14 +479,14 @@ func TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_Ed25519(t *testin
 	vcBytes, err := json.Marshal(vc)
 	r.NoError(err)
 
-	vcWithLdp, _, err := newTestCredential(vcBytes,
+	vcWithLdp, err := parseTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(SingleKey(pubKey, "Ed25519Signature2018")))
 	r.NoError(err)
 	r.Equal(vc, vcWithLdp)
 }
 
-func TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_ecdsaP256(t *testing.T) {
+func TestParseCredentialFromLinkedDataProof_JsonWebSignature2020_ecdsaP256(t *testing.T) {
 	r := require.New(t)
 
 	// TODO replace ecdsa.GenerateKey with KMS.Create(kms.ECDSAP256TypeIEEEP1363) and use localkms and Crypto for signing
@@ -504,7 +504,7 @@ func TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_ecdsaP256(t *test
 		VerificationMethod:      "did:example:123456#key1",
 	}
 
-	vc, _, err := newTestCredential([]byte(validCredential))
+	vc, err := parseTestCredential([]byte(validCredential))
 	r.NoError(err)
 
 	err = vc.AddLinkedDataProof(ldpContext)
@@ -515,7 +515,7 @@ func TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_ecdsaP256(t *test
 
 	pubKeyBytes := elliptic.Marshal(privateKey.Curve, privateKey.X, privateKey.Y)
 
-	vcWithLdp, _, err := newTestCredential(vcBytes,
+	vcWithLdp, err := parseTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(func(issuerID, keyID string) (*sigverifier.PublicKey, error) {
 			return &sigverifier.PublicKey{
@@ -535,7 +535,7 @@ func TestNewCredentialFromLinkedDataProof_JsonWebSignature2020_ecdsaP256(t *test
 	r.Equal(vc, vcWithLdp)
 }
 
-func TestNewCredentialFromLinkedDataProof_EcdsaSecp256k1Signature2019(t *testing.T) {
+func TestParseCredentialFromLinkedDataProof_EcdsaSecp256k1Signature2019(t *testing.T) {
 	r := require.New(t)
 
 	privateKey, err := ecdsa.GenerateKey(btcec.S256(), rand.Reader)
@@ -554,7 +554,7 @@ func TestNewCredentialFromLinkedDataProof_EcdsaSecp256k1Signature2019(t *testing
 		VerificationMethod:      "did:example:123456#key1",
 	}
 
-	vc, _, err := newTestCredential([]byte(validCredential))
+	vc, err := parseTestCredential([]byte(validCredential))
 	r.NoError(err)
 
 	err = vc.AddLinkedDataProof(ldpContext)
@@ -564,7 +564,7 @@ func TestNewCredentialFromLinkedDataProof_EcdsaSecp256k1Signature2019(t *testing
 	r.NoError(err)
 
 	// JWK encoded public key
-	vcWithLdp, _, err := newTestCredential(vcBytes,
+	vcWithLdp, err := parseTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(func(issuerID, keyID string) (*sigverifier.PublicKey, error) {
 			return &sigverifier.PublicKey{
@@ -584,7 +584,7 @@ func TestNewCredentialFromLinkedDataProof_EcdsaSecp256k1Signature2019(t *testing
 
 	// Bytes encoded public key (can come in e.g. publicKeyHex field)
 	pubKeyBytes := elliptic.Marshal(privateKey.Curve, privateKey.X, privateKey.Y)
-	vcWithLdp, _, err = newTestCredential(vcBytes,
+	vcWithLdp, err = parseTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(sigSuite),
 		WithPublicKeyFetcher(func(issuerID, keyID string) (*sigverifier.PublicKey, error) {
 			return &sigverifier.PublicKey{
@@ -597,7 +597,7 @@ func TestNewCredentialFromLinkedDataProof_EcdsaSecp256k1Signature2019(t *testing
 }
 
 //nolint:lll
-func TestNewCredential_JSONLiteralsNotSupported(t *testing.T) {
+func TestParseCredential_JSONLiteralsNotSupported(t *testing.T) {
 	cmtrJSONLD := `
 {
   "@context": {
@@ -837,7 +837,7 @@ func TestNewCredential_JSONLiteralsNotSupported(t *testing.T) {
 
 	publicKeyBytes := base58.Decode("At4yQndGdrJs5AVFjYXqwDRALfm3ghLAmzhLux5eJkhh")
 
-	vc, _, err := NewCredential([]byte(vcJSON),
+	vc, err := ParseCredential([]byte(vcJSON),
 		WithPublicKeyFetcher(SingleKey(publicKeyBytes, "Ed25519Signature2018")),
 		WithEmbeddedSignatureSuites(ed25519signature2018.New(
 			suite.WithVerifier(suite.NewCryptoVerifier(createLocalCrypto())))),
@@ -850,7 +850,7 @@ func TestNewCredential_JSONLiteralsNotSupported(t *testing.T) {
 }
 
 //nolint:lll
-func TestNewCredential_ProofCreatedWithMillisec(t *testing.T) {
+func TestParseCredential_ProofCreatedWithMillisec(t *testing.T) {
 	vcJSON := `
 	{
 	       "issuanceDate": "2020-03-10T04:24:12.164Z",
@@ -885,7 +885,7 @@ func TestNewCredential_ProofCreatedWithMillisec(t *testing.T) {
 
 	publicKeyBytes := base58.Decode("DNwKNoq5MnZ185AyatKe3kT7MMCDD7R2PeNDV6FndMkz")
 
-	vc, _, err := newTestCredential([]byte(vcJSON),
+	vc, err := parseTestCredential([]byte(vcJSON),
 		WithPublicKeyFetcher(SingleKey(publicKeyBytes, "Ed25519Signature2018")),
 		WithEmbeddedSignatureSuites(ed25519signature2018.New(
 			suite.WithVerifier(suite.NewCryptoVerifier(createLocalCrypto())))),
@@ -895,7 +895,7 @@ func TestNewCredential_ProofCreatedWithMillisec(t *testing.T) {
 	require.NotNil(t, vc)
 }
 
-func TestNewCredentialWithSeveralLinkedDataProofs(t *testing.T) {
+func TestParseCredentialWithSeveralLinkedDataProofs(t *testing.T) {
 	r := require.New(t)
 
 	ed25519PubKey, ed25519PrivKey, err := ed25519.GenerateKey(rand.Reader)
@@ -906,7 +906,7 @@ func TestNewCredentialWithSeveralLinkedDataProofs(t *testing.T) {
 		suite.WithSigner(getEd25519TestSigner(ed25519PrivKey)),
 		suite.WithVerifier(ed25519signature2018.NewPublicKeyVerifier()))
 
-	vc, _, err := newTestCredential([]byte(validCredential))
+	vc, err := parseTestCredential([]byte(validCredential))
 	r.NoError(err)
 
 	err = vc.AddLinkedDataProof(&LinkedDataProofContext{
@@ -936,7 +936,7 @@ func TestNewCredentialWithSeveralLinkedDataProofs(t *testing.T) {
 	r.NoError(err)
 	r.NotEmpty(vcBytes)
 
-	vcWithLdp, _, err := newTestCredential(vcBytes,
+	vcWithLdp, err := parseTestCredential(vcBytes,
 		WithEmbeddedSignatureSuites(ed25519SigSuite, ecdsaSigSuite),
 		WithPublicKeyFetcher(func(issuerID, keyID string) (*sigverifier.PublicKey, error) {
 			switch keyID {
@@ -1054,7 +1054,7 @@ func TestCredential_AddLinkedDataProof(t *testing.T) {
 	r.NoError(err)
 
 	t.Run("Add a valid JWS Linked Data proof to VC", func(t *testing.T) {
-		vc, _, err := newTestCredential([]byte(validCredential))
+		vc, err := parseTestCredential([]byte(validCredential))
 		r.NoError(err)
 
 		originalVCMap, err := toMap(vc)
@@ -1093,7 +1093,7 @@ func TestCredential_AddLinkedDataProof(t *testing.T) {
 	})
 
 	t.Run("Add invalid Linked Data proof to VC", func(t *testing.T) {
-		vc, _, err := newTestCredential([]byte(validCredential))
+		vc, err := parseTestCredential([]byte(validCredential))
 		require.NoError(t, err)
 
 		vc.CustomFields = map[string]interface{}{

--- a/pkg/doc/verifiable/example_credential_test.go
+++ b/pkg/doc/verifiable/example_credential_test.go
@@ -122,12 +122,17 @@ func ExampleCredential_embedding() {
 
 	fmt.Println(jws)
 
-	// Decode JWS and make sure it's coincide with JSON.
-	_, vcBytesFromJWS, err := verifiable.NewCredential(
+	// Parse JWS and make sure it's coincide with JSON.
+	vcParsed, err := verifiable.ParseCredential(
 		[]byte(jws),
 		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(issuerPubKey, kms.ED25519)))
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to encode VC from JWS: %w", err))
+	}
+
+	vcBytesFromJWS, err := vcParsed.MarshalJSON()
+	if err != nil {
+		panic(fmt.Errorf("failed to marshal VC: %w", err))
 	}
 
 	// todo missing referenceNumber here (https://github.com/hyperledger/aries-framework-go/issues/847)
@@ -191,12 +196,17 @@ func ExampleCredential_extraFields() {
 
 	fmt.Println(jws)
 
-	// Decode JWS and make sure it's coincide with JSON.
-	_, vcBytesFromJWS, err := verifiable.NewCredential(
+	// Parse JWS and make sure it's coincide with JSON.
+	vcParsed, err := verifiable.ParseCredential(
 		[]byte(jws),
 		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(issuerPubKey, kms.ED25519)))
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to encode VC from JWS: %w", err))
+	}
+
+	vcBytesFromJWS, err := vcParsed.MarshalJSON()
+	if err != nil {
+		panic(fmt.Errorf("failed to marshal VC: %w", err))
 	}
 
 	fmt.Println(string(vcBytesFromJWS))
@@ -208,7 +218,7 @@ func ExampleCredential_extraFields() {
 }
 
 //nolint:lll
-func ExampleNewCredential() {
+func ExampleParseCredential() {
 	// Issuer is about to issue the university degree credential for the Holder
 	vcEncoded := &verifiable.Credential{
 		Context: []string{
@@ -251,11 +261,16 @@ func ExampleNewCredential() {
 	}
 
 	// The Holder receives JWS and decodes it.
-	_, vcDecodedBytes, err := verifiable.NewCredential(
+	vcParsed, err := verifiable.ParseCredential(
 		[]byte(jws),
 		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(issuerPubKey, kms.ED25519)))
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to decode VC JWS: %w", err))
+	}
+
+	vcDecodedBytes, err := vcParsed.MarshalJSON()
+	if err != nil {
+		panic(fmt.Errorf("failed to marshal VC: %w", err))
 	}
 
 	// The Holder then e.g. can save the credential to her personal verifiable credential wallet.
@@ -298,7 +313,7 @@ func ExampleCredential_JWTClaims() {
 `
 
 	// The Holder wants to send the credential to the Verifier in JWS.
-	vc, _, err := verifiable.NewCredential([]byte(vcStrFromWallet))
+	vc, err := verifiable.ParseCredential([]byte(vcStrFromWallet))
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to decode VC JSON: %w", err))
 	}
@@ -352,7 +367,7 @@ func ExampleCredential_AddLinkedDataProof() {
 }
 `
 
-	vc, _, err := verifiable.NewCredential([]byte(vcJSON))
+	vc, err := verifiable.ParseCredential([]byte(vcJSON))
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to decode VC JSON: %w", err))
 	}
@@ -446,7 +461,7 @@ func ExampleCredential_AddLinkedDataProofMultiProofs() {
 }
 `
 
-	vc, _, err := verifiable.NewCredential([]byte(vcJSON))
+	vc, err := verifiable.ParseCredential([]byte(vcJSON))
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to decode VC JSON: %w", err))
 	}
@@ -487,7 +502,7 @@ func ExampleCredential_AddLinkedDataProofMultiProofs() {
 	ed25519Suite := ed25519signature2018.New(suite.WithVerifier(ed25519signature2018.NewPublicKeyVerifier()))
 	jsonWebSignatureSuite := jsonwebsignature2020.New(suite.WithVerifier(jsonwebsignature2020.NewPublicKeyVerifier()))
 
-	_, _, err = verifiable.NewCredential(vcBytes,
+	_, err = verifiable.ParseCredential(vcBytes,
 		verifiable.WithEmbeddedSignatureSuites(ed25519Suite, jsonWebSignatureSuite),
 		verifiable.WithPublicKeyFetcher(func(issuerID, keyID string) (*sigverifier.PublicKey, error) {
 			switch keyID {

--- a/pkg/doc/verifiable/example_presentation_test.go
+++ b/pkg/doc/verifiable/example_presentation_test.go
@@ -25,12 +25,12 @@ var (
 )
 
 //nolint:lll
-func ExampleNewPresentation() {
+func ExampleParsePresentation() {
 	// A Holder sends to the Verifier a verifiable presentation in JWS form.
 	vpJWS := "eyJhbGciOiJFZERTQSIsImtpZCI6ImtleS0xIiwidHlwIjoiSldUIn0.eyJpc3MiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJqdGkiOiJ1cm46dXVpZDozOTc4MzQ0Zi04NTk2LTRjM2EtYTk3OC04ZmNhYmEzOTAzYzUiLCJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiIsIlVuaXZlcnNpdHlEZWdyZWVDcmVkZW50aWFsIl0sInZlcmlmaWFibGVDcmVkZW50aWFsIjpbeyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sImNyZWRlbnRpYWxTY2hlbWEiOltdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwidW5pdmVyc2l0eSI6Ik1JVCJ9LCJpZCI6ImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSIsIm5hbWUiOiJKYXlkZW4gRG9lIiwic3BvdXNlIjoiZGlkOmV4YW1wbGU6YzI3NmUxMmVjMjFlYmZlYjFmNzEyZWJjNmYxIn0sImV4cGlyYXRpb25EYXRlIjoiMjAyMC0wMS0wMVQxOToyMzoyNFoiLCJpZCI6Imh0dHA6Ly9leGFtcGxlLmVkdS9jcmVkZW50aWFscy8xODcyIiwiaXNzdWFuY2VEYXRlIjoiMjAxMC0wMS0wMVQxOToyMzoyNFoiLCJpc3N1ZXIiOnsiaWQiOiJkaWQ6ZXhhbXBsZTo3NmUxMmVjNzEyZWJjNmYxYzIyMWViZmViMWYiLCJuYW1lIjoiRXhhbXBsZSBVbml2ZXJzaXR5In0sInJlZmVyZW5jZU51bWJlciI6OC4zMjk0ODQ3ZSswNywidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIlVuaXZlcnNpdHlEZWdyZWVDcmVkZW50aWFsIl19XX19.RlO_1B-7qhQNwo2mmOFUWSa8A6hwaJrtq3q7yJDkKq4k6B-EJ-oyLNM6H_g2_nko2Yg9Im1CiROFm6nK12U_AQ" //nolint:lll
 
 	// Holder received and decodes it.
-	vp, err := verifiable.NewPresentation(
+	vp, err := verifiable.ParsePresentation(
 		[]byte(vpJWS),
 
 		verifiable.WithPresPublicKeyFetcher(verifiable.SingleKey(holderPubKey, kms.ED25519)))
@@ -98,7 +98,7 @@ func ExamplePresentation_JWTClaims() {
 `
 
 	// The Holder wants to send the presentation to the Verifier in JWS.
-	vp, err := verifiable.NewUnverifiedPresentation([]byte(vpStrFromWallet))
+	vp, err := verifiable.ParseUnverifiedPresentation([]byte(vpStrFromWallet))
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to decode VP JSON: %w", err))
 	}
@@ -154,7 +154,7 @@ func ExampleCredential_Presentation() {
 }
 `
 
-	vc, _, err := verifiable.NewCredential([]byte(vcStrFromWallet))
+	vc, err := verifiable.ParseCredential([]byte(vcStrFromWallet))
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to decode VC JSON: %w", err))
 	}
@@ -195,7 +195,7 @@ func ExamplePresentation_SetCredentials() {
 		Holder: "did:example:ebfeb1f712ebc6f1c276e12ec21",
 	}
 
-	// The first VC is created on fly (or just decoded using NewCredential).
+	// The first VC is created on fly (or just decoded using ParseCredential).
 	vc := &verifiable.Credential{
 		Context: []string{
 			"https://www.w3.org/2018/credentials/v1",
@@ -478,7 +478,7 @@ func ExamplePresentation_MarshalledCredentials() {
 	// Decode VP from JWS.
 	// Note that VC-s inside will be decoded as well. If they are JWS, their signature is verified
 	// and thus we need to make sure the public key fetcher can access the
-	vp, err = verifiable.NewPresentation(
+	vp, err = verifiable.ParsePresentation(
 		[]byte(vpJWS),
 		verifiable.WithPresPublicKeyFetcher(func(issuerID, keyID string) (*verifier.PublicKey, error) {
 			switch issuerID {
@@ -512,7 +512,7 @@ func ExamplePresentation_MarshalledCredentials() {
 
 	// Decoded credential. Note that no public key fetcher is passed as the VC was already decoded (and proof verified)
 	// when VP was decoded.
-	vcDecoded, _, err := verifiable.NewCredential(vpCreds[0])
+	vcDecoded, err := verifiable.ParseCredential(vpCreds[0])
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to decode VC: %w", err))
 	}

--- a/pkg/doc/verifiable/linked_data_proof.go
+++ b/pkg/doc/verifiable/linked_data_proof.go
@@ -113,7 +113,7 @@ func addLinkedDataProof(context *LinkedDataProofContext, jsonldBytes []byte) ([]
 		return nil, err
 	}
 
-	proofs, err := decodeProof(rProof.Proof)
+	proofs, err := parseProof(rProof.Proof)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/doc/verifiable/linked_data_proof_test.go
+++ b/pkg/doc/verifiable/linked_data_proof_test.go
@@ -104,7 +104,7 @@ func TestLinkedDataProofSignerAndVerifier(t *testing.T) {
 		verifierSuite := ed25519signature2018.New(
 			suite.WithVerifier(ed25519signature2018.NewPublicKeyVerifier()),
 			suite.WithCompactProof())
-		vcDecoded, _, err := newTestCredential(vcWithEd25519ProofBytes,
+		vcDecoded, err := parseTestCredential(vcWithEd25519ProofBytes,
 			WithEmbeddedSignatureSuites(verifierSuite),
 			WithPublicKeyFetcher(SingleKey(ed25519PubKey, kms.ED25519)))
 		require.NoError(t, err)
@@ -120,14 +120,14 @@ func TestLinkedDataProofSignerAndVerifier(t *testing.T) {
 				suite.WithVerifier(ecdsasecp256k1signature2019.NewPublicKeyVerifier())),
 		}
 
-		vcDecoded, _, err := newTestCredential(vcWithEd25519ProofBytes,
+		vcDecoded, err := parseTestCredential(vcWithEd25519ProofBytes,
 			WithEmbeddedSignatureSuites(verifierSuites...),
 			WithPublicKeyFetcher(SingleKey(ed25519PubKey, kms.ED25519)))
 		require.NoError(t, err)
 		require.Equal(t, vcWithEd25519Proof, vcDecoded)
 
 		pubKeyBytes := elliptic.Marshal(ecdsaPrivKey.Curve, ecdsaPrivKey.X, ecdsaPrivKey.Y)
-		vcDecoded, _, err = newTestCredential(vcWithSecp256k1ProofBytes,
+		vcDecoded, err = parseTestCredential(vcWithSecp256k1ProofBytes,
 			WithEmbeddedSignatureSuites(verifierSuites...),
 			WithPublicKeyFetcher(func(issuerID, keyID string) (*verifier.PublicKey, error) {
 				return &verifier.PublicKey{
@@ -148,7 +148,7 @@ func TestLinkedDataProofSignerAndVerifier(t *testing.T) {
 	})
 
 	t.Run("no signature suite defined", func(t *testing.T) {
-		vcDecoded, _, err := newTestCredential(vcWithEd25519ProofBytes,
+		vcDecoded, err := parseTestCredential(vcWithEd25519ProofBytes,
 			WithPublicKeyFetcher(SingleKey(ed25519PubKey, kms.ED25519)))
 		require.NoError(t, err)
 		require.NotNil(t, vcDecoded)
@@ -156,7 +156,7 @@ func TestLinkedDataProofSignerAndVerifier(t *testing.T) {
 }
 
 func prepareVCWithEd25519LDP(t *testing.T, vcJSON string, privKey []byte) *Credential {
-	vc, err := NewUnverifiedCredential([]byte(vcJSON))
+	vc, err := ParseUnverifiedCredential([]byte(vcJSON))
 	require.NoError(t, err)
 
 	ed25519SignerSuite := ed25519signature2018.New(
@@ -181,7 +181,7 @@ func prepareVCWithEd25519LDP(t *testing.T, vcJSON string, privKey []byte) *Crede
 }
 
 func prepareVCWithSecp256k1LDP(t *testing.T, vcJSON string, privKey *ecdsa.PrivateKey) *Credential {
-	vc, err := NewUnverifiedCredential([]byte(vcJSON))
+	vc, err := ParseUnverifiedCredential([]byte(vcJSON))
 	require.NoError(t, err)
 
 	ed25519SignerSuite := ecdsasecp256k1signature2019.New(

--- a/pkg/doc/verifiable/presentation.go
+++ b/pkg/doc/verifiable/presentation.go
@@ -163,7 +163,7 @@ const basePresentationSchema = `
 var basePresentationSchemaLoader = gojsonschema.NewStringLoader(basePresentationSchema)
 
 // MarshalledCredential defines marshalled Verifiable Credential enclosed into Presentation.
-// MarshalledCredential can be passed to verifiable.NewCredential().
+// MarshalledCredential can be passed to verifiable.ParseCredential().
 type MarshalledCredential []byte
 
 // Presentation Verifiable Presentation base data model definition
@@ -210,7 +210,7 @@ func (vp *Presentation) SetCredentials(creds ...interface{}) error {
 
 	convertToVC := func(vcStr string) (interface{}, error) {
 		// Check if passed VC is correct one.
-		vc, err := NewUnverifiedCredential([]byte(vcStr))
+		vc, err := ParseUnverifiedCredential([]byte(vcStr))
 		if err != nil {
 			return nil, fmt.Errorf("check VC: %w", err)
 		}
@@ -367,9 +367,9 @@ func WithPresJSONLDDocumentLoader(documentLoader ld.DocumentLoader) Presentation
 	}
 }
 
-// NewPresentation creates an instance of Verifiable Presentation by reading a JSON document from bytes.
+// ParsePresentation creates an instance of Verifiable Presentation by reading a JSON document from bytes.
 // It also applies miscellaneous options like custom decoders or settings of schema validation.
-func NewPresentation(vpData []byte, opts ...PresentationOpt) (*Presentation, error) {
+func ParsePresentation(vpData []byte, opts ...PresentationOpt) (*Presentation, error) {
 	// Apply options
 	vpOpts := defaultPresentationOpts()
 
@@ -399,10 +399,10 @@ func NewPresentation(vpData []byte, opts ...PresentationOpt) (*Presentation, err
 	return p, nil
 }
 
-// NewUnverifiedPresentation decodes Verifiable Presentation from bytes which could be marshalled JSON or
+// ParseUnverifiedPresentation parses Verifiable Presentation from bytes which could be marshalled JSON or
 // serialized JWT. It does not make a proof check though. Can be used for purposes of decoding of VP stored in a wallet.
 // Please use this function with caution.
-func NewUnverifiedPresentation(vpBytes []byte) (*Presentation, error) {
+func ParseUnverifiedPresentation(vpBytes []byte) (*Presentation, error) {
 	// Apply options
 	vpOpts := &presentationOpts{
 		disabledProofCheck: true,
@@ -432,7 +432,7 @@ func newPresentation(vpRaw *rawPresentation, vpOpts *presentationOpts) (*Present
 		return nil, fmt.Errorf("decode credentials of presentation: %w", err)
 	}
 
-	proofs, err := decodeProof(vpRaw.Proof)
+	proofs, err := parseProof(vpRaw.Proof)
 	if err != nil {
 		return nil, fmt.Errorf("fill credential proof from raw: %w", err)
 	}

--- a/pkg/doc/verifiable/presentation_jwt_proof_test.go
+++ b/pkg/doc/verifiable/presentation_jwt_proof_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
-func TestNewPresentationFromJWS(t *testing.T) {
+func TestParsePresentationFromJWS(t *testing.T) {
 	vpBytes := []byte(validPresentation)
 
 	keyFetcher := createPresKeyFetcher(t)
@@ -90,7 +90,7 @@ func TestNewPresentationFromJWS(t *testing.T) {
 	})
 }
 
-func TestNewPresentationFromJWS_EdDSA(t *testing.T) {
+func TestParsePresentationFromJWS_EdDSA(t *testing.T) {
 	vpBytes := []byte(validPresentation)
 
 	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
@@ -116,7 +116,7 @@ func TestNewPresentationFromJWS_EdDSA(t *testing.T) {
 	require.Equal(t, vp, vpFromJWS)
 }
 
-func TestNewPresentationFromUnsecuredJWT(t *testing.T) {
+func TestParsePresentationFromUnsecuredJWT(t *testing.T) {
 	vpBytes := []byte(validPresentation)
 
 	t.Run("Decoding presentation from unsecured JWT", func(t *testing.T) {
@@ -142,7 +142,7 @@ func TestNewPresentationFromUnsecuredJWT(t *testing.T) {
 	})
 }
 
-func TestNewPresentationWithVCJWT(t *testing.T) {
+func TestParsePresentationWithVCJWT(t *testing.T) {
 	r := require.New(t)
 
 	// Create and encode VP.
@@ -229,7 +229,7 @@ func TestNewPresentationWithVCJWT(t *testing.T) {
 		r.NoError(err)
 		r.Len(vpCreds, 1)
 
-		vcDecoded, _, err := newTestCredential(vpCreds[0])
+		vcDecoded, err := parseTestCredential(vpCreds[0])
 		r.NoError(err)
 
 		r.Equal(vc.stringJSON(t), vcDecoded.stringJSON(t))
@@ -264,7 +264,7 @@ func TestNewPresentationWithVCJWT(t *testing.T) {
 		r.NoError(err)
 		r.Len(vpCreds, 1)
 
-		vcDecoded, _, err := newTestCredential(vpCreds[0])
+		vcDecoded, err := parseTestCredential(vpCreds[0])
 		r.NoError(err)
 
 		r.Equal(vc.stringJSON(t), vcDecoded.stringJSON(t))

--- a/pkg/doc/verifiable/presentation_ldp_test.go
+++ b/pkg/doc/verifiable/presentation_ldp_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
-func TestNewPresentationFromLinkedDataProof(t *testing.T) {
+func TestParsePresentationFromLinkedDataProof(t *testing.T) {
 	r := require.New(t)
 
 	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)

--- a/pkg/doc/verifiable/presentation_test.go
+++ b/pkg/doc/verifiable/presentation_test.go
@@ -76,7 +76,7 @@ const validEmptyPresentation = `
 }
 `
 
-func TestNewPresentation(t *testing.T) {
+func TestParsePresentation(t *testing.T) {
 	t.Run("creates a new Verifiable Presentation from JSON with valid structure", func(t *testing.T) {
 		vp, err := newTestPresentation([]byte(validPresentation), WithPresStrictValidation())
 		require.NoError(t, err)
@@ -355,7 +355,7 @@ func TestPresentation_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, vp2)
 
-	// verify that verifiable presentations created by NewPresentation() and MarshalJSON() matches
+	// verify that verifiable presentations created by ParsePresentation() and MarshalJSON() matches
 	require.Equal(t, vp, vp2)
 }
 
@@ -363,7 +363,7 @@ func TestPresentation_SetCredentials(t *testing.T) {
 	r := require.New(t)
 	vp := Presentation{}
 
-	vc, err := NewUnverifiedCredential([]byte(validCredential))
+	vc, err := ParseUnverifiedCredential([]byte(validCredential))
 	r.NoError(err)
 
 	// Pass Credential struct pointer
@@ -431,7 +431,7 @@ func TestPresentation_decodeCredentials(t *testing.T) {
 	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
 	r.NoError(err)
 
-	vc, _, err := newTestCredential([]byte(validCredential))
+	vc, err := parseTestCredential([]byte(validCredential))
 	r.NoError(err)
 
 	jwtClaims, err := vc.JWTClaims(false)
@@ -491,9 +491,9 @@ func TestWithPresJSONLDDocumentLoader(t *testing.T) {
 	require.Equal(t, documentLoader, opts.jsonldDocumentLoader)
 }
 
-func TestNewUnverifiedPresentation(t *testing.T) {
+func TestParseUnverifiedPresentation(t *testing.T) {
 	// happy path
-	vp, err := NewUnverifiedPresentation([]byte(validPresentation))
+	vp, err := ParseUnverifiedPresentation([]byte(validPresentation))
 	require.NoError(t, err)
 	require.NotNil(t, vp)
 
@@ -507,12 +507,12 @@ func TestNewUnverifiedPresentation(t *testing.T) {
 	vpWithoutProofBytes, err := json.Marshal(vpJSON)
 	require.NoError(t, err)
 
-	vp, err = NewUnverifiedPresentation(vpWithoutProofBytes)
+	vp, err = ParseUnverifiedPresentation(vpWithoutProofBytes)
 	require.NoError(t, err)
 	require.NotNil(t, vp)
 
 	// VP decoding error
-	vp, err = NewUnverifiedPresentation([]byte("invalid"))
+	vp, err = ParseUnverifiedPresentation([]byte("invalid"))
 	require.Error(t, err)
 	require.Nil(t, vp)
 }

--- a/pkg/doc/verifiable/support_test.go
+++ b/pkg/doc/verifiable/support_test.go
@@ -276,7 +276,7 @@ func publicKeyPemToBytes(publicKey *rsa.PublicKey) []byte {
 }
 
 func createVCWithLinkedDataProof() (*Credential, PublicKeyFetcher) {
-	vc, err := NewUnverifiedCredential([]byte(validCredential))
+	vc, err := ParseUnverifiedCredential([]byte(validCredential))
 	if err != nil {
 		panic(err)
 	}
@@ -303,7 +303,7 @@ func createVCWithLinkedDataProof() (*Credential, PublicKeyFetcher) {
 }
 
 func createVCWithTwoLinkedDataProofs() (*Credential, PublicKeyFetcher) {
-	vc, err := NewUnverifiedCredential([]byte(validCredential))
+	vc, err := ParseUnverifiedCredential([]byte(validCredential))
 	if err != nil {
 		panic(err)
 	}
@@ -408,10 +408,11 @@ func addJSONLDCachedContext(loader *ld.CachingDocumentLoader, contextURL, contex
 	loader.AddDocument(contextURL, reader)
 }
 
-func newTestCredential(vcData []byte, opts ...CredentialOpt) (*Credential, []byte, error) {
-	return NewCredential(vcData, append([]CredentialOpt{WithJSONLDDocumentLoader(testDocumentLoader)}, opts...)...)
+func parseTestCredential(vcData []byte, opts ...CredentialOpt) (*Credential, error) {
+	return ParseCredential(vcData, append([]CredentialOpt{WithJSONLDDocumentLoader(testDocumentLoader)}, opts...)...)
 }
 
 func newTestPresentation(vpData []byte, opts ...PresentationOpt) (*Presentation, error) {
-	return NewPresentation(vpData, append([]PresentationOpt{WithPresJSONLDDocumentLoader(testDocumentLoader)}, opts...)...)
+	return ParsePresentation(vpData,
+		append([]PresentationOpt{WithPresJSONLDDocumentLoader(testDocumentLoader)}, opts...)...)
 }

--- a/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
+++ b/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
@@ -79,7 +79,7 @@ func main() {
 }
 
 func encodeVCToJWS(vcBytes []byte, privateKey *rsa.PrivateKey) {
-	credential, _, err := verifiable.NewCredential(vcBytes, verifiable.WithNoProofCheck())
+	credential, err := verifiable.ParseCredential(vcBytes, verifiable.WithNoProofCheck())
 	if err != nil {
 		abort("failed to decode credential: %v", err)
 	}
@@ -98,7 +98,7 @@ func encodeVCToJWS(vcBytes []byte, privateKey *rsa.PrivateKey) {
 }
 
 func encodeVPToJWS(vpBytes []byte, audience string, privateKey *rsa.PrivateKey, publicKey *rsa.PublicKey) {
-	vp, err := verifiable.NewPresentation(vpBytes,
+	vp, err := verifiable.ParsePresentation(vpBytes,
 		// do not test the cryptographic proofs (see https://github.com/w3c/vc-test-suite/issues/101)
 		verifiable.WithPresNoProofCheck(),
 		// the public key is used to decode verifiable credentials passed as JWS to the presentation
@@ -121,7 +121,7 @@ func encodeVPToJWS(vpBytes []byte, audience string, privateKey *rsa.PrivateKey, 
 }
 
 func encodeVCToJWTUnsecured(vcBytes []byte) {
-	credential, _, err := verifiable.NewCredential(vcBytes, verifiable.WithNoProofCheck())
+	credential, err := verifiable.ParseCredential(vcBytes, verifiable.WithNoProofCheck())
 	if err != nil {
 		abort("failed to decode credential: %v", err)
 	}
@@ -141,7 +141,7 @@ func encodeVCToJWTUnsecured(vcBytes []byte) {
 
 func decodeVCJWTToJSON(vcBytes []byte, publicKey *rsa.PublicKey) {
 	// Asked to decode JWT
-	credential, _, err := verifiable.NewCredential(vcBytes,
+	credential, err := verifiable.ParseCredential(vcBytes,
 		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(publicKeyPemToBytes(publicKey), kms.RSA)),
 		// do not test the cryptographic proofs (see https://github.com/w3c/vc-test-suite/issues/101)
 		verifiable.WithNoProofCheck())
@@ -209,7 +209,7 @@ func encodeVCToJSON(vcBytes []byte, testFileName string) {
 		vcOpts = append(vcOpts, verifiable.WithBaseContextValidation())
 	}
 
-	credential, _, err := verifiable.NewCredential(vcBytes, vcOpts...)
+	credential, err := verifiable.ParseCredential(vcBytes, vcOpts...)
 	if err != nil {
 		abort("failed to decode credential: %v", err)
 	}
@@ -225,7 +225,7 @@ func encodeVCToJSON(vcBytes []byte, testFileName string) {
 func encodeVPToJSON(vcBytes []byte) {
 	// https://www.w3.org/TR/vc-data-model/#presentations-0 states "If present" under verifiableCredential
 	// but the test suite requires the element to be present. Hence, WithPresRequireVC is used in test suite runs.
-	vp, err := verifiable.NewPresentation(vcBytes, verifiable.WithPresRequireVC())
+	vp, err := verifiable.ParsePresentation(vcBytes, verifiable.WithPresRequireVC())
 	if err != nil {
 		abort("failed to decode presentation: %v", err)
 	}

--- a/pkg/store/verifiable/store.go
+++ b/pkg/store/verifiable/store.go
@@ -162,7 +162,7 @@ func (s *StoreImplementation) GetCredential(id string) (*verifiable.Credential, 
 		return nil, fmt.Errorf("failed to get vc: %w", err)
 	}
 
-	vc, err := verifiable.NewUnverifiedCredential(vcBytes)
+	vc, err := verifiable.ParseUnverifiedCredential(vcBytes)
 	if err != nil {
 		return nil, fmt.Errorf("new credential failed: %w", err)
 	}
@@ -177,7 +177,7 @@ func (s *StoreImplementation) GetPresentation(id string) (*verifiable.Presentati
 		return nil, fmt.Errorf("failed to get vc: %w", err)
 	}
 
-	vp, err := verifiable.NewPresentation(vpBytes, verifiable.WithDisabledPresentationProofCheck())
+	vp, err := verifiable.ParsePresentation(vpBytes, verifiable.WithDisabledPresentationProofCheck())
 	if err != nil {
 		return nil, fmt.Errorf("new presentation failed: %w", err)
 	}

--- a/pkg/store/verifiable/store_test.go
+++ b/pkg/store/verifiable/store_test.go
@@ -298,7 +298,7 @@ func TestGetVC(t *testing.T) {
 			StorageProviderValue: mockstore.NewMockStoreProvider(),
 		})
 		require.NoError(t, err)
-		udVC, _, err := verifiable.NewCredential([]byte(udCredential))
+		udVC, err := verifiable.ParseCredential([]byte(udCredential))
 		require.NoError(t, err)
 		require.NoError(t, s.SaveCredential(sampleCredentialName, udVC))
 		vc, err := s.GetCredential("http://example.edu/credentials/1872")
@@ -321,7 +321,7 @@ func TestGetVC(t *testing.T) {
 			StorageProviderValue: mockstore.NewMockStoreProvider(),
 		})
 		require.NoError(t, err)
-		udVC, _, err := verifiable.NewCredential([]byte(udCredentialWithoutID))
+		udVC, err := verifiable.ParseCredential([]byte(udCredentialWithoutID))
 		require.NoError(t, err)
 		require.NoError(t, s.SaveCredential(sampleCredentialName, udVC))
 
@@ -509,7 +509,7 @@ func TestGetVP(t *testing.T) {
 			StorageProviderValue: mockstore.NewMockStoreProvider(),
 		})
 		require.NoError(t, err)
-		udVP, err := verifiable.NewPresentation([]byte(udPresentation),
+		udVP, err := verifiable.ParsePresentation([]byte(udPresentation),
 			verifiable.WithDisabledPresentationProofCheck())
 		require.NoError(t, err)
 		require.NoError(t, s.SavePresentation(samplePresentationName, udVP))
@@ -531,7 +531,7 @@ func TestGetVP(t *testing.T) {
 			StorageProviderValue: mockstore.NewMockStoreProvider(),
 		})
 		require.NoError(t, err)
-		udVP, err := verifiable.NewPresentation([]byte(udVerifiablePresentation))
+		udVP, err := verifiable.ParsePresentation([]byte(udVerifiablePresentation))
 		require.NoError(t, err)
 		require.NoError(t, s.SavePresentation(samplePresentationName, udVP))
 
@@ -657,7 +657,7 @@ func TestGetPresentations(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		udVP, err := verifiable.NewPresentation([]byte(udVerifiablePresentation))
+		udVP, err := verifiable.ParsePresentation([]byte(udVerifiablePresentation))
 		require.NoError(t, err)
 		require.NoError(t, s.SavePresentation(samplePresentationName, udVP))
 

--- a/test/bdd/pkg/presentproof/presentproof_sdk_steps.go
+++ b/test/bdd/pkg/presentproof/presentproof_sdk_steps.go
@@ -161,7 +161,7 @@ func (a *SDKSteps) acceptRequestPresentation(prover, verifier string) error {
 		return err
 	}
 
-	vp, err := verifiable.NewUnverifiedPresentation(
+	vp, err := verifiable.ParseUnverifiedPresentation(
 		[]byte(fmt.Sprintf(vpStrFromWallet, conn.MyDID, conn.MyDID)),
 	)
 	if err != nil {

--- a/test/bdd/pkg/verifiable/verifiable_steps.go
+++ b/test/bdd/pkg/verifiable/verifiable_steps.go
@@ -148,7 +148,7 @@ func (s *SDKSteps) verifyCredential(holder string) error {
 
 	sigSuite := ed25519signature2018.New(suite.WithVerifier(ed25519signature2018.NewPublicKeyVerifier()))
 
-	parsedVC, _, err := verifiable.NewCredential(s.issuedVCBytes,
+	parsedVC, err := verifiable.ParseCredential(s.issuedVCBytes,
 		verifiable.WithPublicKeyFetcher(pKeyFetcher),
 		verifiable.WithEmbeddedSignatureSuites(sigSuite))
 	if err != nil {


### PR DESCRIPTION
closes #1839

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

The following is refactored:
1. Renaming of API functions:
  - NewCredential()  -> ParseCredential()
  - NewUnverifiedCredential -> ParseUnverifiedCredential()
  - NewPresentation() -> ParsePresentation()
  - NewUnverifiedPresentation() -> ParseUnverifiedPresentation() 
2. Return 2 values from NewCredential() - the second []byte is useless in the most of the cases.