### PR TITLE
test: JsonWebSignature2020 and EcdsaSecp256k1Signature2019 signature suites in VC BDD tests

### DIFF
--- a/pkg/doc/did/contexts.go
+++ b/pkg/doc/did/contexts.go
@@ -1,0 +1,294 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package did
+
+const didV1Context = `
+{
+  "@context": {
+    "@version": 1.1,
+    "id": "@id",
+    "type": "@type",
+    "dc": "http://purl.org/dc/terms/",
+    "schema": "http://schema.org/",
+    "sec": "https://w3id.org/security#",
+    "didv": "https://w3id.org/did#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "EcdsaSecp256k1Signature2019": "sec:EcdsaSecp256k1Signature2019",
+    "EcdsaSecp256k1VerificationKey2019": "sec:EcdsaSecp256k1VerificationKey2019",
+    "Ed25519Signature2018": "sec:Ed25519Signature2018",
+    "Ed25519VerificationKey2018": "sec:Ed25519VerificationKey2018",
+    "RsaSignature2018": "sec:RsaSignature2018",
+    "RsaVerificationKey2018": "sec:RsaVerificationKey2018",
+    "SchnorrSecp256k1Signature2019": "sec:SchnorrSecp256k1Signature2019",
+    "SchnorrSecp256k1VerificationKey2019": "sec:SchnorrSecp256k1VerificationKey2019",
+    "ServiceEndpointProxyService": "didv:ServiceEndpointProxyService",
+    "allowedAction": "sec:allowedAction",
+    "assertionMethod": {
+      "@id": "sec:assertionMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "authentication": {
+      "@id": "sec:authenticationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "capability": {
+      "@id": "sec:capability",
+      "@type": "@id"
+    },
+    "capabilityAction": "sec:capabilityAction",
+    "capabilityChain": {
+      "@id": "sec:capabilityChain",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "capabilityDelegation": {
+      "@id": "sec:capabilityDelegationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "capabilityInvocation": {
+      "@id": "sec:capabilityInvocationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "capabilityStatusList": {
+      "@id": "sec:capabilityStatusList",
+      "@type": "@id"
+    },
+    "canonicalizationAlgorithm": "sec:canonicalizationAlgorithm",
+    "caveat": {
+      "@id": "sec:caveat",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "challenge": "sec:challenge",
+    "controller": {
+      "@id": "sec:controller",
+      "@type": "@id"
+    },
+    "created": {
+      "@id": "dc:created",
+      "@type": "xsd:dateTime"
+    },
+    "creator": {
+      "@id": "dc:creator",
+      "@type": "@id"
+    },
+    "delegator": {
+      "@id": "sec:delegator",
+      "@type": "@id"
+    },
+    "domain": "sec:domain",
+    "expirationDate": {
+      "@id": "sec:expiration",
+      "@type": "xsd:dateTime"
+    },
+    "invocationTarget": {
+      "@id": "sec:invocationTarget",
+      "@type": "@id"
+    },
+    "invoker": {
+      "@id": "sec:invoker",
+      "@type": "@id"
+    },
+    "jws": "sec:jws",
+    "keyAgreement": {
+      "@id": "sec:keyAgreementMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "nonce": "sec:nonce",
+    "owner": {
+      "@id": "sec:owner",
+      "@type": "@id"
+    },
+    "proof": {
+      "@id": "sec:proof",
+      "@type": "@id",
+      "@container": "@graph"
+    },
+    "proofPurpose": {
+      "@id": "sec:proofPurpose",
+      "@type": "@vocab"
+    },
+    "proofValue": "sec:proofValue",
+    "publicKey": {
+      "@id": "sec:publicKey",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "publicKeyBase58": "sec:publicKeyBase58",
+    "publicKeyPem": "sec:publicKeyPem",
+    "publicKeyJwk": {
+      "@id": "sec:publicKeyJwk",
+      "@type": "@json"
+    },
+    "revoked": {
+      "@id": "sec:revoked",
+      "@type": "xsd:dateTime"
+    },
+    "service": {
+      "@id": "didv:service",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "serviceEndpoint": {
+      "@id": "didv:serviceEndpoint",
+      "@type": "@id"
+    },
+    "updated": {
+      "@id": "dc:modified",
+      "@type": "xsd:dateTime"
+    },
+    "verificationMethod": {
+      "@id": "sec:verificationMethod",
+      "@type": "@id"
+    }
+  }
+}
+`
+
+const didV011Context = `
+{
+  "@context": {
+    "@version": 1.1,
+    "id": "@id",
+    "type": "@type",
+    "dc": "http://purl.org/dc/terms/",
+    "schema": "http://schema.org/",
+    "sec": "https://w3id.org/security#",
+    "didv": "https://w3id.org/did#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "EcdsaSecp256k1Signature2019": "sec:EcdsaSecp256k1Signature2019",
+    "EcdsaSecp256k1VerificationKey2019": "sec:EcdsaSecp256k1VerificationKey2019",
+    "Ed25519Signature2018": "sec:Ed25519Signature2018",
+    "Ed25519VerificationKey2018": "sec:Ed25519VerificationKey2018",
+    "RsaSignature2018": "sec:RsaSignature2018",
+    "RsaVerificationKey2018": "sec:RsaVerificationKey2018",
+    "X25519KeyAgreementKey2019": "sec:X25519KeyAgreementKey2019",
+    "SchnorrSecp256k1Signature2019": "sec:SchnorrSecp256k1Signature2019",
+    "SchnorrSecp256k1VerificationKey2019": "sec:SchnorrSecp256k1VerificationKey2019",
+    "ServiceEndpointProxyService": "didv:ServiceEndpointProxyService",
+    "allowedAction": "sec:allowedAction",
+    "assertionMethod": {
+      "@id": "sec:assertionMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "authentication": {
+      "@id": "sec:authenticationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "capability": {
+      "@id": "sec:capability",
+      "@type": "@id"
+    },
+    "capabilityAction": "sec:capabilityAction",
+    "capabilityChain": {
+      "@id": "sec:capabilityChain",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "capabilityDelegation": {
+      "@id": "sec:capabilityDelegationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "capabilityInvocation": {
+      "@id": "sec:capabilityInvocationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "capabilityStatusList": {
+      "@id": "sec:capabilityStatusList",
+      "@type": "@id"
+    },
+    "canonicalizationAlgorithm": "sec:canonicalizationAlgorithm",
+    "caveat": {
+      "@id": "sec:caveat",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "challenge": "sec:challenge",
+    "controller": {
+      "@id": "sec:controller",
+      "@type": "@id"
+    },
+    "created": {
+      "@id": "dc:created",
+      "@type": "xsd:dateTime"
+    },
+    "creator": {
+      "@id": "dc:creator",
+      "@type": "@id"
+    },
+    "delegator": {
+      "@id": "sec:delegator",
+      "@type": "@id"
+    },
+    "domain": "sec:domain",
+    "expirationDate": {
+      "@id": "sec:expiration",
+      "@type": "xsd:dateTime"
+    },
+    "invocationTarget": {
+      "@id": "sec:invocationTarget",
+      "@type": "@id"
+    },
+    "invoker": {
+      "@id": "sec:invoker",
+      "@type": "@id"
+    },
+    "jws": "sec:jws",
+    "keyAgreement": {
+      "@id": "sec:keyAgreementMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "nonce": "sec:nonce",
+    "owner": {
+      "@id": "sec:owner",
+      "@type": "@id"
+    },
+    "proof": {
+      "@id": "sec:proof",
+      "@type": "@id",
+      "@container": "@graph"
+    },
+    "proofPurpose": {
+      "@id": "sec:proofPurpose",
+      "@type": "@vocab"
+    },
+    "proofValue": "sec:proofValue",
+    "publicKey": {
+      "@id": "sec:publicKey",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "publicKeyBase58": "sec:publicKeyBase58",
+    "publicKeyPem": "sec:publicKeyPem",
+    "revoked": {
+      "@id": "sec:revoked",
+      "@type": "xsd:dateTime"
+    },
+    "service": {
+      "@id": "didv:service",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "serviceEndpoint": {
+      "@id": "didv:serviceEndpoint",
+      "@type": "@id"
+    },
+    "verificationMethod": {
+      "@id": "sec:verificationMethod",
+      "@type": "@id"
+    }
+  }
+}`

