### PR TITLE
proposed solution to issue 1134

### DIFF
--- a/pkg/client/mediator/client_test.go
+++ b/pkg/client/mediator/client_test.go
@@ -30,6 +30,22 @@ func TestNew(t *testing.T) {
 		require.NotNil(t, svc)
 	})
 
+	t.Run("test new client with all options applied", func(t *testing.T) {
+		i := 0
+		svc, err := New(&mockprovider.Provider{
+			ServiceValue: &mockroute.MockMediatorSvc{}},
+			func(opts *mediatorOpts) {
+				i += 1 // nolint
+			},
+			func(opts *mediatorOpts) {
+				i += 2
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+		require.Equal(t, 1+2, i)
+	})
+
 	t.Run("test error from get service from context", func(t *testing.T) {
 		_, err := New(&mockprovider.Provider{ServiceErr: fmt.Errorf("service error")})
 		require.Error(t, err)

--- a/pkg/mock/didcomm/protocol/mediator/mock_mediator.go
+++ b/pkg/mock/didcomm/protocol/mediator/mock_mediator.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package mediator
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
@@ -30,6 +32,7 @@ type MockMediatorSvc struct {
 	ConnectionID       string
 	GetConnectionIDErr error
 	AddKeyFunc         func(string) error
+	SetTimeoutFunc     func(t time.Duration)
 }
 
 // HandleInbound msg
@@ -116,4 +119,11 @@ func (m *MockMediatorSvc) GetConnection() (string, error) {
 	}
 
 	return m.ConnectionID, nil
+}
+
+// SetTimeout timeout value waiting for responses received from the router
+func (m *MockMediatorSvc) SetTimeout(t time.Duration) {
+	if m.SetTimeoutFunc != nil {
+		m.SetTimeoutFunc(t)
+	}
 }


### PR DESCRIPTION
**Title:**
Setting timeout on router client/service

**Description:**
Resolves https://github.com/hyperledger/aries-framework-go/issues/1134

Summary:

Decorator on router client for setting a timeout. The timeout is then propagated down to the route/mediator service.

I chose to modify the interface with an additional setTimeout method.

I preferred this to changing the Register() signature but options there could be:

explicitly with a timeout:
`Register(connectionID string, timeout time.Duration) error`

introduce some form of options for Register:
`Register(connectionID string, opts ..*.Option) error`

This seemed the most backward compatible with what is out there.
