### PR TITLE
refactor: use signature signers in linked data proof package

### DIFF
--- a/pkg/doc/signature/suite/ed25519signature2018/public_key_verifier_test.go
+++ b/pkg/doc/signature/suite/ed25519signature2018/public_key_verifier_test.go
@@ -7,27 +7,27 @@ SPDX-License-Identifier: Apache-2.0
 package ed25519signature2018
 
 import (
-	"crypto/ed25519"
-	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util/signature"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
 func TestPublicKeyVerifier_Verify(t *testing.T) {
-	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	signer, err := signature.NewEd25519Signer()
 	require.NoError(t, err)
 
 	msg := []byte("test message")
 
-	msgSig := ed25519.Sign(privateKey, msg)
+	msgSig, err := signer.Sign(msg)
+	require.NoError(t, err)
 
 	pubKey := &verifier.PublicKey{
 		Type:  kms.ED25519,
-		Value: publicKey,
+		Value: signer.PublicKey,
 	}
 	v := NewPublicKeyVerifier()
 

--- a/pkg/doc/util/signature/ecdsa.go
+++ b/pkg/doc/util/signature/ecdsa.go
@@ -11,6 +11,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"errors"
 
 	"github.com/btcsuite/btcd/btcec"
 )
@@ -30,6 +31,36 @@ func GetECDSAP256Signer(privKey *ecdsa.PrivateKey) *ECDSASigner {
 	return &ECDSASigner{privateKey: privKey, PublicKey: &privKey.PublicKey, hash: crypto.SHA256}
 }
 
+// NewECDSAP384Signer creates a new ECDSA P384 signer with generated key.
+func NewECDSAP384Signer() (*ECDSASigner, error) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ECDSASigner{privateKey: privKey, PublicKey: &privKey.PublicKey, hash: crypto.SHA384}, nil
+}
+
+// GetECDSAP384Signer creates a new ECDSA P384 signer with passed ECDSA P384 private key.
+func GetECDSAP384Signer(privKey *ecdsa.PrivateKey) *ECDSASigner {
+	return &ECDSASigner{privateKey: privKey, PublicKey: &privKey.PublicKey, hash: crypto.SHA384}
+}
+
+// NewECDSAP521Signer creates a new ECDSA P521 signer with generated key.
+func NewECDSAP521Signer() (*ECDSASigner, error) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ECDSASigner{privateKey: privKey, PublicKey: &privKey.PublicKey, hash: crypto.SHA512}, nil
+}
+
+// GetECDSAP521Signer creates a new ECDSA P521 signer with passed ECDSA P521 private key.
+func GetECDSAP521Signer(privKey *ecdsa.PrivateKey) *ECDSASigner {
+	return &ECDSASigner{privateKey: privKey, PublicKey: &privKey.PublicKey, hash: crypto.SHA512}
+}
+
 // NewECDSASecp256k1Signer creates a new ECDSA Secp256k1 signer with generated key.
 func NewECDSASecp256k1Signer() (*ECDSASigner, error) {
 	privKey, err := ecdsa.GenerateKey(btcec.S256(), rand.Reader)
@@ -43,6 +74,26 @@ func NewECDSASecp256k1Signer() (*ECDSASigner, error) {
 // GetECDSASecp256k1Signer creates a new ECDSA Secp256k1 signer with passed ECDSA Secp256k1 private key.
 func GetECDSASecp256k1Signer(privKey *ecdsa.PrivateKey) *ECDSASigner {
 	return &ECDSASigner{privateKey: privKey, PublicKey: &privKey.PublicKey, hash: crypto.SHA256}
+}
+
+// NewECDSASigner creates a new ECDSA signer based on the input elliptic curve.
+func NewECDSASigner(curve elliptic.Curve) (*ECDSASigner, error) {
+	switch curve {
+	case elliptic.P256():
+		return NewECDSAP256Signer()
+
+	case elliptic.P384():
+		return NewECDSAP384Signer()
+
+	case elliptic.P521():
+		return NewECDSAP521Signer()
+
+	case btcec.S256():
+		return NewECDSASecp256k1Signer()
+
+	default:
+		return nil, errors.New("unsupported curve")
+	}
 }
 
 // ECDSASigner makes ECDSA based signatures.

--- a/pkg/doc/util/signature/ecdsa_test.go
+++ b/pkg/doc/util/signature/ecdsa_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"errors"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec"
@@ -35,6 +36,73 @@ func TestGetECDSAP256Signer(t *testing.T) {
 	require.NotNil(t, signer)
 	require.Equal(t, privKey, signer.privateKey)
 	require.Equal(t, &privKey.PublicKey, signer.PublicKey)
+}
+
+func TestNewECDSAP384Signer(t *testing.T) {
+	signer, err := NewECDSAP384Signer()
+
+	require.NoError(t, err)
+	require.NotNil(t, signer)
+	require.NotNil(t, signer.privateKey)
+	require.NotNil(t, signer.PublicKey)
+	require.Equal(t, crypto.SHA384, signer.hash)
+}
+
+func TestGetECDSAP384Signer(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+
+	signer := GetECDSAP384Signer(privKey)
+	require.NotNil(t, signer)
+	require.Equal(t, privKey, signer.privateKey)
+	require.Equal(t, &privKey.PublicKey, signer.PublicKey)
+}
+
+func TestNewECDSAP521Signer(t *testing.T) {
+	signer, err := NewECDSAP521Signer()
+
+	require.NoError(t, err)
+	require.NotNil(t, signer)
+	require.NotNil(t, signer.privateKey)
+	require.NotNil(t, signer.PublicKey)
+	require.Equal(t, crypto.SHA512, signer.hash)
+}
+
+func TestGetECDSAP521Signer(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	require.NoError(t, err)
+
+	signer := GetECDSAP521Signer(privKey)
+	require.NotNil(t, signer)
+	require.Equal(t, privKey, signer.privateKey)
+	require.Equal(t, &privKey.PublicKey, signer.PublicKey)
+}
+
+func TestNewECDSASigner(t *testing.T) {
+	tests := []struct {
+		curve elliptic.Curve
+		err   error
+	}{
+		{elliptic.P256(), nil},
+		{elliptic.P384(), nil},
+		{elliptic.P521(), nil},
+		{btcec.S256(), nil},
+		{elliptic.P224(), errors.New("unsupported curve")},
+	}
+
+	for _, test := range tests {
+		signer, err := NewECDSASigner(test.curve)
+		if test.err != nil {
+			require.Nil(t, signer)
+			require.Error(t, err)
+			require.EqualError(t, err, test.err.Error())
+
+			continue
+		}
+
+		require.NoError(t, err)
+		require.NotNil(t, signer)
+	}
 }
 
 func TestNewECDSASecp256k1Signer(t *testing.T) {

--- a/pkg/doc/util/signature/rsa.go
+++ b/pkg/doc/util/signature/rsa.go
@@ -41,3 +41,37 @@ func (s RS256Signer) Sign(msg []byte) ([]byte, error) {
 
 	return rsa.SignPKCS1v15(rand.Reader, s.privateKey, crypto.SHA256, hashed)
 }
+
+// NewPS256Signer creates a new PS256 signer with generated key.
+func NewPS256Signer() (*PS256Signer, error) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PS256Signer{privateKey: privKey, PublicKey: &privKey.PublicKey}, nil
+}
+
+// GetPS256Signer creates a new PS256 signer with provided RSA private key.
+func GetPS256Signer(privKey *rsa.PrivateKey) *PS256Signer {
+	return &PS256Signer{privateKey: privKey, PublicKey: &privKey.PublicKey}
+}
+
+// PS256Signer makes PS256 based signatures.
+type PS256Signer struct {
+	privateKey *rsa.PrivateKey
+	PublicKey  *rsa.PublicKey
+}
+
+// Sign signs a message.
+func (s PS256Signer) Sign(msg []byte) ([]byte, error) {
+	hasher := crypto.SHA256.New()
+
+	_, _ = hasher.Write(msg) //nolint:errcheck
+
+	hashed := hasher.Sum(nil)
+
+	return rsa.SignPSS(rand.Reader, s.privateKey, crypto.SHA256, hashed, &rsa.PSSOptions{
+		SaltLength: rsa.PSSSaltLengthEqualsHash,
+	})
+}

--- a/pkg/doc/util/signature/rsa_test.go
+++ b/pkg/doc/util/signature/rsa_test.go
@@ -41,3 +41,31 @@ func TestRS256Signer_Sign(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, signature)
 }
+
+func TestNewPS256Signer(t *testing.T) {
+	signer, err := NewPS256Signer()
+
+	require.NoError(t, err)
+	require.NotNil(t, signer)
+	require.NotNil(t, signer.privateKey)
+	require.NotNil(t, signer.PublicKey)
+}
+
+func TestGetPS256Signer(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	signer := GetPS256Signer(privKey)
+	require.NotNil(t, signer)
+	require.Equal(t, privKey, signer.privateKey)
+	require.Equal(t, &privKey.PublicKey, signer.PublicKey)
+}
+
+func TestPS256Signer_Sign(t *testing.T) {
+	signer, err := NewPS256Signer()
+	require.NoError(t, err)
+
+	signature, err := signer.Sign([]byte("test message"))
+	require.NoError(t, err)
+	require.NotEmpty(t, signature)
+}


### PR DESCRIPTION
Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

#1852

Signature signers are used in the tests of the linked data proof package.
Signature signers package is not made an internal because it's used by two packages `verifiable` and `signature`.

Follow-up PR-s:
- add signer based on crypto/kms
- use signature singer in JWS related code