### PR TITLE
proposed solution to https://github.com/hyperledger/aries-framework-g…

### DIFF
--- a/pkg/client/mediator/client_test.go
+++ b/pkg/client/mediator/client_test.go
@@ -10,10 +10,12 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
 	mockroute "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/mediator"
 	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
 )
@@ -41,12 +43,22 @@ func TestNew(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cast service to route service failed")
 	})
+
+	t.Run("test timeout is applied to options", func(t *testing.T) {
+		timeout := 1 * time.Second
+
+		option := WithTimeout(timeout)
+		opts := &mediator.ClientOptions{}
+		option(opts)
+
+		require.Equal(t, timeout, opts.Timeout)
+	})
 }
 
 func TestRegister(t *testing.T) {
 	t.Run("test register - success", func(t *testing.T) {
 		c, err := New(&mockprovider.Provider{
-			ServiceValue: &mockroute.MockMediatorSvc{RegisterFunc: func(connectionID string) error {
+			ServiceValue: &mockroute.MockMediatorSvc{RegisterFunc: func(connectionID string, options ...mediator.ClientOption) error { // nolint: lll
 				return nil
 			}}})
 		require.NoError(t, err)
@@ -57,7 +69,7 @@ func TestRegister(t *testing.T) {
 
 	t.Run("test register - error", func(t *testing.T) {
 		c, err := New(&mockprovider.Provider{
-			ServiceValue: &mockroute.MockMediatorSvc{RegisterFunc: func(connectionID string) error {
+			ServiceValue: &mockroute.MockMediatorSvc{RegisterFunc: func(connectionID string, options ...mediator.ClientOption) error { // nolint: lll
 				return errors.New("register error")
 			}}})
 		require.NoError(t, err)

--- a/pkg/client/mediator/example_test.go
+++ b/pkg/client/mediator/example_test.go
@@ -137,7 +137,7 @@ func mockContext() provider {
 
 func routeService() *mockroute.MockMediatorSvc {
 	return &mockroute.MockMediatorSvc{
-		RegisterFunc: func(connectionID string) error {
+		RegisterFunc: func(connectionID string, options ...mediator.ClientOption) error {
 			if connectionID == "" {
 				return errors.New("connection ID is mandatory")
 			}

--- a/pkg/controller/command/mediator/command_test.go
+++ b/pkg/controller/command/mediator/command_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
 	mockroute "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/mediator"
 	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
 )
@@ -98,7 +99,7 @@ func TestRegisterRoute(t *testing.T) {
 		cmd, err := New(
 			&mockprovider.Provider{
 				ServiceValue: &mockroute.MockMediatorSvc{
-					RegisterFunc: func(connectionID string) error {
+					RegisterFunc: func(connectionID string, options ...mediator.ClientOption) error {
 						return errors.New("register error")
 					},
 				},

--- a/pkg/didcomm/protocol/mediator/models.go
+++ b/pkg/didcomm/protocol/mediator/models.go
@@ -6,11 +6,16 @@ SPDX-License-Identifier: Apache-2.0
 
 package mediator
 
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+)
+
 // Request route request message.
 // https://github.com/hyperledger/aries-rfcs/tree/master/features/0211-route-coordination#route-request
 type Request struct {
-	Type string `json:"@type,omitempty"`
-	ID   string `json:"@id,omitempty"`
+	Type             string `json:"@type,omitempty"`
+	ID               string `json:"@id,omitempty"`
+	decorator.Timing `json:"~timing,omitempty"`
 }
 
 // Grant route grant message.

--- a/pkg/mock/didcomm/protocol/mediator/mock_mediator.go
+++ b/pkg/mock/didcomm/protocol/mediator/mock_mediator.go
@@ -21,7 +21,7 @@ type MockMediatorSvc struct {
 	HandleFunc         func(service.DIDCommMsg) (string, error)
 	HandleOutboundFunc func(msg service.DIDCommMsg, myDID, theirDID string) error
 	AcceptFunc         func(string) bool
-	RegisterFunc       func(connectionID string) error
+	RegisterFunc       func(connectionID string, options ...mediator.ClientOption) error
 	RouterEndpoint     string
 	RoutingKeys        []string
 	ConfigErr          error
@@ -69,9 +69,9 @@ func (m *MockMediatorSvc) Name() string {
 }
 
 // Register registers agent with the router.
-func (m *MockMediatorSvc) Register(connectionID string) error {
+func (m *MockMediatorSvc) Register(connectionID string, options ...mediator.ClientOption) error {
 	if m.RegisterFunc != nil {
-		return m.RegisterFunc(connectionID)
+		return m.RegisterFunc(connectionID, options...)
 	}
 
 	return nil


### PR DESCRIPTION
**Title:**
Setting timeout on router client/service

**Description:**
Resolves https://github.com/hyperledger/aries-framework-go/issues/1134

Summary:

Decorator on router client for setting a timeout. If set the timeout is then propagated down to the route/mediator service, the previous default remains in place.

I chose to modify the interface with an additional setTimeout method.

I preferred this to changing the Register() signature but options there could be:

explicitly with a timeout:
`Register(connectionID string, timeout time.Duration) error`

introduce some form of options for Register:
`Register(connectionID string, opts ..*.Option) error`

This seemed the most backward compatible with what is out there.

My impetus for needing to override the existing five second default was when testing internally with the route client.

Usage:

`myRouter, err := route.New(ctx, route.WithTimeout(30 * time.Second))`