### PR TITLE
feature: create Anoncrypt Packer

### DIFF
--- a/pkg/didcomm/packer/anoncrypt/pack.go
+++ b/pkg/didcomm/packer/anoncrypt/pack.go
@@ -1,0 +1,202 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package anoncrypt
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/tink/go/keyset"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/packer"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+// Package anoncrypt includes a Packer implementation to build and parse JWE messages using Anoncrypt. It allows sending
+// messages anonymously between parties with message repudiation, ie the sender identity is not revealed (and therefore
+// not authenticated) to the recipient(s).
+
+const encodingType = "didcomm-envelope-enc"
+
+var logger = log.New("aries-framework/pkg/didcomm/packer/anoncrypt")
+
+// Packer represents an Anoncrypt Pack/Unpacker that outputs/reads Aries envelopes
+type Packer struct {
+	kms    kms.KeyManager
+	encAlg jose.EncAlg
+}
+
+// New will create an Packer instance to 'AnonCrypt' payloads for a given list of recipients.
+// The returned Packer contains all the information required to pack and unpack payloads.
+func New(ctx packer.Provider, encAlg jose.EncAlg) *Packer {
+	k := ctx.KMS()
+
+	return &Packer{
+		kms:    k,
+		encAlg: encAlg,
+	}
+}
+
+// Pack will encode the payload argument
+// Using the protocol defined by the Anoncrypt message of Aries RFC 0334
+// Anoncrypt ignores the sender argument, it's added to meet the Packer interface
+func (p *Packer) Pack(payload, _ []byte, recipientsPubKeys [][]byte) ([]byte, error) {
+	if len(recipientsPubKeys) == 0 {
+		return nil, fmt.Errorf("anoncrypt Pack: empty recipientsPubKeys")
+	}
+
+	recECKeys, err := unmarshalRecipientKeys(recipientsPubKeys)
+	if err != nil {
+		return nil, fmt.Errorf("anoncrypt Pack: failed to convert recipient keys: %w", err)
+	}
+
+	jweEncrypter, err := jose.NewJWEEncrypt(p.encAlg, recECKeys)
+	if err != nil {
+		return nil, fmt.Errorf("anoncrypt Pack: failed to new JWEEncrypt instance: %w", err)
+	}
+
+	jwe, err := jweEncrypter.Encrypt(payload)
+	if err != nil {
+		return nil, fmt.Errorf("anoncrypt Pack: failed to encrypt payload: %w", err)
+	}
+
+	var s string
+
+	if len(recipientsPubKeys) == 1 {
+		s, err = jwe.CompactSerialize(json.Marshal)
+	} else {
+		s, err = jwe.FullSerialize(json.Marshal)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("anoncrypt Pack: failed to serialize JWE message: %w", err)
+	}
+
+	return []byte(s), nil
+}
+
+func unmarshalRecipientKeys(keys [][]byte) ([]subtle.PublicKey, error) {
+	var pubKeys []subtle.PublicKey
+
+	for _, key := range keys {
+		var ecKey subtle.PublicKey
+
+		err := json.Unmarshal(key, &ecKey)
+		if err != nil {
+			return nil, err
+		}
+
+		pubKeys = append(pubKeys, ecKey)
+	}
+
+	return pubKeys, nil
+}
+
+// Unpack will decode the envelope using a standard format
+func (p *Packer) Unpack(envelope []byte) (*transport.Envelope, error) {
+	jwe, err := jose.Deserialize(string(envelope))
+	if err != nil {
+		return nil, fmt.Errorf("anoncrypt Unpack: failed to deserialize JWE message: %w", err)
+	}
+
+	for i := range jwe.Recipients {
+		kid, err := getKID(i, jwe)
+		if err != nil {
+			return nil, fmt.Errorf("anoncrypt Unpack: %w", err)
+		}
+
+		kh, err := p.kms.Get(kid)
+		if err != nil {
+			if strings.EqualFold(err.Error(), fmt.Sprintf("cannot read data for keysetID %s: %s", kid,
+				storage.ErrDataNotFound)) {
+				retriesMsg := ""
+
+				if i < len(jwe.Recipients) {
+					retriesMsg = ", will try another recipient"
+				}
+
+				logger.Debugf("anoncrypt Unpack: recipient keyID not found in KMS: %v%s", kid, retriesMsg)
+
+				continue
+			}
+
+			return nil, fmt.Errorf("anoncrypt Unpack: failed to get key from kms: %w", err)
+		}
+
+		keyHandle, ok := kh.(*keyset.Handle)
+		if !ok {
+			return nil, fmt.Errorf("anoncrypt Unpack: invalid keyset handle")
+		}
+
+		jweDecrypter := jose.NewJWEDecrypt(keyHandle)
+
+		pt, err := jweDecrypter.Decrypt(jwe)
+		if err != nil {
+			return nil, fmt.Errorf("anoncrypt Unpack: failed to decrypt JWE envelope: %w", err)
+		}
+
+		// TODO get mapped verKey for the recipient encryption key (kid)
+		ecdhesPubKeyByes, err := exportPubKeyBytes(keyHandle)
+		if err != nil {
+			return nil, fmt.Errorf("anoncrypt Unpack: failed to export public key bytes: %w", err)
+		}
+
+		return &transport.Envelope{
+			Message:  pt,
+			ToVerKey: ecdhesPubKeyByes,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("anoncrypt Unpack: no matching recipient in envelope")
+}
+
+func getKID(i int, jwe *jose.JSONWebEncryption) (string, error) {
+	var kid string
+
+	if i == 0 && len(jwe.Recipients) == 1 { // compact serialization, recipient headers are in jwe.ProtectedHeaders
+		ok := false
+
+		kid, ok = jwe.ProtectedHeaders.KeyID()
+		if !ok {
+			return "", fmt.Errorf("single recipient missing 'KID' in jwe.ProtectHeaders")
+		}
+	} else {
+		kid = jwe.Recipients[i].Header.KID
+	}
+
+	return kid, nil
+}
+
+func exportPubKeyBytes(keyHandle *keyset.Handle) ([]byte, error) {
+	pubKH, err := keyHandle.Public()
+	if err != nil {
+		return nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	pubKeyWriter := ecdhes.NewWriter(buf)
+
+	err = pubKH.WriteWithNoSecrets(pubKeyWriter)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// EncodingType for didcomm
+func (p *Packer) EncodingType() string {
+	return encodingType
+}

--- a/pkg/didcomm/packer/anoncrypt/pack_test.go
+++ b/pkg/didcomm/packer/anoncrypt/pack_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package anoncrypt
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/tink/go/keyset"
+	"github.com/stretchr/testify/require"
+
+	ecdhessubtle "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
+	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
+)
+
+func TestAnoncryptPackerSuccess(t *testing.T) {
+	k := createKMS(t)
+	_, recipientsKeys, keyHandles := createRecipients(t, k, 10)
+
+	anonPacker := New(newMockProviderWithCustomKMS(k), jose.A256GCM)
+
+	origMsg := []byte("secret message")
+	ct, err := anonPacker.Pack(origMsg, nil, recipientsKeys)
+	require.NoError(t, err)
+
+	msg, err := anonPacker.Unpack(ct)
+	require.NoError(t, err)
+
+	recKey, err := exportPubKeyBytes(keyHandles[0])
+	require.NoError(t, err)
+
+	require.EqualValues(t, &transport.Envelope{Message: origMsg, ToVerKey: recKey}, msg)
+
+	// TODO uncomment with https://github.com/hyperledger/aries-framework-go/issues/1872
+	// // try with only 1 recipient
+	// ct, err = anonPacker.Pack(origMsg, nil, [][]byte{recipientsKeys[0]})
+	// require.NoError(t, err)
+	//
+	// msg, err = anonPacker.Unpack(ct)
+	// require.NoError(t, err)
+	//
+	// require.EqualValues(t, &transport.Envelope{Message: origMsg, ToVerKey: recKey}, msg)
+
+	require.Equal(t, encodingType, anonPacker.EncodingType())
+}
+
+func TestAnoncryptPackerFail(t *testing.T) {
+	k := createKMS(t)
+	_, recipientsKeys, _ := createRecipients(t, k, 10)
+	origMsg := []byte("secret message")
+	anonPacker := New(newMockProviderWithCustomKMS(k), jose.A256GCM)
+
+	t.Run("pack fail with empty recipients keys", func(t *testing.T) {
+		_, err := anonPacker.Pack(origMsg, nil, nil)
+		require.EqualError(t, err, "anoncrypt Pack: empty recipientsPubKeys")
+	})
+
+	t.Run("pack fail with invalid recipients keys", func(t *testing.T) {
+		_, err := anonPacker.Pack(origMsg, nil, [][]byte{[]byte("invalid")})
+		require.EqualError(t, err, "anoncrypt Pack: failed to convert recipient keys: invalid character 'i' "+
+			"looking for beginning of value")
+	})
+
+	t.Run("pack fail with invalid encAlg", func(t *testing.T) {
+		invalidAlg := "invalidAlg"
+		invalidAnonPacker := New(newMockProviderWithCustomKMS(k), jose.EncAlg(invalidAlg))
+		_, err := invalidAnonPacker.Pack(origMsg, nil, recipientsKeys)
+		require.EqualError(t, err, fmt.Sprintf("anoncrypt Pack: failed to new JWEEncrypt instance: encryption"+
+			" algorithm '%s' not supported", invalidAlg))
+	})
+
+	t.Run("pack success but unpack fails with invalid payload", func(t *testing.T) {
+		validAnonPacker := New(newMockProviderWithCustomKMS(k), jose.A256GCM)
+		_, err := validAnonPacker.Pack(origMsg, nil, recipientsKeys)
+		require.NoError(t, err)
+
+		_, err = validAnonPacker.Unpack([]byte("invalid jwe envelope"))
+		require.EqualError(t, err, "anoncrypt Unpack: failed to deserialize JWE message: invalid compact "+
+			"JWE: it must have five parts")
+	})
+
+	t.Run("pack success but unpack fails with missing keyID in protectedHeader", func(t *testing.T) {
+		validAnonPacker := New(newMockProviderWithCustomKMS(k), jose.A256GCM)
+		ct, err := validAnonPacker.Pack(origMsg, nil, [][]byte{recipientsKeys[0]})
+		require.NoError(t, err)
+
+		jwe, err := jose.Deserialize(string(ct))
+		require.NoError(t, err)
+
+		delete(jwe.ProtectedHeaders, jose.HeaderKeyID)
+
+		newCT, err := jwe.CompactSerialize(json.Marshal)
+		require.NoError(t, err)
+
+		_, err = validAnonPacker.Unpack([]byte(newCT))
+		require.EqualError(t, err, "anoncrypt Unpack: single recipient missing 'KID' in jwe.ProtectHeaders")
+	})
+
+	t.Run("pack success but unpack fails with missing kid in kms", func(t *testing.T) {
+		kids, newRecKeys, _ := createRecipients(t, k, 2)
+		validAnonPacker := New(newMockProviderWithCustomKMS(k), jose.A256GCM)
+		ct, err := validAnonPacker.Pack(origMsg, nil, newRecKeys)
+		require.NoError(t, err)
+
+		// rotate keys to update keyID and force a failure
+		_, _, err = k.Rotate(kms.ECDHES256AES256GCMType, kids[0])
+		require.NoError(t, err)
+
+		_, _, err = k.Rotate(kms.ECDHES256AES256GCMType, kids[1])
+		require.NoError(t, err)
+
+		_, err = validAnonPacker.Unpack(ct)
+		require.EqualError(t, err, "anoncrypt Unpack: no matching recipient in envelope")
+	})
+}
+
+// createRecipients and return their public key and keyset.Handle
+func createRecipients(t *testing.T, k *localkms.LocalKMS, recipientsCount int) ([]string, [][]byte, []*keyset.Handle) {
+	t.Helper()
+
+	var (
+		r    [][]byte
+		rKH  []*keyset.Handle
+		kids []string
+	)
+
+	for i := 0; i < recipientsCount; i++ {
+		kid, marshalledPubKey, kh := createAndMarshalRecipient(t, k)
+
+		r = append(r, marshalledPubKey)
+		rKH = append(rKH, kh)
+		kids = append(kids, kid)
+	}
+
+	return kids, r, rKH
+}
+
+// createAndMarshalRecipient creates a new recipient keyset.Handle, extracts public key, marshals it and returns
+// both marshalled public key and original recipient keyset.Handle
+func createAndMarshalRecipient(t *testing.T, k *localkms.LocalKMS) (string, []byte, *keyset.Handle) {
+	t.Helper()
+
+	kid, keyHandle, err := k.Create(kms.ECDHES256AES256GCMType)
+	require.NoError(t, err)
+
+	kh, ok := keyHandle.(*keyset.Handle)
+	require.True(t, ok)
+
+	pubKeyBytes, err := exportPubKeyBytes(kh)
+	require.NoError(t, err)
+
+	key := &ecdhessubtle.PublicKey{}
+	err = json.Unmarshal(pubKeyBytes, key)
+	require.NoError(t, err)
+
+	key.KID = kid
+	mKey, err := json.Marshal(key)
+	require.NoError(t, err)
+
+	return kid, mKey, kh
+}
+
+func createKMS(t *testing.T) *localkms.LocalKMS {
+	t.Helper()
+
+	p := mockkms.NewProviderForKMS(mockstorage.NewMockStoreProvider(), &noop.NoLock{})
+
+	k, err := localkms.New("local-lock://test/key/uri", p)
+	require.NoError(t, err)
+
+	return k
+}
+
+func newMockProviderWithCustomKMS(customKMS kms.KeyManager) *mockprovider.Provider {
+	return &mockprovider.Provider{
+		KMSValue: customKMS,
+	}
+}

--- a/pkg/doc/jose/common.go
+++ b/pkg/doc/jose/common.go
@@ -67,6 +67,9 @@ const (
 	// For JWS: this JWS header specification and/or JWA are being used that MUST be understood and processed.
 	// For JWE: this JWE header specification and/or JWA are being used that MUST be understood and processed.
 	HeaderCritical = "crit" // array
+
+	// HeaderEPK is used by JWE applications to wrap/unwrap the CEK for a recipient
+	HeaderEPK = "epk" // JSON
 )
 
 // Header defined in https://tools.ietf.org/html/rfc7797

--- a/pkg/doc/jose/jwe.go
+++ b/pkg/doc/jose/jwe.go
@@ -35,6 +35,7 @@ var errPerRecipientHeaderUnsupported = errors.New(errCompactSerializationCommonT
 // JSONWebEncryption represents a JWE as defined in https://tools.ietf.org/html/rfc7516.
 type JSONWebEncryption struct {
 	ProtectedHeaders   Headers
+	OrigProtectedHders string
 	UnprotectedHeaders Headers
 	Recipients         []*Recipient
 	AAD                string
@@ -296,6 +297,7 @@ func deserializeFromRawJWE(rawJWE *rawJSONWebEncryption) (*JSONWebEncryption, er
 
 	deserializedJWE := JSONWebEncryption{
 		ProtectedHeaders:   *protectedHeaders,
+		OrigProtectedHders: rawJWE.B64ProtectedHeaders,
 		UnprotectedHeaders: *unprotectedHeaders,
 		Recipients:         recipients,
 		AAD:                string(aad),


### PR DESCRIPTION
This change introduces the new Anoncrypt Packer. It is yet not the default packer
since didComm requires Authcrypt.

The packer also introduces the use of the Compact JWE Serialization for single recipient envelopes.

closes: #1798

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
