### PR TITLE
refactor: use crypto signers by default

### DIFF
--- a/pkg/doc/jwt/verifier_test.go
+++ b/pkg/doc/jwt/verifier_test.go
@@ -67,7 +67,7 @@ func TestNewVerifier(t *testing.T) {
 
 		v := NewVerifier(getTestKeyResolver(
 			&verifier.PublicKey{
-				Type:  kms.RSA,
+				Type:  kms.RSARS256,
 				Value: x509.MarshalPKCS1PublicKey(pubKey),
 			}, nil))
 		_, err = jose.ParseJWS(jws, v)
@@ -82,7 +82,7 @@ func TestBasicVerifier_Verify(t *testing.T) { // error corner cases
 	r.NoError(err)
 
 	v := NewVerifier(getTestKeyResolver(&verifier.PublicKey{
-		Type:  kms.RSA,
+		Type:  kms.RSARS256,
 		Value: pubKey,
 	}, nil))
 
@@ -168,7 +168,7 @@ func TestVerifyRS256(t *testing.T) {
 	r.NoError(err)
 
 	err = VerifyRS256(&verifier.PublicKey{
-		Type:  kms.RSA,
+		Type:  kms.RSARS256,
 		Value: x509.MarshalPKCS1PublicKey(&privKey.PublicKey),
 	}, []byte("test message"), signature)
 	r.NoError(err)
@@ -177,7 +177,7 @@ func TestVerifyRS256(t *testing.T) {
 	r.NoError(err)
 
 	err = VerifyRS256(&verifier.PublicKey{
-		Type:  kms.RSA,
+		Type:  kms.RSARS256,
 		Value: x509.MarshalPKCS1PublicKey(&anotherPrivKey.PublicKey),
 	}, []byte("test message"), signature)
 	r.Error(err)

--- a/pkg/doc/signature/suite/jsonwebsignature2020/suite_crypto_test.go
+++ b/pkg/doc/signature/suite/jsonwebsignature2020/suite_crypto_test.go
@@ -24,7 +24,8 @@ import (
 )
 
 func TestNewCryptoSignerAndVerifier(t *testing.T) {
-	lKMS := createKMS()
+	lKMS, err := createKMS()
+	require.NoError(t, err)
 
 	kid, kh := createKeyHandle(lKMS, kmsapi.ECDSAP256TypeIEEEP1363)
 
@@ -91,15 +92,10 @@ func createKeyHandle(kms *localkms.LocalKMS, keyType kmsapi.KeyType) (string, *k
 	return kid, kh.(*keyset.Handle)
 }
 
-func createKMS() *localkms.LocalKMS {
+func createKMS() (*localkms.LocalKMS, error) {
 	p := mockkms.NewProviderForKMS(storage.NewMockStoreProvider(), &noop.NoLock{})
 
-	k, err := localkms.New("local-lock://custom/master/key/", p)
-	if err != nil {
-		panic(err)
-	}
-
-	return k
+	return localkms.New("local-lock://custom/master/key/", p)
 }
 
 func mapKeyTypeToKMS(t string) (kmsapi.KeyType, error) {

--- a/pkg/doc/util/signature/api.go
+++ b/pkg/doc/util/signature/api.go
@@ -1,0 +1,19 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package signature
+
+// Signer defines generic signer.
+type Signer interface {
+	// Sign signs the message.
+	Sign(msg []byte) ([]byte, error)
+
+	// PublicKey returns a public key object (e.g. ed25519.PublicKey or *ecdsa.PublicKey).
+	PublicKey() interface{}
+
+	// PublicKeyBytes returns bytes of the public key.
+	PublicKeyBytes() []byte
+}

--- a/pkg/doc/util/signature/internal/signer/crypto_signer.go
+++ b/pkg/doc/util/signature/internal/signer/crypto_signer.go
@@ -1,0 +1,118 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package signer
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/x509"
+	"errors"
+	"fmt"
+
+	cryptoapi "github.com/hyperledger/aries-framework-go/pkg/crypto"
+	kmsapi "github.com/hyperledger/aries-framework-go/pkg/kms"
+)
+
+// CryptoSigner defines signer based on crypto.
+type CryptoSigner struct {
+	PubKeyBytes []byte
+	PubKey      interface{}
+
+	crypto cryptoapi.Crypto
+	kh     interface{}
+}
+
+// Sign will sign document and return signature.
+func (s *CryptoSigner) Sign(msg []byte) ([]byte, error) {
+	return s.crypto.Sign(msg, s.kh)
+}
+
+// PublicKey returns a public key object (e.g. ed25519.PublicKey or *ecdsa.PublicKey).
+func (s *CryptoSigner) PublicKey() interface{} {
+	return s.PubKey
+}
+
+// PublicKeyBytes returns bytes of the public key.
+func (s *CryptoSigner) PublicKeyBytes() []byte {
+	return s.PubKeyBytes
+}
+
+// NewCryptoSigner creates a new CryptoSigner.
+func NewCryptoSigner(crypto cryptoapi.Crypto, kms kmsapi.KeyManager, keyType kmsapi.KeyType) (*CryptoSigner, error) {
+	kid, kh, err := kms.Create(keyType)
+	if err != nil {
+		return nil, err
+	}
+
+	pubKeyBytes, err := kms.ExportPubKeyBytes(kid)
+	if err != nil {
+		return nil, err
+	}
+
+	pubKey, err := getPublicKey(keyType, pubKeyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CryptoSigner{
+		crypto:      crypto,
+		kh:          kh,
+		PubKey:      pubKey,
+		PubKeyBytes: pubKeyBytes,
+	}, nil
+}
+
+func getPublicKey(keyType kmsapi.KeyType, pubKeyBytes []byte) (interface{}, error) {
+	switch keyType {
+	case kmsapi.ECDSAP256TypeDER, kmsapi.ECDSAP384TypeDER, kmsapi.ECDSAP521TypeDER:
+		pubKey, err := x509.ParsePKIXPublicKey(pubKeyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse ECDSA public key: %w", err)
+		}
+
+		ecdsaPubKey, ok := pubKey.(*ecdsa.PublicKey)
+		if !ok {
+			return nil, errors.New("unexpected type of ecdsa public key")
+		}
+
+		return ecdsaPubKey, nil
+
+	case kmsapi.ECDSAP256TypeIEEEP1363:
+		x, y := elliptic.Unmarshal(elliptic.P256(), pubKeyBytes)
+
+		return &ecdsa.PublicKey{
+			Curve: elliptic.P256(),
+			X:     x,
+			Y:     y,
+		}, nil
+
+	case kmsapi.ECDSAP384TypeIEEEP1363:
+		x, y := elliptic.Unmarshal(elliptic.P384(), pubKeyBytes)
+
+		return &ecdsa.PublicKey{
+			Curve: elliptic.P384(),
+			X:     x,
+			Y:     y,
+		}, nil
+
+	case kmsapi.ECDSAP521TypeIEEEP1363:
+		x, y := elliptic.Unmarshal(elliptic.P521(), pubKeyBytes)
+
+		return &ecdsa.PublicKey{
+			Curve: elliptic.P521(),
+			X:     x,
+			Y:     y,
+		}, nil
+
+	case kmsapi.ED25519Type:
+		return ed25519.PublicKey(pubKeyBytes), nil
+
+	default:
+		return nil, errors.New("unsupported key type")
+	}
+}

--- a/pkg/doc/util/signature/internal/signer/crypto_signer_test.go
+++ b/pkg/doc/util/signature/internal/signer/crypto_signer_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package signer
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"errors"
+	"testing"
+
+	"github.com/google/tink/go/keyset"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto"
+	kmsapi "github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
+)
+
+func TestNewCryptoSigner(t *testing.T) {
+	localKMS, err := createKMS()
+	require.NoError(t, err)
+
+	tinkCrypto, err := tinkcrypto.New()
+	require.NoError(t, err)
+
+	tests := []struct {
+		keyType      kmsapi.KeyType
+		expectedType interface{}
+	}{
+		{kmsapi.ED25519Type, ed25519.PublicKey{}},
+		{kmsapi.ECDSAP256TypeDER, &ecdsa.PublicKey{}},
+		{kmsapi.ECDSAP384TypeDER, &ecdsa.PublicKey{}},
+		{kmsapi.ECDSAP521TypeDER, &ecdsa.PublicKey{}},
+		{kmsapi.ECDSAP256TypeIEEEP1363, &ecdsa.PublicKey{}},
+		{kmsapi.ECDSAP384TypeIEEEP1363, &ecdsa.PublicKey{}},
+		{kmsapi.ECDSAP521TypeIEEEP1363, &ecdsa.PublicKey{}},
+	}
+
+	for _, test := range tests {
+		signer, err := NewCryptoSigner(tinkCrypto, localKMS, test.keyType)
+		require.NoError(t, err)
+		require.NotNil(t, signer.PubKey)
+		require.IsType(t, test.expectedType, signer.PublicKey())
+		require.NotEmpty(t, signer.PublicKeyBytes())
+
+		msg := []byte("test message")
+		sigMsg, err := signer.Sign(msg)
+		require.NoError(t, err)
+
+		keyHandle, ok := signer.kh.(*keyset.Handle)
+		require.True(t, ok)
+
+		publicKeyHandle, err := keyHandle.Public()
+		require.NoError(t, err)
+
+		err = tinkCrypto.Verify(sigMsg, msg, publicKeyHandle)
+		require.NoError(t, err)
+	}
+
+	t.Run("error corner cases", func(t *testing.T) {
+		kms := &mockkms.KeyManager{
+			CreateKeyErr: errors.New("key creation error"),
+		}
+		signer, err := NewCryptoSigner(tinkCrypto, kms, kmsapi.ED25519Type)
+		require.Error(t, err)
+		require.EqualError(t, err, "key creation error")
+		require.Nil(t, signer)
+
+		kms = &mockkms.KeyManager{
+			ExportPubKeyBytesErr: errors.New("export public key bytes error"),
+		}
+		signer, err = NewCryptoSigner(tinkCrypto, kms, kmsapi.ED25519Type)
+		require.Error(t, err)
+		require.EqualError(t, err, "export public key bytes error")
+		require.Nil(t, signer)
+
+		kms = &mockkms.KeyManager{
+			ExportPubKeyBytesValue: []byte("not a public key"),
+		}
+		signer, err = NewCryptoSigner(tinkCrypto, kms, kmsapi.ECDSAP256TypeDER)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parse ECDSA public key")
+		require.Nil(t, signer)
+
+		publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+		pubKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+		require.NoError(t, err)
+		kms = &mockkms.KeyManager{
+			ExportPubKeyBytesValue: pubKeyBytes,
+		}
+		signer, err = NewCryptoSigner(tinkCrypto, kms, kmsapi.ECDSAP256TypeDER)
+		require.Error(t, err)
+		require.EqualError(t, err, "unexpected type of ecdsa public key")
+		require.Nil(t, signer)
+
+		kms = &mockkms.KeyManager{}
+		signer, err = NewCryptoSigner(tinkCrypto, kms, kmsapi.ChaCha20Poly1305Type)
+		require.Error(t, err)
+		require.EqualError(t, err, "unsupported key type")
+		require.Nil(t, signer)
+	})
+}
+
+func createKMS() (*localkms.LocalKMS, error) {
+	p := mockkms.NewProviderForKMS(storage.NewMockStoreProvider(), &noop.NoLock{})
+
+	return localkms.New("local-lock://custom/master/key/", p)
+}

--- a/pkg/doc/util/signature/internal/signer/ecdsa.go
+++ b/pkg/doc/util/signature/internal/signer/ecdsa.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package signature
+package signer
 
 import (
 	"crypto"
@@ -23,12 +23,12 @@ func NewECDSAP256Signer() (*ECDSASigner, error) {
 		return nil, err
 	}
 
-	return &ECDSASigner{privateKey: privKey, PublicKey: &privKey.PublicKey, hash: crypto.SHA256}, nil
+	return newECDSASigner(privKey, &privKey.PublicKey, crypto.SHA256), nil
 }
 
 // GetECDSAP256Signer creates a new ECDSA P256 signer with passed ECDSA P256 private key.
 func GetECDSAP256Signer(privKey *ecdsa.PrivateKey) *ECDSASigner {
-	return &ECDSASigner{privateKey: privKey, PublicKey: &privKey.PublicKey, hash: crypto.SHA256}
+	return newECDSASigner(privKey, &privKey.PublicKey, crypto.SHA256)
 }
 
 // NewECDSAP384Signer creates a new ECDSA P384 signer with generated key.
@@ -38,12 +38,12 @@ func NewECDSAP384Signer() (*ECDSASigner, error) {
 		return nil, err
 	}
 
-	return &ECDSASigner{privateKey: privKey, PublicKey: &privKey.PublicKey, hash: crypto.SHA384}, nil
+	return newECDSASigner(privKey, &privKey.PublicKey, crypto.SHA384), nil
 }
 
 // GetECDSAP384Signer creates a new ECDSA P384 signer with passed ECDSA P384 private key.
 func GetECDSAP384Signer(privKey *ecdsa.PrivateKey) *ECDSASigner {
-	return &ECDSASigner{privateKey: privKey, PublicKey: &privKey.PublicKey, hash: crypto.SHA384}
+	return newECDSASigner(privKey, &privKey.PublicKey, crypto.SHA384)
 }
 
 // NewECDSAP521Signer creates a new ECDSA P521 signer with generated key.
@@ -53,12 +53,12 @@ func NewECDSAP521Signer() (*ECDSASigner, error) {
 		return nil, err
 	}
 
-	return &ECDSASigner{privateKey: privKey, PublicKey: &privKey.PublicKey, hash: crypto.SHA512}, nil
+	return newECDSASigner(privKey, &privKey.PublicKey, crypto.SHA512), nil
 }
 
 // GetECDSAP521Signer creates a new ECDSA P521 signer with passed ECDSA P521 private key.
 func GetECDSAP521Signer(privKey *ecdsa.PrivateKey) *ECDSASigner {
-	return &ECDSASigner{privateKey: privKey, PublicKey: &privKey.PublicKey, hash: crypto.SHA512}
+	return newECDSASigner(privKey, &privKey.PublicKey, crypto.SHA512)
 }
 
 // NewECDSASecp256k1Signer creates a new ECDSA Secp256k1 signer with generated key.
@@ -68,12 +68,12 @@ func NewECDSASecp256k1Signer() (*ECDSASigner, error) {
 		return nil, err
 	}
 
-	return &ECDSASigner{privateKey: privKey, PublicKey: &privKey.PublicKey, hash: crypto.SHA256}, nil
+	return newECDSASigner(privKey, &privKey.PublicKey, crypto.SHA256), nil
 }
 
 // GetECDSASecp256k1Signer creates a new ECDSA Secp256k1 signer with passed ECDSA Secp256k1 private key.
 func GetECDSASecp256k1Signer(privKey *ecdsa.PrivateKey) *ECDSASigner {
-	return &ECDSASigner{privateKey: privKey, PublicKey: &privKey.PublicKey, hash: crypto.SHA256}
+	return newECDSASigner(privKey, &privKey.PublicKey, crypto.SHA256)
 }
 
 // NewECDSASigner creates a new ECDSA signer based on the input elliptic curve.
@@ -98,9 +98,29 @@ func NewECDSASigner(curve elliptic.Curve) (*ECDSASigner, error) {
 
 // ECDSASigner makes ECDSA based signatures.
 type ECDSASigner struct {
-	privateKey *ecdsa.PrivateKey
-	PublicKey  *ecdsa.PublicKey
-	hash       crypto.Hash
+	privateKey  *ecdsa.PrivateKey
+	PubKey      *ecdsa.PublicKey
+	pubKeyBytes []byte
+	hash        crypto.Hash
+}
+
+func newECDSASigner(privKey *ecdsa.PrivateKey, pubKey *ecdsa.PublicKey, hash crypto.Hash) *ECDSASigner {
+	return &ECDSASigner{
+		privateKey:  privKey,
+		PubKey:      pubKey,
+		pubKeyBytes: elliptic.Marshal(pubKey.Curve, pubKey.X, pubKey.Y),
+		hash:        hash,
+	}
+}
+
+// PublicKey returns a public key object (*ecdsa.PublicKey).
+func (es *ECDSASigner) PublicKey() interface{} {
+	return es.PubKey
+}
+
+// PublicKeyBytes returns bytes of the public key.
+func (es *ECDSASigner) PublicKeyBytes() []byte {
+	return es.pubKeyBytes
 }
 
 // Sign signs a message.

--- a/pkg/doc/util/signature/internal/signer/ecdsa_test.go
+++ b/pkg/doc/util/signature/internal/signer/ecdsa_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package signature
+package signer
 
 import (
 	"crypto"
@@ -24,7 +24,7 @@ func TestNewECDSAP256Signer(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, signer)
 	require.NotNil(t, signer.privateKey)
-	require.NotNil(t, signer.PublicKey)
+	require.NotNil(t, signer.PubKey)
 	require.Equal(t, crypto.SHA256, signer.hash)
 }
 
@@ -35,7 +35,7 @@ func TestGetECDSAP256Signer(t *testing.T) {
 	signer := GetECDSAP256Signer(privKey)
 	require.NotNil(t, signer)
 	require.Equal(t, privKey, signer.privateKey)
-	require.Equal(t, &privKey.PublicKey, signer.PublicKey)
+	require.Equal(t, &privKey.PublicKey, signer.PubKey)
 }
 
 func TestNewECDSAP384Signer(t *testing.T) {
@@ -44,7 +44,7 @@ func TestNewECDSAP384Signer(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, signer)
 	require.NotNil(t, signer.privateKey)
-	require.NotNil(t, signer.PublicKey)
+	require.NotNil(t, signer.PubKey)
 	require.Equal(t, crypto.SHA384, signer.hash)
 }
 
@@ -55,7 +55,7 @@ func TestGetECDSAP384Signer(t *testing.T) {
 	signer := GetECDSAP384Signer(privKey)
 	require.NotNil(t, signer)
 	require.Equal(t, privKey, signer.privateKey)
-	require.Equal(t, &privKey.PublicKey, signer.PublicKey)
+	require.Equal(t, &privKey.PublicKey, signer.PubKey)
 }
 
 func TestNewECDSAP521Signer(t *testing.T) {
@@ -64,7 +64,7 @@ func TestNewECDSAP521Signer(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, signer)
 	require.NotNil(t, signer.privateKey)
-	require.NotNil(t, signer.PublicKey)
+	require.NotNil(t, signer.PubKey)
 	require.Equal(t, crypto.SHA512, signer.hash)
 }
 
@@ -75,7 +75,7 @@ func TestGetECDSAP521Signer(t *testing.T) {
 	signer := GetECDSAP521Signer(privKey)
 	require.NotNil(t, signer)
 	require.Equal(t, privKey, signer.privateKey)
-	require.Equal(t, &privKey.PublicKey, signer.PublicKey)
+	require.Equal(t, &privKey.PublicKey, signer.PubKey)
 }
 
 func TestNewECDSASigner(t *testing.T) {
@@ -111,7 +111,7 @@ func TestNewECDSASecp256k1Signer(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, signer)
 	require.NotNil(t, signer.privateKey)
-	require.NotNil(t, signer.PublicKey)
+	require.NotNil(t, signer.PubKey)
 	require.Equal(t, crypto.SHA256, signer.hash)
 }
 
@@ -122,7 +122,7 @@ func TestGetECDSASecp256k1Signer(t *testing.T) {
 	signer := GetECDSASecp256k1Signer(privKey)
 	require.NotNil(t, signer)
 	require.Equal(t, privKey, signer.privateKey)
-	require.Equal(t, &privKey.PublicKey, signer.PublicKey)
+	require.Equal(t, &privKey.PublicKey, signer.PubKey)
 }
 
 func TestECDSASigner_Sign(t *testing.T) {

--- a/pkg/doc/util/signature/internal/signer/ed25519.go
+++ b/pkg/doc/util/signature/internal/signer/ed25519.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package signature
+package signer
 
 import (
 	"crypto/ed25519"
@@ -19,18 +19,28 @@ func NewEd25519Signer() (*Ed25519Signer, error) {
 		return nil, err
 	}
 
-	return &Ed25519Signer{privateKey: privKey, PublicKey: pubKey}, nil
+	return &Ed25519Signer{privateKey: privKey, PubKey: pubKey}, nil
 }
 
 // GetEd25519Signer creates a new Ed25519 signer with passed Ed25519 key pair.
 func GetEd25519Signer(privKey ed25519.PrivateKey, pubKey ed25519.PublicKey) *Ed25519Signer {
-	return &Ed25519Signer{privateKey: privKey, PublicKey: pubKey}
+	return &Ed25519Signer{privateKey: privKey, PubKey: pubKey}
 }
 
 // Ed25519Signer makes Ed25519 based signatures.
 type Ed25519Signer struct {
 	privateKey ed25519.PrivateKey
-	PublicKey  ed25519.PublicKey
+	PubKey     ed25519.PublicKey
+}
+
+// PublicKey returns a public key object (ed25519.PublicKey).
+func (s *Ed25519Signer) PublicKey() interface{} {
+	return s.PubKey
+}
+
+// PublicKeyBytes returns bytes of the public key.
+func (s *Ed25519Signer) PublicKeyBytes() []byte {
+	return s.PubKey
 }
 
 // Sign signs a message.

--- a/pkg/doc/util/signature/internal/signer/ed25519_test.go
+++ b/pkg/doc/util/signature/internal/signer/ed25519_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package signature
+package signer
 
 import (
 	"crypto/ed25519"
@@ -19,7 +19,7 @@ func TestNewEd25519Signer(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, signer)
 	require.NotNil(t, signer.privateKey)
-	require.NotNil(t, signer.PublicKey)
+	require.NotNil(t, signer.PubKey)
 }
 
 func TestGetEd25519Signer(t *testing.T) {
@@ -28,7 +28,7 @@ func TestGetEd25519Signer(t *testing.T) {
 
 	signer := GetEd25519Signer(privKey, pubKey)
 	require.NotNil(t, signer)
-	require.Equal(t, pubKey, signer.PublicKey)
+	require.Equal(t, pubKey, signer.PubKey)
 	require.Equal(t, privKey, signer.privateKey)
 }
 
@@ -40,7 +40,7 @@ func TestEd25519Signer_Sign(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, signature)
 
-	signer = GetEd25519Signer([]byte("invalid private key"), signer.PublicKey)
+	signer = GetEd25519Signer([]byte("invalid private key"), signer.PubKey)
 	signature, err = signer.Sign([]byte("test message"))
 	require.Error(t, err)
 	require.EqualError(t, err, "ed25519: bad private key length")

--- a/pkg/doc/util/signature/internal/signer/rsa.go
+++ b/pkg/doc/util/signature/internal/signer/rsa.go
@@ -4,12 +4,13 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package signature
+package signer
 
 import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 )
 
 // NewRS256Signer creates a new RS256 signer with generated key.
@@ -19,22 +20,25 @@ func NewRS256Signer() (*RS256Signer, error) {
 		return nil, err
 	}
 
-	return &RS256Signer{privateKey: privKey, PublicKey: &privKey.PublicKey}, nil
+	return newRS256Signer(privKey), nil
 }
 
 // GetRS256Signer creates a new RS256 signer with provided RSA private key.
 func GetRS256Signer(privKey *rsa.PrivateKey) *RS256Signer {
-	return &RS256Signer{privateKey: privKey, PublicKey: &privKey.PublicKey}
+	return newRS256Signer(privKey)
+}
+
+func newRS256Signer(privKey *rsa.PrivateKey) *RS256Signer {
+	return &RS256Signer{*newRSASigner(privKey)}
 }
 
 // RS256Signer makes RS256 based signatures.
 type RS256Signer struct {
-	privateKey *rsa.PrivateKey
-	PublicKey  *rsa.PublicKey
+	rsaSigner
 }
 
 // Sign signs a message.
-func (s RS256Signer) Sign(msg []byte) ([]byte, error) {
+func (s *RS256Signer) Sign(msg []byte) ([]byte, error) {
 	hasher := crypto.SHA256.New()
 	_, _ = hasher.Write(msg) //nolint:errcheck
 	hashed := hasher.Sum(nil)
@@ -49,22 +53,25 @@ func NewPS256Signer() (*PS256Signer, error) {
 		return nil, err
 	}
 
-	return &PS256Signer{privateKey: privKey, PublicKey: &privKey.PublicKey}, nil
+	return newPS256Signer(privKey), nil
 }
 
 // GetPS256Signer creates a new PS256 signer with provided RSA private key.
 func GetPS256Signer(privKey *rsa.PrivateKey) *PS256Signer {
-	return &PS256Signer{privateKey: privKey, PublicKey: &privKey.PublicKey}
+	return newPS256Signer(privKey)
+}
+
+func newPS256Signer(privKey *rsa.PrivateKey) *PS256Signer {
+	return &PS256Signer{*newRSASigner(privKey)}
 }
 
 // PS256Signer makes PS256 based signatures.
 type PS256Signer struct {
-	privateKey *rsa.PrivateKey
-	PublicKey  *rsa.PublicKey
+	rsaSigner
 }
 
 // Sign signs a message.
-func (s PS256Signer) Sign(msg []byte) ([]byte, error) {
+func (s *PS256Signer) Sign(msg []byte) ([]byte, error) {
 	hasher := crypto.SHA256.New()
 
 	_, _ = hasher.Write(msg) //nolint:errcheck
@@ -74,4 +81,28 @@ func (s PS256Signer) Sign(msg []byte) ([]byte, error) {
 	return rsa.SignPSS(rand.Reader, s.privateKey, crypto.SHA256, hashed, &rsa.PSSOptions{
 		SaltLength: rsa.PSSSaltLengthEqualsHash,
 	})
+}
+
+func newRSASigner(privKey *rsa.PrivateKey) *rsaSigner {
+	pubKey := &privKey.PublicKey
+
+	return &rsaSigner{
+		privateKey:  privKey,
+		PubKey:      pubKey,
+		pubKeyBytes: x509.MarshalPKCS1PublicKey(pubKey),
+	}
+}
+
+type rsaSigner struct {
+	privateKey  *rsa.PrivateKey
+	PubKey      *rsa.PublicKey
+	pubKeyBytes []byte
+}
+
+func (s *rsaSigner) PublicKey() interface{} {
+	return s.PubKey
+}
+
+func (s *rsaSigner) PublicKeyBytes() []byte {
+	return s.pubKeyBytes
 }

--- a/pkg/doc/util/signature/internal/signer/rsa_test.go
+++ b/pkg/doc/util/signature/internal/signer/rsa_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package signature
+package signer
 
 import (
 	"crypto/rand"
@@ -20,7 +20,7 @@ func TestNewRS256Signer(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, signer)
 	require.NotNil(t, signer.privateKey)
-	require.NotNil(t, signer.PublicKey)
+	require.NotNil(t, signer.PubKey)
 }
 
 func TestGetRS256Signer(t *testing.T) {
@@ -30,7 +30,7 @@ func TestGetRS256Signer(t *testing.T) {
 	signer := GetRS256Signer(privKey)
 	require.NotNil(t, signer)
 	require.Equal(t, privKey, signer.privateKey)
-	require.Equal(t, &privKey.PublicKey, signer.PublicKey)
+	require.Equal(t, &privKey.PublicKey, signer.PubKey)
 }
 
 func TestRS256Signer_Sign(t *testing.T) {
@@ -48,7 +48,7 @@ func TestNewPS256Signer(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, signer)
 	require.NotNil(t, signer.privateKey)
-	require.NotNil(t, signer.PublicKey)
+	require.NotNil(t, signer.PubKey)
 }
 
 func TestGetPS256Signer(t *testing.T) {
@@ -58,7 +58,7 @@ func TestGetPS256Signer(t *testing.T) {
 	signer := GetPS256Signer(privKey)
 	require.NotNil(t, signer)
 	require.Equal(t, privKey, signer.privateKey)
-	require.Equal(t, &privKey.PublicKey, signer.PublicKey)
+	require.Equal(t, &privKey.PublicKey, signer.PubKey)
 }
 
 func TestPS256Signer_Sign(t *testing.T) {

--- a/pkg/doc/util/signature/signer.go
+++ b/pkg/doc/util/signature/signer.go
@@ -1,0 +1,74 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package signature
+
+import (
+	"crypto/ed25519"
+	"errors"
+
+	cryptoapi "github.com/hyperledger/aries-framework-go/pkg/crypto"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util/signature/internal/signer"
+	kmsapi "github.com/hyperledger/aries-framework-go/pkg/kms"
+)
+
+// NewCryptoSigner creates a new signer based on crypto if possible.
+func NewCryptoSigner(crypto cryptoapi.Crypto, kms kmsapi.KeyManager, keyType kmsapi.KeyType) (Signer, error) {
+	switch keyType {
+	case kmsapi.ECDSAP256TypeDER, kmsapi.ECDSAP256TypeIEEEP1363,
+		kmsapi.ECDSAP384TypeDER, kmsapi.ECDSAP384TypeIEEEP1363,
+		kmsapi.ECDSAP521TypeDER, kmsapi.ECDSAP521TypeIEEEP1363,
+		kmsapi.ED25519Type:
+		return signer.NewCryptoSigner(crypto, kms, keyType)
+
+	case kmsapi.ECDSASecp256k1TypeIEEEP1363:
+		// TODO use crypto signer when available (https://github.com/hyperledger/aries-framework-go/issues/1285)
+		return signer.NewECDSASecp256k1Signer()
+
+	case kmsapi.RSARS256Type:
+		return signer.NewRS256Signer()
+
+	case kmsapi.RSAPS256Type:
+		return signer.NewPS256Signer()
+
+	default:
+		return nil, errors.New("unsupported key type")
+	}
+}
+
+// NewSigner creates a new signer.
+func NewSigner(keyType kmsapi.KeyType) (Signer, error) {
+	switch keyType {
+	case kmsapi.ED25519Type:
+		return signer.NewEd25519Signer()
+
+	case kmsapi.ECDSAP256TypeDER, kmsapi.ECDSAP256TypeIEEEP1363:
+		return signer.NewECDSAP256Signer()
+
+	case kmsapi.ECDSAP384TypeDER, kmsapi.ECDSAP384TypeIEEEP1363:
+		return signer.NewECDSAP384Signer()
+
+	case kmsapi.ECDSAP521TypeDER, kmsapi.ECDSAP521TypeIEEEP1363:
+		return signer.NewECDSAP521Signer()
+
+	case kmsapi.ECDSASecp256k1TypeIEEEP1363:
+		return signer.NewECDSASecp256k1Signer()
+
+	case kmsapi.RSARS256Type:
+		return signer.NewRS256Signer()
+
+	case kmsapi.RSAPS256Type:
+		return signer.NewPS256Signer()
+
+	default:
+		return nil, errors.New("unsupported key type")
+	}
+}
+
+// GetEd25519Signer returns Ed25519 Signer with predefined private and public keys.
+func GetEd25519Signer(privKey ed25519.PrivateKey, pubKey ed25519.PublicKey) Signer {
+	return signer.GetEd25519Signer(privKey, pubKey)
+}

--- a/pkg/doc/util/signature/signer_test.go
+++ b/pkg/doc/util/signature/signer_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package signature
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util/signature/internal/signer"
+	kmsapi "github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
+)
+
+func TestNewCryptoSigner(t *testing.T) {
+	p := mockkms.NewProviderForKMS(storage.NewMockStoreProvider(), &noop.NoLock{})
+	localKMS, err := localkms.New("local-lock://custom/master/key/", p)
+	require.NoError(t, err)
+
+	tinkCrypto, err := tinkcrypto.New()
+	require.NoError(t, err)
+
+	for _, keyType := range [...]kmsapi.KeyType{
+		kmsapi.ECDSAP256TypeDER, kmsapi.ECDSAP384TypeDER, kmsapi.ECDSAP521TypeDER,
+		kmsapi.ECDSAP256TypeIEEEP1363, kmsapi.ECDSAP521TypeIEEEP1363, kmsapi.ED25519Type,
+		kmsapi.ECDSAP384TypeIEEEP1363, kmsapi.ECDSASecp256k1TypeIEEEP1363, kmsapi.RSARS256Type, kmsapi.RSAPS256Type,
+	} {
+		newSigner, signerErr := NewCryptoSigner(tinkCrypto, localKMS, keyType)
+		require.NoError(t, signerErr)
+
+		msgSig, signerErr := newSigner.Sign([]byte("test message"))
+		require.NoError(t, signerErr)
+		require.NotEmpty(t, msgSig)
+	}
+
+	newSigner, err := NewCryptoSigner(tinkCrypto, localKMS, kmsapi.ChaCha20Poly1305Type)
+	require.Error(t, err)
+	require.EqualError(t, err, "unsupported key type")
+	require.Nil(t, newSigner)
+}
+
+func TestNewSigner(t *testing.T) {
+	for _, keyType := range [...]kmsapi.KeyType{
+		kmsapi.ECDSAP256TypeDER, kmsapi.ECDSAP384TypeDER, kmsapi.ECDSAP521TypeDER,
+		kmsapi.ECDSAP256TypeIEEEP1363, kmsapi.ECDSAP521TypeIEEEP1363, kmsapi.ED25519Type,
+		kmsapi.ECDSAP384TypeIEEEP1363, kmsapi.ECDSASecp256k1TypeIEEEP1363, kmsapi.RSARS256Type, kmsapi.RSAPS256Type,
+	} {
+		newSigner, signerErr := NewSigner(keyType)
+		require.NoError(t, signerErr)
+
+		msgSig, signerErr := newSigner.Sign([]byte("test message"))
+		require.NoError(t, signerErr)
+		require.NotEmpty(t, msgSig)
+	}
+
+	invalidSigner, err := NewSigner(kmsapi.ChaCha20Poly1305Type)
+	require.Error(t, err)
+	require.EqualError(t, err, "unsupported key type")
+	require.Nil(t, invalidSigner)
+}
+
+func TestGetEd25519Signer(t *testing.T) {
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	ed25519Signer := GetEd25519Signer(privKey, pubKey)
+	require.NotNil(t, ed25519Signer)
+	require.IsType(t, &signer.Ed25519Signer{}, ed25519Signer)
+}

--- a/pkg/doc/util/signature/utils.go
+++ b/pkg/doc/util/signature/utils.go
@@ -1,0 +1,36 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package signature
+
+import (
+	"crypto/elliptic"
+	"errors"
+
+	"github.com/btcsuite/btcd/btcec"
+
+	kmsapi "github.com/hyperledger/aries-framework-go/pkg/kms"
+)
+
+// MapECCurveToKeyType makes a mapping of Elliptic Curve to KeyType of kms.
+func MapECCurveToKeyType(curve elliptic.Curve) (kmsapi.KeyType, error) {
+	switch curve {
+	case elliptic.P256():
+		return kmsapi.ECDSAP256TypeIEEEP1363, nil
+
+	case elliptic.P384():
+		return kmsapi.ECDSAP384TypeIEEEP1363, nil
+
+	case elliptic.P521():
+		return kmsapi.ECDSAP521TypeIEEEP1363, nil
+
+	case btcec.S256():
+		return kmsapi.ECDSASecp256k1TypeIEEEP1363, nil
+
+	default:
+		return "", errors.New("unsupported curve")
+	}
+}

--- a/pkg/doc/util/signature/utils_test.go
+++ b/pkg/doc/util/signature/utils_test.go
@@ -1,0 +1,55 @@
+package signature
+
+import (
+	"crypto/elliptic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/btcsuite/btcd/btcec"
+
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+)
+
+func TestMapECCurveToKeyType(t *testing.T) {
+	tests := []struct {
+		name    string
+		curve   elliptic.Curve
+		keyType kms.KeyType
+	}{
+		{
+			name:    "P256",
+			curve:   elliptic.P256(),
+			keyType: kms.ECDSAP256TypeIEEEP1363,
+		},
+		{
+			name:    "P384",
+			curve:   elliptic.P384(),
+			keyType: kms.ECDSAP384TypeIEEEP1363,
+		},
+		{
+			name:    "P521",
+			curve:   elliptic.P521(),
+			keyType: kms.ECDSAP521TypeIEEEP1363,
+		},
+		{
+			name:    "secp256k1",
+			curve:   btcec.S256(),
+			keyType: kms.ECDSASecp256k1TypeIEEEP1363,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			keyType, err := MapECCurveToKeyType(tt.curve)
+			require.NoError(t, err)
+			require.Equal(t, tt.keyType, keyType)
+		})
+	}
+
+	_, err := MapECCurveToKeyType(elliptic.P224())
+	require.Error(t, err)
+	require.EqualError(t, err, "unsupported curve")
+}

--- a/pkg/doc/verifiable/credential_jws_test.go
+++ b/pkg/doc/verifiable/credential_jws_test.go
@@ -16,12 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/util/signature"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
 func TestJWTCredClaimsMarshalJWS(t *testing.T) {
-	signer, err := signature.NewRS256Signer()
+	signer, err := newCryptoSigner(kms.RSARS256Type)
 	require.NoError(t, err)
 
 	vc, err := parseTestCredential([]byte(validCredential))
@@ -36,8 +35,8 @@ func TestJWTCredClaimsMarshalJWS(t *testing.T) {
 
 		vcBytes, err := decodeCredJWS(jws, true, func(issuerID, keyID string) (*verifier.PublicKey, error) {
 			return &verifier.PublicKey{
-				Type:  kms.RSA,
-				Value: publicKeyPemToBytes(signer.PublicKey),
+				Type:  kms.RSARS256,
+				Value: signer.PublicKeyBytes(),
 			}, nil
 		})
 		require.NoError(t, err)
@@ -58,13 +57,13 @@ type invalidCredClaims struct {
 }
 
 func TestCredJWSDecoderUnmarshal(t *testing.T) {
-	signer, err := signature.NewRS256Signer()
+	signer, err := newCryptoSigner(kms.RSARS256Type)
 	require.NoError(t, err)
 
 	pkFetcher := func(_, _ string) (*verifier.PublicKey, error) { //nolint:unparam
 		return &verifier.PublicKey{
-			Type:  kms.RSA,
-			Value: publicKeyPemToBytes(signer.PublicKey),
+			Type:  kms.RSARS256,
+			Value: signer.PublicKeyBytes(),
 		}, nil
 	}
 
@@ -116,12 +115,12 @@ func TestCredJWSDecoderUnmarshal(t *testing.T) {
 	t.Run("Invalid signature of JWS", func(t *testing.T) {
 		pkFetcherOther := func(issuerID, keyID string) (*verifier.PublicKey, error) {
 			// use public key of VC Holder (while expecting to use the ones of Issuer)
-			holderSigner, err := signature.NewRS256Signer()
+			holderSigner, err := newCryptoSigner(kms.RSARS256Type)
 			require.NoError(t, err)
 
 			return &verifier.PublicKey{
-				Type:  kms.RSA,
-				Value: publicKeyPemToBytes(holderSigner.PublicKey),
+				Type:  kms.RSARS256,
+				Value: holderSigner.PublicKeyBytes(),
 			}, nil
 		}
 

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ed25519signature2018"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/util/signature"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
@@ -1718,7 +1717,7 @@ func TestCredential_raw(t *testing.T) {
 }
 
 func TestParseUnverifiedCredential(t *testing.T) {
-	signer, err := signature.NewEd25519Signer()
+	signer, err := newCryptoSigner(kms.ED25519Type)
 	require.NoError(t, err)
 
 	t.Run("ParseUnverifiedCredential() for JWS", func(t *testing.T) {

--- a/pkg/doc/verifiable/example_credential_test.go
+++ b/pkg/doc/verifiable/example_credential_test.go
@@ -8,7 +8,6 @@ package verifiable_test
 
 import (
 	"crypto/ed25519"
-	"crypto/elliptic"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -461,7 +460,7 @@ func ExampleCredential_AddLinkedDataProofMultiProofs() {
 		panic(err)
 	}
 
-	ecdsaSigner, err := signature.NewECDSASecp256k1Signer()
+	ecdsaSigner, err := signature.NewSigner(kms.ECDSASecp256k1TypeIEEEP1363)
 	if err != nil {
 		panic(err)
 	}
@@ -486,7 +485,7 @@ func ExampleCredential_AddLinkedDataProofMultiProofs() {
 	ed25519Suite := ed25519signature2018.New(suite.WithVerifier(ed25519signature2018.NewPublicKeyVerifier()))
 	jsonWebSignatureSuite := jsonwebsignature2020.New(suite.WithVerifier(jsonwebsignature2020.NewPublicKeyVerifier()))
 
-	jwk, err := jose.JWKFromPublicKey(ecdsaSigner.PublicKey)
+	jwk, err := jose.JWKFromPublicKey(ecdsaSigner.PublicKey())
 	if err != nil {
 		panic(err)
 	}
@@ -504,7 +503,7 @@ func ExampleCredential_AddLinkedDataProofMultiProofs() {
 			case "#key2":
 				return &sigverifier.PublicKey{
 					Type:  "JwsVerificationKey2020",
-					Value: elliptic.Marshal(ecdsaSigner.PublicKey.Curve, ecdsaSigner.PublicKey.X, ecdsaSigner.PublicKey.Y),
+					Value: ecdsaSigner.PublicKeyBytes(),
 					JWK:   jwk,
 				}, nil
 			}

--- a/pkg/doc/verifiable/presentation_ldp_test.go
+++ b/pkg/doc/verifiable/presentation_ldp_test.go
@@ -14,14 +14,13 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ed25519signature2018"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/util/signature"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
 func TestParsePresentationFromLinkedDataProof(t *testing.T) {
 	r := require.New(t)
 
-	signer, err := signature.NewEd25519Signer()
+	signer, err := newCryptoSigner(kms.ED25519Type)
 	r.NoError(err)
 
 	ss := ed25519signature2018.New(suite.WithSigner(signer))
@@ -43,7 +42,7 @@ func TestParsePresentationFromLinkedDataProof(t *testing.T) {
 
 	vcWithLdp, err := newTestPresentation(vcBytes,
 		WithPresEmbeddedSignatureSuites(ss),
-		WithPresPublicKeyFetcher(SingleKey(signer.PublicKey, kms.ED25519)))
+		WithPresPublicKeyFetcher(SingleKey(signer.PublicKeyBytes(), kms.ED25519)))
 	r.NoError(err)
 
 	r.NoError(err)
@@ -53,7 +52,7 @@ func TestParsePresentationFromLinkedDataProof(t *testing.T) {
 func TestPresentation_AddLinkedDataProof(t *testing.T) {
 	r := require.New(t)
 
-	signer, err := signature.NewEd25519Signer()
+	signer, err := newCryptoSigner(kms.ED25519Type)
 	r.NoError(err)
 
 	ldpContext := &LinkedDataProofContext{

--- a/pkg/doc/verifiable/presentation_test.go
+++ b/pkg/doc/verifiable/presentation_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ed25519signature2018"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/util/signature"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
@@ -427,7 +426,7 @@ func TestPresentation_SetCredentials(t *testing.T) {
 func TestPresentation_decodeCredentials(t *testing.T) {
 	r := require.New(t)
 
-	signer, err := signature.NewEd25519Signer()
+	signer, err := newCryptoSigner(kms.ED25519Type)
 	r.NoError(err)
 
 	vc, err := parseTestCredential([]byte(validCredential))
@@ -441,7 +440,7 @@ func TestPresentation_decodeCredentials(t *testing.T) {
 
 	// single credential - JWS
 	opts := defaultPresentationOpts()
-	opts.publicKeyFetcher = SingleKey(signer.PublicKey, kms.ED25519)
+	opts.publicKeyFetcher = SingleKey(signer.PublicKeyBytes(), kms.ED25519)
 	dCreds, err := decodeCredentials(jws, opts)
 	r.NoError(err)
 	r.Len(dCreds, 1)

--- a/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
+++ b/pkg/doc/verifiable/test-suite/verifiable_suite_test.go
@@ -102,7 +102,7 @@ func encodeVPToJWS(vpBytes []byte, audience string, privateKey *rsa.PrivateKey, 
 		// do not test the cryptographic proofs (see https://github.com/w3c/vc-test-suite/issues/101)
 		verifiable.WithPresNoProofCheck(),
 		// the public key is used to decode verifiable credentials passed as JWS to the presentation
-		verifiable.WithPresPublicKeyFetcher(verifiable.SingleKey(publicKeyPemToBytes(publicKey), kms.RSA)))
+		verifiable.WithPresPublicKeyFetcher(verifiable.SingleKey(publicKeyPemToBytes(publicKey), kms.RSARS256)))
 	if err != nil {
 		abort("failed to decode presentation: %v", err)
 	}
@@ -142,7 +142,7 @@ func encodeVCToJWTUnsecured(vcBytes []byte) {
 func decodeVCJWTToJSON(vcBytes []byte, publicKey *rsa.PublicKey) {
 	// Asked to decode JWT
 	credential, err := verifiable.ParseCredential(vcBytes,
-		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(publicKeyPemToBytes(publicKey), kms.RSA)),
+		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(publicKeyPemToBytes(publicKey), kms.RSARS256)),
 		// do not test the cryptographic proofs (see https://github.com/w3c/vc-test-suite/issues/101)
 		verifiable.WithNoProofCheck())
 	if err != nil {

--- a/pkg/kms/api.go
+++ b/pkg/kms/api.go
@@ -91,10 +91,14 @@ const (
 	ECDSAP384IEEEP1363 = "ECDSAP384IEEEP1363"
 	// ECDSAP521IEEEP1363 key type value
 	ECDSAP521IEEEP1363 = "ECDSAP521IEEEP1363"
+	// ECDSASecp256k1IEEEP1363 key type value
+	ECDSASecp256k1IEEEP1363 = "ECDSASecp256k1IEEEP1363"
 	// ED25519 key type value
 	ED25519 = "ED25519"
-	// RSA key type value
-	RSA = "RSA"
+	// RSARS256 key type value
+	RSARS256 = "RSARS256"
+	// RSAPS256 key type value
+	RSAPS256 = "RSAPS256"
 	// HMACSHA256Tag256 key type value
 	HMACSHA256Tag256 = "HMACSHA256Tag256"
 	// ECDHES256AES256GCM key type value
@@ -127,10 +131,14 @@ const (
 	ECDSAP384TypeIEEEP1363 = KeyType(ECDSAP384IEEEP1363)
 	// ECDSAP521TypeIEEEP1363 key type value
 	ECDSAP521TypeIEEEP1363 = KeyType(ECDSAP521IEEEP1363)
+	// ECDSASecp256k1TypeIEEEP1363 key type value
+	ECDSASecp256k1TypeIEEEP1363 = KeyType(ECDSASecp256k1IEEEP1363)
 	// ED25519Type key type value
 	ED25519Type = KeyType(ED25519)
-	// RSAType key type value
-	RSAType = KeyType(RSA)
+	// RSARS256Type key type value
+	RSARS256Type = KeyType(RSARS256)
+	// RSAPS256Type key type value
+	RSAPS256Type = KeyType(RSAPS256)
 	// HMACSHA256Tag256Type key type value
 	HMACSHA256Tag256Type = KeyType(HMACSHA256Tag256)
 	// ECDHES256AES256GCMType key type value

--- a/pkg/kms/localkms/localkms.go
+++ b/pkg/kms/localkms/localkms.go
@@ -178,7 +178,7 @@ func getKeyTemplate(keyType kms.KeyType) (*tinkpb.KeyTemplate, error) {
 		// JWS keys should sign using IEEE_P1363 format only (not DER format)
 		return createECDSAIEEE1363KeyTemplate(commonpb.HashType_SHA256, commonpb.EllipticCurveType_NIST_P256), nil
 	case kms.ECDSAP384TypeIEEEP1363:
-		return createECDSAIEEE1363KeyTemplate(commonpb.HashType_SHA512, commonpb.EllipticCurveType_NIST_P384), nil
+		return createECDSAIEEE1363KeyTemplate(commonpb.HashType_SHA384, commonpb.EllipticCurveType_NIST_P384), nil
 	case kms.ECDSAP521TypeIEEEP1363:
 		return createECDSAIEEE1363KeyTemplate(commonpb.HashType_SHA512, commonpb.EllipticCurveType_NIST_P521), nil
 	case kms.ED25519Type:


### PR DESCRIPTION
Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>

#1852

1. Added `signature.CryptoSigner` which is used by default in `signature` (linked data proofs package) and `verifiable`.
2. Added generic factory `signature.NewCryptoSigner()` which creates `crypto signers` for `key types` which are supported by crypto/kms. For example, `secp256k1` and `RSA` are not supported by crypto/kms (`tink` lib) and thus use non-crypto signers. This can be replaced by crypto signers in the future whenever the missing algorithms will be supported (e.g. https://github.com/hyperledger/aries-framework-go/issues/1285).
3. Signers internals are moved to `internal` subpackage. ![image](https://user-images.githubusercontent.com/20474355/83308651-e8abbe00-a20f-11ea-9e74-629c291d5b07.png)

One more follow-up is needed: to use signers in JWS.