### PR TITLE
fix: Spool mysql instead of using mock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@
 module github.com/hyperledger/aries-framework-go
 
 require (
-	github.com/DATA-DOG/go-sqlmock v1.4.1
 	github.com/VictoriaMetrics/fastcache v1.5.7
 	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/btcsuite/btcutil v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1MRDJM=
-github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=

--- a/pkg/storage/mysql/mysqlstore_test.go
+++ b/pkg/storage/mysql/mysqlstore_test.go
@@ -6,67 +6,73 @@ SPDX-License-Identifier: Apache-2.0
 package mysql
 
 import (
+	"database/sql"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
-
-	"github.com/DATA-DOG/go-sqlmock"
-	_ "github.com/go-sql-driver/mysql"
-	"github.com/stretchr/testify/require"
+	"time"
 
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
+
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/go-sql-driver/mysql"
 )
 
 const (
 	sqlStoreDBURL = "root:my-secret-pw@tcp(127.0.0.1:3306)/"
 )
 
+// For these unit tests to run, you must ensure you have a SQL DB instance running at the URL specified in
+// sqlStoreDBURL. 'make unit-test' from the terminal will take care of this for you.
+// To run the tests manually, start an instance by running the following command in the terminal
+// docker run -p 3306:3306 --name MYSQLStoreTest -e MYSQL_ROOT_PASSWORD=my-secret-pw -d mysql:8.0.20
+
+func TestMain(m *testing.M) {
+	err := waitForSQLDBToStart()
+	if err != nil {
+		fmt.Printf(err.Error() +
+			". Make sure you start a sqlStoreDB instance using" +
+			" 'docker run -p 3306:3306 mysql:8.0.20' before running the unit tests")
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}
+
+func waitForSQLDBToStart() error {
+	db, err := sql.Open("mysql", sqlStoreDBURL)
+	if err != nil {
+		return err
+	}
+
+	timeout := time.After(10 * time.Second)
+
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timeout: couldn't reach sql db server")
+		default:
+			err := db.Ping()
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}
+	}
+}
+
 func TestSQLDBStore(t *testing.T) {
 	t.Run("Test sql db store put and get", func(t *testing.T) {
-		db, mock, err := sqlmock.New()
-		if err != nil {
-			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-		}
-
-		const key = "did:example:124"
-
-		data := []byte("value")
-
-		columns := []string{"`value`"}
-
-		data2 := []byte(`{"key1":"value1"}`)
-
-		did2 := "did:example:789"
-
-		mock.ExpectBegin()
-		mock.ExpectExec("CREATE DATABASE IF NOT EXISTS").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("USE ").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("CREATE Table IF NOT EXISTS t_test ").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("INSERT INTO t_test (.+)").WithArgs(key, data, data).WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectQuery("SELECT (.+) FROM t_test (.+)").WithArgs(key).WillReturnRows(
-			sqlmock.NewRows(columns).AddRow(data))
-		mock.ExpectExec("INSERT INTO t_test (.+)").WithArgs(key, data2, data2).WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("INSERT INTO t_test (.+)").WithArgs(key, data2, data2).WillReturnError(err)
-		mock.ExpectQuery("SELECT (.+) FROM t_test (.+)").WithArgs(key).WillReturnRows(
-			sqlmock.NewRows(columns).AddRow(data2))
-		mock.ExpectQuery("SELECT (.+) FROM t_test (.+)").WithArgs(did2).WillReturnError(
-			storage.ErrDataNotFound)
-		mock.ExpectQuery("SELECT (.+) FROM t_test (.+)").WithArgs(did2).WillReturnError(
-			fmt.Errorf("no rows"))
-		mock.ExpectClose()
-
 		prov, err := NewProvider(sqlStoreDBURL)
 		require.NoError(t, err)
-
-		prov.db = db
-
 		store, err := prov.OpenStore("test")
 		require.NoError(t, err)
+
+		const key = "did:example:124"
+		data := []byte("value")
 
 		err = store.Put(key, data)
 		require.NoError(t, err)
@@ -76,19 +82,17 @@ func TestSQLDBStore(t *testing.T) {
 		require.NotEmpty(t, doc)
 		require.Equal(t, data, doc)
 
-		// test changing value of the key
-		err = store.Put(key, data2)
+		// test update
+		data = []byte(`{"key1":"value1"}`)
+		err = store.Put(key, data)
 		require.NoError(t, err)
-
-		// testing error
-		err = store.Put(key, data2)
-		require.Error(t, err)
 
 		doc, err = store.Get(key)
 		require.NoError(t, err)
 		require.NotEmpty(t, doc)
-		require.Equal(t, data2, doc)
+		require.Equal(t, data, doc)
 
+		did2 := "did:example:789"
 		_, err = store.Get(did2)
 		require.Error(t, err)
 		require.Contains(t, storage.ErrDataNotFound.Error(), err.Error())
@@ -96,79 +100,27 @@ func TestSQLDBStore(t *testing.T) {
 		// nil key
 		_, err = store.Get("")
 		require.Error(t, err)
-		require.Equal(t, storage.ErrKeyRequired, err)
+		require.Equal(t, "key is mandatory", err.Error())
 
 		// nil key
 		err = store.Put("", data)
 		require.Error(t, err)
-		require.Equal(t, storage.ErrKeyRequired, err)
-
-		_, err = store.Get(did2)
-		require.Error(t, err)
-		require.Contains(t, storage.ErrDataNotFound.Error(), err.Error())
+		require.Equal(t, "key is mandatory", err.Error())
 
 		err = prov.Close()
 		require.NoError(t, err)
-
-		// we make sure that all expectations were met
-		if err := mock.ExpectationsWereMet(); err != nil {
-			t.Errorf("there were unfulfilled expectations: %s", err)
-		}
 	})
-}
-func TestSQLStoreMultiGetAndPut(t *testing.T) {
+
 	t.Run("Test sql multi store put and get", func(t *testing.T) {
-		db, mock, err := sqlmock.New()
-		if err != nil {
-			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-		}
-
-		const commonKey = "did:example:1"
-
-		data := []byte("value")
-
-		columns := []string{"`value`"}
-
-		// store1
-		mock.ExpectBegin()
-		mock.ExpectExec("CREATE DATABASE IF NOT EXISTS").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("USE ").WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec("CREATE Table IF NOT EXISTS t_store1 ").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-
-		// store 2
-		mock.ExpectBegin()
-		mock.ExpectExec("CREATE DATABASE IF NOT EXISTS").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("USE ").WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec("CREATE Table IF NOT EXISTS t_store2 ").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("INSERT INTO t_store1 (.+)").WithArgs(commonKey, data, data).WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectQuery("SELECT (.+) FROM t_store1 (.+)").WithArgs(commonKey).WillReturnRows(
-			sqlmock.NewRows(columns).AddRow(data))
-		mock.ExpectQuery("SELECT (.+) FROM t_store2 (.+)").WithArgs(commonKey).WillReturnError(
-			storage.ErrDataNotFound)
-		mock.ExpectExec("INSERT INTO t_store2 (.+)").WithArgs(commonKey, data, data).WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectQuery("SELECT (.+) FROM t_store2 (.+)").WithArgs(commonKey).WillReturnRows(
-			sqlmock.NewRows(columns).AddRow(data))
-		// recreate store1
-		mock.ExpectBegin()
-		mock.ExpectExec("CREATE DATABASE IF NOT EXISTS").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("USE ").WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec("CREATE Table IF NOT EXISTS t_store1 ").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectQuery("SELECT (.+) FROM t_store1 (.+)").WithArgs(commonKey).WillReturnRows(
-			sqlmock.NewRows(columns).AddRow(data))
-		mock.ExpectQuery("SELECT (.+) FROM t_store1 (.+)").WithArgs(commonKey).WillReturnError(err)
-
 		prov, err := NewProvider(sqlStoreDBURL)
 		require.NoError(t, err)
+		const commonKey = "did:example:1"
+		data := []byte("value1")
 
-		prov.db = db
+		_, err = prov.OpenStore("")
+		require.Error(t, err)
+		require.Equal(t, err.Error(), "store name is required")
+
 		// create store 1 & store 2
 		store1, err := prov.OpenStore("store1")
 		require.NoError(t, err)
@@ -185,12 +137,6 @@ func TestSQLStoreMultiGetAndPut(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, doc)
 		require.Equal(t, data, doc)
-
-		// get in store 2 - not found
-		doc, err = store2.Get(commonKey)
-		require.Error(t, err)
-		require.Equal(t, err, storage.ErrDataNotFound)
-		require.Empty(t, doc)
 
 		// put in store 2
 		err = store2.Put(commonKey, data)
@@ -212,27 +158,38 @@ func TestSQLStoreMultiGetAndPut(t *testing.T) {
 		require.NotEmpty(t, doc)
 		require.Equal(t, data, doc)
 
-		// testing err
-		doc, err = store3.Get(commonKey)
-		require.Error(t, err)
-		require.Empty(t, doc)
-
 		// store length
 		require.Len(t, prov.dbs, 2)
-
-		// we make sure that all expectations were met
-		if err := mock.ExpectationsWereMet(); err != nil {
-			t.Errorf("there were unfulfilled expectations: %s", err)
-		}
 	})
-}
-func TestSQLStoreFailure(t *testing.T) {
-	t.Run("Test sql db store failures", func(t *testing.T) {
-		db, mock, err := sqlmock.New()
-		if err != nil {
-			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-		}
+	t.Run("Test put, get, delete, iterator error", func(t *testing.T) {
+		prov, err := NewProvider("root:@tcp(127.0.0.1:45454)/")
+		require.NoError(t, err)
 
+		storeErr := &sqlDBStore{
+			db: prov.db,
+		}
+		const commonKey = "did:example:1"
+		data := []byte("value1")
+		// put err
+		err = storeErr.Put(commonKey, data)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to insert key and value record")
+
+		// get err
+		rows, err := storeErr.Get(commonKey)
+		require.Error(t, err)
+		require.Nil(t, rows)
+		require.Contains(t, err.Error(), "failed to get row")
+
+		err = storeErr.Delete(commonKey)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to delete row")
+
+		itr := storeErr.Iterator(commonKey, "test")
+		require.Error(t, itr.Error())
+		require.Contains(t, itr.Error().Error(), "failed to query rows")
+	})
+	t.Run("Test sql db store failures", func(t *testing.T) {
 		prov, err := NewProvider("")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), blankDBPathErrMsg)
@@ -243,128 +200,54 @@ func TestSQLStoreFailure(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to open connection")
 
-		// sample
-		mock.ExpectBegin()
-		mock.ExpectExec("CREATE DATABASE IF NOT EXISTS").WillReturnError(
-			fmt.Errorf("failed to create db %s: %w", "sample", err))
-
-		// sample 2
-		mock.ExpectBegin()
-		mock.ExpectExec("CREATE DATABASE IF NOT EXISTS").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("USE ").WillReturnError(
-			fmt.Errorf("failed to use db %s: %w", "sample2", err))
-
-		prov, err = NewProvider(sqlStoreDBURL)
+		prov, err = NewProvider("root:@tcp(127.0.0.1:45454)/")
 		require.NoError(t, err)
-
-		prov.db = db
 
 		store, err := prov.OpenStore("sample")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to create db")
 		require.Nil(t, store)
-
-		prov, err = NewProvider(sqlStoreDBURL)
-		require.NoError(t, err)
-
-		// wrong path
-		prov.db = db
-		store, err = prov.OpenStore("sample2")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to use db")
-		require.Nil(t, store)
-
-		// we make sure that all expectations were met
-		if err := mock.ExpectationsWereMet(); err != nil {
-			t.Errorf("there were unfulfilled expectations: %s", err)
-		}
 	})
-}
-func TestSQLStoreMultiStore(t *testing.T) {
-	t.Run("Test sqlDB multi store close by name", func(t *testing.T) {
-		db, mock, err := sqlmock.New()
-		if err != nil {
-			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-		}
 
-		const commonKey = "did:example:1"
-		data := []byte("value")
-		columns := []string{"`value`"}
-		// store1
-		mock.ExpectBegin()
-		mock.ExpectExec("CREATE DATABASE IF NOT EXISTS").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("USE ").WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec("CREATE Table IF NOT EXISTS t_store_1 ").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("INSERT INTO t_store_1 (.+)").WithArgs(commonKey, data, data).WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectQuery("SELECT (.+) FROM t_store_1 (.+)").WithArgs(commonKey).WillReturnRows(
-			sqlmock.NewRows(columns).AddRow(data))
-
-		// store2
-		mock.ExpectBegin()
-		mock.ExpectExec("CREATE DATABASE IF NOT EXISTS").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("USE ").WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec("CREATE Table IF NOT EXISTS t_store_2 ").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("INSERT INTO t_store_2 (.+)").WithArgs(commonKey, data, data).WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectQuery("SELECT (.+) FROM t_store_2 (.+)").WithArgs(commonKey).WillReturnRows(
-			sqlmock.NewRows(columns).AddRow(data))
-
-		// store3
-		mock.ExpectBegin()
-		mock.ExpectExec("CREATE DATABASE IF NOT EXISTS").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("USE ").WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec("CREATE Table IF NOT EXISTS t_store_3 ").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("INSERT INTO t_store_3 (.+)").WithArgs(commonKey, data, data).WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectQuery("SELECT (.+) FROM t_store_3 (.+)").WithArgs(commonKey).WillReturnRows(
-			sqlmock.NewRows(columns).AddRow(data))
-
-		// store4
-		mock.ExpectBegin()
-		mock.ExpectExec("CREATE DATABASE IF NOT EXISTS").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("USE ").WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec("CREATE Table IF NOT EXISTS t_store_4 ").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("INSERT INTO t_store_4 (.+)").WithArgs(commonKey, data, data).WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectQuery("SELECT (.+) FROM t_store_4 (.+)").WithArgs(commonKey).WillReturnRows(
-			sqlmock.NewRows(columns).AddRow(data))
-
-		// store5
-		mock.ExpectBegin()
-		mock.ExpectExec("CREATE DATABASE IF NOT EXISTS").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("USE ").WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec("CREATE Table IF NOT EXISTS t_store_5 ").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("INSERT INTO t_store_5 (.+)").WithArgs(commonKey, data, data).WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectQuery("SELECT (.+) FROM t_store_5 (.+)").WithArgs(commonKey).WillReturnRows(
-			sqlmock.NewRows(columns).AddRow(data))
-		mock.ExpectClose()
-
+	t.Run("Test the open new connection error", func(t *testing.T) {
 		prov, err := NewProvider(sqlStoreDBURL)
 		require.NoError(t, err)
 
+		// invalid db url
+		prov.dbURL = "fake-url"
+
+		_, err = prov.OpenStore("testErr")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to create new connection fake-url")
+
+		//  valid but not available db url
+		prov.dbURL = "root:my-secret-pw@tcp(127.0.0.1:3307)/"
+
+		_, err = prov.OpenStore("testErr")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to use db testErr")
+	})
+
+	t.Run("Test sqlDB multi store close by name", func(t *testing.T) {
+		prov, err := NewProvider(sqlStoreDBURL)
+		require.NoError(t, err)
+
+		const commonKey = "did:example:1"
+		data := []byte("value1")
+
 		storeNames := []string{"store_1", "store_2", "store_3", "store_4", "store_5"}
 		storesToClose := []string{"store_1", "store_3", "store_5"}
-
-		prov.db = db
 
 		for _, name := range storeNames {
 			store, e := prov.OpenStore(name)
 			require.NoError(t, e)
 
 			e = store.Put(commonKey, data)
+			require.NoError(t, e)
+		}
+
+		for _, name := range storeNames {
+			store, e := prov.OpenStore(name)
 			require.NoError(t, e)
 
 			dataRead, e := store.Get(commonKey)
@@ -376,7 +259,11 @@ func TestSQLStoreMultiStore(t *testing.T) {
 		require.Len(t, prov.dbs, 5)
 
 		for _, name := range storesToClose {
-			e := prov.CloseStore(name)
+			store, e := prov.OpenStore(name)
+			require.NoError(t, e)
+			require.NotNil(t, store)
+
+			e = prov.CloseStore(name)
 			require.NoError(t, e)
 		}
 
@@ -399,46 +286,45 @@ func TestSQLStoreMultiStore(t *testing.T) {
 		// try close all again
 		err = prov.Close()
 		require.NoError(t, err)
+	})
 
-		// we make sure that all expectations were met
-		if err := mock.ExpectationsWereMet(); err != nil {
-			t.Errorf("there were unfulfilled expectations: %s", err)
+	t.Run("Test sql db store iterator", func(t *testing.T) {
+		prov, err := NewProvider(sqlStoreDBURL)
+		require.NoError(t, err)
+		store, err := prov.OpenStore("testIterator")
+		require.NoError(t, err)
+
+		const valPrefix = "val-for-%s"
+		keys := []string{"abc_123", "abc_124", "abc_125", "abc_126", "jkl_123", "mno_123"}
+
+		for _, key := range keys {
+			err = store.Put(key, []byte(fmt.Sprintf(valPrefix, key)))
+			require.NoError(t, err)
 		}
+
+		itr := store.Iterator("abc_", "abc"+storage.EndKeySuffix)
+		verifyItr(t, itr, 4, "abc_")
+
+		itr = store.Iterator("", "")
+		verifyItr(t, itr, 0, "")
+
+		itr = store.Iterator("abc_", "mno"+storage.EndKeySuffix)
+		verifyItr(t, itr, 6, "")
+
+		itr = store.Iterator("abc_", "mno_123")
+		verifyItr(t, itr, 5, "")
 	})
 }
+
 func TestSQLDBStoreDelete(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-
 	const commonKey = "did:example:1234"
-
-	data := []byte("value1")
-
-	columns := []string{"`value`"}
-
-	mock.ExpectBegin()
-	mock.ExpectExec("CREATE DATABASE IF NOT EXISTS").WillReturnResult(
-		sqlmock.NewResult(1, 1))
-	mock.ExpectExec("USE ").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("CREATE Table IF NOT EXISTS t_store1").WillReturnResult(
-		sqlmock.NewResult(1, 1))
-	mock.ExpectExec("INSERT INTO t_store1 (.+)").WithArgs(commonKey, data, data).WillReturnResult(
-		sqlmock.NewResult(1, 1))
-	mock.ExpectQuery("SELECT (.+) FROM t_store1 (.+)").WithArgs(commonKey).WillReturnRows(
-		sqlmock.NewRows(columns).AddRow(data))
-	mock.ExpectExec("DELETE FROM t_store1 (.+)").WithArgs(commonKey).WillReturnResult(
-		sqlmock.NewResult(1, 1))
-	mock.ExpectQuery("SELECT (.+) FROM t_store1 (.+)").WithArgs(commonKey).WillReturnError(
-		storage.ErrDataNotFound)
-	mock.ExpectExec("DELETE FROM t_store1 (.+)").WithArgs(commonKey).WillReturnError(err)
 
 	prov, err := NewProvider(sqlStoreDBURL)
 	require.NoError(t, err)
 
-	prov.db = db
-	// create store 1
+	data := []byte("value1")
+
+	// create store 1 & store 2
 	store1, err := prov.OpenStore("store1")
 	require.NoError(t, err)
 
@@ -463,106 +349,6 @@ func TestSQLDBStoreDelete(t *testing.T) {
 	doc, err = store1.Get(commonKey)
 	require.EqualError(t, err, storage.ErrDataNotFound.Error())
 	require.Empty(t, doc)
-
-	err = store1.Delete(commonKey)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to delete row")
-
-	// we make sure that all expectations were met
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expectations: %s", err)
-	}
-}
-func TestSQLDBStoreIterator(t *testing.T) {
-	t.Run("Test sql db store iterator", func(t *testing.T) {
-		db, mock, err := sqlmock.New()
-		if err != nil {
-			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-		}
-
-		const valPrefix = "val-for-%s"
-
-		columns := []string{"`key`", "`value`"}
-
-		mock.ExpectBegin()
-		mock.ExpectExec("CREATE DATABASE IF NOT EXISTS").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-		mock.ExpectExec("USE ").WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec("CREATE Table IF NOT EXISTS t_testIterator").WillReturnResult(
-			sqlmock.NewResult(1, 1))
-
-		prov, err := NewProvider(sqlStoreDBURL)
-		require.NoError(t, err)
-
-		prov.db = db
-		store, err := prov.OpenStore("testIterator")
-		require.NoError(t, err)
-
-		keys := []string{"abc_123", "abc_124", "abc_125", "abc_126", "jkl_123", "mno_123"}
-
-		for _, key := range keys {
-			mock.ExpectExec("INSERT INTO t_testIterator (.+)").WithArgs(key,
-				[]byte(fmt.Sprintf(valPrefix, key)),
-				[]byte(fmt.Sprintf(valPrefix, key))).WillReturnResult(sqlmock.NewResult(1, 1))
-			err = store.Put(key, []byte(fmt.Sprintf(valPrefix, key)))
-			require.NoError(t, err)
-		}
-		rowSet0 := sqlmock.NewRows(columns)
-		rowSet1 := sqlmock.NewRows(columns).
-			AddRow("abc_123", "val-for-abc_123").
-			AddRow("abc_124", "val-for-abc_124").
-			AddRow("abc_125", "val-for-abc_125").
-			AddRow("abc_126", "val-for-abc_126")
-
-		rowSet2 := sqlmock.NewRows(columns).
-			AddRow("abc_123", "val-for-abc_123").
-			AddRow("abc_124", "val-for-abc_124").
-			AddRow("abc_125", "val-for-abc_125").
-			AddRow("abc_126", "val-for-abc_126").
-			AddRow("jkl_123", "val-for-jkl_123").
-			AddRow("mno_123", "val-for-mno_123")
-
-		rowSet3 := sqlmock.NewRows(columns).
-			AddRow("abc_123", "val-for-abc_123").
-			AddRow("abc_124", "val-for-abc_124").
-			AddRow("abc_125", "val-for-abc_125").
-			AddRow("abc_126", "val-for-abc_126").
-			AddRow("jkl_123", "val-for-jkl_123")
-
-		mock.ExpectQuery("SELECT (.+)").WithArgs("abc_",
-			"abc_~").WillReturnRows(rowSet1)
-		mock.ExpectQuery("SELECT (.+)").WithArgs("abc_",
-			"mno_~").WillReturnRows(rowSet2)
-		mock.ExpectQuery("SELECT (.+)").WithArgs("abc_",
-			"mno_123").WillReturnRows(rowSet3)
-		mock.ExpectQuery("SELECT (.+)").WithArgs("",
-			"").WillReturnRows(rowSet0)
-
-		itr := store.Iterator("abc_", "abc_"+storage.EndKeySuffix)
-		require.NoError(t, itr.Error())
-		verifyItr(t, itr, 4, "abc_")
-
-		itr = store.Iterator("abc_", "mno_"+storage.EndKeySuffix)
-		require.NoError(t, itr.Error())
-		verifyItr(t, itr, 6, "")
-
-		itr = store.Iterator("abc_", "mno_123")
-		require.NoError(t, itr.Error())
-		verifyItr(t, itr, 5, "")
-
-		itr = store.Iterator("", "")
-		require.NoError(t, itr.Error())
-		verifyItr(t, itr, 0, "")
-
-		itr = store.Iterator("abc", "mno_123")
-		require.Error(t, itr.Error())
-		require.Contains(t, itr.Error().Error(), "failed to query rows")
-
-		// we make sure that all expectations were met
-		if err := mock.ExpectationsWereMet(); err != nil {
-			t.Errorf("there were unfulfilled expectations: %s", err)
-		}
-	})
 }
 
 func verifyItr(t *testing.T, itr storage.StoreIterator, count int, prefix string) {

--- a/scripts/check_unit.sh
+++ b/scripts/check_unit.sh
@@ -24,12 +24,14 @@ fi
 remove_docker_container () {
 docker kill CouchDBStoreTest >/dev/null 2>&1 || true
 docker rm CouchDBStoreTest >/dev/null 2>&1 || true
+docker kill MYSQLStoreTest >/dev/null 2>&1 || true
+docker rm MYSQLStoreTest >/dev/null 2>&1 || true
 }
 
 remove_docker_container
 
 docker run -p 5984:5984 -d --name CouchDBStoreTest couchdb:2.3.1 >/dev/null || true
-
+docker run -p 3306:3306 --name MYSQLStoreTest -e MYSQL_ROOT_PASSWORD=my-secret-pw -d mysql:8.0.20 >/dev/null || true
 
 # Running aries-framework-go unit test
 PKGS=`go list github.com/hyperledger/aries-framework-go/... 2> /dev/null | \


### PR DESCRIPTION
Right now, sql store unit test are using sql mock : https://github.com/DATA-DOG/go-sqlmock 
As per the discussion with the team, seems like its not so viable option to choose. Therefore, update the the unit-test to use the mysql db instead of mock. 

Fix the below from the list 1948: 
- open a new sql.DB and exec the "USE" statement on that one. Assign it to the storage.Store: https://github.com/hyperledger/aries-framework-go/pull/1938/files#diff-5c03fdd2a42c9a160e4a9b056cb9db20R102
- mocking the database in tests


closes #1948 

Signed-off-by: talwinder.kaur <talwinder.kaur@securekey.com>

