### PR TITLE
fix: #1989 didexchange.Client.SaveConnection not saving did-key mappings to did store

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -66,6 +66,9 @@ type protocolService interface {
 	// CreateImplicitInvitation creates implicit invitation. Inviter DID is required, invitee DID is optional.
 	// If invitee DID is not provided new peer DID will be created for implicit invitation exchange request.
 	CreateImplicitInvitation(inviterLabel, inviterDID, inviteeLabel, inviteeDID string) (string, error)
+
+	// SaveConnectionRecord saves the connection record.
+	SaveConnectionRecord(*connection.Record) error
 }
 
 // New return new instance of didexchange client
@@ -300,7 +303,7 @@ func (c *Client) SaveConnection(req *ConnectionReq) (string, error) {
 		Namespace:       connection.MyNSPrefix,
 	}
 
-	err := c.connectionStore.SaveConnectionRecord(rec)
+	err := c.didexchangeSvc.SaveConnectionRecord(rec)
 	if err != nil {
 		return "", fmt.Errorf("save connection: err: %w", err)
 	}

--- a/pkg/didcomm/common/service/destination.go
+++ b/pkg/didcomm/common/service/destination.go
@@ -30,7 +30,7 @@ const (
 func GetDestination(did string, vdr vdri.Registry) (*Destination, error) {
 	didDoc, err := vdr.Resolve(did)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to resolve did [%s] : %w", did, err)
 	}
 
 	return CreateDestination(didDoc)

--- a/pkg/didcomm/protocol/didexchange/persistence.go
+++ b/pkg/didcomm/protocol/didexchange/persistence.go
@@ -49,9 +49,18 @@ func (c *connectionStore) saveConnectionRecord(record *connection.Record) error 
 		return fmt.Errorf(" failed to save connection record : %w", err)
 	}
 
+	// myDID may be empty if a record is being saved when a didexchange request is received
+	if record.MyDID != "" {
+		err := c.SaveDIDByResolving(record.MyDID)
+		if err != nil {
+			return fmt.Errorf("failed to save myDID by resolving : %w", err)
+		}
+	}
+
+	// theirDID may not be empty, such as when an incoming didexchange request is received
 	if record.State == StateIDCompleted {
 		if err := c.SaveDIDByResolving(record.TheirDID, record.RecipientKeys...); err != nil {
-			return fmt.Errorf(" failed to save DID by resolving : %w", err)
+			return fmt.Errorf("failed to save theirDID by resolving : %w", err)
 		}
 	}
 

--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -551,7 +551,13 @@ func (s *Service) update(msgType string, connectionRecord *connection.Record) er
 		return s.connectionStore.saveConnectionRecordWithMapping(connectionRecord)
 	}
 
-	return s.connectionStore.saveConnectionRecord(connectionRecord)
+	return s.SaveConnectionRecord(connectionRecord)
+}
+
+// SaveConnectionRecord saves the record to the connection store and maps TheirDID to their recipient keys in
+// the did connection store.
+func (s *Service) SaveConnectionRecord(record *connection.Record) error {
+	return s.connectionStore.saveConnectionRecord(record)
 }
 
 func (s *Service) connectionRecord(msg service.DIDCommMsg) (*connection.Record, error) {
@@ -607,7 +613,7 @@ func (s *Service) oobInvitationMsgRecord(msg service.DIDCommMsg) (*connection.Re
 		connRecord.InvitationDID = publicDID
 	}
 
-	if err := s.connectionStore.saveConnectionRecord(connRecord); err != nil {
+	if err := s.SaveConnectionRecord(connRecord); err != nil {
 		return nil, err
 	}
 
@@ -644,7 +650,7 @@ func (s *Service) invitationMsgRecord(msg service.DIDCommMsg) (*connection.Recor
 		Namespace:       findNamespace(msg.Type()),
 	}
 
-	if err := s.connectionStore.saveConnectionRecord(connRecord); err != nil {
+	if err := s.SaveConnectionRecord(connRecord); err != nil {
 		return nil, err
 	}
 
@@ -673,7 +679,7 @@ func (s *Service) requestMsgRecord(msg service.DIDCommMsg) (*connection.Record, 
 		Namespace:    theirNSPrefix,
 	}
 
-	if err := s.connectionStore.saveConnectionRecord(connRecord); err != nil {
+	if err := s.SaveConnectionRecord(connRecord); err != nil {
 		return nil, err
 	}
 

--- a/pkg/mock/didcomm/protocol/didexchange/mock_didexchange.go
+++ b/pkg/mock/didcomm/protocol/didexchange/mock_didexchange.go
@@ -22,6 +22,7 @@ import (
 	mockstore "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 	mockvdri "github.com/hyperledger/aries-framework-go/pkg/mock/vdri"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
 )
 
 // MockDIDExchangeSvc mock did exchange service
@@ -38,6 +39,7 @@ type MockDIDExchangeSvc struct {
 	ImplicitInvitationErr    error
 	RespondToFunc            func(*didexchange.OOBInvitation) (string, error)
 	SaveFunc                 func(invitation *didexchange.OOBInvitation) error
+	SaveConnRecordFunc       func(*connection.Record) error
 }
 
 // HandleInbound msg
@@ -152,6 +154,15 @@ func (m *MockDIDExchangeSvc) RespondTo(i *didexchange.OOBInvitation) (string, er
 func (m *MockDIDExchangeSvc) SaveInvitation(i *didexchange.OOBInvitation) error {
 	if m.SaveFunc != nil {
 		return m.SaveFunc(i)
+	}
+
+	return nil
+}
+
+// SaveConnectionRecord saves the connection record.
+func (m *MockDIDExchangeSvc) SaveConnectionRecord(r *connection.Record) error {
+	if m.SaveConnRecordFunc != nil {
+		return m.SaveConnRecordFunc(r)
 	}
 
 	return nil

--- a/pkg/store/did/didconnection.go
+++ b/pkg/store/did/didconnection.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/btcsuite/btcutil/base58"
 
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	diddoc "github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
@@ -83,6 +84,13 @@ func (c *ConnectionStore) SaveDIDFromDoc(doc *diddoc.Doc) error {
 	for i := range doc.PublicKey {
 		// TODO fix hardcode base58 https://github.com/hyperledger/aries-framework-go/issues/1207
 		keys = append(keys, base58.Encode(doc.PublicKey[i].Value))
+	}
+
+	// save recipientKeys from didcomm-enabled service entries
+	// an error is returned only if the doc does not have a valid didcomm service entry, so we ignore it
+	svc, err := service.CreateDestination(doc)
+	if err == nil {
+		keys = append(keys, svc.RecipientKeys...)
 	}
 
 	return c.SaveDID(doc.ID, keys...)


### PR DESCRIPTION
fixes #1989 

* TODO [merge connection stores](https://github.com/hyperledger/aries-framework-go/issues/1004)
* TODO [decouple connection storage from DID exchange protocol](https://github.com/hyperledger/aries-framework-go/issues/943)

Signed-off-by: George Aristy <george.aristy@securekey.com>