--- a/pkg/doc/did/doc_test.go
+++ b/pkg/doc/did/doc_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/signer"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ed25519signature2018"
@@ -1429,7 +1430,7 @@ func createSignedDidDocument(privKey, pubKey []byte) []byte {
 	s := signer.New(ed25519signature2018.New(
 		suite.WithSigner(getSigner(privKey))))
 
-	signedDoc, err := s.Sign(context, jsonDoc)
+	signedDoc, err := s.Sign(context, jsonDoc, jsonld.WithDocumentLoader(createDocumentLoader()))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/doc/jose/jwk_test.go
+++ b/pkg/doc/jose/jwk_test.go
@@ -146,6 +146,10 @@ func TestDecodePublicKey(t *testing.T) {
 				jwkBytes, err := json.Marshal(&jwk)
 				require.NoError(t, err)
 				require.NotEmpty(t, jwkBytes)
+
+				jwkKey, err := JWKFromPublicKey(jwk.Key)
+				require.NoError(t, err)
+				require.NotNil(t, jwkKey)
 			})
 		}
 	})
@@ -305,6 +309,13 @@ func TestCurveSize(t *testing.T) {
 	require.Equal(t, 28, curveSize(elliptic.P224()))
 	require.Equal(t, 48, curveSize(elliptic.P384()))
 	require.Equal(t, 66, curveSize(elliptic.P521()))
+}
+
+func TestJWKFromPublicKeyFailure(t *testing.T) {
+	key, err := JWKFromPublicKey(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "create JWK")
+	require.Nil(t, key)
 }
 
 func TestJWK_PublicKeyBytesValidation(t *testing.T) {

--- a/pkg/doc/signature/signer/signer.go
+++ b/pkg/doc/signature/signer/signer.go
@@ -61,7 +61,7 @@ func New(signatureSuites ...SignatureSuite) *DocumentSigner {
 }
 
 // Sign  will sign JSON LD document
-func (signer *DocumentSigner) Sign(context *Context, jsonLdDoc []byte) ([]byte, error) {
+func (signer *DocumentSigner) Sign(context *Context, jsonLdDoc []byte, opts ...jsonld.ProcessorOpts) ([]byte, error) {
 	var jsonLdObject map[string]interface{}
 
 	err := json.Unmarshal(jsonLdDoc, &jsonLdObject)
@@ -69,7 +69,7 @@ func (signer *DocumentSigner) Sign(context *Context, jsonLdDoc []byte) ([]byte, 
 		return nil, fmt.Errorf("failed to unmarshal json ld document: %w", err)
 	}
 
-	err = signer.signObject(context, jsonLdObject)
+	err = signer.signObject(context, jsonLdObject, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,8 @@ func (signer *DocumentSigner) Sign(context *Context, jsonLdDoc []byte) ([]byte, 
 }
 
 // signObject is a helper method that operates on JSON LD objects
-func (signer *DocumentSigner) signObject(context *Context, jsonLdObject map[string]interface{}) error {
+func (signer *DocumentSigner) signObject(context *Context, jsonLdObject map[string]interface{},
+	opts []jsonld.ProcessorOpts) error {
 	if err := isValidContext(context); err != nil {
 		return err
 	}
@@ -121,7 +122,7 @@ func (signer *DocumentSigner) signObject(context *Context, jsonLdObject map[stri
 		p.JWS = proof.CreateDetachedJWTHeader(p) + ".."
 	}
 
-	message, err := proof.CreateVerifyData(suite, jsonLdObject, p, jsonld.WithValidateRDF())
+	message, err := proof.CreateVerifyData(suite, jsonLdObject, p, append(opts, jsonld.WithValidateRDF())...)
 	if err != nil {
 		return err
 	}

--- a/pkg/doc/verifiable/example_credential_test.go
+++ b/pkg/doc/verifiable/example_credential_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec"
-	gojose "github.com/square/go-jose/v3"
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
@@ -502,6 +501,11 @@ func ExampleCredential_AddLinkedDataProofMultiProofs() {
 	ed25519Suite := ed25519signature2018.New(suite.WithVerifier(ed25519signature2018.NewPublicKeyVerifier()))
 	jsonWebSignatureSuite := jsonwebsignature2020.New(suite.WithVerifier(jsonwebsignature2020.NewPublicKeyVerifier()))
 
+	jwk, err := jose.JWKFromPublicKey(&ecdsaPrivKey.PublicKey)
+	if err != nil {
+		panic(err)
+	}
+
 	_, err = verifiable.ParseCredential(vcBytes,
 		verifiable.WithEmbeddedSignatureSuites(ed25519Suite, jsonWebSignatureSuite),
 		verifiable.WithPublicKeyFetcher(func(issuerID, keyID string) (*sigverifier.PublicKey, error) {
@@ -516,14 +520,7 @@ func ExampleCredential_AddLinkedDataProofMultiProofs() {
 				return &sigverifier.PublicKey{
 					Type:  "JwsVerificationKey2020",
 					Value: elliptic.Marshal(ecdsaPrivKey.Curve, ecdsaPrivKey.X, ecdsaPrivKey.Y),
-					JWK: &jose.JWK{
-						JSONWebKey: gojose.JSONWebKey{
-							Algorithm: "ES256",
-							Key:       &ecdsaPrivKey.PublicKey,
-						},
-						Crv: "P-256",
-						Kty: "EC",
-					},
+					JWK:   jwk,
 				}, nil
 			}
 

--- a/pkg/doc/verifiable/linked_data_proof_test.go
+++ b/pkg/doc/verifiable/linked_data_proof_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec"
-	gojose "github.com/square/go-jose/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
@@ -127,20 +126,17 @@ func TestLinkedDataProofSignerAndVerifier(t *testing.T) {
 		require.Equal(t, vcWithEd25519Proof, vcDecoded)
 
 		pubKeyBytes := elliptic.Marshal(ecdsaPrivKey.Curve, ecdsaPrivKey.X, ecdsaPrivKey.Y)
+
+		jwk, err := jose.JWKFromPublicKey(&ecdsaPrivKey.PublicKey)
+		require.NoError(t, err)
+
 		vcDecoded, err = parseTestCredential(vcWithSecp256k1ProofBytes,
 			WithEmbeddedSignatureSuites(verifierSuites...),
 			WithPublicKeyFetcher(func(issuerID, keyID string) (*verifier.PublicKey, error) {
 				return &verifier.PublicKey{
 					Type:  "EcdsaSecp256k1VerificationKey2019",
 					Value: pubKeyBytes,
-					JWK: &jose.JWK{
-						JSONWebKey: gojose.JSONWebKey{
-							Algorithm: "ES256K",
-							Key:       &ecdsaPrivKey.PublicKey,
-						},
-						Crv: "secp256k1",
-						Kty: "EC",
-					},
+					JWK:   jwk,
 				}, nil
 			}))
 		require.NoError(t, err)

--- a/test/bdd/cmd/sidetree/main.go
+++ b/test/bdd/cmd/sidetree/main.go
@@ -6,14 +6,32 @@ SPDX-License-Identifier: Apache-2.0
 package main
 
 import (
+	"crypto/ed25519"
+	"encoding/base64"
 	"fmt"
 	"os"
 
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/sidetree"
 )
 
 func main() {
-	doc, err := sidetree.CreateDID(os.Args[1], os.Args[2], os.Args[3], os.Args[4])
+	key, err := base64.RawURLEncoding.DecodeString(os.Args[3])
+	if err != nil {
+		panic(err)
+	}
+
+	jwk, err := jose.JWKFromPublicKey(ed25519.PublicKey(key))
+	if err != nil {
+		panic(err)
+	}
+
+	doc, err := sidetree.CreateDID(&sidetree.CreateDIDParams{
+		URL:             os.Args[1],
+		KeyID:           os.Args[2],
+		JWK:             jwk,
+		ServiceEndpoint: os.Args[4],
+	})
 	if err != nil {
 		fmt.Println(err.Error())
 		return

--- a/test/bdd/features/verifiable_credential.feature
+++ b/test/bdd/features/verifiable_credential.feature
@@ -7,12 +7,32 @@
 @all
 @verifiable
 Feature: Issue Verifiable Credential
-  @issue_vc_ldp
-  Scenario: Issue University Degree Credential with JWS Linked Data proof
-    When "Stanford University" issues credential at "2018-03-15" regarding "Bachelor Degree" to "Alice" with "JWS Ed25519Signature2018 Linked data" proof
+  @issue_vc_ldp_ed25519signature2018
+  Scenario: Issue University Degree Credential with Ed25519Signature2018 Linked Data proof
+    When "Stanford University" issues credential at "2018-03-15" regarding "Bachelor Degree" to "Alice" with "Ed25519Signature2018 Linked Data" proof
+    Then "Alice" receives the credential and verifies it
+
+  @issue_vc_ldp_jsonwebsignature2020_ec_p256
+  Scenario: Issue University Degree Credential with JsonWebSignature2020 (EC P256) Linked Data proof
+    When "Stanford University" issues credential at "2018-03-15" regarding "Bachelor Degree" to "Alice" with "JsonWebSignature2020 (EC P256) Linked Data" proof
+    Then "Alice" receives the credential and verifies it
+
+  @issue_vc_ldp_jsonwebsignature2020_ed25519
+  Scenario: Issue University Degree Credential with JsonWebSignature2020 (Ed25519) Linked Data proof
+    When "Stanford University" issues credential at "2018-03-15" regarding "Bachelor Degree" to "Alice" with "JsonWebSignature2020 (Ed25519) Linked Data" proof
+    Then "Alice" receives the credential and verifies it
+
+  @issue_vc_ldp_jsonwebsignature2020_ec_secp256k1
+  Scenario: Issue University Degree Credential with JsonWebSignature2020 (secp256k1) Linked Data proof
+    When "Stanford University" issues credential at "2018-03-15" regarding "Bachelor Degree" to "Alice" with "JsonWebSignature2020 (secp256k1) Linked Data" proof
+    Then "Alice" receives the credential and verifies it
+
+  @issue_vc_ldp_ecdsasecp256k1signature2019
+  Scenario: Issue University Degree Credential with EcdsaSecp256k1Signature2019 Linked Data proof
+    When "Stanford University" issues credential at "2018-03-15" regarding "Bachelor Degree" to "Alice" with "EcdsaSecp256k1Signature2019 Linked Data" proof
     Then "Alice" receives the credential and verifies it
 
   @issue_vc_jws
   Scenario: Issue University Degree Credential with JWS proof
-    When "Berkley" issues credential at "2019-03-15" regarding "Master Degree" to "Bob" with "JWS" proof
+    When "Berkley" issues credential at "2019-03-15" regarding "Master Degree" to "Bob" with "Ed25519 JWS" proof
     Then "Bob" receives the credential and verifies it

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -8,6 +8,7 @@ go 1.14
 
 require (
 	github.com/Microsoft/hcsshim v0.8.7 // indirect
+	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/btcsuite/btcutil v1.0.1
 	github.com/containerd/containerd v1.3.3 // indirect
 	github.com/containerd/continuity v0.0.0-20200107194136-26c1120b8d41 // indirect

--- a/test/bdd/pkg/context/context.go
+++ b/test/bdd/pkg/context/context.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/messaging/msghandler"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/context"
 )
@@ -31,6 +32,8 @@ type BDDContext struct {
 	RouteClients       map[string]*mediator.Client
 	RouteCallbacks     map[string]chan interface{}
 	PublicDIDDocs      map[string]*did.Doc
+	PublicKeys         map[string]*jose.JWK
+	KeyHandles         map[string]interface{}
 	PublicDIDs         map[string]string
 	Agents             map[string]*aries.Aries
 	AgentCtx           map[string]*context.Provider
@@ -51,6 +54,8 @@ func NewBDDContext() *BDDContext {
 		RouteClients:       make(map[string]*mediator.Client),
 		RouteCallbacks:     make(map[string]chan interface{}),
 		PublicDIDDocs:      make(map[string]*did.Doc),
+		PublicKeys:         make(map[string]*jose.JWK),
+		KeyHandles:         make(map[string]interface{}),
 		PublicDIDs:         make(map[string]string),
 		Agents:             make(map[string]*aries.Aries),
 		AgentCtx:           make(map[string]*context.Provider),

--- a/test/bdd/pkg/introduce/introduce_sdk_steps.go
+++ b/test/bdd/pkg/introduce/introduce_sdk_steps.go
@@ -108,7 +108,7 @@ func (a *SDKSteps) createConnections(introducees, introducer string) error {
 		return err
 	}
 
-	if err := didresolver.CreateDIDDocument(a.bddContext, participants, acceptDidMethod); err != nil {
+	if err := didresolver.CreateDIDDocument(a.bddContext, participants, ""); err != nil {
 		return err
 	}
 

--- a/test/bdd/pkg/verifiable/signer.go
+++ b/test/bdd/pkg/verifiable/signer.go
@@ -7,18 +7,65 @@ SPDX-License-Identifier: Apache-2.0
 package verifiable
 
 import (
-	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+
+	ariescrypto "github.com/hyperledger/aries-framework-go/pkg/crypto"
 )
 
-type signer struct {
-	kms   legacykms.Signer
-	keyID string
+type cryptoSigner struct {
+	cr ariescrypto.Crypto
+	kh interface{}
 }
 
-func newSigner(kms legacykms.Signer, keyID string) *signer {
-	return &signer{kms: kms, keyID: keyID}
+func newCryptoSigner(cr ariescrypto.Crypto, keyHandle interface{}) *cryptoSigner {
+	return &cryptoSigner{cr: cr, kh: keyHandle}
 }
 
-func (s *signer) Sign(data []byte) ([]byte, error) {
-	return s.kms.SignMessage(data, s.keyID)
+func (s *cryptoSigner) Sign(data []byte) ([]byte, error) {
+	return s.cr.Sign(data, s.kh)
+}
+
+type secp256k1Signer struct {
+	privKey *ecdsa.PrivateKey
+}
+
+func newSecp256k1Signer(privKey *ecdsa.PrivateKey) *secp256k1Signer {
+	return &secp256k1Signer{
+		privKey: privKey,
+	}
+}
+
+//nolint:gomnd
+func (signer *secp256k1Signer) Sign(payload []byte) ([]byte, error) {
+	hasher := crypto.SHA256.New()
+
+	_, err := hasher.Write(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	hashed := hasher.Sum(nil)
+
+	r, s, err := ecdsa.Sign(rand.Reader, signer.privKey, hashed)
+	if err != nil {
+		return nil, err
+	}
+
+	curveBits := signer.privKey.Curve.Params().BitSize
+
+	keyBytes := curveBits / 8
+	if curveBits%8 > 0 {
+		keyBytes++
+	}
+
+	copyPadded := func(source []byte, size int) []byte {
+		dest := make([]byte, size)
+		copy(dest[size-len(source):], source)
+
+		return dest
+	}
+
+	return append(copyPadded(r.Bytes(), keyBytes), copyPadded(s.Bytes(), keyBytes)...), nil
 }

--- a/test/bdd/pkg/verifiable/verifiable_steps.go
+++ b/test/bdd/pkg/verifiable/verifiable_steps.go
@@ -7,18 +7,27 @@ SPDX-License-Identifier: Apache-2.0
 package verifiable
 
 import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
 	"errors"
 	"time"
 
-	"github.com/btcsuite/btcutil/base58"
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/cucumber/godog"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/signer"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ecdsasecp256k1signature2019"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ed25519signature2018"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/jsonwebsignature2020"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
-	"github.com/hyperledger/aries-framework-go/test/bdd/agent"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+	bddagent "github.com/hyperledger/aries-framework-go/test/bdd/agent"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/context"
 	bddDIDExchange "github.com/hyperledger/aries-framework-go/test/bdd/pkg/didexchange"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/didresolver"
@@ -26,8 +35,9 @@ import (
 
 // SDKSteps is steps for verifiable credentials using client SDK
 type SDKSteps struct {
-	bddContext    *context.BDDContext
-	issuedVCBytes []byte
+	bddContext       *context.BDDContext
+	issuedVCBytes    []byte
+	secp256k1PrivKey *ecdsa.PrivateKey
 }
 
 // NewVerifiableCredentialSDKSteps creates steps for verifiable credential with SDK
@@ -36,11 +46,13 @@ func NewVerifiableCredentialSDKSteps() *SDKSteps {
 }
 
 const (
-	// TODO support JsonWebSignature2020 and EcdsaSecp256k1Signature2019 signature suites
-	//  (https://github.com/hyperledger/aries-framework-go/issues/1596)
-	jwsLinkedDataProofEd25519Signature2018 = "JWS Ed25519Signature2018 Linked data"
+	ldpEd25519Signature2018        = "Ed25519Signature2018 Linked Data"
+	ldpJSONWebSignatureECP256      = "JsonWebSignature2020 (EC P256) Linked Data"
+	ldpJSONWebSignatureEd25519     = "JsonWebSignature2020 (Ed25519) Linked Data"
+	ldpJSONWebSignatureSecp256k1   = "JsonWebSignature2020 (secp256k1) Linked Data"
+	ldpEcdsaSecp256k1Signature2019 = "EcdsaSecp256k1Signature2019 Linked Data"
 
-	jwsProof = "JWS"
+	jwsProof = "Ed25519 JWS"
 )
 
 // SetContext is called before every scenario is run with a fresh new context
@@ -55,7 +67,7 @@ func (s *SDKSteps) RegisterSteps(gs *godog.Suite) {
 }
 
 func (s *SDKSteps) issueCredential(issuer, issuedAt, subject, holder, proofType string) error {
-	err := s.createDID(issuer, holder)
+	err := s.createDID(issuer, holder, proofType)
 	if err != nil {
 		return err
 	}
@@ -104,53 +116,118 @@ func (s *SDKSteps) createVC(issuedAt, subject, issuer string) (*verifiable.Crede
 
 func (s *SDKSteps) addVCProof(vc *verifiable.Credential, issuer, proofType string) ([]byte, error) {
 	doc := s.getPublicDID(issuer)
-	pubKey := doc.PublicKey[0]
+	pubKeyID := doc.PublicKey[0].ID
 
-	kms := s.bddContext.AgentCtx[issuer].Signer()
-	signer := newSigner(kms, base58.Encode(pubKey.Value))
+	cr := s.bddContext.AgentCtx[issuer].Crypto()
+	cryptoSigner := newCryptoSigner(cr, s.bddContext.KeyHandles[issuer])
+	secp256k1Signer := newSecp256k1Signer(s.secp256k1PrivKey)
 
 	switch proofType {
-	case jwsLinkedDataProofEd25519Signature2018:
-		err := vc.AddLinkedDataProof(&verifiable.LinkedDataProofContext{
-			SignatureType:           "Ed25519Signature2018",
-			Suite:                   ed25519signature2018.New(suite.WithSigner(signer)),
-			SignatureRepresentation: verifiable.SignatureJWS,
-			Created:                 &vc.Issued.Time,
-			VerificationMethod:      pubKey.ID,
-		})
-		if err != nil {
-			return nil, err
-		}
+	case ldpEd25519Signature2018:
+		return s.getVCWithEd25519LDP(vc, cryptoSigner, pubKeyID)
 
-		return vc.MarshalJSON()
+	case ldpJSONWebSignatureECP256, ldpJSONWebSignatureEd25519, ldpJSONWebSignatureSecp256k1:
+		return s.getVCWithJSONWebSignatureLDP(vc, proofType, secp256k1Signer, cryptoSigner, pubKeyID)
+
+	case ldpEcdsaSecp256k1Signature2019:
+		return s.getVCWithEcdsaSecp256k1Signature2019LDP(vc, secp256k1Signer, pubKeyID)
 
 	case jwsProof:
-		jwtClaims, err := vc.JWTClaims(false)
-		if err != nil {
-			return nil, err
-		}
-
-		jws, err := jwtClaims.MarshalJWS(verifiable.EdDSA, signer, pubKey.ID)
-		if err != nil {
-			return nil, err
-		}
-
-		return []byte(jws), nil
+		return s.getVCAsJWS(vc, cryptoSigner, pubKeyID)
 
 	default:
 		return nil, errors.New("unsupported proof type: " + proofType)
 	}
 }
 
+func (s *SDKSteps) getVCAsJWS(vc *verifiable.Credential,
+	cryptoSigner verifiable.Signer, pubKeyID string) ([]byte, error) {
+	jwtClaims, err := vc.JWTClaims(false)
+	if err != nil {
+		return nil, err
+	}
+
+	jws, err := jwtClaims.MarshalJWS(verifiable.EdDSA, cryptoSigner, pubKeyID)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(jws), nil
+}
+
+func (s *SDKSteps) getVCWithEcdsaSecp256k1Signature2019LDP(vc *verifiable.Credential,
+	secp256k1Signer verifiable.Signer, pubKeyID string) ([]byte, error) {
+	err := vc.AddLinkedDataProof(&verifiable.LinkedDataProofContext{
+		SignatureType:           "EcdsaSecp256k1Signature2019",
+		Suite:                   ecdsasecp256k1signature2019.New(suite.WithSigner(secp256k1Signer)),
+		SignatureRepresentation: verifiable.SignatureJWS,
+		Created:                 &vc.Issued.Time,
+		VerificationMethod:      pubKeyID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return vc.MarshalJSON()
+}
+
+func (s *SDKSteps) getVCWithJSONWebSignatureLDP(vc *verifiable.Credential, proofType string,
+	secp256k1Signer, cryptoSigner verifiable.Signer, pubKeyID string) ([]byte, error) {
+	var vcSuite signer.SignatureSuite
+
+	if proofType == ldpJSONWebSignatureSecp256k1 {
+		vcSuite = jsonwebsignature2020.New(suite.WithSigner(secp256k1Signer))
+	} else {
+		vcSuite = jsonwebsignature2020.New(suite.WithSigner(cryptoSigner))
+	}
+
+	err := vc.AddLinkedDataProof(&verifiable.LinkedDataProofContext{
+		SignatureType:           "JsonWebSignature2020",
+		Suite:                   vcSuite,
+		SignatureRepresentation: verifiable.SignatureJWS,
+		Created:                 &vc.Issued.Time,
+		VerificationMethod:      pubKeyID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return vc.MarshalJSON()
+}
+
+func (s *SDKSteps) getVCWithEd25519LDP(vc *verifiable.Credential,
+	cryptoSigner verifiable.Signer, pubKeyID string) ([]byte, error) {
+	err := vc.AddLinkedDataProof(&verifiable.LinkedDataProofContext{
+		SignatureType:           "Ed25519Signature2018",
+		Suite:                   ed25519signature2018.New(suite.WithSigner(cryptoSigner)),
+		SignatureRepresentation: verifiable.SignatureJWS,
+		Created:                 &vc.Issued.Time,
+		VerificationMethod:      pubKeyID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return vc.MarshalJSON()
+}
+
 func (s *SDKSteps) verifyCredential(holder string) error {
 	vdriRegistry := s.bddContext.AgentCtx[holder].VDRIRegistry()
 	pKeyFetcher := verifiable.NewDIDKeyResolver(vdriRegistry).PublicKeyFetcher()
 
-	sigSuite := ed25519signature2018.New(suite.WithVerifier(ed25519signature2018.NewPublicKeyVerifier()))
+	localKMS, ok := s.bddContext.AgentCtx[holder].KMS().(*localkms.LocalKMS)
+	if !ok {
+		return errors.New("expected Local KMS")
+	}
+
+	verifier := suite.NewCryptoVerifier(newLocalCryptoVerifier(s.bddContext.AgentCtx[holder].Crypto(), localKMS))
 
 	parsedVC, err := verifiable.ParseCredential(s.issuedVCBytes,
 		verifiable.WithPublicKeyFetcher(pKeyFetcher),
-		verifiable.WithEmbeddedSignatureSuites(sigSuite))
+		verifiable.WithEmbeddedSignatureSuites(
+			ed25519signature2018.New(suite.WithVerifier(verifier)),
+			jsonwebsignature2020.New(suite.WithVerifier(jsonwebsignature2020.NewPublicKeyVerifier())),
+			ecdsasecp256k1signature2019.New(suite.WithVerifier(ecdsasecp256k1signature2019.NewPublicKeyVerifier()))))
 	if err != nil {
 		return err
 	}
@@ -166,7 +243,7 @@ func (s *SDKSteps) getPublicDID(agentName string) *did.Doc {
 	return s.bddContext.PublicDIDDocs[agentName]
 }
 
-func (s *SDKSteps) createDID(issuer, holder string) error {
+func (s *SDKSteps) createDID(issuer, holder, proofType string) error {
 	const (
 		inboundHost     = "localhost"
 		inboundPort     = "random"
@@ -175,7 +252,7 @@ func (s *SDKSteps) createDID(issuer, holder string) error {
 	)
 
 	participants := issuer + "," + holder
-	agentSDK := agent.NewSDKSteps()
+	agentSDK := bddagent.NewSDKSteps()
 	agentSDK.SetContext(s.bddContext)
 
 	err := agentSDK.CreateAgentWithHTTPDIDResolver(participants, inboundHost, inboundPort, endpointURL, acceptDidMethod)
@@ -183,7 +260,11 @@ func (s *SDKSteps) createDID(issuer, holder string) error {
 		return err
 	}
 
-	if err := didresolver.CreateDIDDocument(s.bddContext, participants, acceptDidMethod); err != nil {
+	if err := s.createKeyPair(issuer, proofType); err != nil {
+		return err
+	}
+
+	if err := didresolver.CreateDIDDocument(s.bddContext, participants, mapDIDKeyType(proofType)); err != nil {
 		return err
 	}
 
@@ -191,4 +272,102 @@ func (s *SDKSteps) createDID(issuer, holder string) error {
 	didExchangeSDK.SetContext(s.bddContext)
 
 	return didExchangeSDK.WaitForPublicDID(participants, 10)
+}
+
+func (s *SDKSteps) createKeyPair(agent, proofType string) error {
+	// TODO A special case for Secp256k1 - Crypto/KMS does not support it for now
+	//  (https://github.com/hyperledger/aries-framework-go/issues/1285)
+	if proofType == ldpJSONWebSignatureSecp256k1 || proofType == ldpEcdsaSecp256k1Signature2019 {
+		return s.createSecp256k1KeyPair(agent)
+	}
+
+	localKMS, ok := s.bddContext.AgentCtx[agent].KMS().(*localkms.LocalKMS)
+	if !ok {
+		return errors.New("expected LocalKMS type of KMS")
+	}
+
+	keyType := mapCryptoKeyType(proofType)
+
+	kid, kh, err := localKMS.Create(keyType)
+	if err != nil {
+		return err
+	}
+
+	pubKeyBytes, err := localKMS.ExportPubKeyBytes(kid)
+	if err != nil {
+		return err
+	}
+
+	pubKeyJWK, err := createJWK(pubKeyBytes, keyType)
+	if err != nil {
+		return err
+	}
+
+	s.bddContext.PublicKeys[agent] = pubKeyJWK
+	s.bddContext.KeyHandles[agent] = kh
+
+	return nil
+}
+
+func (s *SDKSteps) createSecp256k1KeyPair(agent string) error {
+	btcecPrivKey, err := btcec.NewPrivateKey(btcec.S256())
+	if err != nil {
+		return err
+	}
+
+	ecdsaPrivKey := btcecPrivKey.ToECDSA()
+
+	jwk, err := jose.JWKFromPublicKey(&ecdsaPrivKey.PublicKey)
+	if err != nil {
+		return err
+	}
+
+	s.bddContext.PublicKeys[agent] = jwk
+	s.secp256k1PrivKey = ecdsaPrivKey
+
+	return nil
+}
+
+func createJWK(pubKeyBytes []byte, keyType kms.KeyType) (*jose.JWK, error) {
+	var pubKey interface{}
+
+	switch keyType {
+	case kms.ED25519Type:
+		pubKey = ed25519.PublicKey(pubKeyBytes)
+	case kms.ECDSAP256TypeIEEEP1363:
+		x, y := elliptic.Unmarshal(elliptic.P256(), pubKeyBytes)
+		pubKey = &ecdsa.PublicKey{
+			Curve: elliptic.P256(),
+			X:     x,
+			Y:     y,
+		}
+	default:
+		return nil, errors.New("unsupported key type: " + string(keyType))
+	}
+
+	return jose.JWKFromPublicKey(pubKey)
+}
+
+func mapCryptoKeyType(proofType string) kms.KeyType {
+	switch proofType {
+	case ldpEd25519Signature2018, ldpJSONWebSignatureEd25519, jwsProof:
+		return kms.ED25519Type
+	case ldpJSONWebSignatureECP256:
+		return kms.ECDSAP256TypeIEEEP1363
+	default:
+		panic("unsupported proof type: " + proofType)
+	}
+}
+
+func mapDIDKeyType(proofType string) string {
+	switch proofType {
+	case ldpEd25519Signature2018, jwsProof:
+		return "Ed25519VerificationKey2018"
+	case ldpJSONWebSignatureECP256, ldpJSONWebSignatureEd25519, ldpJSONWebSignatureSecp256k1:
+		return "JwsVerificationKey2020"
+	case ldpEcdsaSecp256k1Signature2019:
+		return "EcdsaSecp256k1VerificationKey2019"
+	default:
+		panic("unsupported proof type: " + proofType)
+	}
 }

--- a/test/bdd/pkg/verifiable/verifier.go
+++ b/test/bdd/pkg/verifiable/verifier.go
@@ -1,0 +1,80 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifiable
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	sigverifier "github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+)
+
+// localCryptoVerifier defines a verifier which is based on Local KMS and Crypto
+// which uses keyset.Handle as input for verification.
+type localCryptoVerifier struct {
+	crypto.Crypto
+	localKMS *localkms.LocalKMS
+}
+
+func newLocalCryptoVerifier(cr crypto.Crypto, localKMS *localkms.LocalKMS) *localCryptoVerifier {
+	return &localCryptoVerifier{
+		Crypto:   cr,
+		localKMS: localKMS,
+	}
+}
+
+func (t *localCryptoVerifier) Verify(sig, msg []byte, kh interface{}) error {
+	pubKey, ok := kh.(*sigverifier.PublicKey)
+	if !ok {
+		return errors.New("bad key handle format")
+	}
+
+	kmsKeyType, err := mapPublicKeyToKMSKeyType(pubKey)
+	if err != nil {
+		return err
+	}
+
+	handle, err := t.localKMS.PubKeyBytesToHandle(pubKey.Value, kmsKeyType)
+	if err != nil {
+		return err
+	}
+
+	return t.Crypto.Verify(sig, msg, handle)
+}
+
+func mapPublicKeyToKMSKeyType(pubKey *sigverifier.PublicKey) (kms.KeyType, error) {
+	switch pubKey.Type {
+	case "Ed25519VerificationKey2018":
+		return kms.ED25519Type, nil
+	case "JwsVerificationKey2020":
+		return mapJWKToKMSKeyType(pubKey.JWK)
+	default:
+		return "", fmt.Errorf("unsupported key type: %s", pubKey.Type)
+	}
+}
+
+func mapJWKToKMSKeyType(jwk *jose.JWK) (kms.KeyType, error) {
+	switch jwk.Kty {
+	case "OKP":
+		return kms.ED25519Type, nil
+	case "EC":
+		switch jwk.Crv {
+		case "P-256":
+			return kms.ECDSAP256TypeIEEEP1363, nil
+		case "P-384":
+			return kms.ECDSAP384TypeIEEEP1363, nil
+		case "P-521":
+			return kms.ECDSAP521TypeIEEEP1363, nil
+		}
+	}
+
+	return "", fmt.Errorf("unsupported JWK: %v", jwk)
+}


### PR DESCRIPTION
closes #1596

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

This PR includes bugfix and extension of `jose.JWK`:
- added `JWKFromPublicKey()` function which takes a public key struct (e.g. `*ecdsa.PublicKey` and builds `JWK` from it
- fixed JSON marshalling for  secp256k1-based key.

For VC BDD tests, tinkcrypto/local KMS is used instead of legacy KMS.
Also, DID creation at sidetree is made less hardcoded, we can now create public keys with different types (previously `JwsVerificationKey2020` was hardcoded). This allows checking a different kind of VC Linked Data suites.