### PR TITLE
feat: command controller for mediator reconnect

### DIFF
--- a/cmd/aries-js-worker/src/agent-rest-client.js
+++ b/cmd/aries-js-worker/src/agent-rest-client.js
@@ -110,6 +110,10 @@ const pkgs = {
             path: "/mediator/connection",
             method: "GET"
         },
+        Reconnect: {
+            path: "/mediator/reconnect",
+            method: "POST"
+        },
     },
     verifiable: {
         ValidateCredential: {

--- a/cmd/aries-js-worker/src/aries.js
+++ b/cmd/aries-js-worker/src/aries.js
@@ -836,7 +836,7 @@ const Aries = function (opts) {
             /**
              * Registers an agent with the router.
              *
-             * @param req - json document
+             * @param req - json document containing connection ID
              * @returns {Promise<Object>}
              */
             register: async function (req) {
@@ -860,6 +860,16 @@ const Aries = function (opts) {
             getConnection: async function () {
                 // console.log("router get connection")
                 return invoke(aw, pending, this.pkgname, "Connection", "{}", "timeout while fetching router connection id")
+            },
+
+            /**
+             * Reconnects an agent with the router.
+             *
+             * @param req - json document containing connection ID
+             * @returns {Promise<Object>}
+             */
+            reconnect: async function (req) {
+                return invoke(aw, pending, this.pkgname, "Reconnect", req, "timeout while reconnecting to router")
             }
         },
 

--- a/pkg/client/messagepickup/client.go
+++ b/pkg/client/messagepickup/client.go
@@ -39,7 +39,7 @@ type protocolService interface {
 func New(ctx provider) (*Client, error) {
 	svc, err := ctx.Service(messagepickup.MessagePickup)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create msg pickup service: %w", err)
 	}
 
 	messagepickupSvc, ok := svc.(protocolService)

--- a/pkg/controller/command/mediator/models.go
+++ b/pkg/controller/command/mediator/models.go
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 package mediator
 
-// RegisterRoute contains parameters for registering router.
+// RegisterRoute contains parameters for registering/reconnecting router.
 type RegisterRoute struct {
 	ConnectionID string `json:"connectionID"`
 }

--- a/pkg/controller/rest/mediator/models.go
+++ b/pkg/controller/rest/mediator/models.go
@@ -35,3 +35,15 @@ type ConnectionRes struct { // nolint: unused,deadcode
 	// in: body
 	Params mediator.RegisterRoute
 }
+
+// reconnectRouteReq model
+//
+// This is used register router for the agent.
+//
+// swagger:parameters reconnectRouteRequest
+type reconnectRouteReq struct { // nolint: unused,deadcode
+	// Params for reconnecting the router
+	//
+	// in: body
+	Params mediator.RegisterRoute
+}

--- a/pkg/controller/rest/mediator/operation.go
+++ b/pkg/controller/rest/mediator/operation.go
@@ -20,6 +20,7 @@ const (
 	registerPath      = routeOperationID + "/register"
 	unregisterPath    = routeOperationID + "/unregister"
 	getConnectionPath = routeOperationID + "/connection"
+	reconnectPath     = routeOperationID + "/reconnect"
 )
 
 // provider contains dependencies for the route protocol and is typically created by using aries.Context().
@@ -59,6 +60,7 @@ func (o *Operation) registerHandler() {
 		cmdutil.NewHTTPHandler(registerPath, http.MethodPost, o.Register),
 		cmdutil.NewHTTPHandler(unregisterPath, http.MethodDelete, o.Unregister),
 		cmdutil.NewHTTPHandler(getConnectionPath, http.MethodGet, o.Connection),
+		cmdutil.NewHTTPHandler(reconnectPath, http.MethodPost, o.Reconnect),
 	}
 }
 
@@ -92,4 +94,14 @@ func (o *Operation) Unregister(rw http.ResponseWriter, req *http.Request) {
 //    200: getConnectionResponse
 func (o *Operation) Connection(rw http.ResponseWriter, req *http.Request) {
 	rest.Execute(o.command.Connection, rw, req.Body)
+}
+
+// Reconnect swagger:route POST /mediator/reconnect mediator reconnectRouteRequest
+//
+// Reconnect the agent with the router to re-establish lost connection.
+//
+// Responses:
+//    default: genericError
+func (o *Operation) Reconnect(rw http.ResponseWriter, req *http.Request) {
+	rest.Execute(o.command.Reconnect, rw, req.Body)
 }

--- a/pkg/didcomm/protocol/messagepickup/service.go
+++ b/pkg/didcomm/protocol/messagepickup/service.go
@@ -67,6 +67,8 @@ type connections interface {
 
 // Service for the messagepickup protocol
 type Service struct {
+	service.Action
+	service.Message
 	connectionLookup connections
 	outbound         dispatcher.Outbound
 	msgStore         storage.Store
@@ -499,7 +501,7 @@ func (s *Service) Noop(connectionID string) error {
 		return err
 	}
 
-	noop := &Noop{}
+	noop := &Noop{ID: uuid.New().String(), Type: NoopMsgType}
 	if err := s.outbound.SendToDID(noop, conn.MyDID, conn.TheirDID); err != nil {
 		return fmt.Errorf("send noop request: %w", err)
 	}

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/introduce"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/issuecredential"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/messagepickup"
 	mdissuecredential "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/middleware/issuecredential"
 	mdpresentproof "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/middleware/presentproof"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/outofband"
@@ -68,7 +69,7 @@ func defFrameworkOpts(frameworkOpts *Aries) error {
 	// - Introduce depends on OutOfBand
 	frameworkOpts.protocolSvcCreators = append(frameworkOpts.protocolSvcCreators,
 		newRouteSvc(), newExchangeSvc(), newOutOfBandSvc(), newIntroduceSvc(),
-		newIssueCredentialSvc(), newPresentProofSvc(),
+		newIssueCredentialSvc(), newPresentProofSvc(), messagepickup.ServiceCreator(),
 	)
 
 	if frameworkOpts.secretLock == nil && frameworkOpts.kmsCreator == nil {


### PR DESCRIPTION
- added JS, command, REST controller for mediator reconnect by sending
noop message to router
- Closes #2000

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
