### PR TITLE
docs: Fixes openapi validation warnings

### DIFF
--- a/cmd/aries-agent-mobile/go.sum
+++ b/cmd/aries-agent-mobile/go.sum
@@ -120,6 +120,7 @@ github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT9
 github.com/piprate/json-gold v0.3.0 h1:a1vHx7Q1jOO1pjCtKwTI/WCzwaQwRt9VM7apK2uy200=
 github.com/piprate/json-gold v0.3.0/go.mod h1:OK1z7UgtBZk06n2cDE2OSq1kffmjFFp5/2yhLLCz9UM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/cmd/aries-agent-rest/go.sum
+++ b/cmd/aries-agent-rest/go.sum
@@ -137,6 +137,7 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/piprate/json-gold v0.3.0 h1:a1vHx7Q1jOO1pjCtKwTI/WCzwaQwRt9VM7apK2uy200=
 github.com/piprate/json-gold v0.3.0/go.mod h1:OK1z7UgtBZk06n2cDE2OSq1kffmjFFp5/2yhLLCz9UM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/cmd/aries-js-worker/go.sum
+++ b/cmd/aries-js-worker/go.sum
@@ -120,6 +120,7 @@ github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4P
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/controller/rest/didexchange/models.go
+++ b/pkg/controller/rest/didexchange/models.go
@@ -30,13 +30,11 @@ type createInvitationRequest struct { // nolint: unused,deadcode
 // swagger:response createInvitationResponse
 type createInvitationResponse struct { // nolint: unused,deadcode
 	// in: body
-	Invitation *didexchangeSvc.Invitation `json:"invitation"`
-
-	// in: body
-	Alias string `json:"alias"`
-
-	// in: body
-	InvitationURL string `json:"invitation_url"`
+	Body struct {
+		Invitation    struct{ *didexchangeSvc.Invitation } `json:"invitation"`
+		Alias         string                               `json:"alias"`
+		InvitationURL string                               `json:"invitation_url"`
+	}
 }
 
 // receiveInvitationRequest model
@@ -49,7 +47,9 @@ type receiveInvitationRequest struct { // nolint: unused,deadcode
 	//
 	// required: true
 	// in: body
-	Invitation didexchangeSvc.Invitation `json:""`
+	Invitation struct {
+		*didexchangeSvc.Invitation
+	}
 }
 
 // receiveInvitationResponse model
@@ -58,7 +58,10 @@ type receiveInvitationRequest struct { // nolint: unused,deadcode
 //
 // swagger:response receiveInvitationResponse
 type receiveInvitationResponse struct { // nolint: unused,deadcode
-	didexchange.ReceiveInvitationResponse
+	// in: body
+	Body struct {
+		didexchange.ReceiveInvitationResponse
+	}
 }
 
 // acceptInvitationRequest model
@@ -83,7 +86,10 @@ type acceptInvitationRequest struct { // nolint: unused,deadcode
 //
 // swagger:response acceptInvitationResponse
 type acceptInvitationResponse struct { // nolint: unused,deadcode
-	didexchange.AcceptInvitationResponse
+	// in: body
+	Body struct {
+		didexchange.AcceptInvitationResponse
+	}
 }
 
 // implicitInvitationRequest model
@@ -101,7 +107,10 @@ type implicitInvitationRequest struct { // nolint: unused,deadcode
 //
 // swagger:response implicitInvitationResponse
 type implicitInvitationResponse struct { // nolint: unused,deadcode
-	didexchange.ImplicitInvitationResponse
+	// in: body
+	Body struct {
+		didexchange.ImplicitInvitationResponse
+	}
 }
 
 // getConnectionRequest model
@@ -136,9 +145,10 @@ type queryConnections struct { // nolint: unused,deadcode
 //
 // swagger:response queryConnectionResponse
 type queryConnectionResponse struct { // nolint: unused,deadcode
-
 	// in: body
-	Result *didexchangeSvc.Connection `json:"result,omitempty"`
+	Body struct {
+		Result *didexchangeSvc.Connection `json:"result,omitempty"`
+	}
 }
 
 // queryConnectionsResponse model
@@ -149,7 +159,9 @@ type queryConnectionResponse struct { // nolint: unused,deadcode
 type queryConnectionsResponse struct { // nolint: unused,deadcode
 
 	// in: body
-	Results []*didexchangeSvc.Connection `json:"results,omitempty"`
+	Body struct {
+		Results []*didexchangeSvc.Connection `json:"results,omitempty"`
+	}
 }
 
 // acceptExchangeRequestParams model
@@ -177,7 +189,7 @@ type acceptExchangeRequestParams struct { // nolint: unused,deadcode
 type acceptExchangeResult struct { // nolint: unused,deadcode
 
 	// in: body
-	Result didexchange.ExchangeResponse `json:""`
+	Result didexchange.ExchangeResponse
 }
 
 // RemoveConnectionRequest model
@@ -199,6 +211,8 @@ type RemoveConnectionRequest struct { // nolint: unused,deadcode
 //
 // swagger:response removeConnectionResponse
 type RemoveConnectionResponse struct { // nolint: unused,deadcode
+	// in: body
+	Body struct{}
 }
 
 // createConnectionResp model

--- a/pkg/controller/rest/introduce/models.go
+++ b/pkg/controller/rest/introduce/models.go
@@ -26,7 +26,7 @@ type introduceActionsRequest struct{} // nolint: unused,deadcode
 type introduceActionsResponse struct { // nolint: unused,deadcode
 	// in: body
 	Body struct {
-		Actions []protocol.Action `json:"actions"`
+		Actions []struct{ *protocol.Action } `json:"actions"`
 	}
 }
 
@@ -38,7 +38,7 @@ type introduceActionsResponse struct { // nolint: unused,deadcode
 type introduceSendProposalRequest struct { // nolint: unused,deadcode
 	// in: body
 	Body struct {
-		Recipients []*protocol.Recipient `json:"recipients"`
+		Recipients []struct{ *protocol.Recipient } `json:"recipients"`
 	}
 }
 
@@ -65,10 +65,10 @@ type introduceSendProposalWithOOBRequest struct { // nolint: unused,deadcode
 	Body struct {
 		// Request is the out-of-band protocol's 'request' message.
 		// required: true
-		Request *outofband.Request `json:"request"`
+		Request struct{ *outofband.Request } `json:"request"`
 		// Recipient specifies to whom proposal will be sent
 		// required: true
-		Recipient *protocol.Recipient `json:"recipient"`
+		Recipient struct{ *protocol.Recipient } `json:"recipient"`
 	}
 }
 
@@ -99,7 +99,7 @@ type introduceAcceptProposalWithOOBRequest struct { // nolint: unused,deadcode
 	// in: body
 	Body struct {
 		// Request is the out-of-band protocol's 'request' message.
-		Request *outofband.Request `json:"request"`
+		Request struct{ *outofband.Request } `json:"request"`
 	}
 }
 
@@ -127,9 +127,9 @@ type introduceAcceptRequestWithPublicOOBRequest struct { // nolint: unused,deadc
 	// in: body
 	Body struct {
 		// Request is the out-of-band protocol's 'request' message.
-		Request *outofband.Request `json:"request"`
+		Request struct{ *outofband.Request } `json:"request"`
 		// To keeps information about the introduction
-		To *protocol.To `json:"to"`
+		To struct{ *protocol.To } `json:"to"`
 	}
 }
 
@@ -157,9 +157,9 @@ type introduceAcceptRequestWithRecipients struct { // nolint: unused,deadcode
 	// in: body
 	Body struct {
 		// Recipient specifies to whom proposal will be sent
-		Recipient *protocol.Recipient `json:"recipient"`
+		Recipient struct{ *protocol.Recipient } `json:"recipient"`
 		// To keeps information about the introduction
-		To *protocol.To `json:"to"`
+		To struct{ *protocol.To } `json:"to"`
 	}
 }
 
@@ -189,7 +189,7 @@ type introduceSendRequest struct { // nolint: unused,deadcode
 		TheirDID string `json:"their_did"`
 		// PleaseIntroduceTo keeps information about the introduction
 		// required: true
-		PleaseIntroduceTo *protocol.PleaseIntroduceTo `json:"please_introduce_to"`
+		PleaseIntroduceTo struct{ *protocol.PleaseIntroduceTo } `json:"please_introduce_to"`
 	}
 }
 

--- a/pkg/controller/rest/issuecredential/models.go
+++ b/pkg/controller/rest/issuecredential/models.go
@@ -23,7 +23,7 @@ type issueCredentialAcceptProposalRequest struct { // nolint: unused,deadcode
 	// in: body
 	Body struct {
 		// required: true
-		OfferCredential protocol.OfferCredential `json:"offer_credential"`
+		OfferCredential struct{ *protocol.OfferCredential } `json:"offer_credential"`
 	}
 }
 
@@ -75,7 +75,7 @@ type issueCredentialAcceptRequestRequest struct { // nolint: unused,deadcode
 	// in: body
 	Body struct {
 		// required: true
-		IssueCredential protocol.IssueCredential `json:"issue_credential"`
+		IssueCredential struct{ *protocol.IssueCredential } `json:"issue_credential"`
 	}
 }
 
@@ -237,7 +237,7 @@ type issueCredentialNegotiateProposalRequest struct { // nolint: unused,deadcode
 	// in: body
 	Body struct {
 		// required: true
-		ProposeCredential protocol.ProposeCredential `json:"propose_credential"`
+		ProposeCredential struct{ *protocol.ProposeCredential } `json:"propose_credential"`
 	}
 }
 
@@ -266,7 +266,7 @@ type issueCredentialActionsRequest struct{} // nolint: unused,deadcode
 type issueCredentialActionsResponse struct { // nolint: unused,deadcode
 	// in: body
 	Body struct {
-		Actions []protocol.Action `json:"actions"`
+		Actions []struct{ *protocol.Action } `json:"actions"`
 	}
 }
 
@@ -287,7 +287,7 @@ type issueCredentialSendOfferRequest struct { // nolint: unused,deadcode
 		// OfferCredential is a message describing the credential intend to offer and
 		// possibly the price they expect to be paid.
 		// required: true
-		OfferCredential *protocol.OfferCredential `json:"offer_credential"`
+		OfferCredential struct{ *protocol.OfferCredential } `json:"offer_credential"`
 	}
 }
 
@@ -320,7 +320,7 @@ type issueCredentialSendProposalRequest struct { // nolint: unused,deadcode
 		TheirDID string `json:"their_did"`
 		// ProposeCredential is a message sent by the potential Holder to the Issuer to initiate the protocol
 		// required: true
-		ProposeCredential *protocol.ProposeCredential `json:"propose_credential"`
+		ProposeCredential struct{ *protocol.ProposeCredential } `json:"propose_credential"`
 	}
 }
 
@@ -354,7 +354,7 @@ type issueCredentialSendRequestRequest struct { // nolint: unused,deadcode
 		// RequestCredential is a message sent by the potential Holder to the Issuer,
 		// to request the issuance of a credential.
 		// required: true
-		RequestCredential *protocol.RequestCredential `json:"request_credential"`
+		RequestCredential struct{ *protocol.RequestCredential } `json:"request_credential"`
 	}
 }
 

--- a/pkg/controller/rest/outofband/models.go
+++ b/pkg/controller/rest/outofband/models.go
@@ -37,7 +37,7 @@ type outofbandCreateRequest struct { // nolint: unused,deadcode
 type outofbandCreateRequestResponse struct { // nolint: unused,deadcode
 	// in: body
 	Body struct {
-		Request *protocol.Request `json:"request"`
+		Request struct{ *protocol.Request } `json:"request"`
 	}
 }
 
@@ -65,7 +65,7 @@ type outofbandCreateInvitationRequest struct { // nolint: unused,deadcode
 type outofbandCreateInvitationResponse struct { // nolint: unused,deadcode
 	// in: body
 	Body struct {
-		Invitation *protocol.Invitation `json:"invitation"`
+		Invitation struct{ *protocol.Invitation } `json:"invitation"`
 	}
 }
 
@@ -77,8 +77,8 @@ type outofbandCreateInvitationResponse struct { // nolint: unused,deadcode
 type outofbandAcceptRequest struct { // nolint: unused,deadcode
 	// in: body
 	Body struct {
-		Request *protocol.Request `json:"request"`
-		MyLabel string            `json:"my_label"`
+		Request struct{ *protocol.Request } `json:"request"`
+		MyLabel string                      `json:"my_label"`
 	}
 }
 
@@ -102,8 +102,8 @@ type outofbandAcceptRequestResponse struct { // nolint: unused,deadcode
 type outofbandAcceptInvitationRequest struct { // nolint: unused,deadcode
 	// in: body
 	Body struct {
-		Invitation *protocol.Invitation `json:"invitation"`
-		MyLabel    string               `json:"my_label"`
+		Invitation struct{ *protocol.Invitation } `json:"invitation"`
+		MyLabel    string                         `json:"my_label"`
 	}
 }
 
@@ -134,7 +134,7 @@ type outofbandActionsRequest struct{} // nolint: unused,deadcode
 type outofbandActionsResponse struct { // nolint: unused,deadcode
 	// in: body
 	Body struct {
-		Actions []protocol.Action `json:"actions"`
+		Actions []struct{ *protocol.Action } `json:"actions"`
 	}
 }
 

--- a/pkg/controller/rest/presentproof/models.go
+++ b/pkg/controller/rest/presentproof/models.go
@@ -23,7 +23,7 @@ type presentProofActionsRequest struct{} // nolint: unused,deadcode
 type presentProofActionsResponse struct { // nolint: unused,deadcode
 	// in: body
 	Body struct {
-		Actions []protocol.Action `json:"actions"`
+		Actions []struct{ *protocol.Action } `json:"actions"`
 	}
 }
 
@@ -43,7 +43,7 @@ type presentProofSendRequestPresentationRequest struct { // nolint: unused,deadc
 		TheirDID string `json:"their_did"`
 		// RequestPresentation describes values that need to be revealed and predicates that need to be fulfilled.
 		// required: true
-		RequestPresentation *protocol.RequestPresentation `json:"request_presentation"`
+		RequestPresentation struct{ *protocol.RequestPresentation } `json:"request_presentation"`
 	}
 }
 
@@ -76,7 +76,7 @@ type presentProofSendProposePresentationRequest struct { // nolint: unused,deadc
 		TheirDID string `json:"their_did"`
 		// ProposePresentation is a message sent by the Prover to the verifier to initiate a proof presentation process.
 		// required: true
-		ProposePresentation *protocol.ProposePresentation `json:"propose_presentation"`
+		ProposePresentation struct{ *protocol.ProposePresentation } `json:"propose_presentation"`
 	}
 }
 
@@ -110,7 +110,7 @@ type presentProofAcceptRequestPresentationRequest struct { // nolint: unused,dea
 		// Presentation is a message that contains signed presentations.
 		//
 		// required: true
-		Presentation *protocol.Presentation `json:"presentation"`
+		Presentation struct{ *protocol.Presentation } `json:"presentation"`
 	}
 }
 
@@ -141,7 +141,7 @@ type presentProofAcceptProposePresentationRequest struct { // nolint: unused,dea
 		// RequestPresentation describes values that need to be revealed and predicates that need to be fulfilled.
 		//
 		// required: true
-		RequestPresentation *protocol.RequestPresentation `json:"request_presentation"`
+		RequestPresentation struct{ *protocol.RequestPresentation } `json:"request_presentation"`
 	}
 }
 
@@ -202,7 +202,7 @@ type presentProofNegotiateRequestPresentationRequest struct { // nolint: unused,
 		// propose using a different presentation format.
 		//
 		// required: true
-		ProposePresentation *protocol.ProposePresentation `json:"propose_presentation"`
+		ProposePresentation struct{ *protocol.ProposePresentation } `json:"propose_presentation"`
 	}
 }
 

--- a/pkg/didcomm/protocol/outofband/service.go
+++ b/pkg/didcomm/protocol/outofband/service.go
@@ -97,7 +97,6 @@ type Action struct {
 	ProtocolName string
 	MyDID        string
 	TheirDID     string
-	Properties   *eventProps
 }
 
 // transitionalPayload keeps payload needed for Continue function to proceed with the action
@@ -200,7 +199,6 @@ func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) 
 			MyDID:        myDID,
 			TheirDID:     theirDID,
 			ProtocolName: Name,
-			Properties:   &eventProps{},
 		},
 	})
 	if err != nil {
@@ -239,7 +237,6 @@ func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) 
 					logger.Errorf("delete transitional payload: %s", err)
 				}
 			},
-			Properties: &eventProps{},
 		}
 
 		events <- event

--- a/pkg/didcomm/protocol/outofband/service_test.go
+++ b/pkg/didcomm/protocol/outofband/service_test.go
@@ -148,11 +148,7 @@ func TestHandleInbound(t *testing.T) {
 		case e := <-events:
 			require.Equal(t, Name, e.ProtocolName)
 			require.Equal(t, expected, e.Message)
-			require.NotNil(t, e.Properties)
-			props, ok := e.Properties.(*eventProps)
-			require.True(t, ok)
-			require.Empty(t, props.ConnectionID())
-			require.NoError(t, props.Error())
+			require.Nil(t, e.Properties)
 		case <-time.After(1 * time.Second):
 			t.Error("timeout waiting for action event")
 		}


### PR DESCRIPTION
This PR fixes collisions related to Invitation and Action structures. 

What was the problem?
We have two `Invitation` structures in our framework (outofband and didexchange).
When we generate `swagger` it uses only one `Invitation` definition e.g '#/definitions/Invitation'.
Due to this collision the spec was incorrect.
The same was related to the `Action` structure.

Closes #1975 

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>