### PR TITLE
feat: add Authcrypt packer using ECDH1PU

### DIFF
--- a/pkg/didcomm/packer/api.go
+++ b/pkg/didcomm/packer/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
 // LegacyProvider interface for Packer ctx
@@ -20,6 +21,7 @@ type LegacyProvider interface {
 // Provider interface for Packer ctx
 type Provider interface {
 	KMS() kms.KeyManager
+	StorageProvider() storage.Provider
 }
 
 // LegacyCreator method to create new legacy Packer service

--- a/pkg/didcomm/packer/authcrypt/pack.go
+++ b/pkg/didcomm/packer/authcrypt/pack.go
@@ -1,0 +1,230 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package authcrypt
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/tink/go/keyset"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/keyio"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/packer"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+// Package authcrypt includes a Packer implementation to build and parse JWE messages using Authcrypt. It allows sending
+// messages between parties with non-repudiation messages, ie the sender identity is revealed (and therefore
+// authenticated) to the recipient(s). The assumption of using this package is that public keys exchange has previously
+// occurred between the sender and the recipient(s).
+
+const (
+	encodingType = "didcomm-envelope-enc"
+	// ThirdPartyKeysDB is a store name containing keys of third party agents
+	ThirdPartyKeysDB = "thirdPartyKeysDB"
+)
+
+var logger = log.New("aries-framework/pkg/didcomm/packer/authcrypt")
+
+// Packer represents an Authcrypt Pack/Unpacker that outputs/reads Aries envelopes
+type Packer struct {
+	kms    kms.KeyManager
+	encAlg jose.EncAlg
+	store  storage.Store
+}
+
+// New will create an Packer instance to 'AuthCrypt' payloads for a given sender and list of recipients keys.
+// It will open a store (fetch cached one) that will contain third party keys. This store must be pre-populated with
+// the sender key required by a recipient to Unpack a JWE envelope. It is not needed by the sender (as the sender packs
+// the envelope with its own key).
+// The returned Packer contains all the information required to pack and unpack payloads.
+func New(ctx packer.Provider, encAlg jose.EncAlg) (*Packer, error) {
+	k := ctx.KMS()
+
+	store, err := ctx.StorageProvider().OpenStore(ThirdPartyKeysDB)
+	if err != nil {
+		return nil, fmt.Errorf("authcrypt: %w", err)
+	}
+
+	return &Packer{
+		kms:    k,
+		encAlg: encAlg,
+		store:  store,
+	}, nil
+}
+
+// Pack will encode the payload argument
+// Using the protocol defined by the Authcrypt message of Aries RFC 0334
+// with the following arguments:
+// payload: the payload message that will be protected
+// senderID: the key id of the sender (stored in the KMS)
+// recipientsPubKeys:
+func (p *Packer) Pack(payload, senderID []byte, recipientsPubKeys [][]byte) ([]byte, error) {
+	if len(recipientsPubKeys) == 0 {
+		return nil, fmt.Errorf("authcrypt Pack: empty recipientsPubKeys")
+	}
+
+	recECKeys, err := unmarshalRecipientKeys(recipientsPubKeys)
+	if err != nil {
+		return nil, fmt.Errorf("authcrypt Pack: failed to convert recipient keys: %w", err)
+	}
+
+	kh, err := p.kms.Get(string(senderID))
+	if err != nil {
+		return nil, fmt.Errorf("authcrypt Pack: failed to get sender key from KMS: %w", err)
+	}
+
+	jweEncrypter, err := jose.NewJWEEncrypt(p.encAlg, string(senderID), kh.(*keyset.Handle), recECKeys)
+	if err != nil {
+		return nil, fmt.Errorf("authcrypt Pack: failed to new JWEEncrypt instance: %w", err)
+	}
+
+	jwe, err := jweEncrypter.Encrypt(payload)
+	if err != nil {
+		return nil, fmt.Errorf("authcrypt Pack: failed to encrypt payload: %w", err)
+	}
+
+	var s string
+
+	if len(recipientsPubKeys) == 1 {
+		s, err = jwe.CompactSerialize(json.Marshal)
+	} else {
+		s, err = jwe.FullSerialize(json.Marshal)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("authcrypt Pack: failed to serialize JWE message: %w", err)
+	}
+
+	return []byte(s), nil
+}
+
+func unmarshalRecipientKeys(keys [][]byte) ([]*composite.PublicKey, error) {
+	var pubKeys []*composite.PublicKey
+
+	for _, key := range keys {
+		var ecKey *composite.PublicKey
+
+		err := json.Unmarshal(key, &ecKey)
+		if err != nil {
+			return nil, err
+		}
+
+		pubKeys = append(pubKeys, ecKey)
+	}
+
+	return pubKeys, nil
+}
+
+// Unpack will decode the envelope using a standard format
+func (p *Packer) Unpack(envelope []byte) (*transport.Envelope, error) {
+	jwe, err := jose.Deserialize(string(envelope))
+	if err != nil {
+		return nil, fmt.Errorf("authcrypt Unpack: failed to deserialize JWE message: %w", err)
+	}
+
+	for i := range jwe.Recipients {
+		var (
+			kid                   string
+			kh                    interface{}
+			pt, ecdh1puPubKeyByes []byte
+		)
+
+		kid, err = getKID(i, jwe)
+		if err != nil {
+			return nil, fmt.Errorf("authcrypt Unpack: %w", err)
+		}
+
+		kh, err = p.kms.Get(kid)
+		if err != nil {
+			if errors.Is(err, storage.ErrDataNotFound) {
+				retriesMsg := ""
+
+				if i < len(jwe.Recipients) {
+					retriesMsg = ", will try another recipient"
+				}
+
+				logger.Debugf("authcrypt Unpack: recipient keyID not found in KMS: %v%s", kid, retriesMsg)
+
+				continue
+			}
+
+			return nil, fmt.Errorf("authcrypt Unpack: failed to get key from kms: %w", err)
+		}
+
+		keyHandle, ok := kh.(*keyset.Handle)
+		if !ok {
+			return nil, fmt.Errorf("authcrypt Unpack: invalid keyset handle")
+		}
+
+		jweDecrypter := jose.NewJWEDecrypt(p.store, keyHandle)
+
+		pt, err = jweDecrypter.Decrypt(jwe)
+		if err != nil {
+			return nil, fmt.Errorf("authcrypt Unpack: failed to decrypt JWE envelope: %w", err)
+		}
+
+		// TODO get mapped verKey for the recipient encryption key (kid)
+		ecdh1puPubKeyByes, err = exportPubKeyBytes(keyHandle)
+		if err != nil {
+			return nil, fmt.Errorf("authcrypt Unpack: failed to export public key bytes: %w", err)
+		}
+
+		return &transport.Envelope{
+			Message:  pt,
+			ToVerKey: ecdh1puPubKeyByes,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("authcrypt Unpack: no matching recipient in envelope")
+}
+
+func getKID(i int, jwe *jose.JSONWebEncryption) (string, error) {
+	var kid string
+
+	if i == 0 && len(jwe.Recipients) == 1 { // compact serialization, recipient headers are in jwe.ProtectedHeaders
+		ok := false
+
+		kid, ok = jwe.ProtectedHeaders.KeyID()
+		if !ok {
+			return "", fmt.Errorf("single recipient missing 'KID' in jwe.ProtectHeaders")
+		}
+	} else {
+		kid = jwe.Recipients[i].Header.KID
+	}
+
+	return kid, nil
+}
+
+func exportPubKeyBytes(keyHandle *keyset.Handle) ([]byte, error) {
+	pubKH, err := keyHandle.Public()
+	if err != nil {
+		return nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	pubKeyWriter := keyio.NewWriter(buf)
+
+	err = pubKH.WriteWithNoSecrets(pubKeyWriter)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// EncodingType for didcomm
+func (p *Packer) EncodingType() string {
+	return encodingType
+}

--- a/pkg/didcomm/packer/authcrypt/pack_test.go
+++ b/pkg/didcomm/packer/authcrypt/pack_test.go
@@ -1,0 +1,248 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package authcrypt
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/tink/go/keyset"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
+	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+func TestAuthryptPackerSuccess(t *testing.T) {
+	k := createKMS(t)
+	_, recipientsKeys, keyHandles := createRecipients(t, k, 10)
+
+	skid, senderKey, _ := createAndMarshalKey(t, k)
+
+	mockStoreMap := make(map[string][]byte)
+	mockStoreProvider := &mockstorage.MockStoreProvider{Store: &mockstorage.MockStore{
+		Store: mockStoreMap,
+	}}
+
+	authPacker, err := New(newMockProvider(mockStoreProvider, k), jose.A256GCM)
+	require.NoError(t, err)
+
+	// add sender key in store (prep step before Authcrypt.Pack()/Unpack())
+	mockStoreMap[skid] = senderKey
+
+	origMsg := []byte("secret message")
+	ct, err := authPacker.Pack(origMsg, []byte(skid), recipientsKeys)
+	require.NoError(t, err)
+
+	msg, err := authPacker.Unpack(ct)
+	require.NoError(t, err)
+
+	recKey, err := exportPubKeyBytes(keyHandles[0])
+	require.NoError(t, err)
+
+	require.EqualValues(t, &transport.Envelope{Message: origMsg, ToVerKey: recKey}, msg)
+
+	// try with only 1 recipient
+	ct, err = authPacker.Pack(origMsg, []byte(skid), [][]byte{recipientsKeys[0]})
+	require.NoError(t, err)
+
+	msg, err = authPacker.Unpack(ct)
+	require.NoError(t, err)
+
+	require.EqualValues(t, &transport.Envelope{Message: origMsg, ToVerKey: recKey}, msg)
+
+	require.Equal(t, encodingType, authPacker.EncodingType())
+}
+
+func TestAuthcryptPackerFail(t *testing.T) {
+	k := createKMS(t)
+
+	skid, senderKey, _ := createAndMarshalKey(t, k)
+
+	t.Run("new Pack fail with bad store provider", func(t *testing.T) {
+		badStoreProvider := &mockstorage.MockStoreProvider{
+			ErrOpenStoreHandle: errors.New("failed to open store"),
+			FailNamespace:      ThirdPartyKeysDB,
+		}
+
+		_, err := New(newMockProvider(badStoreProvider, k), jose.A256GCM)
+		require.EqualError(t, err, "authcrypt: failed to open store for name space thirdPartyKeysDB")
+	})
+
+	mockStoreMap := make(map[string][]byte)
+	mockStoreProvider := &mockstorage.MockStoreProvider{Store: &mockstorage.MockStore{
+		Store: mockStoreMap,
+	}}
+
+	_, recipientsKeys, _ := createRecipients(t, k, 10)
+	origMsg := []byte("secret message")
+	authPacker, err := New(newMockProvider(mockStoreProvider, k), jose.A256GCM)
+	require.NoError(t, err)
+
+	mockStoreMap[skid] = senderKey
+	skidB := []byte(skid)
+
+	t.Run("pack fail with empty recipients keys", func(t *testing.T) {
+		_, err := authPacker.Pack(origMsg, nil, nil)
+		require.EqualError(t, err, "authcrypt Pack: empty recipientsPubKeys")
+	})
+
+	t.Run("pack fail with invalid recipients keys", func(t *testing.T) {
+		_, err := authPacker.Pack(origMsg, nil, [][]byte{[]byte("invalid")})
+		require.EqualError(t, err, "authcrypt Pack: failed to convert recipient keys: invalid character 'i' "+
+			"looking for beginning of value")
+	})
+
+	t.Run("pack fail with invalid encAlg", func(t *testing.T) {
+		invalidAlg := "invalidAlg"
+		invalidAuthPacker, err := New(newMockProvider(mockStoreProvider, k), jose.EncAlg(invalidAlg))
+		require.NoError(t, err)
+
+		_, err = invalidAuthPacker.Pack(origMsg, skidB, recipientsKeys)
+		require.EqualError(t, err, fmt.Sprintf("authcrypt Pack: failed to new JWEEncrypt instance: encryption"+
+			" algorithm '%s' not supported", invalidAlg))
+	})
+
+	t.Run("pack fail with KMS can't get sender key", func(t *testing.T) {
+		badKMSStoreProvider := mockstorage.NewCustomMockStoreProvider(
+			&mockstorage.MockStore{ErrGet: errors.New("bad fake key ID")})
+		p := mockkms.NewProviderForKMS(badKMSStoreProvider, &noop.NoLock{})
+
+		badKMS, err := localkms.New("local-lock://test/key/uri", p)
+		require.NoError(t, err)
+
+		badAuthPacker, err := New(newMockProvider(mockStoreProvider, badKMS), jose.A256GCM)
+		require.NoError(t, err)
+
+		_, err = badAuthPacker.Pack(origMsg, skidB, recipientsKeys)
+		require.Contains(t, fmt.Sprintf("%v", err), "bad fake key ID")
+	})
+
+	t.Run("pack success but unpack fails with invalid payload", func(t *testing.T) {
+		validAuthPacker, err := New(newMockProvider(mockStoreProvider, k), jose.A256GCM)
+		require.NoError(t, err)
+
+		_, err = validAuthPacker.Pack(origMsg, skidB, recipientsKeys)
+		require.NoError(t, err)
+
+		_, err = validAuthPacker.Unpack([]byte("invalid jwe envelope"))
+		require.EqualError(t, err, "authcrypt Unpack: failed to deserialize JWE message: invalid compact "+
+			"JWE: it must have five parts")
+	})
+
+	t.Run("pack success but unpack fails with missing keyID in protectedHeader", func(t *testing.T) {
+		validAuthPacker, err := New(newMockProvider(mockStoreProvider, k), jose.A256GCM)
+		require.NoError(t, err)
+
+		ct, err := validAuthPacker.Pack(origMsg, skidB, [][]byte{recipientsKeys[0]})
+		require.NoError(t, err)
+
+		jwe, err := jose.Deserialize(string(ct))
+		require.NoError(t, err)
+
+		delete(jwe.ProtectedHeaders, jose.HeaderKeyID)
+
+		newCT, err := jwe.CompactSerialize(json.Marshal)
+		require.NoError(t, err)
+
+		_, err = validAuthPacker.Unpack([]byte(newCT))
+		require.EqualError(t, err, "authcrypt Unpack: single recipient missing 'KID' in jwe.ProtectHeaders")
+	})
+
+	t.Run("pack success but unpack fails with missing kid in kms", func(t *testing.T) {
+		kids, newRecKeys, _ := createRecipients(t, k, 2)
+		validAuthPacker, err := New(newMockProvider(mockStoreProvider, k), jose.A256GCM)
+		require.NoError(t, err)
+
+		ct, err := validAuthPacker.Pack(origMsg, skidB, newRecKeys)
+		require.NoError(t, err)
+
+		// rotate keys to update keyID and force a failure
+		_, _, err = k.Rotate(kms.ECDH1PU256AES256GCMType, kids[0])
+		require.NoError(t, err)
+
+		_, _, err = k.Rotate(kms.ECDH1PU256AES256GCMType, kids[1])
+		require.NoError(t, err)
+
+		_, err = validAuthPacker.Unpack(ct)
+		require.EqualError(t, err, "authcrypt Unpack: no matching recipient in envelope")
+	})
+}
+
+// createRecipients and return their public key and keyset.Handle
+func createRecipients(t *testing.T, k *localkms.LocalKMS, recipientsCount int) ([]string, [][]byte, []*keyset.Handle) {
+	t.Helper()
+
+	var (
+		r    [][]byte
+		rKH  []*keyset.Handle
+		kids []string
+	)
+
+	for i := 0; i < recipientsCount; i++ {
+		kid, marshalledPubKey, kh := createAndMarshalKey(t, k)
+
+		r = append(r, marshalledPubKey)
+		rKH = append(rKH, kh)
+		kids = append(kids, kid)
+	}
+
+	return kids, r, rKH
+}
+
+// createAndMarshalKey creates a new recipient keyset.Handle, extracts public key, marshals it and returns
+// both marshalled public key and original recipient keyset.Handle
+func createAndMarshalKey(t *testing.T, k *localkms.LocalKMS) (string, []byte, *keyset.Handle) {
+	t.Helper()
+
+	kid, keyHandle, err := k.Create(kms.ECDH1PU256AES256GCMType)
+	require.NoError(t, err)
+
+	kh, ok := keyHandle.(*keyset.Handle)
+	require.True(t, ok)
+
+	pubKeyBytes, err := exportPubKeyBytes(kh)
+	require.NoError(t, err)
+
+	key := &composite.PublicKey{}
+	err = json.Unmarshal(pubKeyBytes, key)
+	require.NoError(t, err)
+
+	key.KID = kid
+	mKey, err := json.Marshal(key)
+	require.NoError(t, err)
+
+	return kid, mKey, kh
+}
+
+func createKMS(t *testing.T) *localkms.LocalKMS {
+	t.Helper()
+
+	p := mockkms.NewProviderForKMS(mockstorage.NewMockStoreProvider(), &noop.NoLock{})
+
+	k, err := localkms.New("local-lock://test/key/uri", p)
+	require.NoError(t, err)
+
+	return k
+}
+
+func newMockProvider(customStoreProvider storage.Provider, customKMS kms.KeyManager) *mockprovider.Provider {
+	return &mockprovider.Provider{
+		KMSValue:             customKMS,
+		StorageProviderValue: customStoreProvider,
+	}
+}

--- a/pkg/doc/jose/common.go
+++ b/pkg/doc/jose/common.go
@@ -31,6 +31,11 @@ const (
 	// For JWE: which references the public key to which the JWE was encrypted.
 	HeaderKeyID = "kid" // string
 
+	// HeaderSenderKeyID is a hint:
+	// For JWS: not used.
+	// For JWE: which references the (sender) public key used in the JWE key derivation/wrapping to encrypt the CEK.
+	HeaderSenderKeyID = "skid" // string
+
 	// HeaderX509URL is a URI that refers to a resource for the X.509 public key certificate or certificate chain:
 	// For JWS: corresponding to the key used to digitally sign the JWS.
 	// For JWE: corresponding to the public key to which the JWE was encrypted.
@@ -85,6 +90,11 @@ type Headers map[string]interface{}
 // KeyID gets Key ID from JOSE headers.
 func (h Headers) KeyID() (string, bool) {
 	return h.stringValue(HeaderKeyID)
+}
+
+// SenderKeyID gets the sender Key ID from Jose headers
+func (h Headers) SenderKeyID() (string, bool) {
+	return h.stringValue(HeaderSenderKeyID)
 }
 
 // Algorithm gets Algorithm from JOSE headers.


### PR DESCRIPTION
This change also introduces a thirdPartyKeysDB storage to store third party keys
It must be updated with the senderKey prior to Authcrypt.Decrypt() execution

closes #986

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
