### PR TITLE
fix: #1997 didexchange.Client.SaveConnection not saving 'theirDID'

### DIFF
--- a/cmd/aries-js-worker/src/aries.js
+++ b/cmd/aries-js-worker/src/aries.js
@@ -676,8 +676,8 @@ const Aries = function (opts) {
              * @param req - json document
              * @returns {Promise<Object>}
              */
-            saveConnection: async function (req) {
-                return invoke(aw, pending, this.pkgname, "SaveConnection", req, "timeout while saving invitation")
+            createConnection: async function (req) {
+                return invoke(aw, pending, this.pkgname, "CreateConnection", req, "timeout while creating connection")
             },
 
             /**

--- a/pkg/client/didexchange/models.go
+++ b/pkg/client/didexchange/models.go
@@ -61,16 +61,3 @@ type DIDInfo struct {
 	// the label associated with DID
 	Label string
 }
-
-// ConnectionReq contains fields to save the connection.
-type ConnectionReq struct {
-	ThreadID        string   `json:"threadID,omitempty"`
-	ParentThreadID  string   `json:"parentThreadID,omitempty"`
-	TheirLabel      string   `json:"theirLabel,omitempty"`
-	TheirDID        string   `json:"theirDID,omitempty"`
-	MyDID           string   `json:"myDID,omitempty"`
-	ServiceEndPoint string   `json:"serviceEndPoint,omitempty"`
-	RecipientKeys   []string `json:"recipientKeys,omitempty"`
-	RoutingKeys     []string `json:"routingKeys,omitempty"`
-	InvitationID    string   `json:"invitationID,omitempty"`
-}

--- a/pkg/controller/command/didexchange/models.go
+++ b/pkg/controller/command/didexchange/models.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package didexchange
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
@@ -297,4 +298,24 @@ type RemoveConnectionRequest struct {
 type ConnectionIDArg struct {
 	// Connection ID
 	ID string `json:"id"`
+}
+
+// CreateConnectionRequest model
+//
+type CreateConnectionRequest struct {
+	MyDID          string      `json:"myDID"`
+	TheirDID       DIDDocument `json:"theirDID"`
+	TheirLabel     string      `json:"theirLabel,omitempty"`
+	InvitationID   string      `json:"invitationID,omitempty"`
+	InvitationDID  string      `json:"invitationDID,omitempty"`
+	ParentThreadID string      `json:"parentThreadID,omitempty"`
+	ThreadID       string      `json:"threadID,omitempty"`
+	Implicit       bool        `json:"implicit,omitempty"`
+}
+
+// DIDDocument model
+//
+type DIDDocument struct {
+	ID       string          `json:"id"`
+	Contents json.RawMessage `json:"contents"`
 }

--- a/pkg/controller/rest/didexchange/models.go
+++ b/pkg/controller/rest/didexchange/models.go
@@ -201,14 +201,29 @@ type RemoveConnectionRequest struct { // nolint: unused,deadcode
 type RemoveConnectionResponse struct { // nolint: unused,deadcode
 }
 
-// saveConnectionResp model
+// createConnectionResp model
 //
 // This is used as the response model for save connection api.
 //
-// swagger:response saveConnectionResp
-type saveConnectionResp struct { // nolint: unused,deadcode
-	// The ID of the connection to get
+// swagger:response createConnectionResp
+type createConnectionResp struct { // nolint: unused,deadcode
+	// in: body
+	Body struct {
+		// The ID of the connection to get
+		//
+		ID string `json:"id"`
+	}
+}
+
+// createConnectionRequest model
+//
+// Request to create a new connection between two DIDs.
+//
+// swagger:parameters createConnection
+type createConnectionRequest struct { // nolint: unused,deadcode
+	// Params for creating a connection.
 	//
 	// in: body
-	ID string `json:"id"`
+	// required: true
+	Request didexchange.CreateConnectionRequest
 }

--- a/pkg/controller/rest/didexchange/operation.go
+++ b/pkg/controller/rest/didexchange/operation.go
@@ -32,7 +32,7 @@ const (
 	connections                  = operationID
 	connectionsByID              = operationID + "/{id}"
 	acceptExchangeRequest        = operationID + "/{id}/accept-request"
-	saveConnection               = operationID + "/create"
+	createConnection             = operationID + "/create"
 	removeConnection             = operationID + "/{id}/remove"
 )
 
@@ -80,7 +80,7 @@ func (c *Operation) registerHandler() {
 		cmdutil.NewHTTPHandler(receiveInvitationPath, http.MethodPost, c.ReceiveInvitation),
 		cmdutil.NewHTTPHandler(acceptInvitationPath, http.MethodPost, c.AcceptInvitation),
 		cmdutil.NewHTTPHandler(acceptExchangeRequest, http.MethodPost, c.AcceptExchangeRequest),
-		cmdutil.NewHTTPHandler(saveConnection, http.MethodPost, c.SaveConnection),
+		cmdutil.NewHTTPHandler(createConnection, http.MethodPost, c.CreateConnection),
 		cmdutil.NewHTTPHandler(removeConnection, http.MethodPost, c.RemoveConnection),
 	}
 }
@@ -201,15 +201,15 @@ func (c *Operation) QueryConnectionByID(rw http.ResponseWriter, req *http.Reques
 	rest.Execute(c.command.QueryConnectionByID, rw, bytes.NewBufferString(request))
 }
 
-// SaveConnection swagger:route POST /connections/create did-exchange saveConnection
+// CreateConnection swagger:route POST /connections/create did-exchange createConnection
 //
 // Saves the connection record.
 //
 // Responses:
 //    default: genericError
-//    200: saveConnectionResp
-func (c *Operation) SaveConnection(rw http.ResponseWriter, req *http.Request) {
-	rest.Execute(c.command.SaveConnection, rw, req.Body)
+//    200: createConnectionResp
+func (c *Operation) CreateConnection(rw http.ResponseWriter, req *http.Request) {
+	rest.Execute(c.command.CreateConnection, rw, req.Body)
 }
 
 // RemoveConnection swagger:route POST /connections/{id}/remove did-exchange removeConnection

--- a/pkg/didcomm/dispatcher/outbound.go
+++ b/pkg/didcomm/dispatcher/outbound.go
@@ -56,12 +56,13 @@ func NewOutbound(prov provider) *OutboundDispatcher {
 func (o *OutboundDispatcher) SendToDID(msg interface{}, myDID, theirDID string) error {
 	dest, err := service.GetDestination(theirDID, o.vdRegistry)
 	if err != nil {
-		return err
+		return fmt.Errorf(
+			"outboundDispatcher.SendToDID failed to get didcomm destination for theirDID [%s]: %w", theirDID, err)
 	}
 
 	src, err := service.GetDestination(myDID, o.vdRegistry)
 	if err != nil {
-		return err
+		return fmt.Errorf("outboundDispatcher.SendToDID failed to get didcomm destination for myDID [%s]: %w", myDID, err)
 	}
 
 	// We get at least one recipient key, so we can use the first one

--- a/pkg/mock/didcomm/protocol/didexchange/mock_didexchange.go
+++ b/pkg/mock/didcomm/protocol/didexchange/mock_didexchange.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/dispatcher"
@@ -39,7 +40,7 @@ type MockDIDExchangeSvc struct {
 	ImplicitInvitationErr    error
 	RespondToFunc            func(*didexchange.OOBInvitation) (string, error)
 	SaveFunc                 func(invitation *didexchange.OOBInvitation) error
-	SaveConnRecordFunc       func(*connection.Record) error
+	CreateConnRecordFunc     func(*connection.Record, *did.Doc) error
 }
 
 // HandleInbound msg
@@ -159,10 +160,10 @@ func (m *MockDIDExchangeSvc) SaveInvitation(i *didexchange.OOBInvitation) error 
 	return nil
 }
 
-// SaveConnectionRecord saves the connection record.
-func (m *MockDIDExchangeSvc) SaveConnectionRecord(r *connection.Record) error {
-	if m.SaveConnRecordFunc != nil {
-		return m.SaveConnRecordFunc(r)
+// CreateConnection saves the connection record.
+func (m *MockDIDExchangeSvc) CreateConnection(r *connection.Record, theirDID *did.Doc) error {
+	if m.CreateConnRecordFunc != nil {
+		return m.CreateConnRecordFunc(r, theirDID)
 	}
 
 	return nil

--- a/pkg/mock/vdri/mock_registry.go
+++ b/pkg/mock/vdri/mock_registry.go
@@ -22,6 +22,7 @@ type MockVDRIRegistry struct {
 	CreateValue  *did.Doc
 	CreateFunc   func(string, ...vdriapi.DocOpts) (*did.Doc, error)
 	MemStore     map[string]*did.Doc
+	StoreFunc    func(*did.Doc) error
 	PutErr       error
 	ResolveErr   error
 	ResolveValue *did.Doc
@@ -31,6 +32,10 @@ type MockVDRIRegistry struct {
 // Store stores the key and the record
 func (m *MockVDRIRegistry) Store(doc *did.Doc) error {
 	k := doc.ID
+
+	if m.StoreFunc != nil {
+		return m.StoreFunc(doc)
+	}
 
 	if len(m.MemStore) == 0 {
 		m.MemStore = make(map[string]*did.Doc)

--- a/pkg/store/did/didconnection.go
+++ b/pkg/store/did/didconnection.go
@@ -103,7 +103,7 @@ func (c *ConnectionStore) SaveDIDByResolving(did string, keys ...string) error {
 	if errors.Is(err, vdri.ErrNotFound) {
 		return c.SaveDID(did, keys...)
 	} else if err != nil {
-		return err
+		return fmt.Errorf("failed to read from vdri store : %w", err)
 	}
 
 	return c.SaveDIDFromDoc(doc)

--- a/pkg/vdri/peer/store.go
+++ b/pkg/vdri/peer/store.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
 type docDelta struct {
@@ -61,7 +62,7 @@ func (v *VDRI) Get(id string) (*did.Doc, error) {
 
 	deltas, err := v.getDeltas(id)
 	if err != nil {
-		return nil, fmt.Errorf("delta data fetch from store failed: %w", err)
+		return nil, fmt.Errorf("delta data fetch from store for did [%s] failed: %w", id, err)
 	}
 
 	// For now, assume storage contains only one delta(genesis document)
@@ -87,6 +88,10 @@ func (v *VDRI) Close() error {
 
 func (v *VDRI) getDeltas(id string) ([]docDelta, error) {
 	val, err := v.store.Get(id)
+	if errors.Is(err, storage.ErrDataNotFound) {
+		return nil, vdriapi.ErrNotFound
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("fetching data from store failed: %w", err)
 	}

--- a/pkg/vdri/peer/store_test.go
+++ b/pkg/vdri/peer/store_test.go
@@ -7,12 +7,14 @@ SPDX-License-Identifier: Apache-2.0
 package peer
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	vdriapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
 	"github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 )
 
@@ -67,7 +69,16 @@ func TestPeerDIDStore(t *testing.T) {
 	v, err := store.Get("not-json")
 	require.NotNil(t, err)
 	require.Nil(t, v)
-	require.Contains(t, err.Error(), "delta data fetch from store failed")
+	require.Contains(t, err.Error(), "delta data fetch from store")
+
+	t.Run("returns vdri.ErrNotFound if did is not resolved", func(t *testing.T) {
+		store, err := New(storage.NewMockStoreProvider())
+		require.NoError(t, err)
+
+		_, err = store.Get("nonexistent")
+		require.Error(t, err)
+		require.True(t, errors.Is(err, vdriapi.ErrNotFound))
+	})
 }
 
 func TestVDRI_Close(t *testing.T) {

--- a/pkg/vdri/registry.go
+++ b/pkg/vdri/registry.go
@@ -90,7 +90,7 @@ func (r *Registry) Resolve(did string, opts ...vdriapi.ResolveOpts) (*diddoc.Doc
 	return didDoc, nil
 }
 
-// Create returns new DID Document
+// Create a new DID Document and store it in this registry.
 func (r *Registry) Create(didMethod string, opts ...vdriapi.DocOpts) (*diddoc.Doc, error) {
 	docOpts := &vdriapi.CreateDIDOpts{KeyType: defaultKeyType}
 


### PR DESCRIPTION
fixes #1997 

* refactored SaveConnection() -> CreateConnection()
* Parameters are now: myDID string, theirDID *did.Doc, and options
* REST/Controller APIs refactored accordingly
* fix: did:peer vdri not returning vdriapi.ErrNotFound when deltas not
  found

BDD tests TODO #1997 (but I've tested this change in another project's bdd tests)

Signed-off-by: George Aristy <george.aristy@securekey.com>

