### PR TITLE
feat: log error in case of abandoning of credential issuing process

### DIFF
--- a/pkg/didcomm/protocol/issuecredential/service.go
+++ b/pkg/didcomm/protocol/issuecredential/service.go
@@ -305,6 +305,7 @@ func (s *Service) startInternalListener() {
 			continue
 		}
 
+		logger.Errorf("abandoning: %s", msg.err)
 		msg.state = &abandoning{Code: codeInternalError}
 
 		if err := s.handle(msg); err != nil {


### PR DESCRIPTION
Signed-off-by: Aleksei Belezeko <aleksei.belezeko@t-systems.com>

In case of error during issuing credential process abandoning without any information about reason.

