### PR TITLE
feat: Common notifier for the didexchange

### DIFF
--- a/pkg/controller/command/didexchange/models.go
+++ b/pkg/controller/command/didexchange/models.go
@@ -298,22 +298,3 @@ type ConnectionIDArg struct {
 	// Connection ID
 	ID string `json:"id"`
 }
-
-// ConnectionMsg is sent when a pairwise connection record is updated.
-type ConnectionMsg struct {
-	ConnectionID        string `json:"connection_id"`
-	State               string `json:"state"`
-	MyDid               string `json:"myDid"`
-	TheirDid            string `json:"theirDid"`
-	TheirLabel          string `json:"theirLabel"`
-	TheirRole           string `json:"theirRole"`
-	InboundConnectionID string `json:"inbound_connection_id"`
-	Initiator           string `json:"initiator"`
-	InvitationKey       string `json:"invitation_key"`
-	RequestID           string `json:"request_id"`
-	RoutingState        string `json:"routing_state"`
-	Accept              string `json:"accept"`
-	ErrorMsg            string `json:"error_msg"`
-	InvitationMode      string `json:"invitation_mode"`
-	Alias               string `json:"alias"`
-}

--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -257,7 +257,7 @@ func (s *Service) handle(msg *message, aEvent chan<- service.DIDCommAction) erro
 		s.sendMsgEvents(&service.StateMsg{
 			ProtocolName: DIDExchange,
 			Type:         service.PreState,
-			Msg:          msg.Msg,
+			Msg:          msg.Msg.Clone(),
 			StateID:      next.Name(),
 			Properties:   createEventProperties(msg.ConnRecord.ConnectionID, msg.ConnRecord.InvitationID),
 		})
@@ -314,7 +314,7 @@ func (s *Service) handle(msg *message, aEvent chan<- service.DIDCommAction) erro
 		s.sendMsgEvents(&service.StateMsg{
 			ProtocolName: DIDExchange,
 			Type:         service.PostState,
-			Msg:          msg.Msg,
+			Msg:          msg.Msg.Clone(),
 			StateID:      prev.Name(),
 			Properties:   createEventProperties(connectionRecord.ConnectionID, connectionRecord.InvitationID),
 		})
@@ -362,7 +362,7 @@ func (s *Service) sendActionEvent(internalMsg *message, aEvent chan<- service.DI
 		// trigger action event
 		aEvent <- service.DIDCommAction{
 			ProtocolName: DIDExchange,
-			Message:      internalMsg.Msg,
+			Message:      internalMsg.Msg.Clone(),
 			Continue: func(args interface{}) {
 				switch v := args.(type) {
 				case opts:


### PR DESCRIPTION
This PR adds notification support for the StateMsg and Action.
The topics you might listen to are:
* didexchange_actions
* didexchange_states

Closes #1950 

NOTE: no more `connections` topic

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>