### PR TITLE
feat: Present Proof saves the presentation to the verifiable store

### DIFF
--- a/pkg/client/presentproof/client.go
+++ b/pkg/client/presentproof/client.go
@@ -136,8 +136,8 @@ func (c *Client) DeclineProposePresentation(piID, reason string) error {
 }
 
 // AcceptPresentation is used by the Verifier to accept a presentation.
-func (c *Client) AcceptPresentation(piID string) error {
-	return c.service.ActionContinue(piID, nil)
+func (c *Client) AcceptPresentation(piID string, names ...string) error {
+	return c.service.ActionContinue(piID, WithFriendlyNames(names...))
 }
 
 // DeclinePresentation is used by the Verifier to decline a presentation.
@@ -164,4 +164,9 @@ func WithProposePresentation(msg *ProposePresentation) presentproof.Opt {
 func WithRequestPresentation(msg *RequestPresentation) presentproof.Opt {
 	origin := presentproof.RequestPresentation(*msg)
 	return presentproof.WithRequestPresentation(&origin)
+}
+
+// WithFriendlyNames allows providing names for the presentations.
+func WithFriendlyNames(names ...string) presentproof.Opt {
+	return presentproof.WithFriendlyNames(names...)
 }

--- a/pkg/controller/command/presentproof/command.go
+++ b/pkg/controller/command/presentproof/command.go
@@ -377,7 +377,7 @@ func (c *Command) AcceptPresentation(rw io.Writer, req io.Reader) command.Error 
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyPIID))
 	}
 
