### PR TITLE
fix: Fixes didconn key prefix

### DIFF
--- a/pkg/store/connection/connection_lookup.go
+++ b/pkg/store/connection/connection_lookup.go
@@ -25,8 +25,8 @@ const (
 	connIDKeyPrefix     = "conn"
 	connStateKeyPrefix  = "connstate"
 	invKeyPrefix        = "inv"
-	eventDataKeyprefix  = "connevent"
-	didConnMapKeyprefix = "didconn_%s,%s"
+	eventDataKeyPrefix  = "connevent"
+	didConnMapKeyPrefix = "didconn"
 	// limitPattern with `~` at the end for lte of given prefix (less than or equal)
 	limitPattern    = "%s" + storage.EndKeySuffix
 	keySeparator    = "_"
@@ -255,14 +255,14 @@ func getNamespaceKeyPrefix(prefix string) KeyPrefix {
 // getEventDataKeyPrefix key prefix for saving event data
 func getEventDataKeyPrefix() KeyPrefix {
 	return func(key ...string) string {
-		return fmt.Sprintf(keyPattern, eventDataKeyprefix, strings.Join(key, keySeparator))
+		return fmt.Sprintf(keyPattern, eventDataKeyPrefix, strings.Join(key, keySeparator))
 	}
 }
 
 // getDIDConnMapKeyPrefix key prefix for saving mapping between DID and ConnectionID
 func getDIDConnMapKeyPrefix() KeyPrefix {
 	return func(key ...string) string {
-		return fmt.Sprintf(keyPattern, didConnMapKeyprefix, strings.Join(key, keySeparator))
+		return fmt.Sprintf(keyPattern, didConnMapKeyPrefix, strings.Join(key, keySeparator))
 	}
 }
 


### PR DESCRIPTION
The `key` in DB was incorect `didconn_%s,%s_did:peer:1zQmXWSdspH9n2oFqciqEGQR`

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>