### PR TITLE
refactor: simplify did key constructor

### DIFF
--- a/pkg/vdri/key/creator_test.go
+++ b/pkg/vdri/key/creator_test.go
@@ -27,7 +27,7 @@ const (
 
 func TestBuild(t *testing.T) {
 	t.Run("validate not supported public key", func(t *testing.T) {
-		v := newVDRI(t)
+		v := New()
 
 		pubKey := &vdriapi.PubKey{
 			Type: "not-supported-type",
@@ -40,7 +40,7 @@ func TestBuild(t *testing.T) {
 	})
 
 	t.Run("validate did:key compliance with generic syntax", func(t *testing.T) {
-		v := newVDRI(t)
+		v := New()
 
 		pubKey := &vdriapi.PubKey{
 			Type:  ed25519VerificationKey2018,
@@ -57,7 +57,7 @@ func TestBuild(t *testing.T) {
 	})
 
 	t.Run("build with default key type", func(t *testing.T) {
-		v := newVDRI(t)
+		v := New()
 
 		pubKey := &vdriapi.PubKey{
 			Type:  ed25519VerificationKey2018,
@@ -70,14 +70,6 @@ func TestBuild(t *testing.T) {
 
 		assertDoc(t, doc)
 	})
-}
-
-func newVDRI(t *testing.T) *VDRI {
-	v, err := New()
-	require.NoError(t, err)
-	require.NotNil(t, v)
-
-	return v
 }
 
 func assertDoc(t *testing.T, doc *did.Doc) {

--- a/pkg/vdri/key/resolver_test.go
+++ b/pkg/vdri/key/resolver_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestRead(t *testing.T) {
 	t.Run("validate did:key", func(t *testing.T) {
-		v := newVDRI(t)
+		v := New()
 
 		doc, err := v.Read("invalid")
 		require.Error(t, err)
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) {
 	})
 
 	t.Run("validate did:key method specific ID", func(t *testing.T) {
-		v := newVDRI(t)
+		v := New()
 
 		doc, err := v.Read("did:key:invalid")
 		require.Error(t, err)
@@ -32,7 +32,7 @@ func TestRead(t *testing.T) {
 	})
 
 	t.Run("validate not supported public key", func(t *testing.T) {
-		v := newVDRI(t)
+		v := New()
 
 		doc, err := v.Read("did:key:z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc")
 		require.Error(t, err)
@@ -41,7 +41,7 @@ func TestRead(t *testing.T) {
 	})
 
 	t.Run("resolve assuming default key type", func(t *testing.T) {
-		v := newVDRI(t)
+		v := New()
 
 		doc, err := v.Read(didKey)
 		require.NoError(t, err)

--- a/pkg/vdri/key/vdri.go
+++ b/pkg/vdri/key/vdri.go
@@ -18,8 +18,8 @@ type VDRI struct {
 }
 
 // New returns new instance of VDRI that works with did:key method.
-func New() (*VDRI, error) {
-	return &VDRI{}, nil
+func New() *VDRI {
+	return &VDRI{}
 }
 
 // Accept accepts did:key method.

--- a/pkg/vdri/key/vdri_test.go
+++ b/pkg/vdri/key/vdri_test.go
@@ -18,8 +18,7 @@ var _ vdri.VDRI = (*VDRI)(nil) // verify interface compliance
 
 func TestAccept(t *testing.T) {
 	t.Run("key method", func(t *testing.T) {
-		v, err := New()
-		require.NoError(t, err)
+		v := New()
 		require.NotNil(t, v)
 
 		accept := v.Accept("key")
@@ -27,8 +26,7 @@ func TestAccept(t *testing.T) {
 	})
 
 	t.Run("other method", func(t *testing.T) {
-		v, err := New()
-		require.NoError(t, err)
+		v := New()
 		require.NotNil(t, v)
 
 		accept := v.Accept("other")
@@ -38,16 +36,16 @@ func TestAccept(t *testing.T) {
 
 func TestStore(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
-		v, err := New()
-		require.NoError(t, err)
+		v := New()
+		require.NotNil(t, v)
 		require.NoError(t, v.Store(nil, nil))
 	})
 }
 
 func TestClose(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
-		v, err := New()
-		require.NoError(t, err)
+		v := New()
+		require.NotNil(t, v)
 		require.NoError(t, v.Close())
 	})
 }


### PR DESCRIPTION
Removes unnecessary returning type (error) from the constructor of did key vdri.

Signed-off-by: Andriy Holovko <andriy.holovko@gmail.com>


