### PR TITLE
feat: support single recipient compact JWE format

### DIFF
--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_common.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_aead_composite_common.go
@@ -12,26 +12,31 @@ package subtle
 // EncryptedData represents the Encryption's output data as a result of ECDHESEncrypt.Encrypt(pt, aad) call
 // The user of the primitive must unmarshal the result and build their own ECDH-ES compliant message (ie JWE msg)
 type EncryptedData struct {
-	EncAlg     string                 `json:"EncAlg,omitempty"`
-	Ciphertext []byte                 `json:"Ciphertext,omitempty"`
-	IV         []byte                 `json:"IV,omitempty"`
-	Tag        []byte                 `json:"Tag,omitempty"`
-	Recipients []*RecipientWrappedKey `json:"Recipients,omitempty"`
+	EncAlg     string                 `json:"encalg,omitempty"`
+	Ciphertext []byte                 `json:"ciphertext,omitempty"`
+	IV         []byte                 `json:"iv,omitempty"`
+	Tag        []byte                 `json:"tag,omitempty"`
+	Recipients []*RecipientWrappedKey `json:"recipients,omitempty"`
+	// SingleRecipientAAD is the result of an AAD update using a single recipient JWE envelope with recipient headers.
+	// The JWE encrypter in this framework rebuilds this AAD value when building/parsing the JWE envelope. It does not
+	// use this field. It is added here to provide access to the updated AAD for single recipient encryption use by
+	// external users of this crypto primitive.
+	SingleRecipientAAD []byte `json:"singlerecipientaad,omitempty"`
 }
 
 // RecipientWrappedKey contains recipient key material required to unwrap CEK
 type RecipientWrappedKey struct {
 	KID          string    `json:"kid,omitempty"`
-	EncryptedCEK []byte    `json:"EncryptedCEK,omitempty"`
-	EPK          PublicKey `json:"EPK,omitempty"`
-	Alg          string    `json:"Alg,omitempty"`
+	EncryptedCEK []byte    `json:"encryptedcek,omitempty"`
+	EPK          PublicKey `json:"epk,omitempty"`
+	Alg          string    `json:"alg,omitempty"`
 }
 
 // PublicKey mainly to exchange EPK in RecipientWrappedKey
 type PublicKey struct {
 	KID   string `json:"kid,omitempty"`
-	X     []byte `json:"X,omitempty"`
-	Y     []byte `json:"Y,omitempty"`
+	X     []byte `json:"x,omitempty"`
+	Y     []byte `json:"y,omitempty"`
 	Curve string `json:"curve,omitempty"`
 	Type  string `json:"type,omitempty"`
 }

--- a/pkg/didcomm/packer/anoncrypt/pack_test.go
+++ b/pkg/didcomm/packer/anoncrypt/pack_test.go
@@ -43,15 +43,14 @@ func TestAnoncryptPackerSuccess(t *testing.T) {
 
 	require.EqualValues(t, &transport.Envelope{Message: origMsg, ToVerKey: recKey}, msg)
 
-	// TODO uncomment with https://github.com/hyperledger/aries-framework-go/issues/1872
-	// // try with only 1 recipient
-	// ct, err = anonPacker.Pack(origMsg, nil, [][]byte{recipientsKeys[0]})
-	// require.NoError(t, err)
-	//
-	// msg, err = anonPacker.Unpack(ct)
-	// require.NoError(t, err)
-	//
-	// require.EqualValues(t, &transport.Envelope{Message: origMsg, ToVerKey: recKey}, msg)
+	// try with only 1 recipient
+	ct, err = anonPacker.Pack(origMsg, nil, [][]byte{recipientsKeys[0]})
+	require.NoError(t, err)
+
+	msg, err = anonPacker.Unpack(ct)
+	require.NoError(t, err)
+
+	require.EqualValues(t, &transport.Envelope{Message: origMsg, ToVerKey: recKey}, msg)
 
 	require.Equal(t, encodingType, anonPacker.EncodingType())
 }

--- a/pkg/doc/jose/encrypter_decrypter_test.go
+++ b/pkg/doc/jose/encrypter_decrypter_test.go
@@ -174,34 +174,33 @@ func TestJWEEncryptRoundTrip(t *testing.T) {
 	}
 }
 
-// TODO uncomment test with https://github.com/hyperledger/aries-framework-go/issues/1872
-// func TestJWEEncryptRoundTripWithSingleRecipient(t *testing.T) {
-//	recECKeys, recKHs := createRecipients(t, 1)
-//
-//	jweEncrypter, err := NewJWEEncrypt(A256GCM, recECKeys)
-//	require.NoError(t, err, "NewJWEEncrypt should not fail with non empty recipientPubKeys")
-//
-//	pt := []byte("some msg")
-//	jwe, err := jweEncrypter.Encrypt(pt)
-//	require.NoError(t, err)
-//	require.Equal(t, len(recECKeys), len(jwe.Recipients))
-//
-//	serializedJWE, err := jwe.CompactSerialize(json.Marshal)
-//	require.NoError(t, err)
-//	require.NotEmpty(t, serializedJWE)
-//
-//	// try to deserialize with local package
-//	localJWE, err := Deserialize(serializedJWE)
-//	require.NoError(t, err)
-//
-//	jweDecrypter := NewJWEDecrypt(recKHs[0])
-//
-//	var msg []byte
-//
-//	msg, err = jweDecrypter.Decrypt(localJWE)
-//	require.NoError(t, err)
-//	require.EqualValues(t, pt, msg)
-// }
+func TestJWEEncryptRoundTripWithSingleRecipient(t *testing.T) {
+	recECKeys, recKHs := createRecipients(t, 1)
+
+	jweEncrypter, err := NewJWEEncrypt(A256GCM, recECKeys)
+	require.NoError(t, err, "NewJWEEncrypt should not fail with non empty recipientPubKeys")
+
+	pt := []byte("some msg")
+	jwe, err := jweEncrypter.Encrypt(pt)
+	require.NoError(t, err)
+	require.Equal(t, len(recECKeys), len(jwe.Recipients))
+
+	serializedJWE, err := jwe.CompactSerialize(json.Marshal)
+	require.NoError(t, err)
+	require.NotEmpty(t, serializedJWE)
+
+	// try to deserialize with local package
+	localJWE, err := Deserialize(serializedJWE)
+	require.NoError(t, err)
+
+	jweDecrypter := NewJWEDecrypt(recKHs[0])
+
+	var msg []byte
+
+	msg, err = jweDecrypter.Decrypt(localJWE)
+	require.NoError(t, err)
+	require.EqualValues(t, pt, msg)
+}
 
 func TestInteropWithGoJoseEncryptAndLocalJoseDecryptUsingCompactSerialize(t *testing.T) {
 	recECKeys, recKHs := createRecipients(t, 1)


### PR DESCRIPTION
This change adds the single recipient headers to the AAD in the ECDHES
Tink primitive to AAD to support JWE encryption with a single recipient 
for Compact serialization.

closes #1872

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