-	if err := c.client.AcceptPresentation(args.PIID); err != nil {
+	if err := c.client.AcceptPresentation(args.PIID, args.Names...); err != nil {
 		logutil.LogError(logger, commandName, acceptPresentation, err.Error())
 		return command.NewExecuteError(AcceptPresentationErrorCode, err)
 	}

--- a/pkg/controller/command/presentproof/models.go
+++ b/pkg/controller/command/presentproof/models.go
@@ -74,6 +74,8 @@ type ActionsResponse struct {
 type AcceptPresentationArgs struct {
 	// PIID Protocol instance ID
 	PIID string `json:"piid"`
+	// Names represent the names of how presentations will be stored
+	Names []string `json:"names"`
 }
 
 // AcceptPresentationResponse model

--- a/pkg/controller/rest/presentproof/models.go
+++ b/pkg/controller/rest/presentproof/models.go
@@ -140,6 +140,10 @@ type presentProofAcceptPresentationRequest struct { // nolint: unused,deadcode
 	// in: path
 	// required: true
 	PIID string `json:"piid"`
+
+	// in: body
+	// required: true
+	Names []string `json:""`
 }
 
 // presentProofAcceptPresentationResponse model

--- a/pkg/controller/rest/presentproof/operation_test.go
+++ b/pkg/controller/rest/presentproof/operation_test.go
@@ -147,9 +147,24 @@ func TestOperation_AcceptPresentation(t *testing.T) {
 		operation, err := New(provider(ctrl))
 		require.NoError(t, err)
 
-		_, code, err := sendRequestToHandler(
+		buf, code, err := sendRequestToHandler(
 			handlerLookup(t, operation, acceptPresentation),
 			nil,
+			strings.Replace(acceptPresentation, `{piid}`, "1234", 1),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, code)
+		require.Contains(t, buf.String(), "names payload was not provided")
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		operation, err := New(provider(ctrl))
+		require.NoError(t, err)
+
+		_, code, err := sendRequestToHandler(
+			handlerLookup(t, operation, acceptPresentation),
+			bytes.NewBufferString(`[]`),
 			strings.Replace(acceptPresentation, `{piid}`, "1234", 1),
 		)
 

--- a/pkg/internal/gomocks/didcomm/protocol/presentproof/mocks.go
+++ b/pkg/internal/gomocks/didcomm/protocol/presentproof/mocks.go
@@ -9,6 +9,7 @@ import (
 	service "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	vdri "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	storage "github.com/hyperledger/aries-framework-go/pkg/storage"
+	verifiable "github.com/hyperledger/aries-framework-go/pkg/store/verifiable"
 	reflect "reflect"
 )
 
@@ -75,4 +76,18 @@ func (m *MockProvider) VDRIRegistry() vdri.Registry {
 func (mr *MockProviderMockRecorder) VDRIRegistry() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VDRIRegistry", reflect.TypeOf((*MockProvider)(nil).VDRIRegistry))
+}
+
+// VerifiableStore mocks base method
+func (m *MockProvider) VerifiableStore() verifiable.Store {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifiableStore")
+	ret0, _ := ret[0].(verifiable.Store)
+	return ret0
+}
+
+// VerifiableStore indicates an expected call of VerifiableStore
+func (mr *MockProviderMockRecorder) VerifiableStore() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifiableStore", reflect.TypeOf((*MockProvider)(nil).VerifiableStore))
 }

--- a/test/aries-js-worker/test/didexchange/didexchange_e2e.js
+++ b/test/aries-js-worker/test/didexchange/didexchange_e2e.js
@@ -30,6 +30,8 @@ const wasmMode = 'wasm'
  *
  */
 export const didExchangeClient = class {
+    hasMediator = false;
+
     constructor(agent1, agent2,mode) {
         this.agent1 = agent1
         this.agent2 = agent2
@@ -51,6 +53,7 @@ export const didExchangeClient = class {
     }
 
     async performDIDExchangeE2EWASM() {
+        this.hasMediator = true;
         // receive an invitation from the router via the controller API
         var invitation = await this.createInvitationFromRouter(routerCreateInvitationPath)
         // agent1 accepts the invitation from the router
@@ -95,8 +98,10 @@ export const didExchangeClient = class {
     }
 
     async destroy(){
-        await this.agent1.router.unregister()
-        await this.agent2.router.unregister()
+        if (this.hasMediator){
+            await this.agent1.mediator.unregister()
+            await this.agent2.mediator.unregister()
+        }
 
         this.agent1.destroy()
         this.agent2.destroy()

--- a/test/aries-js-worker/test/presentproof/presentproof.js
+++ b/test/aries-js-worker/test/presentproof/presentproof.js
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import {environment} from "../environment.js";
-import {newDIDExchangeClient,newDIDExchangeRESTClient} from "../didexchange/didexchange_e2e.js";
+import {newDIDExchangeClient, newDIDExchangeRESTClient} from "../didexchange/didexchange_e2e.js";
 
 const agent1ControllerApiUrl = `${environment.HTTP_SCHEME}://${environment.SECOND_USER_HOST}:${environment.SECOND_USER_API_PORT}`
 const agent2ControllerApiUrl = `${environment.HTTP_SCHEME}://${environment.USER_HOST}:${environment.USER_API_PORT}`
@@ -12,13 +12,26 @@ const agent2ControllerApiUrl = `${environment.HTTP_SCHEME}://${environment.USER_
 const restMode = 'rest'
 const wasmMode = 'wasm'
 
-describe("Present Proof - The Verifier begins with a request presentation", async function() {
-    describe(restMode, function() { presentProof(restMode) })
-    describe(wasmMode, function() { presentProof(wasmMode) })
+const presentation = {
+    "presentations~attach": [{
+        "lastmod_time": "0001-01-01T00:00:00Z",
+        "data": {
+            "base64": "ZXlKaGJHY2lPaUp1YjI1bElpd2lkSGx3SWpvaVNsZFVJbjAuZXlKcGMzTWlPaUprYVdRNlpYaGhiWEJzWlRwbFltWmxZakZtTnpFeVpXSmpObVl4WXpJM05tVXhNbVZqTWpFaUxDSnFkR2tpT2lKMWNtNDZkWFZwWkRvek9UYzRNelEwWmkwNE5UazJMVFJqTTJFdFlUazNPQzA0Wm1OaFltRXpPVEF6WXpVaUxDSjJjQ0k2ZXlKQVkyOXVkR1Y0ZENJNld5Sm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3ZNakF4T0M5amNtVmtaVzUwYVdGc2N5OTJNU0lzSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk4eU1ERTRMMk55WldSbGJuUnBZV3h6TDJWNFlXMXdiR1Z6TDNZeElsMHNJbWh2YkdSbGNpSTZJbVJwWkRwbGVHRnRjR3hsT21WaVptVmlNV1kzTVRKbFltTTJaakZqTWpjMlpURXlaV015TVNJc0ltbGtJam9pZFhKdU9uVjFhV1E2TXprM09ETTBOR1l0T0RVNU5pMDBZek5oTFdFNU56Z3RPR1pqWVdKaE16a3dNMk0xSWl3aWRIbHdaU0k2V3lKV1pYSnBabWxoWW14bFVISmxjMlZ1ZEdGMGFXOXVJaXdpUTNKbFpHVnVkR2xoYkUxaGJtRm5aWEpRY21WelpXNTBZWFJwYjI0aVhTd2lkbVZ5YVdacFlXSnNaVU55WldSbGJuUnBZV3dpT201MWJHeDlmUS4="
+        }
+    }]
+}
+
+describe("Present Proof - The Verifier begins with a request presentation", async function () {
+    describe(restMode, function () {
+        presentProof(restMode)
+    })
+    describe(wasmMode, function () {
+        presentProof(wasmMode)
+    })
 })
 
 // scenarios
-async function presentProof (mode) {
+async function presentProof(mode) {
     const verifierID = "verifier"
     const proverID = "prover"
     let connections
@@ -54,25 +67,52 @@ async function presentProof (mode) {
         })
     })
 
-    it("Prover accepts a request and sends a presentation to the Verifier", async function() {
+    it("Prover accepts a request and sends a presentation to the Verifier", async function () {
         let action = await getAction(prover)
         return prover.presentproof.acceptRequestPresentation({
             piid: action.piid,
-            // TODO need to add presentation depends on [Issue #1749]
-            presentation: {},
-            body: {}
+            presentation: presentation,
+            body: presentation
         })
     })
 
-    it("Verifier accepts a presentation", async function() {
+    const name = mode + ".js.presentation.test"
+
+    it("Verifier accepts a presentation", async function () {
         let action = await getAction(verifier)
         return verifier.presentproof.acceptPresentation({
             piid: action.piid,
+            names: [name],
+            body: [name],
         })
+    })
+
+    it("Verifier checks presentation", async function () {
+        await getPresentation(verifier, name)
     })
 }
 
-const retries = 15;
+const retries = 14;
+
+async function getPresentation(agent, name) {
+    for (let i = 0; i < retries; i++) {
+        try {
+            let res = await agent.verifiable.getPresentations()
+            if (res.result) {
+                for (let j = 0; j < res.result.length; j++) {
+                    if (res.result[j].name === name) {
+                        return
+                    }
+                }
+            }
+        } catch (e) {
+        }
+
+        await sleep(1000);
+    }
+
+    throw new Error("presentation not found")
+}
 
 async function getAction(agent) {
     for (let i = 0; i < retries; i++) {

--- a/test/aries-js-worker/test/vdri/vdri.js
+++ b/test/aries-js-worker/test/vdri/vdri.js
@@ -48,12 +48,13 @@ describe("VDRI", function () {
                     }
 
                     resp = await agents[i].vdri.resolveDID({id: id})
+                    break
                 } catch (e) {
-                    assert.fail(e.message);
                     if (!e.message.includes("DID does not exist")) {
                         assert.fail(e.message);
                     }
                     await new Promise(r => setTimeout(r, 1000));
+                    console.warn(e.message)
                 }
             }
             await agents[i].vdri.saveDID({

--- a/test/aries-js-worker/test/verifiable/verifiable.js
+++ b/test/aries-js-worker/test/verifiable/verifiable.js
@@ -144,12 +144,13 @@ async function verifiableStore(newAries, mode = wasmMode) {
         for (let i = 0; i < retries; i++) {
             try {
                 resp = await aries.vdri.resolveDID({id:getID(mode, didID)})
+                break
             }catch (e) {
-                assert.fail(e.message);
                 if (!e.message.includes("DID does not exist")) {
                     assert.fail(e.message);
                 }
                 await new Promise(r => setTimeout(r, 1000));
+                console.warn(e.message)
             }
         }
         did=resp.did

--- a/test/bdd/features/presentproof.feature
+++ b/test/bdd/features/presentproof.feature
@@ -12,9 +12,9 @@ Feature: Present Proof protocol
     Given "Alice" exchange DIDs with "Bob"
     Then "Alice" sends a request presentation to the "Bob"
     And "Bob" accepts a request and sends a presentation to the "Alice"
-    And "Alice" accepts a presentation
+    And "Alice" accepts a presentation with name "license"
+    And "Alice" checks that presentation is being stored under "license" name
     Then "Bob" checks the history of events "request-received,request-received,presentation-sent,presentation-sent,done,done"
-    And "Alice" checks the history of events "request-sent,request-sent,presentation-received,presentation-received,done,done"
   @decline_presentation
   Scenario: The Verifier declines presentation
     Given "Thomas" exchange DIDs with "Paul"
@@ -36,9 +36,9 @@ Feature: Present Proof protocol
     Then "Carol" sends a propose presentation to the "Andrew"
     And "Andrew" accepts a proposal and sends a request to the Prover
     And "Carol" accepts a request and sends a presentation to the "Andrew"
-    And "Andrew" accepts a presentation
+    And "Andrew" accepts a presentation with name "passport"
+    And "Andrew" checks that presentation is being stored under "passport" name
     Then "Carol" checks the history of events "proposal-sent,proposal-sent,request-received,request-received,presentation-sent,presentation-sent,done,done"
-    And "Andrew" checks the history of events "proposal-received,proposal-received,request-sent,request-sent,presentation-received,presentation-received,done,done"
   @decline_propose_presentation
   Scenario: The Verifier declines a propose presentation
     Given "Michael" exchange DIDs with "David"
@@ -53,9 +53,9 @@ Feature: Present Proof protocol
     Then "Felix" negotiates about the request presentation with a proposal
     And "William" accepts a proposal and sends a request to the Prover
     And "Felix" accepts a request and sends a presentation to the "William"
-    And "William" accepts a presentation
+    And "William" accepts a presentation with name "passport"
+    And "William" checks that presentation is being stored under "passport" name
     Then "Felix" checks the history of events "request-received,request-received,proposal-sent,proposal-sent,request-received,request-received,presentation-sent,presentation-sent,done,done"
-    And "William" checks the history of events "request-sent,request-sent,proposal-received,proposal-received,request-sent,request-sent,presentation-received,presentation-received,done,done"
   @begin_with_propose_presentation_negotiation
   Scenario: The Prover begins with a proposal (negotiation)
     Given "Jason" exchange DIDs with "Jesse"
@@ -64,6 +64,6 @@ Feature: Present Proof protocol
     Then "Jason" negotiates about the request presentation with a proposal
     And "Jesse" accepts a proposal and sends a request to the Prover
     And "Jason" accepts a request and sends a presentation to the "Jesse"
-    And "Jesse" accepts a presentation
+    And "Jesse" accepts a presentation with name "bachelors degree"
+    And "Jesse" checks that presentation is being stored under "bachelors degree" name
     Then "Jason" checks the history of events "proposal-sent,proposal-sent,request-received,request-received,proposal-sent,proposal-sent,request-received,request-received,presentation-sent,presentation-sent,done,done"
-    And "Jesse" checks the history of events "proposal-received,proposal-received,request-sent,request-sent,proposal-received,proposal-received,request-sent,request-sent,presentation-received,presentation-received,done,done"

--- a/test/bdd/features/presentproof_controller.feature
+++ b/test/bdd/features/presentproof_controller.feature
@@ -17,7 +17,8 @@ Feature: Present Proof using controller API
     When  "Alice" sends a request presentation to "Bob" through PresentProof controller
       And "Bob" accepts a request and sends a presentation to the Verifier through PresentProof controller
 
-    Then  "Alice" successfully accepts a presentation through PresentProof controller
+    Then  "Alice" successfully accepts a presentation with "passport" name through PresentProof controller
+      And "Alice" checks that presentation is being stored under the "passport" name
 
   Scenario: The Prover begins with a presentation proposal
     Given "Carol" agent is running on "localhost" port "8081" with controller "http://localhost:8082"
@@ -28,7 +29,8 @@ Feature: Present Proof using controller API
       And "Dan" accepts a proposal and sends a request to the Prover through PresentProof controller
       And "Carol" accepts a request and sends a presentation to the Verifier through PresentProof controller
 
-    Then  "Dan" successfully accepts a presentation through PresentProof controller
+    Then  "Dan" successfully accepts a presentation with "degree" name through PresentProof controller
+      And "Dan" checks that presentation is being stored under the "degree" name
 
   Scenario: The Prover begins with a presentation proposal (negotiation)
     Given "Peggy" agent is running on "localhost" port "8081" with controller "http://localhost:8082"
@@ -41,4 +43,5 @@ Feature: Present Proof using controller API
       And "Victor" accepts a proposal and sends a request to the Prover through PresentProof controller
       And "Peggy" accepts a request and sends a presentation to the Verifier through PresentProof controller
 
-    Then  "Victor" successfully accepts a presentation through PresentProof controller
+    Then  "Victor" successfully accepts a presentation with "license" name through PresentProof controller
+      And "Victor" checks that presentation is being stored under the "license" name


### PR DESCRIPTION
Present Proof saves the presentation to the verifiable store.
This PR also improves BDD/BDD-js tests by adding verifiable presentation payload.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>