### PR TITLE
feat: add verifiable controller mobile wrappers

### DIFF
--- a/cmd/aries-agent-mobile/README.md
+++ b/cmd/aries-agent-mobile/README.md
@@ -67,20 +67,35 @@ This is an example of how the imported module can be used:
 import org.hyperledger.aries.api.AriesController;
 import org.hyperledger.aries.api.IntroduceController;
 import org.hyperledger.aries.ariesagent.Ariesagent;
-import org.hyperledger.aries.wrappers.*;
+import org.hyperledger.aries.models.RequestEnvelope;
+import org.hyperledger.aries.models.ResponseEnvelope;
+import org.hyperledger.aries.config.Options;
+
+import java.nio.charset.StandardCharsets;
 /*
 ...
 */
-        IntroduceActionsResponse res = new IntroduceActionsResponse();
+        // create options
+        Options opts = new Options();
+        opts.setURL("http://example.com");
+        opts.setUseLocalAgent(true);
+
+        ResponseEnvelope res = new ResponseEnvelope();
         try {
-            boolean useLocalAgent = false;
-            AriesController a = Ariesagent.newAriesAgent(useLocalAgent);
+            // create an aries agent instance
+            AriesController a = Ariesagent.newAriesAgent(opts);
+
+            // create a controller
             IntroduceController i = a.getIntroduceController();
-            res = i.actions(new IntroduceActionsRequest());
+
+            // perform an operation
+            res = i.actions(new RequestEnvelope());
         } catch (Exception e) {
             e.printStackTrace();
         }
-        String actionsResponse = res.getActionsResponse();
+
+        String actionsResponse = new String(res.getPayload(), StandardCharsets.UTF_8);
+        System.out.println(actionsResponse);
 ```
 
 
@@ -97,10 +112,35 @@ This is an example of how the imported framework can be used:
 /*
 ...
 */
-    ApiAriesController *ac = (ApiAriesController*) AriesagentNewAriesAgent(false, nil);
-    ApiIntroduceController *ic = (ApiIntroduceController*) [ac getIntroduceController:nil];
-    WrappersIntroduceActionsResponse *resp = [ic actions:nil];
-    NSString *actionsResp = resp.actionsResponse;
+    NSError *error = nil;
+
+    // create options
+    ConfigOptions *opts = [[ConfigOptions alloc] init];
+    opts.url = @"http://example.com";
+    opts.useLocalAgent = true;
+    
+    // create an aries agent instance
+    RestAriesREST *ac = (RestAriesREST*) AriesagentNewAriesAgent(opts, &error);
+    if(error) {
+        NSLog(@"error creating a remote aries agent: %@", error);
+    }
+    
+    // create a controller
+    RestIntroduceREST *ic = (RestIntroduceREST*) [ac getIntroduceController:&error];
+    if(error) {
+        NSLog(@"error creating an introduce controller instance: %@", error);
+    }
+
+    // perform an operation
+    ModelsRequestEnvelope *req = [[ModelsRequestEnvelope alloc] init];
+    req.payload = [@"" dataUsingEncoding:NSUTF8StringEncoding];
+    ModelsResponseEnvelope *resp = [ic actions:req];
+    if(resp.error) {
+        NSLog(@"error getting actions: %@", resp.error.message);
+    }
+    
+    NSString *actionsResp = [[NSString alloc] initWithData:resp.payload encoding:NSUTF8StringEncoding];
+    NSLog(@"actions response: %@", actionsResp);
 ```
 
 

--- a/cmd/aries-agent-mobile/main.go
+++ b/cmd/aries-agent-mobile/main.go
@@ -9,11 +9,12 @@ package ariesagent
 import (
 	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/api"
 	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/command"
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/config"
 	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/rest"
 )
 
 // NewAriesAgent initializes and returns an implementation of the AriesController
-func NewAriesAgent(opts *api.Options) (api.AriesController, error) {
+func NewAriesAgent(opts *config.Options) (api.AriesController, error) {
 	if !opts.UseLocalAgent {
 		return rest.NewAries(opts), nil
 	}

--- a/cmd/aries-agent-mobile/main_test.go
+++ b/cmd/aries-agent-mobile/main_test.go
@@ -11,14 +11,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/api"
 	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/command"
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/config"
 	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/rest"
 )
 
 func TestNewAriesAgent(t *testing.T) {
 	t.Run("test it creates a local agent", func(t *testing.T) {
-		localAgent, err := NewAriesAgent(&api.Options{UseLocalAgent: true})
+		localAgent, err := NewAriesAgent(&config.Options{UseLocalAgent: true})
 		require.NoError(t, err)
 		require.NotNil(t, localAgent)
 
@@ -27,7 +27,7 @@ func TestNewAriesAgent(t *testing.T) {
 	})
 
 	t.Run("test it creates a remote agent", func(t *testing.T) {
-		remoteAgent, err := NewAriesAgent(&api.Options{UseLocalAgent: false})
+		remoteAgent, err := NewAriesAgent(&config.Options{UseLocalAgent: false})
 		require.NoError(t, err)
 		require.NotNil(t, remoteAgent)
 

--- a/cmd/aries-agent-mobile/pkg/api/api.go
+++ b/cmd/aries-agent-mobile/pkg/api/api.go
@@ -6,55 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 
 package api
 
-import (
-	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/models"
-)
-
-// Options represents configurations for Aries
-type Options struct {
-	UseLocalAgent bool
-	URL           string
-	APIToken      string
-}
-
 // AriesController provides Aries agent protocols tailored to mobile platforms
 type AriesController interface {
 
 	// GetIntroduceController returns an implementation of IntroduceController
 	GetIntroduceController() (IntroduceController, error)
-}
 
-// IntroduceController defines methods for the introduce protocol
-type IntroduceController interface {
-
-	// Actions returns unfinished actions for the async usage.
-	Actions(request *models.RequestEnvelope) *models.ResponseEnvelope
-
-	// SendProposal sends a proposal to the introducees (the client has not published an out-of-band message)
-	SendProposal(request *models.RequestEnvelope) *models.ResponseEnvelope
-
-	// SendProposalWithOOBRequest sends a proposal to the introducee (the client has published an out-of-band request)
-	SendProposalWithOOBRequest(request *models.RequestEnvelope) *models.ResponseEnvelope
-
-	// SendRequest sends a request showing that the introducee is willing to share their own out-of-band message
-	SendRequest(request *models.RequestEnvelope) *models.ResponseEnvelope
-
-	// AcceptProposalWithOOBRequest is used when introducee wants to provide an out-of-band request
-	AcceptProposalWithOOBRequest(request *models.RequestEnvelope) *models.ResponseEnvelope
-
-	// AcceptProposal is used when introducee wants to accept a proposal without providing a OOBRequest
-	AcceptProposal(request *models.RequestEnvelope) *models.ResponseEnvelope
-
-	// AcceptRequestWithPublicOOBRequest is used when introducer wants to provide a published out-of-band request
-	AcceptRequestWithPublicOOBRequest(request *models.RequestEnvelope) *models.ResponseEnvelope
-
-	// AcceptRequestWithRecipients is used when the introducer does not have a published out-of-band message on hand
-	// but they are willing to introduce agents to each other
-	AcceptRequestWithRecipients(request *models.RequestEnvelope) *models.ResponseEnvelope
-
-	// DeclineProposal is used to reject the proposal
-	DeclineProposal(request *models.RequestEnvelope) *models.ResponseEnvelope
-
-	// DeclineRequest is used to reject the request
-	DeclineRequest(request *models.RequestEnvelope) *models.ResponseEnvelope
+	// GetVerifiableController returns an implementation of VerifiableController
+	GetVerifiableController() (VerifiableController, error)
 }

--- a/cmd/aries-agent-mobile/pkg/api/introduce.go
+++ b/cmd/aries-agent-mobile/pkg/api/introduce.go
@@ -1,0 +1,46 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+import (
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/models"
+)
+
+// IntroduceController defines methods for the introduce protocol
+type IntroduceController interface {
+
+	// Actions returns unfinished actions for the async usage.
+	Actions(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// SendProposal sends a proposal to the introducees (the client has not published an out-of-band message)
+	SendProposal(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// SendProposalWithOOBRequest sends a proposal to the introducee (the client has published an out-of-band request)
+	SendProposalWithOOBRequest(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// SendRequest sends a request showing that the introducee is willing to share their own out-of-band message
+	SendRequest(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// AcceptProposalWithOOBRequest is used when introducee wants to provide an out-of-band request
+	AcceptProposalWithOOBRequest(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// AcceptProposal is used when introducee wants to accept a proposal without providing a OOBRequest
+	AcceptProposal(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// AcceptRequestWithPublicOOBRequest is used when introducer wants to provide a published out-of-band request
+	AcceptRequestWithPublicOOBRequest(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// AcceptRequestWithRecipients is used when the introducer does not have a published out-of-band message on hand
+	// but they are willing to introduce agents to each other
+	AcceptRequestWithRecipients(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// DeclineProposal is used to reject the proposal
+	DeclineProposal(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// DeclineRequest is used to reject the request
+	DeclineRequest(request *models.RequestEnvelope) *models.ResponseEnvelope
+}

--- a/cmd/aries-agent-mobile/pkg/api/verifiable.go
+++ b/cmd/aries-agent-mobile/pkg/api/verifiable.go
@@ -1,0 +1,48 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+import (
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/models"
+)
+
+// VerifiableController defines methods for the verifiable protocol
+type VerifiableController interface {
+
+	// ValidateCredential validates the verifiable credential.
+	ValidateCredential(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// SaveCredential saves the verifiable credential to the store.
+	SaveCredential(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// SavePresentation saves the presentation to the store.
+	SavePresentation(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// GetCredential retrieves the verifiable credential from the store.
+	GetCredential(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// SignCredential adds proof to given verifiable credential
+	SignCredential(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// GetPresentation retrieves the verifiable presentation from the store.
+	GetPresentation(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// GetCredentialByName retrieves the verifiable credential by name from the store.
+	GetCredentialByName(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// GetCredentials retrieves the verifiable credential records containing name and fields of interest.
+	GetCredentials(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// GetPresentations retrieves the verifiable presentation records containing name and fields of interest.
+	GetPresentations(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// GeneratePresentation generates a verifiable presentation from a verifiable credential.
+	GeneratePresentation(request *models.RequestEnvelope) *models.ResponseEnvelope
+
+	// GeneratePresentationByID generates verifiable presentation from a stored verifiable credential.
+	GeneratePresentationByID(request *models.RequestEnvelope) *models.ResponseEnvelope
+}

--- a/cmd/aries-agent-mobile/pkg/wrappers/command/aries.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/command/aries.go
@@ -8,13 +8,22 @@ package command
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/api"
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/config"
 	"github.com/hyperledger/aries-framework-go/pkg/controller"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
 	cmdintroduce "github.com/hyperledger/aries-framework-go/pkg/controller/command/introduce"
+	cmdverifiable "github.com/hyperledger/aries-framework-go/pkg/controller/command/verifiable"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/messaging/msghandler"
+	arieshttp "github.com/hyperledger/aries-framework-go/pkg/didcomm/transport/http"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport/ws"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/defaults"
 	"github.com/hyperledger/aries-framework-go/pkg/storage/mem"
+	"github.com/hyperledger/aries-framework-go/pkg/vdri/httpbinding"
 )
 
 // Aries is an implementation of AriesController which handles requests locally.
@@ -24,10 +33,13 @@ type Aries struct {
 }
 
 // NewAries returns a new Aries instance that contains handlers and an Aries framework instance.
-func NewAries(opts *api.Options) (*Aries, error) {
-	storageProvider := mem.NewProvider()
+func NewAries(opts *config.Options) (*Aries, error) {
+	options, err := prepareFrameworkOptions(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare framework options: %w", err)
+	}
 
-	framework, err := aries.New(aries.WithStoreProvider(storageProvider))
+	framework, err := aries.New(options...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Aries framework: %w", err)
 	}
@@ -48,14 +60,74 @@ func NewAries(opts *api.Options) (*Aries, error) {
 	return &Aries{framework, handlers}, nil
 }
 
-// GetIntroduceController returns an Introduce instance
-func (a *Aries) GetIntroduceController() (api.IntroduceController, error) {
-	handlers, ok := a.handlers[cmdintroduce.CommandName]
-	if !ok {
-		return nil, fmt.Errorf("no endpoints found for protocol [%s]", cmdintroduce.CommandName)
+func prepareFrameworkOptions(opts *config.Options) ([]aries.Option, error) {
+	msgHandler := msghandler.NewRegistrar()
+
+	var options []aries.Option
+	options = append(options, aries.WithMessageServiceProvider(msgHandler))
+
+	if opts.TransportReturnRoute != "" {
+		options = append(options, aries.WithTransportReturnRoute(opts.TransportReturnRoute))
 	}
 
-	return &Introduce{handlers: handlers}, nil
+	if opts.DBNamespace != "" {
+		options = append(options, defaults.WithStorePath(opts.DBNamespace))
+	} else {
+		options = append(options, aries.WithStoreProvider(mem.NewProvider()))
+	}
+
+	for _, transport := range opts.OutboundTransport {
+		switch transport {
+		case "http":
+			outbound, err := arieshttp.NewOutbound(arieshttp.WithOutboundHTTPClient(&http.Client{}))
+			if err != nil {
+				return nil, err
+			}
+
+			options = append(options, aries.WithOutboundTransports(outbound))
+		case "ws":
+			options = append(options, aries.WithOutboundTransports(ws.NewOutbound()))
+		default:
+			return nil, fmt.Errorf("unsupported transport : %s", transport)
+		}
+	}
+
+	if len(opts.HTTPResolvers) > 0 {
+		rsopts, err := getResolverOpts(opts.HTTPResolvers)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prepare http resolver opts : %w", err)
+		}
+
+		options = append(options, rsopts...)
+	}
+
+	return options, nil
+}
+
+func getResolverOpts(httpResolvers []string) ([]aries.Option, error) {
+	var opts []aries.Option
+
+	const numPartsResolverOption = 2
+
+	if len(httpResolvers) > 0 {
+		for _, httpResolver := range httpResolvers {
+			r := strings.Split(httpResolver, "@")
+			if len(r) != numPartsResolverOption {
+				return nil, fmt.Errorf("invalid http resolver options found")
+			}
+
+			httpVDRI, err := httpbinding.New(r[1],
+				httpbinding.WithAccept(func(method string) bool { return method == r[0] }))
+
+			if err != nil {
+				return nil, fmt.Errorf("failed to setup http resolver :  %w", err)
+			}
+
+			opts = append(opts, aries.WithVDRI(httpVDRI))
+		}
+	}
+
+	return opts, nil
 }
 
 func populateHandlers(commands []command.Handler, pkgMap map[string]map[string]command.Exec) {
@@ -68,4 +140,24 @@ func populateHandlers(commands []command.Handler, pkgMap map[string]map[string]c
 		fnMap[cmd.Method()] = cmd.Handle()
 		pkgMap[cmd.Name()] = fnMap
 	}
+}
+
+// GetIntroduceController returns an Introduce instance
+func (a *Aries) GetIntroduceController() (api.IntroduceController, error) {
+	handlers, ok := a.handlers[cmdintroduce.CommandName]
+	if !ok {
+		return nil, fmt.Errorf("no handlers found for protocol [%s]", cmdintroduce.CommandName)
+	}
+
+	return &Introduce{handlers: handlers}, nil
+}
+
+// GetVerifiableController returns a Verifiable instance
+func (a *Aries) GetVerifiableController() (api.VerifiableController, error) {
+	handlers, ok := a.handlers[cmdverifiable.CommandName]
+	if !ok {
+		return nil, fmt.Errorf("no handlers found for protocol [%s]", cmdverifiable.CommandName)
+	}
+
+	return &Verifiable{handlers: handlers}, nil
 }

--- a/cmd/aries-agent-mobile/pkg/wrappers/command/aries_test.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/command/aries_test.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/api"
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/config"
 )
 
 func TestNewAries(t *testing.T) {
 	t.Run("test it creates an instance with a framework and handlers", func(t *testing.T) {
-		opts := &api.Options{}
+		opts := &config.Options{}
 		a, err := NewAries(opts)
 		require.NoError(t, err)
 		require.NotNil(t, a)
@@ -27,7 +27,7 @@ func TestNewAries(t *testing.T) {
 
 func TestAries_GetIntroduceController(t *testing.T) {
 	t.Run("test it creates an introduce controller instance", func(t *testing.T) {
-		opts := &api.Options{}
+		opts := &config.Options{}
 		a, err := NewAries(opts)
 		require.NoError(t, err)
 

--- a/cmd/aries-agent-mobile/pkg/wrappers/command/introduce_test.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/command/introduce_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/api"
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/config"
 	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/models"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
 	cmdintroduce "github.com/hyperledger/aries-framework-go/pkg/controller/command/introduce"
@@ -35,7 +35,7 @@ func (m *mockCommandRunner) exec(rw io.Writer, _ io.Reader) command.Error {
 
 func TestIntroduce_Actions(t *testing.T) {
 	t.Run("test it performs an actions request", func(t *testing.T) {
-		a, err := NewAries(&api.Options{})
+		a, err := NewAries(&config.Options{})
 		require.NoError(t, err)
 
 		ic, err := a.GetIntroduceController()
@@ -57,7 +57,7 @@ func TestIntroduce_Actions(t *testing.T) {
 
 func TestIntroduce_SendProposal(t *testing.T) {
 	t.Run("test it performs a send proposal request", func(t *testing.T) {
-		a, err := NewAries(&api.Options{})
+		a, err := NewAries(&config.Options{})
 		require.NoError(t, err)
 
 		ic, err := a.GetIntroduceController()
@@ -97,7 +97,7 @@ func TestIntroduce_SendProposal(t *testing.T) {
 
 func TestIntroduce_SendProposalWithOOBRequest(t *testing.T) {
 	t.Run("test it performs a send proposal with out-of-band request", func(t *testing.T) {
-		a, err := NewAries(&api.Options{})
+		a, err := NewAries(&config.Options{})
 		require.NoError(t, err)
 
 		ic, err := a.GetIntroduceController()
@@ -129,7 +129,7 @@ func TestIntroduce_SendProposalWithOOBRequest(t *testing.T) {
 
 func TestIntroduce_SendRequest(t *testing.T) {
 	t.Run("test it performs a send request", func(t *testing.T) {
-		a, err := NewAries(&api.Options{})
+		a, err := NewAries(&config.Options{})
 		require.NoError(t, err)
 
 		ic, err := a.GetIntroduceController()
@@ -158,8 +158,8 @@ func TestIntroduce_SendRequest(t *testing.T) {
 }
 
 func TestIntroduce_AcceptProposalWithOOBRequest(t *testing.T) {
-	t.Run("test it performs an accept proposal with out-of-bound request", func(t *testing.T) {
-		a, err := NewAries(&api.Options{})
+	t.Run("test it performs an accept proposal with out-of-band request", func(t *testing.T) {
+		a, err := NewAries(&config.Options{})
 		require.NoError(t, err)
 
 		ic, err := a.GetIntroduceController()
@@ -186,7 +186,7 @@ func TestIntroduce_AcceptProposalWithOOBRequest(t *testing.T) {
 
 func TestIntroduce_AcceptProposal(t *testing.T) {
 	t.Run("test it accepts a proposal", func(t *testing.T) {
-		a, err := NewAries(&api.Options{})
+		a, err := NewAries(&config.Options{})
 		require.NoError(t, err)
 
 		ic, err := a.GetIntroduceController()
@@ -211,8 +211,8 @@ func TestIntroduce_AcceptProposal(t *testing.T) {
 }
 
 func TestIntroduce_AcceptRequestWithPublicOOBRequest(t *testing.T) {
-	t.Run("test it performs an accept request with a public out-of-bound request", func(t *testing.T) {
-		a, err := NewAries(&api.Options{})
+	t.Run("test it performs an accept request with a public out-of-band request", func(t *testing.T) {
+		a, err := NewAries(&config.Options{})
 		require.NoError(t, err)
 
 		ic, err := a.GetIntroduceController()
@@ -240,7 +240,7 @@ func TestIntroduce_AcceptRequestWithPublicOOBRequest(t *testing.T) {
 
 func TestIntroduce_AcceptRequestWithRecipients(t *testing.T) {
 	t.Run("test it accepts a request with recipients", func(t *testing.T) {
-		a, err := NewAries(&api.Options{})
+		a, err := NewAries(&config.Options{})
 		require.NoError(t, err)
 
 		ic, err := a.GetIntroduceController()
@@ -268,7 +268,7 @@ func TestIntroduce_AcceptRequestWithRecipients(t *testing.T) {
 
 func TestIntroduce_DeclineProposal(t *testing.T) {
 	t.Run("test it declines a proposal", func(t *testing.T) {
-		a, err := NewAries(&api.Options{})
+		a, err := NewAries(&config.Options{})
 		require.NoError(t, err)
 
 		ic, err := a.GetIntroduceController()
@@ -295,7 +295,7 @@ func TestIntroduce_DeclineProposal(t *testing.T) {
 
 func TestIntroduce_DeclineRequest(t *testing.T) {
 	t.Run("test it declines a request", func(t *testing.T) {
-		a, err := NewAries(&api.Options{})
+		a, err := NewAries(&config.Options{})
 		require.NoError(t, err)
 
 		ic, err := a.GetIntroduceController()

--- a/cmd/aries-agent-mobile/pkg/wrappers/command/verifiable.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/command/verifiable.go
@@ -1,0 +1,184 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package command
+
+import (
+	"encoding/json"
+
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/models"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
+	cmdverifiable "github.com/hyperledger/aries-framework-go/pkg/controller/command/verifiable"
+)
+
+// Verifiable contains necessary fields for each of its operations
+type Verifiable struct {
+	handlers map[string]command.Exec
+}
+
+// ValidateCredential validates the verifiable credential.
+func (v *Verifiable) ValidateCredential(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	args := cmdverifiable.Credential{}
+
+	if err := json.Unmarshal(request.Payload, &args); err != nil {
+		return &models.ResponseEnvelope{Error: &models.CommandError{Message: err.Error()}}
+	}
+
+	response, cmdErr := execCommand(v.handlers[cmdverifiable.ValidateCredentialCommandMethod], args)
+	if cmdErr != nil {
+		return &models.ResponseEnvelope{Error: cmdErr}
+	}
+
+	return &models.ResponseEnvelope{Payload: response}
+}
+
+// SaveCredential saves the verifiable credential to the store.
+func (v *Verifiable) SaveCredential(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	args := cmdverifiable.CredentialExt{}
+
+	if err := json.Unmarshal(request.Payload, &args); err != nil {
+		return &models.ResponseEnvelope{Error: &models.CommandError{Message: err.Error()}}
+	}
+
+	response, cmdErr := execCommand(v.handlers[cmdverifiable.SaveCredentialCommandMethod], args)
+	if cmdErr != nil {
+		return &models.ResponseEnvelope{Error: cmdErr}
+	}
+
+	return &models.ResponseEnvelope{Payload: response}
+}
+
+// SavePresentation saves the presentation to the store.
+func (v *Verifiable) SavePresentation(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	args := cmdverifiable.PresentationExt{}
+
+	if err := json.Unmarshal(request.Payload, &args); err != nil {
+		return &models.ResponseEnvelope{Error: &models.CommandError{Message: err.Error()}}
+	}
+
+	response, cmdErr := execCommand(v.handlers[cmdverifiable.SavePresentationCommandMethod], args)
+	if cmdErr != nil {
+		return &models.ResponseEnvelope{Error: cmdErr}
+	}
+
+	return &models.ResponseEnvelope{Payload: response}
+}
+
+// GetCredential retrieves the verifiable credential from the store.
+func (v *Verifiable) GetCredential(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	args := cmdverifiable.IDArg{}
+
+	if err := json.Unmarshal(request.Payload, &args); err != nil {
+		return &models.ResponseEnvelope{Error: &models.CommandError{Message: err.Error()}}
+	}
+
+	response, cmdErr := execCommand(v.handlers[cmdverifiable.GetCredentialCommandMethod], args)
+	if cmdErr != nil {
+		return &models.ResponseEnvelope{Error: cmdErr}
+	}
+
+	return &models.ResponseEnvelope{Payload: response}
+}
+
+// SignCredential adds proof to given verifiable credential
+func (v *Verifiable) SignCredential(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	args := cmdverifiable.SignCredentialRequest{}
+
+	if err := json.Unmarshal(request.Payload, &args); err != nil {
+		return &models.ResponseEnvelope{Error: &models.CommandError{Message: err.Error()}}
+	}
+
+	response, cmdErr := execCommand(v.handlers[cmdverifiable.SignCredentialCommandMethod], args)
+	if cmdErr != nil {
+		return &models.ResponseEnvelope{Error: cmdErr}
+	}
+
+	return &models.ResponseEnvelope{Payload: response}
+}
+
+// GetPresentation retrieves the verifiable presentation from the store.
+func (v *Verifiable) GetPresentation(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	args := cmdverifiable.IDArg{}
+
+	if err := json.Unmarshal(request.Payload, &args); err != nil {
+		return &models.ResponseEnvelope{Error: &models.CommandError{Message: err.Error()}}
+	}
+
+	response, cmdErr := execCommand(v.handlers[cmdverifiable.GetPresentationCommandMethod], args)
+	if cmdErr != nil {
+		return &models.ResponseEnvelope{Error: cmdErr}
+	}
+
+	return &models.ResponseEnvelope{Payload: response}
+}
+
+// GetCredentialByName retrieves the verifiable credential by name from the store.
+func (v *Verifiable) GetCredentialByName(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	args := cmdverifiable.NameArg{}
+
+	if err := json.Unmarshal(request.Payload, &args); err != nil {
+		return &models.ResponseEnvelope{Error: &models.CommandError{Message: err.Error()}}
+	}
+
+	response, cmdErr := execCommand(v.handlers[cmdverifiable.GetCredentialByNameCommandMethod], args)
+	if cmdErr != nil {
+		return &models.ResponseEnvelope{Error: cmdErr}
+	}
+
+	return &models.ResponseEnvelope{Payload: response}
+}
+
+// GetCredentials retrieves the verifiable credential records containing name and fields of interest.
+func (v *Verifiable) GetCredentials(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	response, cmdErr := execCommand(v.handlers[cmdverifiable.GetCredentialsCommandMethod], request)
+	if cmdErr != nil {
+		return &models.ResponseEnvelope{Error: cmdErr}
+	}
+
+	return &models.ResponseEnvelope{Payload: response}
+}
+
+// GetPresentations retrieves the verifiable presentation records containing name and fields of interest.
+func (v *Verifiable) GetPresentations(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	response, cmdErr := execCommand(v.handlers[cmdverifiable.GetPresentationsCommandMethod], request)
+	if cmdErr != nil {
+		return &models.ResponseEnvelope{Error: cmdErr}
+	}
+
+	return &models.ResponseEnvelope{Payload: response}
+}
+
+// GeneratePresentation generates verifiable presentation from a verifiable credential.
+func (v *Verifiable) GeneratePresentation(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	args := cmdverifiable.PresentationRequest{}
+
+	if err := json.Unmarshal(request.Payload, &args); err != nil {
+		return &models.ResponseEnvelope{Error: &models.CommandError{Message: err.Error()}}
+	}
+
+	response, cmdErr := execCommand(v.handlers[cmdverifiable.GeneratePresentationCommandMethod], args)
+	if cmdErr != nil {
+		return &models.ResponseEnvelope{Error: cmdErr}
+	}
+
+	return &models.ResponseEnvelope{Payload: response}
+}
+
+// GeneratePresentationByID generates verifiable presentation from a stored verifiable credential.
+func (v *Verifiable) GeneratePresentationByID(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	args := cmdverifiable.PresentationRequestByID{}
+
+	if err := json.Unmarshal(request.Payload, &args); err != nil {
+		return &models.ResponseEnvelope{Error: &models.CommandError{Message: err.Error()}}
+	}
+
+	response, cmdErr := execCommand(v.handlers[cmdverifiable.GeneratePresentationByIDCommandMethod], args)
+	if cmdErr != nil {
+		return &models.ResponseEnvelope{Error: cmdErr}
+	}
+
+	return &models.ResponseEnvelope{Payload: response}
+}

--- a/cmd/aries-agent-mobile/pkg/wrappers/command/verifiable_test.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/command/verifiable_test.go
@@ -1,0 +1,413 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package command
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/config"
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/models"
+	cmdverifiable "github.com/hyperledger/aries-framework-go/pkg/controller/command/verifiable"
+)
+
+//nolint:lll
+const (
+	mockVC = `
+{
+  "@context":[
+     "https://www.w3.org/2018/credentials/v1",
+	  "https://trustbloc.github.io/context/vc/examples-v1.jsonld"
+  ],
+  "id":"http://example.edu/credentials/1989",
+  "type":"VerifiableCredential",
+  "credentialSubject":{
+     "id":"did:example:iuajk1f712ebc6f1c276e12ec21"
+  },
+  "issuer":{
+     "id":"did:example:09s12ec712ebc6f1c671ebfeb1f",
+     "name":"Example University"
+  },
+  "issuanceDate":"2020-01-01T10:54:01Z",
+  "credentialStatus":{
+     "id":"https://example.gov/status/65",
+     "type":"CredentialStatusList2017"
+  }
+}
+`
+	mockSignedVC             = `{"@context":["https://www.w3.org/2018/credentials/v1","https://trustbloc.github.io/context/vc/examples-v1.jsonld"],"credentialStatus":{"id":"https://example.gov/status/65","type":"CredentialStatusList2017"},"credentialSubject":"did:example:iuajk1f712ebc6f1c276e12ec21","id":"http://example.edu/credentials/1989","issuanceDate":"2020-01-01T10:54:01Z","issuer":{"id":"did:example:09s12ec712ebc6f1c671ebfeb1f","name":"Example University"},"proof":{"created":"2020-07-13T09:25:45.843216-04:00","jws":"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..","proofPurpose":"assertionMethod","type":"Ed25519Signature2018","verificationMethod":"did:peer:123456789abcdefghi#keys-1"},"type":"VerifiableCredential"}`
+	mockPresentationResponse = `
+{
+	"verifiablePresentation": {
+		"@context": [
+			"https://www.w3.org/2018/credentials/v1"
+		],
+		"holder": "did:peer:123456789abcdefghi#inbox",
+		"proof": {
+			"created": "2020-07-10T15:53:25.157489-04:00",
+			"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..",
+			"proofPurpose": "authentication",
+			"type": "Ed25519Signature2018",
+			"verificationMethod": "did:peer:123456789abcdefghi#keys-1"
+		},
+		"type": "VerifiablePresentation",
+		"verifiableCredential": [
+			{
+				"@context": [
+					"https://www.w3.org/2018/credentials/v1",
+					"https://trustbloc.github.io/context/vc/examples-v1.jsonld"
+				],
+				"credentialStatus": {
+					"id": "https://example.gov/status/65",
+					"type": "CredentialStatusList2017"
+				},
+				"credentialSubject": "did:example:iuajk1f712ebc6f1c276e12ec21",
+				"id": "http://example.edu/credentials/1989",
+				"issuanceDate": "2020-01-01T10:54:01Z",
+				"issuer": {
+					"id": "did:example:09s12ec712ebc6f1c671ebfeb1f",
+					"name": "Example University"
+				},
+				"type": "VerifiableCredential"
+			}
+		]
+	}
+}`
+	mockCredentialName   = "mock_credential"
+	mockPresentationName = "mock_vp_name"
+	mockCredentialID     = "http://example.edu/credentials/1989"
+	mockPresentationID   = "http://example.edu/presentations/1989"
+	mockVP               = `{"verifiablePresentation":{"@context":["https://www.w3.org/2018/credentials/v1","https://www.w3.org/2018/credentials/examples/v1"],"type":["VerifiablePresentation"],"id":"http://example.edu/presentations/1989","verifiableCredential":[{"@context":["https://www.w3.org/2018/credentials/v1","https://www.w3.org/2018/credentials/examples/v1"],"credentialSchema":[],"credentialStatus":{"id":"http://issuer.vc.rest.example.com:8070/status/1","type":"CredentialStatusList2017"},"credentialSubject":{"degree":{"degree":"MIT","type":"BachelorDegree"},"id":"did:example:ebfeb1f712ebc6f1c276e12ec21","name":"Jayden Doe","spouse":"did:example:c276e12ec21ebfeb1f712ebc6f1"},"id":"https://example.com/credentials/9315d0fd-da93-436e-9e20-2121f2821df3","issuanceDate":"2020-03-16T22:37:26.544Z","issuer":{"id":"did:elem:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg","name":"alice_ca31684e-6cbb-40f9-b7e6-87e1ab5661ae"},"proof":{"created":"2020-04-08T21:19:02Z","jws":"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..yGHHYmRp4mWd918SDSzmBDs8eq-SX7WPl8moGB8oJeSqEMmuEiI81D4s5-BPWGmKy3VlCsKJxYrTNqrEGJpNAQ","proofPurpose":"assertionMethod","type":"Ed25519Signature2018","verificationMethod":"did:elem:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg#xqc3gS1gz1vch7R3RvNebWMjLvBOY-n_14feCYRPsUo"},"type":["VerifiableCredential","UniversityDegreeCredential"]}]},"name":"sampleVpName"}`
+	mockDID              = "did:peer:123456789abcdefghi#inbox"
+	emptyResponse        = `{}`
+)
+
+func TestVerifiable_ValidateCredential(t *testing.T) {
+	t.Run("test it validates a credential", func(t *testing.T) {
+		a, err := NewAries(&config.Options{})
+		require.NoError(t, err)
+
+		vc, err := a.GetVerifiableController()
+		require.NoError(t, err)
+		require.NotNil(t, vc)
+
+		v, ok := vc.(*Verifiable)
+		require.Equal(t, ok, true)
+
+		mockResponse := emptyResponse
+		fakeHandler := mockCommandRunner{data: []byte(mockResponse)}
+		v.handlers[cmdverifiable.ValidateCredentialCommandMethod] = fakeHandler.exec
+
+		payload := fmt.Sprintf(`{"verifiableCredential": %s}`, strconv.Quote(mockVC))
+
+		req := &models.RequestEnvelope{Payload: []byte(payload)}
+		resp := v.ValidateCredential(req)
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t,
+			mockResponse,
+			string(resp.Payload))
+	})
+}
+
+func TestVerifiable_SaveCredential(t *testing.T) {
+	t.Run("test it saves a credential", func(t *testing.T) {
+		a, err := NewAries(&config.Options{})
+		require.NoError(t, err)
+
+		vc, err := a.GetVerifiableController()
+		require.NoError(t, err)
+		require.NotNil(t, vc)
+
+		v, ok := vc.(*Verifiable)
+		require.Equal(t, ok, true)
+
+		mockResponse := emptyResponse
+		fakeHandler := mockCommandRunner{data: []byte(mockResponse)}
+		v.handlers[cmdverifiable.SaveCredentialCommandMethod] = fakeHandler.exec
+
+		payload := fmt.Sprintf(`{"verifiableCredential": %s, "name": "%s"}`, strconv.Quote(mockVC), mockCredentialName)
+
+		req := &models.RequestEnvelope{Payload: []byte(payload)}
+		resp := v.SaveCredential(req)
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t,
+			mockResponse,
+			string(resp.Payload))
+	})
+}
+
+func TestVerifiable_SavePresentation(t *testing.T) {
+	t.Run("test it saves a presentation", func(t *testing.T) {
+		a, err := NewAries(&config.Options{})
+		require.NoError(t, err)
+
+		vc, err := a.GetVerifiableController()
+		require.NoError(t, err)
+		require.NotNil(t, vc)
+
+		v, ok := vc.(*Verifiable)
+		require.Equal(t, ok, true)
+
+		mockResponse := emptyResponse
+		fakeHandler := mockCommandRunner{data: []byte(mockResponse)}
+		v.handlers[cmdverifiable.SavePresentationCommandMethod] = fakeHandler.exec
+
+		payload := mockVP
+
+		req := &models.RequestEnvelope{Payload: []byte(payload)}
+		resp := v.SavePresentation(req)
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t,
+			mockResponse,
+			string(resp.Payload))
+	})
+}
+
+func TestVerifiable_GetCredential(t *testing.T) {
+	t.Run("test it gets a credential", func(t *testing.T) {
+		a, err := NewAries(&config.Options{})
+		require.NoError(t, err)
+
+		vc, err := a.GetVerifiableController()
+		require.NoError(t, err)
+		require.NotNil(t, vc)
+
+		v, ok := vc.(*Verifiable)
+		require.Equal(t, ok, true)
+
+		mockResponse := fmt.Sprintf(`{"verifiableCredential": %s}`, strconv.Quote(mockVC))
+		fakeHandler := mockCommandRunner{data: []byte(mockResponse)}
+		v.handlers[cmdverifiable.GetCredentialCommandMethod] = fakeHandler.exec
+
+		payload := fmt.Sprintf(`{"id":"%s"}`, mockCredentialID)
+
+		req := &models.RequestEnvelope{Payload: []byte(payload)}
+		resp := v.GetCredential(req)
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t,
+			mockResponse,
+			string(resp.Payload))
+	})
+}
+
+func TestVerifiable_SignCredential(t *testing.T) {
+	t.Run("test it signs a credential", func(t *testing.T) {
+		a, err := NewAries(&config.Options{})
+		require.NoError(t, err)
+
+		vc, err := a.GetVerifiableController()
+		require.NoError(t, err)
+		require.NotNil(t, vc)
+
+		v, ok := vc.(*Verifiable)
+		require.Equal(t, ok, true)
+
+		mockResponse := fmt.Sprintf(`{"verifiableCredential": %s}`, strconv.Quote(mockSignedVC))
+		fakeHandler := mockCommandRunner{data: []byte(mockResponse)}
+		v.handlers[cmdverifiable.SignCredentialCommandMethod] = fakeHandler.exec
+
+		payload := fmt.Sprintf(`{
+		"credential": %s,
+		"did": "%s",
+		"signatureType": "%s"
+}`, strconv.Quote(mockVC), mockDID, cmdverifiable.Ed25519Signature2018)
+
+		req := &models.RequestEnvelope{Payload: []byte(payload)}
+		resp := v.SignCredential(req)
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t,
+			mockResponse,
+			string(resp.Payload))
+	})
+}
+
+func TestVerifiable_GetPresentation(t *testing.T) {
+	t.Run("test it gets a presentation", func(t *testing.T) {
+		a, err := NewAries(&config.Options{})
+		require.NoError(t, err)
+
+		vc, err := a.GetVerifiableController()
+		require.NoError(t, err)
+		require.NotNil(t, vc)
+
+		v, ok := vc.(*Verifiable)
+		require.Equal(t, ok, true)
+
+		mockResponse := fmt.Sprintf(`{"verifiablePresentation": %s}`, strconv.Quote(mockVP))
+		fakeHandler := mockCommandRunner{data: []byte(mockResponse)}
+		v.handlers[cmdverifiable.GetPresentationCommandMethod] = fakeHandler.exec
+
+		payload := fmt.Sprintf(`{"id":"%s"}`, mockPresentationID)
+
+		req := &models.RequestEnvelope{Payload: []byte(payload)}
+		resp := v.GetPresentation(req)
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t,
+			mockResponse,
+			string(resp.Payload))
+	})
+}
+
+func TestVerifiable_GetCredentialByName(t *testing.T) {
+	t.Run("test it gets a verifiable credential by name", func(t *testing.T) {
+		a, err := NewAries(&config.Options{})
+		require.NoError(t, err)
+
+		vc, err := a.GetVerifiableController()
+		require.NoError(t, err)
+		require.NotNil(t, vc)
+
+		v, ok := vc.(*Verifiable)
+		require.Equal(t, ok, true)
+
+		mockResponse := fmt.Sprintf(`{"name": %s, "id": %s}`, mockCredentialName, mockCredentialID)
+		fakeHandler := mockCommandRunner{data: []byte(mockResponse)}
+		v.handlers[cmdverifiable.GetCredentialByNameCommandMethod] = fakeHandler.exec
+
+		payload := fmt.Sprintf(`{"name":"%s"}`, mockCredentialName)
+
+		req := &models.RequestEnvelope{Payload: []byte(payload)}
+		resp := v.GetCredentialByName(req)
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t,
+			mockResponse,
+			string(resp.Payload))
+	})
+}
+
+func TestVerifiable_GetCredentials(t *testing.T) {
+	t.Run("test it gets all stored verifiable credentials", func(t *testing.T) {
+		a, err := NewAries(&config.Options{})
+		require.NoError(t, err)
+
+		vc, err := a.GetVerifiableController()
+		require.NoError(t, err)
+		require.NotNil(t, vc)
+
+		v, ok := vc.(*Verifiable)
+		require.Equal(t, ok, true)
+
+		mockResponse := fmt.Sprintf(`{"result": [{"name": "%s", "id":" %s"}, {"name": "%s"", "id": "%s""}]`,
+			mockCredentialName, mockCredentialID, mockCredentialName, mockCredentialID)
+		fakeHandler := mockCommandRunner{data: []byte(mockResponse)}
+		v.handlers[cmdverifiable.GetCredentialsCommandMethod] = fakeHandler.exec
+
+		payload := "{}"
+
+		req := &models.RequestEnvelope{Payload: []byte(payload)}
+		resp := v.GetCredentials(req)
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t,
+			mockResponse,
+			string(resp.Payload))
+	})
+}
+
+func TestVerifiable_GetPresentations(t *testing.T) {
+	t.Run("test it gets all stored verifiable presentations", func(t *testing.T) {
+		a, err := NewAries(&config.Options{})
+		require.NoError(t, err)
+
+		vc, err := a.GetVerifiableController()
+		require.NoError(t, err)
+		require.NotNil(t, vc)
+
+		v, ok := vc.(*Verifiable)
+		require.Equal(t, ok, true)
+
+		mockResponse := fmt.Sprintf(`{"result": [{"name": "%s", "id":" %s"}, {"name": "%s"", "id": "%s""}]`,
+			mockPresentationName, mockPresentationID, mockPresentationName, mockPresentationID)
+		fakeHandler := mockCommandRunner{data: []byte(mockResponse)}
+		v.handlers[cmdverifiable.GetPresentationsCommandMethod] = fakeHandler.exec
+
+		payload := "{}"
+
+		req := &models.RequestEnvelope{Payload: []byte(payload)}
+		resp := v.GetPresentations(req)
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t,
+			mockResponse,
+			string(resp.Payload))
+	})
+}
+
+func TestVerifiable_GeneratePresentation(t *testing.T) {
+	t.Run("test it generates a presentation", func(t *testing.T) {
+		a, err := NewAries(&config.Options{})
+		require.NoError(t, err)
+
+		vc, err := a.GetVerifiableController()
+		require.NoError(t, err)
+		require.NotNil(t, vc)
+
+		v, ok := vc.(*Verifiable)
+		require.Equal(t, ok, true)
+
+		mockResponse := mockPresentationResponse
+		fakeHandler := mockCommandRunner{data: []byte(mockResponse)}
+		v.handlers[cmdverifiable.GeneratePresentationCommandMethod] = fakeHandler.exec
+
+		credList := fmt.Sprintf(`[%s, %s]`, mockVC, mockVC)
+		payload := fmt.Sprintf(`{
+		"verifiableCredential": %s,
+		"did": "%s",
+		"signatureType": "%s"
+}`, credList, mockDID, cmdverifiable.Ed25519Signature2018)
+
+		req := &models.RequestEnvelope{Payload: []byte(payload)}
+		resp := v.GeneratePresentation(req)
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t,
+			mockResponse,
+			string(resp.Payload))
+	})
+}
+
+func TestVerifiable_GeneratePresentationByID(t *testing.T) {
+	t.Run("test it generates a presentation by id", func(t *testing.T) {
+		a, err := NewAries(&config.Options{})
+		require.NoError(t, err)
+
+		vc, err := a.GetVerifiableController()
+		require.NoError(t, err)
+		require.NotNil(t, vc)
+
+		v, ok := vc.(*Verifiable)
+		require.Equal(t, ok, true)
+
+		mockResponse := mockPresentationResponse
+		fakeHandler := mockCommandRunner{data: []byte(mockResponse)}
+		v.handlers[cmdverifiable.GeneratePresentationByIDCommandMethod] = fakeHandler.exec
+
+		payload := fmt.Sprintf(`{
+		"id": "%s",
+		"did": "%s",
+		"signatureType": "%s"
+}`, mockCredentialID, mockDID, cmdverifiable.Ed25519Signature2018)
+
+		req := &models.RequestEnvelope{Payload: []byte(payload)}
+		resp := v.GeneratePresentationByID(req)
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t,
+			mockResponse,
+			string(resp.Payload))
+	})
+}

--- a/cmd/aries-agent-mobile/pkg/wrappers/config/options.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/config/options.go
@@ -1,0 +1,36 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+// Options represents configurations for Aries
+type Options struct {
+	UseLocalAgent bool
+
+	URL      string
+	APIToken string
+
+	Label                string
+	AutoAccept           bool
+	TransportReturnRoute string
+	LogLevel             string
+	DBNamespace          string
+
+	// expected to be ignored by gomobile
+	// not intended to be used by golang code
+	HTTPResolvers     []string
+	OutboundTransport []string
+}
+
+// AddHTTPResolver appends an http resolver url to the options
+func (o *Options) AddHTTPResolver(resolverURL string) {
+	o.HTTPResolvers = append(o.HTTPResolvers, resolverURL)
+}
+
+// AddOutboundTransport appends a transport type to the options e.g. http or ws
+func (o *Options) AddOutboundTransport(transportType string) {
+	o.OutboundTransport = append(o.OutboundTransport, transportType)
+}

--- a/cmd/aries-agent-mobile/pkg/wrappers/rest/aries.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/rest/aries.go
@@ -8,9 +8,12 @@ package rest
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/api"
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/config"
 	opintroduce "github.com/hyperledger/aries-framework-go/pkg/controller/rest/introduce"
+	opverifiable "github.com/hyperledger/aries-framework-go/pkg/controller/rest/verifiable"
 )
 
 // AriesREST is an Aries implementation with endpoints to execute operations
@@ -23,7 +26,7 @@ type AriesREST struct {
 
 // NewAries returns a new AriesREST instance.
 // Use this if you want your requests to be handled by a remote agent.
-func NewAries(opts *api.Options) *AriesREST {
+func NewAries(opts *config.Options) *AriesREST {
 	endpoints := getProtocolEndpoints()
 
 	return &AriesREST{endpoints: endpoints, URL: opts.URL, Token: opts.APIToken}
@@ -36,5 +39,15 @@ func (ar *AriesREST) GetIntroduceController() (api.IntroduceController, error) {
 		return nil, fmt.Errorf("no endpoints found for protocol [%s]", opintroduce.OperationID)
 	}
 
-	return &IntroduceREST{endpoints: endpoints, URL: ar.URL, Token: ar.Token}, nil
+	return &IntroduceREST{endpoints: endpoints, URL: ar.URL, Token: ar.Token, httpClient: &http.Client{}}, nil
+}
+
+// GetVerifiableController returns an VerifiableREST instance
+func (ar *AriesREST) GetVerifiableController() (api.VerifiableController, error) {
+	endpoints, ok := ar.endpoints[opverifiable.VerifiableOperationID]
+	if !ok {
+		return nil, fmt.Errorf("no endpoints found for protocol [%s]", opverifiable.VerifiableOperationID)
+	}
+
+	return &VerifiableREST{endpoints: endpoints, URL: ar.URL, Token: ar.Token, httpClient: &http.Client{}}, nil
 }

--- a/cmd/aries-agent-mobile/pkg/wrappers/rest/aries_test.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/rest/aries_test.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/api"
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/config"
 )
 
 func TestNewAries(t *testing.T) {
 	t.Run("test it creates a rest client instance with endpoints", func(t *testing.T) {
-		a := NewAries(&api.Options{})
+		a := NewAries(&config.Options{})
 		require.NotNil(t, a)
 		require.NotNil(t, a.endpoints)
 		require.GreaterOrEqual(t, len(a.endpoints), 1)
@@ -25,7 +25,7 @@ func TestNewAries(t *testing.T) {
 
 func TestAriesREST_GetIntroduceController(t *testing.T) {
 	t.Run("test it creates an introduce controller instance", func(t *testing.T) {
-		a := NewAries(&api.Options{})
+		a := NewAries(&config.Options{})
 
 		ic, err := a.GetIntroduceController()
 		require.NoError(t, err)

--- a/cmd/aries-agent-mobile/pkg/wrappers/rest/endpoints.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/rest/endpoints.go
@@ -10,7 +10,10 @@ import (
 	"net/http"
 
 	cmdintroduce "github.com/hyperledger/aries-framework-go/pkg/controller/command/introduce"
+	cmdverifiable "github.com/hyperledger/aries-framework-go/pkg/controller/command/verifiable"
+
 	opintroduce "github.com/hyperledger/aries-framework-go/pkg/controller/rest/introduce"
+	opverifiable "github.com/hyperledger/aries-framework-go/pkg/controller/rest/verifiable"
 )
 
 // Endpoint describes the fields for making calls to external agents
@@ -23,6 +26,7 @@ func getProtocolEndpoints() map[string]map[string]*Endpoint {
 	allEndpoints := make(map[string]map[string]*Endpoint)
 
 	allEndpoints[opintroduce.OperationID] = getIntroduceEndpoints()
+	allEndpoints[opverifiable.VerifiableOperationID] = getVerifiableEndpoints()
 
 	return allEndpoints
 }
@@ -67,6 +71,55 @@ func getIntroduceEndpoints() map[string]*Endpoint {
 		},
 		cmdintroduce.DeclineRequest: {
 			Path:   opintroduce.DeclineRequest,
+			Method: http.MethodPost,
+		},
+	}
+}
+
+func getVerifiableEndpoints() map[string]*Endpoint {
+	return map[string]*Endpoint{
+		cmdverifiable.ValidateCredentialCommandMethod: {
+			Path:   opverifiable.ValidateCredentialPath,
+			Method: http.MethodPost,
+		},
+		cmdverifiable.SaveCredentialCommandMethod: {
+			Path:   opverifiable.SaveCredentialPath,
+			Method: http.MethodPost,
+		},
+		cmdverifiable.SavePresentationCommandMethod: {
+			Path:   opverifiable.SavePresentationPath,
+			Method: http.MethodPost,
+		},
+		cmdverifiable.GetCredentialCommandMethod: {
+			Path:   opverifiable.GetCredentialPath,
+			Method: http.MethodGet,
+		},
+		cmdverifiable.SignCredentialCommandMethod: {
+			Path:   opverifiable.SignCredentialsPath,
+			Method: http.MethodPost,
+		},
+		cmdverifiable.GetPresentationCommandMethod: {
+			Path:   opverifiable.GetPresentationPath,
+			Method: http.MethodGet,
+		},
+		cmdverifiable.GetCredentialByNameCommandMethod: {
+			Path:   opverifiable.GetCredentialByNamePath,
+			Method: http.MethodGet,
+		},
+		cmdverifiable.GetCredentialsCommandMethod: {
+			Path:   opverifiable.GetCredentialsPath,
+			Method: http.MethodGet,
+		},
+		cmdverifiable.GetPresentationsCommandMethod: {
+			Path:   opverifiable.GetPresentationsPath,
+			Method: http.MethodGet,
+		},
+		cmdverifiable.GeneratePresentationCommandMethod: {
+			Path:   opverifiable.GeneratePresentationPath,
+			Method: http.MethodPost,
+		},
+		cmdverifiable.GeneratePresentationByIDCommandMethod: {
+			Path:   opverifiable.GeneratePresentationByIDPath,
 			Method: http.MethodPost,
 		},
 	}

--- a/cmd/aries-agent-mobile/pkg/wrappers/rest/introduce.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/rest/introduce.go
@@ -11,7 +11,7 @@ import (
 	cmdintroduce "github.com/hyperledger/aries-framework-go/pkg/controller/command/introduce"
 )
 
-// IntroduceREST contains an http client and endpoints for each of its operations
+// IntroduceREST contains necessary fields for each of its operations
 type IntroduceREST struct {
 	httpClient httpClient
 	endpoints  map[string]*Endpoint
@@ -27,7 +27,7 @@ func (ir *IntroduceREST) Actions(request *models.RequestEnvelope) *models.Respon
 		url:        ir.URL,
 		token:      ir.Token,
 		httpClient: ir.httpClient,
-		endpoint:   *ir.endpoints[cmdintroduce.Actions],
+		endpoint:   ir.endpoints[cmdintroduce.Actions],
 		request:    request,
 	})
 
@@ -40,7 +40,7 @@ func (ir *IntroduceREST) SendProposal(request *models.RequestEnvelope) *models.R
 		url:        ir.URL,
 		token:      ir.Token,
 		httpClient: ir.httpClient,
-		endpoint:   *ir.endpoints[cmdintroduce.SendProposal],
+		endpoint:   ir.endpoints[cmdintroduce.SendProposal],
 		request:    request,
 	})
 
@@ -54,7 +54,7 @@ func (ir *IntroduceREST) SendProposalWithOOBRequest(request *models.RequestEnvel
 		url:        ir.URL,
 		token:      ir.Token,
 		httpClient: ir.httpClient,
-		endpoint:   *ir.endpoints[cmdintroduce.SendProposalWithOOBRequest],
+		endpoint:   ir.endpoints[cmdintroduce.SendProposalWithOOBRequest],
 		request:    request,
 	})
 
@@ -67,7 +67,7 @@ func (ir *IntroduceREST) SendRequest(request *models.RequestEnvelope) *models.Re
 		url:        ir.URL,
 		token:      ir.Token,
 		httpClient: ir.httpClient,
-		endpoint:   *ir.endpoints[cmdintroduce.SendRequest],
+		endpoint:   ir.endpoints[cmdintroduce.SendRequest],
 		request:    request,
 	})
 
@@ -80,7 +80,7 @@ func (ir *IntroduceREST) AcceptProposalWithOOBRequest(request *models.RequestEnv
 		url:        ir.URL,
 		token:      ir.Token,
 		httpClient: ir.httpClient,
-		endpoint:   *ir.endpoints[cmdintroduce.AcceptProposalWithOOBRequest],
+		endpoint:   ir.endpoints[cmdintroduce.AcceptProposalWithOOBRequest],
 		request:    request,
 	})
 
@@ -93,7 +93,7 @@ func (ir *IntroduceREST) AcceptProposal(request *models.RequestEnvelope) *models
 		url:        ir.URL,
 		token:      ir.Token,
 		httpClient: ir.httpClient,
-		endpoint:   *ir.endpoints[cmdintroduce.AcceptProposal],
+		endpoint:   ir.endpoints[cmdintroduce.AcceptProposal],
 		request:    request,
 	})
 
@@ -107,7 +107,7 @@ func (ir *IntroduceREST) AcceptRequestWithPublicOOBRequest(request *models.Reque
 		url:        ir.URL,
 		token:      ir.Token,
 		httpClient: ir.httpClient,
-		endpoint:   *ir.endpoints[cmdintroduce.AcceptRequestWithPublicOOBRequest],
+		endpoint:   ir.endpoints[cmdintroduce.AcceptRequestWithPublicOOBRequest],
 		request:    request,
 	})
 
@@ -121,7 +121,7 @@ func (ir *IntroduceREST) AcceptRequestWithRecipients(request *models.RequestEnve
 		url:        ir.URL,
 		token:      ir.Token,
 		httpClient: ir.httpClient,
-		endpoint:   *ir.endpoints[cmdintroduce.AcceptRequestWithRecipients],
+		endpoint:   ir.endpoints[cmdintroduce.AcceptRequestWithRecipients],
 		request:    request,
 	})
 
@@ -134,7 +134,7 @@ func (ir *IntroduceREST) DeclineProposal(request *models.RequestEnvelope) *model
 		url:        ir.URL,
 		token:      ir.Token,
 		httpClient: ir.httpClient,
-		endpoint:   *ir.endpoints[cmdintroduce.DeclineProposal],
+		endpoint:   ir.endpoints[cmdintroduce.DeclineProposal],
 		request:    request,
 	})
 
@@ -147,7 +147,7 @@ func (ir *IntroduceREST) DeclineRequest(request *models.RequestEnvelope) *models
 		url:        ir.URL,
 		token:      ir.Token,
 		httpClient: ir.httpClient,
-		endpoint:   *ir.endpoints[cmdintroduce.DeclineRequest],
+		endpoint:   ir.endpoints[cmdintroduce.DeclineRequest],
 		request:    request,
 	})
 

--- a/cmd/aries-agent-mobile/pkg/wrappers/rest/verifiable.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/rest/verifiable.go
@@ -1,0 +1,164 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package rest
+
+import (
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/models"
+	cmdverifiable "github.com/hyperledger/aries-framework-go/pkg/controller/command/verifiable"
+)
+
+// VerifiableREST contains necessary fields for each of its operations
+type VerifiableREST struct {
+	httpClient httpClient
+	endpoints  map[string]*Endpoint
+
+	URL   string
+	Token string
+}
+
+// ValidateCredential validates the verifiable credential.
+func (vr *VerifiableREST) ValidateCredential(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	respEnvelope := execREST(&restOperation{
+		url:        vr.URL,
+		token:      vr.Token,
+		httpClient: vr.httpClient,
+		endpoint:   vr.endpoints[cmdverifiable.ValidateCredentialCommandMethod],
+		request:    request,
+	})
+
+	return respEnvelope
+}
+
+// SaveCredential saves the verifiable credential to the store.
+func (vr *VerifiableREST) SaveCredential(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	respEnvelope := execREST(&restOperation{
+		url:        vr.URL,
+		token:      vr.Token,
+		httpClient: vr.httpClient,
+		endpoint:   vr.endpoints[cmdverifiable.SaveCredentialCommandMethod],
+		request:    request,
+	})
+
+	return respEnvelope
+}
+
+// SavePresentation saves the presentation to the store.
+func (vr *VerifiableREST) SavePresentation(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	respEnvelope := execREST(&restOperation{
+		url:        vr.URL,
+		token:      vr.Token,
+		httpClient: vr.httpClient,
+		endpoint:   vr.endpoints[cmdverifiable.SavePresentationCommandMethod],
+		request:    request,
+	})
+
+	return respEnvelope
+}
+
+// GetCredential retrieves the verifiable credential from the store.
+func (vr *VerifiableREST) GetCredential(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	respEnvelope := execREST(&restOperation{
+		url:        vr.URL,
+		token:      vr.Token,
+		httpClient: vr.httpClient,
+		endpoint:   vr.endpoints[cmdverifiable.GetCredentialCommandMethod],
+		request:    request,
+	})
+
+	return respEnvelope
+}
+
+// SignCredential adds proof to given verifiable credential
+func (vr *VerifiableREST) SignCredential(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	respEnvelope := execREST(&restOperation{
+		url:        vr.URL,
+		token:      vr.Token,
+		httpClient: vr.httpClient,
+		endpoint:   vr.endpoints[cmdverifiable.SignCredentialCommandMethod],
+		request:    request,
+	})
+
+	return respEnvelope
+}
+
+// GetPresentation retrieves the verifiable presentation from the store.
+func (vr *VerifiableREST) GetPresentation(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	respEnvelope := execREST(&restOperation{
+		url:        vr.URL,
+		token:      vr.Token,
+		httpClient: vr.httpClient,
+		endpoint:   vr.endpoints[cmdverifiable.GetPresentationCommandMethod],
+		request:    request,
+	})
+
+	return respEnvelope
+}
+
+// GetCredentialByName retrieves the verifiable credential by name from the store.
+func (vr *VerifiableREST) GetCredentialByName(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	respEnvelope := execREST(&restOperation{
+		url:        vr.URL,
+		token:      vr.Token,
+		httpClient: vr.httpClient,
+		endpoint:   vr.endpoints[cmdverifiable.GetCredentialByNameCommandMethod],
+		request:    request,
+	})
+
+	return respEnvelope
+}
+
+// GetCredentials retrieves the verifiable credential records containing name and fields of interest.
+func (vr *VerifiableREST) GetCredentials(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	respEnvelope := execREST(&restOperation{
+		url:        vr.URL,
+		token:      vr.Token,
+		httpClient: vr.httpClient,
+		endpoint:   vr.endpoints[cmdverifiable.GetCredentialsCommandMethod],
+		request:    request,
+	})
+
+	return respEnvelope
+}
+
+// GetPresentations retrieves the verifiable presentation records containing name and fields of interest.
+func (vr *VerifiableREST) GetPresentations(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	respEnvelope := execREST(&restOperation{
+		url:        vr.URL,
+		token:      vr.Token,
+		httpClient: vr.httpClient,
+		endpoint:   vr.endpoints[cmdverifiable.GetPresentationsCommandMethod],
+		request:    request,
+	})
+
+	return respEnvelope
+}
+
+// GeneratePresentation generates verifiable presentation from a verifiable credential.
+func (vr *VerifiableREST) GeneratePresentation(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	respEnvelope := execREST(&restOperation{
+		url:        vr.URL,
+		token:      vr.Token,
+		httpClient: vr.httpClient,
+		endpoint:   vr.endpoints[cmdverifiable.GeneratePresentationCommandMethod],
+		request:    request,
+	})
+
+	return respEnvelope
+}
+
+// GeneratePresentationByID generates verifiable presentation from a stored verifiable credential.
+func (vr *VerifiableREST) GeneratePresentationByID(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	respEnvelope := execREST(&restOperation{
+		url:        vr.URL,
+		token:      vr.Token,
+		httpClient: vr.httpClient,
+		endpoint:   vr.endpoints[cmdverifiable.GeneratePresentationByIDCommandMethod],
+		request:    request,
+	})
+
+	return respEnvelope
+}

--- a/cmd/aries-agent-mobile/pkg/wrappers/rest/verifiable_test.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/rest/verifiable_test.go
@@ -1,0 +1,327 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/config"
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/models"
+	cmdverifiable "github.com/hyperledger/aries-framework-go/pkg/controller/command/verifiable"
+	opverifiable "github.com/hyperledger/aries-framework-go/pkg/controller/rest/verifiable"
+)
+
+//nolint:lll
+const (
+	mockVC = `{
+  "@context":[
+     "https://www.w3.org/2018/credentials/v1",
+	  "https://trustbloc.github.io/context/vc/examples-v1.jsonld"
+  ],
+  "id":"http://example.edu/credentials/1989",
+  "type":"VerifiableCredential",
+  "credentialSubject":{
+     "id":"did:example:iuajk1f712ebc6f1c276e12ec21"
+  },
+  "issuer":{
+     "id":"did:example:09s12ec712ebc6f1c671ebfeb1f",
+     "name":"Example University"
+  },
+  "issuanceDate":"2020-01-01T10:54:01Z",
+  "credentialStatus":{
+     "id":"https://example.gov/status/65",
+     "type":"CredentialStatusList2017"
+  }
+}`
+	mockSignedVC             = `{"@context":["https://www.w3.org/2018/credentials/v1","https://trustbloc.github.io/context/vc/examples-v1.jsonld"],"credentialStatus":{"id":"https://example.gov/status/65","type":"CredentialStatusList2017"},"credentialSubject":"did:example:iuajk1f712ebc6f1c276e12ec21","id":"http://example.edu/credentials/1989","issuanceDate":"2020-01-01T10:54:01Z","issuer":{"id":"did:example:09s12ec712ebc6f1c671ebfeb1f","name":"Example University"},"proof":{"created":"2020-07-13T09:25:45.843216-04:00","jws":"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..","proofPurpose":"assertionMethod","type":"Ed25519Signature2018","verificationMethod":"did:peer:123456789abcdefghi#keys-1"},"type":"VerifiableCredential"}`
+	mockPresentationResponse = `
+{
+	"verifiablePresentation": {
+		"@context": [
+			"https://www.w3.org/2018/credentials/v1"
+		],
+		"holder": "did:peer:123456789abcdefghi#inbox",
+		"proof": {
+			"created": "2020-07-10T15:53:25.157489-04:00",
+			"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..",
+			"proofPurpose": "authentication",
+			"type": "Ed25519Signature2018",
+			"verificationMethod": "did:peer:123456789abcdefghi#keys-1"
+		},
+		"type": "VerifiablePresentation",
+		"verifiableCredential": [
+			{
+				"@context": [
+					"https://www.w3.org/2018/credentials/v1",
+					"https://trustbloc.github.io/context/vc/examples-v1.jsonld"
+				],
+				"credentialStatus": {
+					"id": "https://example.gov/status/65",
+					"type": "CredentialStatusList2017"
+				},
+				"credentialSubject": "did:example:iuajk1f712ebc6f1c276e12ec21",
+				"id": "http://example.edu/credentials/1989",
+				"issuanceDate": "2020-01-01T10:54:01Z",
+				"issuer": {
+					"id": "did:example:09s12ec712ebc6f1c671ebfeb1f",
+					"name": "Example University"
+				},
+				"type": "VerifiableCredential"
+			}
+		]
+	}
+}`
+	mockCredentialName   = "mock_credential"
+	mockPresentationName = "mock_vp_name"
+	mockCredentialID     = "http://example.edu/credentials/1989"
+	mockPresentationID   = "http://example.edu/presentations/1989"
+	mockVP               = `{"verifiablePresentation":{"@context":["https://www.w3.org/2018/credentials/v1","https://www.w3.org/2018/credentials/examples/v1"],"type":["VerifiablePresentation"],"id":"http://example.edu/presentations/1989","verifiableCredential":[{"@context":["https://www.w3.org/2018/credentials/v1","https://www.w3.org/2018/credentials/examples/v1"],"credentialSchema":[],"credentialStatus":{"id":"http://issuer.vc.rest.example.com:8070/status/1","type":"CredentialStatusList2017"},"credentialSubject":{"degree":{"degree":"MIT","type":"BachelorDegree"},"id":"did:example:ebfeb1f712ebc6f1c276e12ec21","name":"Jayden Doe","spouse":"did:example:c276e12ec21ebfeb1f712ebc6f1"},"id":"https://example.com/credentials/9315d0fd-da93-436e-9e20-2121f2821df3","issuanceDate":"2020-03-16T22:37:26.544Z","issuer":{"id":"did:elem:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg","name":"alice_ca31684e-6cbb-40f9-b7e6-87e1ab5661ae"},"proof":{"created":"2020-04-08T21:19:02Z","jws":"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..yGHHYmRp4mWd918SDSzmBDs8eq-SX7WPl8moGB8oJeSqEMmuEiI81D4s5-BPWGmKy3VlCsKJxYrTNqrEGJpNAQ","proofPurpose":"assertionMethod","type":"Ed25519Signature2018","verificationMethod":"did:elem:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg#xqc3gS1gz1vch7R3RvNebWMjLvBOY-n_14feCYRPsUo"},"type":["VerifiableCredential","UniversityDegreeCredential"]}]},"name":"sampleVpName"}`
+	mockDID              = "did:peer:123456789abcdefghi#inbox"
+	mockAgentURL         = "http://example.com"
+	emptyResponse        = `{}`
+)
+
+func getAgent() *AriesREST {
+	opts := &config.Options{URL: mockAgentURL}
+	return NewAries(opts)
+}
+
+func getVerifiableController(t *testing.T) *VerifiableREST {
+	a := getAgent()
+	vc, err := a.GetVerifiableController()
+	require.NoError(t, err)
+	require.NotNil(t, vc)
+
+	v, ok := vc.(*VerifiableREST)
+	require.Equal(t, ok, true)
+
+	return v
+}
+
+func parseURL(agentURL, operationPath, payload string) (string, error) { //nolint:unparam
+	return embedParams(agentURL+operationPath, []byte(payload))
+}
+
+func TestVerifiableREST_ValidateCredential(t *testing.T) {
+	t.Run("test it preforms a validates credential request", func(t *testing.T) {
+		v := getVerifiableController(t)
+
+		mockResponse := emptyResponse
+		v.httpClient = &mockHTTPClient{data: mockResponse,
+			method: http.MethodPost, url: mockAgentURL + opverifiable.ValidateCredentialPath}
+
+		reqData := fmt.Sprintf(`{"verifiableCredential": %s}`, strconv.Quote(mockVC))
+		req := &models.RequestEnvelope{Payload: []byte(reqData)}
+		resp := v.ValidateCredential(req)
+
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t, mockResponse, string(resp.Payload))
+	})
+}
+
+func TestVerifiableREST_SaveCredential(t *testing.T) {
+	t.Run("test it performs a save credential request", func(t *testing.T) {
+		v := getVerifiableController(t)
+
+		mockResponse := emptyResponse
+		v.httpClient = &mockHTTPClient{data: mockResponse,
+			method: http.MethodPost, url: mockAgentURL + opverifiable.SaveCredentialPath}
+
+		reqData := fmt.Sprintf(`{"verifiableCredential": %s, "name": "%s"}`,
+			strconv.Quote(mockVC), mockCredentialName)
+		req := &models.RequestEnvelope{Payload: []byte(reqData)}
+		resp := v.SaveCredential(req)
+
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t, mockResponse, string(resp.Payload))
+	})
+}
+
+func TestVerifiableREST_SavePresentation(t *testing.T) {
+	t.Run("test it performs a save presentation request", func(t *testing.T) {
+		v := getVerifiableController(t)
+
+		mockResponse := emptyResponse
+		v.httpClient = &mockHTTPClient{data: mockResponse,
+			method: http.MethodPost, url: mockAgentURL + opverifiable.SavePresentationPath}
+
+		req := &models.RequestEnvelope{Payload: []byte(mockVP)}
+		resp := v.SavePresentation(req)
+
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t, mockResponse, string(resp.Payload))
+	})
+}
+
+func TestVerifiableREST_GetCredential(t *testing.T) {
+	t.Run("test it performs a get credential request", func(t *testing.T) {
+		v := getVerifiableController(t)
+
+		mockResponse := fmt.Sprintf(`{"verifiableCredential": %s}`, strconv.Quote(mockVC))
+		reqData := fmt.Sprintf(`{"id":"%s"}`, mockCredentialID)
+
+		mockURL, err := parseURL(mockAgentURL, opverifiable.GetCredentialPath, reqData)
+		require.NoError(t, err, "failed to parse test url")
+
+		v.httpClient = &mockHTTPClient{data: mockResponse,
+			method: http.MethodGet, url: mockURL}
+
+		req := &models.RequestEnvelope{Payload: []byte(reqData)}
+		resp := v.GetCredential(req)
+
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t, mockResponse, string(resp.Payload))
+	})
+}
+
+func TestVerifiableREST_SignCredential(t *testing.T) {
+	t.Run("test it performs a sign credential request", func(t *testing.T) {
+		v := getVerifiableController(t)
+
+		mockResponse := fmt.Sprintf(`{"verifiableCredential": %s}`, strconv.Quote(mockSignedVC))
+		v.httpClient = &mockHTTPClient{data: mockResponse,
+			method: http.MethodPost, url: mockAgentURL + opverifiable.SignCredentialsPath}
+
+		reqData := fmt.Sprintf(`{"credential": %s, "did": "%s", "signatureType": "%s"}`,
+			strconv.Quote(mockVC), mockDID, cmdverifiable.Ed25519Signature2018)
+		req := &models.RequestEnvelope{Payload: []byte(reqData)}
+		resp := v.SignCredential(req)
+
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t, mockResponse, string(resp.Payload))
+	})
+}
+
+func TestVerifiableREST_GetPresentation(t *testing.T) {
+	t.Run("test it performs a get presentation request", func(t *testing.T) {
+		v := getVerifiableController(t)
+
+		mockResponse := fmt.Sprintf(`{"verifiablePresentation": %s}`, strconv.Quote(mockVP))
+		reqData := fmt.Sprintf(`{"id":"%s"}`, mockPresentationID)
+
+		mockURL, err := parseURL(mockAgentURL, opverifiable.GetPresentationPath, reqData)
+		require.NoError(t, err, "failed to parse test url")
+
+		v.httpClient = &mockHTTPClient{data: mockResponse, method: http.MethodGet, url: mockURL}
+
+		req := &models.RequestEnvelope{Payload: []byte(reqData)}
+		resp := v.GetPresentation(req)
+
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t, mockResponse, string(resp.Payload))
+	})
+}
+
+func TestVerifiableREST_GetCredentialByName(t *testing.T) {
+	t.Run("test it performs a get credential by name request", func(t *testing.T) {
+		v := getVerifiableController(t)
+
+		mockResponse := fmt.Sprintf(`{"name": %s, "id": %s}`, mockCredentialName, mockCredentialID)
+		reqData := fmt.Sprintf(`{"name":"%s"}`, mockCredentialName)
+
+		mockURL, err := parseURL(mockAgentURL, opverifiable.GetCredentialByNamePath, reqData)
+		require.NoError(t, err, "failed to parse test url")
+
+		v.httpClient = &mockHTTPClient{data: mockResponse, method: http.MethodGet, url: mockURL}
+
+		req := &models.RequestEnvelope{Payload: []byte(reqData)}
+		resp := v.GetCredentialByName(req)
+
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t, mockResponse, string(resp.Payload))
+	})
+}
+
+func TestVerifiableREST_GetCredentials(t *testing.T) {
+	t.Run("test it performs a get credentials request", func(t *testing.T) {
+		v := getVerifiableController(t)
+
+		mockResponse := fmt.Sprintf(`{"result": [{"name": "%s", "id":" %s"}, {"name": "%s"", "id": "%s""}]`,
+			mockCredentialName, mockCredentialID, mockCredentialName, mockCredentialID)
+		v.httpClient = &mockHTTPClient{data: mockResponse,
+			method: http.MethodGet, url: mockAgentURL + opverifiable.GetCredentialsPath}
+
+		reqData := "{}"
+		req := &models.RequestEnvelope{Payload: []byte(reqData)}
+		resp := v.GetCredentials(req)
+
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t, mockResponse, string(resp.Payload))
+	})
+}
+
+func TestVerifiableREST_GetPresentations(t *testing.T) {
+	t.Run("test it performs a get presentations request", func(t *testing.T) {
+		v := getVerifiableController(t)
+
+		mockResponse := fmt.Sprintf(`{"result": [{"name": "%s", "id":" %s"}, {"name": "%s"", "id": "%s""}]`,
+			mockPresentationName, mockPresentationID, mockPresentationName, mockPresentationID)
+		v.httpClient = &mockHTTPClient{data: mockResponse,
+			method: http.MethodGet, url: mockAgentURL + opverifiable.GetPresentationsPath}
+
+		req := &models.RequestEnvelope{Payload: []byte("{}")}
+		resp := v.GetPresentations(req)
+
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t, mockResponse, string(resp.Payload))
+	})
+}
+
+func TestVerifiableREST_GeneratePresentation(t *testing.T) {
+	t.Run("test it performs a generate presentation request", func(t *testing.T) {
+		v := getVerifiableController(t)
+
+		mockResponse := mockPresentationResponse
+		v.httpClient = &mockHTTPClient{data: mockResponse,
+			method: http.MethodPost, url: mockAgentURL + opverifiable.GeneratePresentationPath}
+
+		credList := fmt.Sprintf(`[%s, %s]`, mockVC, mockVC)
+		reqData := fmt.Sprintf(`{"verifiableCredential": %s, "did": "%s", "signatureType": "%s"}`,
+			credList, mockDID, cmdverifiable.Ed25519Signature2018)
+		req := &models.RequestEnvelope{Payload: []byte(reqData)}
+		resp := v.GeneratePresentation(req)
+
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t, mockResponse, string(resp.Payload))
+	})
+}
+
+func TestVerifiableREST_GeneratePresentationByID(t *testing.T) {
+	t.Run("test it performs a generate presentation by id request", func(t *testing.T) {
+		v := getVerifiableController(t)
+
+		mockResponse := mockPresentationResponse
+		v.httpClient = &mockHTTPClient{data: mockResponse,
+			method: http.MethodPost, url: mockAgentURL + opverifiable.GeneratePresentationByIDPath}
+
+		credList := fmt.Sprintf(`[%s, %s]`, mockVC, mockVC)
+		reqData := fmt.Sprintf(`{"verifiableCredential": %s, "did": "%s", "signatureType": "%s"}`,
+			credList, mockDID, cmdverifiable.Ed25519Signature2018)
+
+		req := &models.RequestEnvelope{Payload: []byte(reqData)}
+		resp := v.GeneratePresentationByID(req)
+
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t, mockResponse, string(resp.Payload))
+	})
+}

--- a/cmd/aries-js-worker/src/aries.js
+++ b/cmd/aries-js-worker/src/aries.js
@@ -739,7 +739,7 @@ const Aries = function (opts) {
             },
 
             /**
-             * Registers a http-over-didcomm service.
+             * Registers an http-over-didcomm service.
              *
              * @param req - json document
              * @returns {Promise<Object>}

--- a/docs/concepts/00_what_is_hl_aries.md
+++ b/docs/concepts/00_what_is_hl_aries.md
@@ -1,10 +1,10 @@
 # What is Hyperledger Aries?
 
-Hyperledger Aries provides a shared, reusable, interoperable tool kit designed for initiatives and solutions focused on creating, transmitting and storing verifiable digital credentials. It is infrastructure for blockchain-rooted, peer-to-peer interactions. This project consumes the cryptographic support provided by Hyperledger Ursa, to provide secure secret management and decentralized key management functionality. (1)
+Hyperledger Aries provides a shared, reusable, interoperable tool kit designed for initiatives and solutions focused on creating, transmitting and storing verifiable digital credentials. It is infrastructure for blockchain-rooted, peer-to-peer interactions. This project consumes the cryptographic support provided by Hyperledger Ursa, to provide secure secret management and decentralized key management functionality. _(1)_
 
 ## Where did Aries come from?
 
-Hyperledger Aries is related to both Hyperledger Indy, which provides a resolver implementation, and Hyperledger Ursa, which it uses for cryptographic functionality. Aries will consume the cryptographic support provided by Ursa to provide both secure secret management and hardware security modules support. (2)
+Hyperledger Aries is related to both Hyperledger Indy, which provides a resolver implementation, and Hyperledger Ursa, which it uses for cryptographic functionality. Aries will consume the cryptographic support provided by Ursa to provide both secure secret management and hardware security modules support. _(2)_
 
 ## Key Characteristics
 
@@ -15,22 +15,36 @@ Hyperledger Aries is related to both Hyperledger Indy, which provides a resolver
 - An encrypted messaging system for allowing off-ledger interaction between those clients using multiple transport protocols.
 - An implementation of ZKP-capable W3C verifiable credentials using the ZKP primitives found in Ursa.
 - An implementation of the Decentralized Key Management System (DKMS) specification currently being incubated in Hyperledger Indy.
-- A mechanism to build higher-level protocols and API-like use cases based on the secure messaging functionality described earlier.  (3)
+- A mechanism to build higher-level protocols and API-like use cases based on the secure messaging functionality described earlier.  _(3)_
 
-## Protocols We Support
+## Supported Controllers
 
-The following protocols are supported by Aries-Framework-Go.
+The following controllers are supported by Aries-Framework-Go.
 
-- DIDExchange
-- Introduce
-- IssueCredential
-- KMS
-- Mediator
-- Messaging
-- OutOfBand
-- PresentProof
-- VDRI
-- Verifiable
+### 1. DIDExchange Protocol
+
+### 2. Introduce Protocol
+
+This protocol describes how an intermediary can introduce two parties that it already knows, but that do not know each other.
+_(4)_
+
+### 3. IssueCredential Protocol
+
+### 4. KMS
+
+### 5. Mediator
+
+### 6. Messaging
+
+### 7. OutOfBand Protocol
+
+### 8. PresentProof Protocol
+
+### 9. VDRI
+
+### 10. Verifiable
+
+This controller allows for the creation, retrieval, validation and signing of [verifiable presentations](./01_terminologies.md#verifiable-presentation) and [verifiable credentials](./01_terminologies.md#verifiable-credential).
 
 ---
 ###### References
@@ -38,4 +52,4 @@ The following protocols are supported by Aries-Framework-Go.
 1. [Official library page](https://www.hyperledger.org/use/aries)
 2. [Blog post annoucement](https://www.hyperledger.org/blog/2019/05/14/announcing-hyperledger-aries-infrastructure-supporting-interoperable-identity-solutions)
 3. [Hyperledger Aries Wiki](https://wiki.hyperledger.org/display/ARIES/Hyperledger+Aries)
-
+4. [Aries RFCs - Introduce](https://github.com/hyperledger/aries-rfcs/tree/master/features/0028-introduce)

--- a/docs/concepts/01_terminologies.md
+++ b/docs/concepts/01_terminologies.md
@@ -1,0 +1,16 @@
+# Terminologies
+
+### Verifiable Credential
+
+A verifiable credential can represent all of the same information that a physical credential represents. It is a tamper-evident credential that has authorship that can be cryptographically verified.
+Examples of verifiable credentials include digital employee identification cards, digital birth certificates, and digital educational certificates.
+
+_Reference: https://www.w3.org/TR/vc-data-model/#what-is-a-verifiable-credential_
+
+
+### Verifiable Presentation
+
+A verifiable presentation expresses data from one or more verifiable credentials, and is packaged in such a way that the authorship of the data is verifiable.
+
+_Reference: https://www.w3.org/TR/vc-data-model/#presentations_
+

--- a/go.sum
+++ b/go.sum
@@ -97,10 +97,7 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile v0.0.0-20200707171512-016c620b82fa h1:7p+QXaLgbN7hqLvrRyAl9gJ6lP4kGwom03q2OPL2o9w=
-github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile v0.0.0-20200708130625-4d37ef9de451 h1:fMVtbv4io3KBqFsBIMrX+kltJoR8w3jpR8+g+BCPnEQ=
-github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile v0.0.0-20200708132022-41f504911967 h1:sZ5y89MapyCiHaCujkkJVqSvPJgfGPnOhq8TdUxErjA=
-github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile v0.0.0-20200708140159-459bb2161e10 h1:D2/5TEWqT2KhnDxfHLBSzIoPsmuy6kowg/a66vpEz2A=
+github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile v0.0.0-20200710222441-0bae8caf5c47 h1:xiFbeyPLYRoI5ur9Nkc+3rEh5x7VWx4QHdtKudmD5sQ=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89 h1:12K8AlpT0/6QUXSfV0yi4Q0jkbq8NDtIKFtF61AoqV0=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/pkg/controller/command/messaging/models.go
+++ b/pkg/controller/command/messaging/models.go
@@ -84,7 +84,7 @@ type SendReplyMessageArgs struct {
 	MessageBody json.RawMessage `json:"message_body"`
 }
 
-// RegisterHTTPMsgSvcArgs contains parameters for registering a HTTP over DIDComm message service to message handler.
+// RegisterHTTPMsgSvcArgs contains parameters for registering an HTTP over DIDComm message service to message handler.
 type RegisterHTTPMsgSvcArgs struct {
 	// Name of the HTTP over DIDComm message service
 	Name string `json:"name"`

--- a/pkg/controller/command/verifiable/command.go
+++ b/pkg/controller/command/verifiable/command.go
@@ -73,22 +73,22 @@ const (
 	SignCredentialErrorCode
 )
 
+// constants for the Verifiable protocol
 const (
-	// command name
-	commandName = "verifiable"
+	CommandName = "verifiable"
 
 	// command methods
-	validateCredentialCommandMethod       = "ValidateCredential"
-	saveCredentialCommandMethod           = "SaveCredential"
-	getCredentialCommandMethod            = "GetCredential"
-	getCredentialByNameCommandMethod      = "GetCredentialByName"
-	getCredentialsCommandMethod           = "GetCredentials"
-	signCredentialCommandMethod           = "SignCredential"
-	savePresentationCommandMethod         = "SavePresentation"
-	getPresentationCommandMethod          = "GetPresentation"
-	getPresentationsCommandMethod         = "GetPresentations"
-	generatePresentationCommandMethod     = "GeneratePresentation"
-	generatePresentationByIDCommandMethod = "GeneratePresentationByID"
+	ValidateCredentialCommandMethod       = "ValidateCredential"
+	SaveCredentialCommandMethod           = "SaveCredential"
+	GetCredentialCommandMethod            = "GetCredential"
+	GetCredentialByNameCommandMethod      = "GetCredentialByName"
+	GetCredentialsCommandMethod           = "GetCredentials"
+	SignCredentialCommandMethod           = "SignCredential"
+	SavePresentationCommandMethod         = "SavePresentation"
+	GetPresentationCommandMethod          = "GetPresentation"
+	GetPresentationsCommandMethod         = "GetPresentations"
+	GeneratePresentationCommandMethod     = "GeneratePresentation"
+	GeneratePresentationByIDCommandMethod = "GeneratePresentationByID"
 
 	// error messages
 	errEmptyCredentialName   = "credential name is mandatory"
@@ -195,17 +195,17 @@ func New(p provider) (*Command, error) {
 // GetHandlers returns list of all commands supported by this controller command.
 func (o *Command) GetHandlers() []command.Handler {
 	return []command.Handler{
-		cmdutil.NewCommandHandler(commandName, validateCredentialCommandMethod, o.ValidateCredential),
-		cmdutil.NewCommandHandler(commandName, saveCredentialCommandMethod, o.SaveCredential),
-		cmdutil.NewCommandHandler(commandName, getCredentialCommandMethod, o.GetCredential),
-		cmdutil.NewCommandHandler(commandName, getCredentialByNameCommandMethod, o.GetCredentialByName),
-		cmdutil.NewCommandHandler(commandName, getCredentialsCommandMethod, o.GetCredentials),
-		cmdutil.NewCommandHandler(commandName, signCredentialCommandMethod, o.SignCredential),
-		cmdutil.NewCommandHandler(commandName, generatePresentationCommandMethod, o.GeneratePresentation),
-		cmdutil.NewCommandHandler(commandName, generatePresentationByIDCommandMethod, o.GeneratePresentationByID),
-		cmdutil.NewCommandHandler(commandName, savePresentationCommandMethod, o.SavePresentation),
-		cmdutil.NewCommandHandler(commandName, getPresentationCommandMethod, o.GetPresentation),
-		cmdutil.NewCommandHandler(commandName, getPresentationsCommandMethod, o.GetPresentations),
+		cmdutil.NewCommandHandler(CommandName, ValidateCredentialCommandMethod, o.ValidateCredential),
+		cmdutil.NewCommandHandler(CommandName, SaveCredentialCommandMethod, o.SaveCredential),
+		cmdutil.NewCommandHandler(CommandName, GetCredentialCommandMethod, o.GetCredential),
+		cmdutil.NewCommandHandler(CommandName, GetCredentialByNameCommandMethod, o.GetCredentialByName),
+		cmdutil.NewCommandHandler(CommandName, GetCredentialsCommandMethod, o.GetCredentials),
+		cmdutil.NewCommandHandler(CommandName, SignCredentialCommandMethod, o.SignCredential),
+		cmdutil.NewCommandHandler(CommandName, GeneratePresentationCommandMethod, o.GeneratePresentation),
+		cmdutil.NewCommandHandler(CommandName, GeneratePresentationByIDCommandMethod, o.GeneratePresentationByID),
+		cmdutil.NewCommandHandler(CommandName, SavePresentationCommandMethod, o.SavePresentation),
+		cmdutil.NewCommandHandler(CommandName, GetPresentationCommandMethod, o.GetPresentation),
+		cmdutil.NewCommandHandler(CommandName, GetPresentationsCommandMethod, o.GetPresentations),
 	}
 }
 
@@ -215,7 +215,7 @@ func (o *Command) ValidateCredential(rw io.Writer, req io.Reader) command.Error 
 
 	err := json.NewDecoder(req).Decode(&request)
 	if err != nil {
-		logutil.LogInfo(logger, commandName, validateCredentialCommandMethod, "request decode : "+err.Error())
+		logutil.LogInfo(logger, CommandName, ValidateCredentialCommandMethod, "request decode : "+err.Error())
 
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf("request decode : %w", err))
 	}
@@ -225,14 +225,14 @@ func (o *Command) ValidateCredential(rw io.Writer, req io.Reader) command.Error 
 	//  verification as options to the function.
 	_, err = verifiable.ParseCredential([]byte(request.VerifiableCredential))
 	if err != nil {
-		logutil.LogInfo(logger, commandName, validateCredentialCommandMethod, "validate vc : "+err.Error())
+		logutil.LogInfo(logger, CommandName, ValidateCredentialCommandMethod, "validate vc : "+err.Error())
 
 		return command.NewValidationError(ValidateCredentialErrorCode, fmt.Errorf("validate vc : %w", err))
 	}
 
 	command.WriteNillableResponse(rw, nil, logger)
 
-	logutil.LogDebug(logger, commandName, validateCredentialCommandMethod, "success")
+	logutil.LogDebug(logger, CommandName, ValidateCredentialCommandMethod, "success")
 
 	return nil
 }
@@ -243,33 +243,33 @@ func (o *Command) SaveCredential(rw io.Writer, req io.Reader) command.Error {
 
 	err := json.NewDecoder(req).Decode(&request)
 	if err != nil {
-		logutil.LogInfo(logger, commandName, saveCredentialCommandMethod, "request decode : "+err.Error())
+		logutil.LogInfo(logger, CommandName, SaveCredentialCommandMethod, "request decode : "+err.Error())
 
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf("request decode : %w", err))
 	}
 
 	if request.Name == "" {
-		logutil.LogDebug(logger, commandName, saveCredentialCommandMethod, errEmptyCredentialName)
+		logutil.LogDebug(logger, CommandName, SaveCredentialCommandMethod, errEmptyCredentialName)
 		return command.NewValidationError(SaveCredentialErrorCode, fmt.Errorf(errEmptyCredentialName))
 	}
 
 	vc, err := verifiable.ParseUnverifiedCredential([]byte(request.VerifiableCredential))
 	if err != nil {
-		logutil.LogError(logger, commandName, saveCredentialCommandMethod, "parse vc : "+err.Error())
+		logutil.LogError(logger, CommandName, SaveCredentialCommandMethod, "parse vc : "+err.Error())
 
 		return command.NewValidationError(SaveCredentialErrorCode, fmt.Errorf("parse vc : %w", err))
 	}
 
 	err = o.verifiableStore.SaveCredential(request.Name, vc)
 	if err != nil {
-		logutil.LogError(logger, commandName, saveCredentialCommandMethod, "save vc : "+err.Error())
+		logutil.LogError(logger, CommandName, SaveCredentialCommandMethod, "save vc : "+err.Error())
 
 		return command.NewValidationError(SaveCredentialErrorCode, fmt.Errorf("save vc : %w", err))
 	}
 
 	command.WriteNillableResponse(rw, nil, logger)
 
-	logutil.LogDebug(logger, commandName, saveCredentialCommandMethod, "success")
+	logutil.LogDebug(logger, CommandName, SaveCredentialCommandMethod, "success")
 
 	return nil
 }
@@ -280,34 +280,34 @@ func (o *Command) SavePresentation(rw io.Writer, req io.Reader) command.Error {
 
 	err := json.NewDecoder(req).Decode(&request)
 	if err != nil {
-		logutil.LogInfo(logger, commandName, savePresentationCommandMethod, "request decode : "+err.Error())
+		logutil.LogInfo(logger, CommandName, SavePresentationCommandMethod, "request decode : "+err.Error())
 
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf("request decode : %w", err))
 	}
 
 	if request.Name == "" {
-		logutil.LogDebug(logger, commandName, savePresentationCommandMethod, errEmptyPresentationName)
+		logutil.LogDebug(logger, CommandName, SavePresentationCommandMethod, errEmptyPresentationName)
 		return command.NewValidationError(SavePresentationErrorCode, fmt.Errorf(errEmptyPresentationName))
 	}
 
 	vp, err := verifiable.ParsePresentation([]byte(request.VerifiablePresentation),
 		verifiable.WithDisabledPresentationProofCheck())
 	if err != nil {
-		logutil.LogError(logger, commandName, savePresentationCommandMethod, "parse vp : "+err.Error())
+		logutil.LogError(logger, CommandName, SavePresentationCommandMethod, "parse vp : "+err.Error())
 
 		return command.NewValidationError(SavePresentationErrorCode, fmt.Errorf("parse vp : %w", err))
 	}
 
 	err = o.verifiableStore.SavePresentation(request.Name, vp)
 	if err != nil {
-		logutil.LogError(logger, commandName, savePresentationCommandMethod, "save vp : "+err.Error())
+		logutil.LogError(logger, CommandName, SavePresentationCommandMethod, "save vp : "+err.Error())
 
 		return command.NewValidationError(SavePresentationErrorCode, fmt.Errorf("save vp : %w", err))
 	}
 
 	command.WriteNillableResponse(rw, nil, logger)
 
-	logutil.LogDebug(logger, commandName, savePresentationCommandMethod, "success")
+	logutil.LogDebug(logger, CommandName, SavePresentationCommandMethod, "success")
 
 	return nil
 }
@@ -318,18 +318,18 @@ func (o *Command) GetCredential(rw io.Writer, req io.Reader) command.Error {
 
 	err := json.NewDecoder(req).Decode(&request)
 	if err != nil {
-		logutil.LogInfo(logger, commandName, getCredentialCommandMethod, err.Error())
+		logutil.LogInfo(logger, CommandName, GetCredentialCommandMethod, err.Error())
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf("request decode : %w", err))
 	}
 
 	if request.ID == "" {
-		logutil.LogDebug(logger, commandName, getCredentialCommandMethod, errEmptyCredentialID)
+		logutil.LogDebug(logger, CommandName, GetCredentialCommandMethod, errEmptyCredentialID)
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyCredentialID))
 	}
 
 	vc, err := o.verifiableStore.GetCredential(request.ID)
 	if err != nil {
-		logutil.LogError(logger, commandName, getCredentialCommandMethod, "get vc : "+err.Error(),
+		logutil.LogError(logger, CommandName, GetCredentialCommandMethod, "get vc : "+err.Error(),
 			logutil.CreateKeyValueString(vcID, request.ID))
 
 		return command.NewValidationError(GetCredentialErrorCode, fmt.Errorf("get vc : %w", err))
@@ -337,7 +337,7 @@ func (o *Command) GetCredential(rw io.Writer, req io.Reader) command.Error {
 
 	vcBytes, err := vc.MarshalJSON()
 	if err != nil {
-		logutil.LogError(logger, commandName, getCredentialCommandMethod, "marshal vc : "+err.Error(),
+		logutil.LogError(logger, CommandName, GetCredentialCommandMethod, "marshal vc : "+err.Error(),
 			logutil.CreateKeyValueString(vcID, request.ID))
 
 		return command.NewValidationError(GetCredentialErrorCode, fmt.Errorf("marshal vc : %w", err))
@@ -347,7 +347,7 @@ func (o *Command) GetCredential(rw io.Writer, req io.Reader) command.Error {
 		VerifiableCredential: string(vcBytes),
 	}, logger)
 
-	logutil.LogDebug(logger, commandName, getCredentialCommandMethod, "success",
+	logutil.LogDebug(logger, CommandName, GetCredentialCommandMethod, "success",
 		logutil.CreateKeyValueString(vcID, request.ID))
 
 	return nil
@@ -359,7 +359,7 @@ func (o *Command) SignCredential(rw io.Writer, req io.Reader) command.Error {
 
 	err := json.NewDecoder(req).Decode(&request)
 	if err != nil {
-		logutil.LogInfo(logger, commandName, signCredentialCommandMethod, "request decode : "+err.Error())
+		logutil.LogInfo(logger, CommandName, SignCredentialCommandMethod, "request decode : "+err.Error())
 
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf("request decode : %w", err))
 	}
@@ -369,7 +369,7 @@ func (o *Command) SignCredential(rw io.Writer, req io.Reader) command.Error {
 	if err != nil {
 		didDoc, err = o.didStore.GetDID(request.DID)
 		if err != nil {
-			logutil.LogError(logger, commandName, signCredentialCommandMethod,
+			logutil.LogError(logger, CommandName, SignCredentialCommandMethod,
 				"failed to get did doc from store or vdri: "+err.Error())
 
 			return command.NewValidationError(SignCredentialErrorCode,
@@ -379,21 +379,21 @@ func (o *Command) SignCredential(rw io.Writer, req io.Reader) command.Error {
 
 	vc, err := verifiable.ParseUnverifiedCredential(request.Credential)
 	if err != nil {
-		logutil.LogError(logger, commandName, signCredentialCommandMethod, "parse credential : "+err.Error())
+		logutil.LogError(logger, CommandName, SignCredentialCommandMethod, "parse credential : "+err.Error())
 
 		return command.NewValidationError(SignCredentialErrorCode, fmt.Errorf("parse vc : %w", err))
 	}
 
 	err = o.addCredentialProof(vc, didDoc, request.ProofOptions)
 	if err != nil {
-		logutil.LogError(logger, commandName, signCredentialCommandMethod, "sign credential : "+err.Error())
+		logutil.LogError(logger, CommandName, SignCredentialCommandMethod, "sign credential : "+err.Error())
 
 		return command.NewValidationError(SignCredentialErrorCode, fmt.Errorf("sign credential : %w", err))
 	}
 
 	vcBytes, err := vc.MarshalJSON()
 	if err != nil {
-		logutil.LogError(logger, commandName, signCredentialCommandMethod, "marshal credential : "+err.Error())
+		logutil.LogError(logger, CommandName, SignCredentialCommandMethod, "marshal credential : "+err.Error())
 
 		return command.NewValidationError(SignCredentialErrorCode, fmt.Errorf("marshal credential : %w", err))
 	}
@@ -402,7 +402,7 @@ func (o *Command) SignCredential(rw io.Writer, req io.Reader) command.Error {
 		VerifiableCredential: vcBytes,
 	}, logger)
 
-	logutil.LogDebug(logger, commandName, signCredentialCommandMethod, "success")
+	logutil.LogDebug(logger, CommandName, SignCredentialCommandMethod, "success")
 
 	return nil
 }
@@ -413,18 +413,18 @@ func (o *Command) GetPresentation(rw io.Writer, req io.Reader) command.Error {
 
 	err := json.NewDecoder(req).Decode(&request)
 	if err != nil {
-		logutil.LogInfo(logger, commandName, getPresentationCommandMethod, err.Error())
+		logutil.LogInfo(logger, CommandName, GetPresentationCommandMethod, err.Error())
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf("request decode : %w", err))
 	}
 
 	if request.ID == "" {
-		logutil.LogDebug(logger, commandName, getPresentationCommandMethod, errEmptyPresentationID)
+		logutil.LogDebug(logger, CommandName, GetPresentationCommandMethod, errEmptyPresentationID)
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyPresentationID))
 	}
 
 	vp, err := o.verifiableStore.GetPresentation(request.ID)
 	if err != nil {
-		logutil.LogError(logger, commandName, getPresentationCommandMethod, "get vp : "+err.Error(),
+		logutil.LogError(logger, CommandName, GetPresentationCommandMethod, "get vp : "+err.Error(),
 			logutil.CreateKeyValueString(vpID, request.ID))
 
 		return command.NewValidationError(GetPresentationErrorCode, fmt.Errorf("get vp : %w", err))
@@ -432,7 +432,7 @@ func (o *Command) GetPresentation(rw io.Writer, req io.Reader) command.Error {
 
 	vpBytes, err := vp.MarshalJSON()
 	if err != nil {
-		logutil.LogError(logger, commandName, getPresentationCommandMethod, "marshal vp : "+err.Error(),
+		logutil.LogError(logger, CommandName, GetPresentationCommandMethod, "marshal vp : "+err.Error(),
 			logutil.CreateKeyValueString(vpID, request.ID))
 
 		return command.NewValidationError(GetPresentationErrorCode, fmt.Errorf("marshal vp : %w", err))
@@ -442,7 +442,7 @@ func (o *Command) GetPresentation(rw io.Writer, req io.Reader) command.Error {
 		VerifiablePresentation: vpBytes,
 	}, logger)
 
-	logutil.LogDebug(logger, commandName, getPresentationCommandMethod, "success",
+	logutil.LogDebug(logger, CommandName, GetPresentationCommandMethod, "success",
 		logutil.CreateKeyValueString(vpID, request.ID))
 
 	return nil
@@ -454,18 +454,18 @@ func (o *Command) GetCredentialByName(rw io.Writer, req io.Reader) command.Error
 
 	err := json.NewDecoder(req).Decode(&request)
 	if err != nil {
-		logutil.LogInfo(logger, commandName, getCredentialByNameCommandMethod, err.Error())
+		logutil.LogInfo(logger, CommandName, GetCredentialByNameCommandMethod, err.Error())
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf("request decode : %w", err))
 	}
 
 	if request.Name == "" {
-		logutil.LogDebug(logger, commandName, getCredentialByNameCommandMethod, errEmptyCredentialName)
+		logutil.LogDebug(logger, CommandName, GetCredentialByNameCommandMethod, errEmptyCredentialName)
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyCredentialName))
 	}
 
 	id, err := o.verifiableStore.GetCredentialIDByName(request.Name)
 	if err != nil {
-		logutil.LogError(logger, commandName, getCredentialByNameCommandMethod, "get vc by name : "+err.Error(),
+		logutil.LogError(logger, CommandName, GetCredentialByNameCommandMethod, "get vc by name : "+err.Error(),
 			logutil.CreateKeyValueString(vcName, request.Name))
 
 		return command.NewValidationError(GetCredentialByNameErrorCode, fmt.Errorf("get vc by name : %w", err))
@@ -476,7 +476,7 @@ func (o *Command) GetCredentialByName(rw io.Writer, req io.Reader) command.Error
 		ID:   id,
 	}, logger)
 
-	logutil.LogDebug(logger, commandName, getCredentialByNameCommandMethod, "success",
+	logutil.LogDebug(logger, CommandName, GetCredentialByNameCommandMethod, "success",
 		logutil.CreateKeyValueString(vcName, request.Name))
 
 	return nil
@@ -486,7 +486,7 @@ func (o *Command) GetCredentialByName(rw io.Writer, req io.Reader) command.Error
 func (o *Command) GetCredentials(rw io.Writer, req io.Reader) command.Error {
 	vcRecords, err := o.verifiableStore.GetCredentials()
 	if err != nil {
-		logutil.LogError(logger, commandName, getCredentialsCommandMethod, "get credential records : "+err.Error())
+		logutil.LogError(logger, CommandName, GetCredentialsCommandMethod, "get credential records : "+err.Error())
 
 		return command.NewValidationError(GetCredentialsErrorCode, fmt.Errorf("get credential records : %w", err))
 	}
@@ -495,7 +495,7 @@ func (o *Command) GetCredentials(rw io.Writer, req io.Reader) command.Error {
 		Result: vcRecords,
 	}, logger)
 
-	logutil.LogDebug(logger, commandName, getCredentialsCommandMethod, "success")
+	logutil.LogDebug(logger, CommandName, GetCredentialsCommandMethod, "success")
 
 	return nil
 }
@@ -504,7 +504,7 @@ func (o *Command) GetCredentials(rw io.Writer, req io.Reader) command.Error {
 func (o *Command) GetPresentations(rw io.Writer, req io.Reader) command.Error {
 	vpRecords, err := o.verifiableStore.GetPresentations()
 	if err != nil {
-		logutil.LogError(logger, commandName, getPresentationsCommandMethod, "get presentation records : "+err.Error())
+		logutil.LogError(logger, CommandName, GetPresentationsCommandMethod, "get presentation records : "+err.Error())
 
 		return command.NewValidationError(GetPresentationsErrorCode, fmt.Errorf("get presentation records : %w", err))
 	}
@@ -513,7 +513,7 @@ func (o *Command) GetPresentations(rw io.Writer, req io.Reader) command.Error {
 		Result: vpRecords,
 	}, logger)
 
-	logutil.LogDebug(logger, commandName, getPresentationsCommandMethod, "success")
+	logutil.LogDebug(logger, CommandName, GetPresentationsCommandMethod, "success")
 
 	return nil
 }
@@ -524,7 +524,7 @@ func (o *Command) GeneratePresentation(rw io.Writer, req io.Reader) command.Erro
 
 	err := json.NewDecoder(req).Decode(&request)
 	if err != nil {
-		logutil.LogInfo(logger, commandName, generatePresentationCommandMethod, "request decode : "+err.Error())
+		logutil.LogInfo(logger, CommandName, GeneratePresentationCommandMethod, "request decode : "+err.Error())
 
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf("request decode : %w", err))
 	}
@@ -534,7 +534,7 @@ func (o *Command) GeneratePresentation(rw io.Writer, req io.Reader) command.Erro
 	if err != nil {
 		didDoc, err = o.didStore.GetDID(request.DID)
 		if err != nil {
-			logutil.LogError(logger, commandName, generatePresentationCommandMethod,
+			logutil.LogError(logger, CommandName, GeneratePresentationCommandMethod,
 				"failed to get did doc from store or vdri: "+err.Error())
 
 			return command.NewValidationError(GeneratePresentationErrorCode,
@@ -544,7 +544,7 @@ func (o *Command) GeneratePresentation(rw io.Writer, req io.Reader) command.Erro
 
 	credentials, presentation, opts, err := o.parsePresentationRequest(request, didDoc)
 	if err != nil {
-		logutil.LogError(logger, commandName, generatePresentationCommandMethod,
+		logutil.LogError(logger, CommandName, GeneratePresentationCommandMethod,
 			"parse presentation request: "+err.Error())
 
 		return command.NewValidationError(GeneratePresentationErrorCode,
@@ -560,24 +560,24 @@ func (o *Command) GeneratePresentationByID(rw io.Writer, req io.Reader) command.
 
 	err := json.NewDecoder(req).Decode(&request)
 	if err != nil {
-		logutil.LogInfo(logger, commandName, generatePresentationCommandMethod, "request decode : "+err.Error())
+		logutil.LogInfo(logger, CommandName, GeneratePresentationCommandMethod, "request decode : "+err.Error())
 
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf("request decode : %w", err))
 	}
 
 	if request.ID == "" {
-		logutil.LogDebug(logger, commandName, getCredentialByNameCommandMethod, errEmptyCredentialID)
+		logutil.LogDebug(logger, CommandName, GetCredentialByNameCommandMethod, errEmptyCredentialID)
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyCredentialID))
 	}
 
 	if request.DID == "" {
-		logutil.LogDebug(logger, commandName, getCredentialByNameCommandMethod, errEmptyDID)
+		logutil.LogDebug(logger, CommandName, GetCredentialByNameCommandMethod, errEmptyDID)
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyDID))
 	}
 
 	vc, err := o.verifiableStore.GetCredential(request.ID)
 	if err != nil {
-		logutil.LogError(logger, commandName, getCredentialByNameCommandMethod, "get vc by id : "+err.Error(),
+		logutil.LogError(logger, CommandName, GetCredentialByNameCommandMethod, "get vc by id : "+err.Error(),
 			logutil.CreateKeyValueString(vcID, request.ID))
 
 		return command.NewValidationError(GeneratePresentationByIDErrorCode, fmt.Errorf("get vc by id : %w", err))
@@ -585,7 +585,7 @@ func (o *Command) GeneratePresentationByID(rw io.Writer, req io.Reader) command.
 
 	doc, err := o.didStore.GetDID(request.DID)
 	if err != nil {
-		logutil.LogError(logger, commandName, generatePresentationCommandMethod,
+		logutil.LogError(logger, CommandName, GeneratePresentationCommandMethod,
 			"failed to get did doc from store: "+err.Error())
 
 		return command.NewValidationError(GeneratePresentationErrorCode,
@@ -600,7 +600,7 @@ func (o *Command) generatePresentation(rw io.Writer, vcs []interface{}, p *verif
 	// prepare vp
 	vp, err := o.createAndSignPresentation(vcs, p, holder, opts)
 	if err != nil {
-		logutil.LogError(logger, commandName, generatePresentationCommandMethod, "create and sign vp: "+err.Error())
+		logutil.LogError(logger, CommandName, GeneratePresentationCommandMethod, "create and sign vp: "+err.Error())
 
 		return command.NewValidationError(GeneratePresentationByIDErrorCode, fmt.Errorf("prepare vp: %w", err))
 	}
@@ -609,7 +609,7 @@ func (o *Command) generatePresentation(rw io.Writer, vcs []interface{}, p *verif
 		VerifiablePresentation: vp,
 	}, logger)
 
-	logutil.LogDebug(logger, commandName, generatePresentationCommandMethod, "success")
+	logutil.LogDebug(logger, CommandName, GeneratePresentationCommandMethod, "success")
 
 	return nil
 }
@@ -619,7 +619,7 @@ func (o *Command) generatePresentationByID(rw io.Writer, vc *verifiable.Credenti
 	// prepare vp by id
 	vp, err := o.createAndSignPresentationByID(vc, didDoc, signatureType)
 	if err != nil {
-		logutil.LogError(logger, commandName, generatePresentationCommandMethod, "create and sign vp by id: "+err.Error())
+		logutil.LogError(logger, CommandName, GeneratePresentationCommandMethod, "create and sign vp by id: "+err.Error())
 
 		return command.NewValidationError(GeneratePresentationByIDErrorCode, fmt.Errorf("prepare vp by id: %w", err))
 	}
@@ -629,7 +629,7 @@ func (o *Command) generatePresentationByID(rw io.Writer, vc *verifiable.Credenti
 		VerifiablePresentation: vp,
 	}, logger)
 
-	logutil.LogDebug(logger, commandName, generatePresentationCommandMethod, "success")
+	logutil.LogDebug(logger, CommandName, GeneratePresentationCommandMethod, "success")
 
 	return nil
 }
@@ -747,7 +747,7 @@ func (o *Command) parsePresentationRequest(request *PresentationRequest,
 
 			vc, e := verifiable.ParseCredential(vcRaw, credOpts...)
 			if e != nil {
-				logutil.LogError(logger, commandName, generatePresentationCommandMethod,
+				logutil.LogError(logger, CommandName, GeneratePresentationCommandMethod,
 					"failed to parse credential from request, invalid credential: "+e.Error())
 				return nil, nil, nil, fmt.Errorf("parse credential failed: %w", e)
 			}
@@ -757,7 +757,7 @@ func (o *Command) parsePresentationRequest(request *PresentationRequest,
 	} else {
 		presentation, err = verifiable.ParseUnverifiedPresentation(request.Presentation)
 		if err != nil {
-			logutil.LogError(logger, commandName, generatePresentationCommandMethod,
+			logutil.LogError(logger, CommandName, GeneratePresentationCommandMethod,
 				"failed to parse presentation from request: "+err.Error())
 			return nil, nil, nil, fmt.Errorf("parse presentation failed: %w", err)
 		}
@@ -765,7 +765,7 @@ func (o *Command) parsePresentationRequest(request *PresentationRequest,
 
 	opts, err := prepareOpts(request.ProofOptions, didDoc, did.Authentication)
 	if err != nil {
-		logutil.LogError(logger, commandName, generatePresentationCommandMethod,
+		logutil.LogError(logger, CommandName, GeneratePresentationCommandMethod,
 			"failed to prepare proof options: "+err.Error())
 		return nil, nil, nil, fmt.Errorf("failed to prepare proof options: %w", err)
 	}

--- a/pkg/controller/rest/messaging/models.go
+++ b/pkg/controller/rest/messaging/models.go
@@ -60,7 +60,7 @@ type SendReplyMessageRequest struct { // nolint: unused,deadcode
 
 // RegisterHTTPMessageServiceRequest model
 //
-// This is used for operation to register a HTTP over DIDComm message service to message handler
+// This is used for operation to register an HTTP over DIDComm message service to message handler
 //
 // swagger:parameters registerHttpMsgSvc
 type registerHTTPMessageServiceRequest struct { // nolint: unused,deadcode

--- a/pkg/controller/rest/verifiable/operation.go
+++ b/pkg/controller/rest/verifiable/operation.go
@@ -23,26 +23,27 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
+// constants for the Verifiable protocol
 const (
 	// roots
-	verifiableOperationID      = "/verifiable"
-	verifiableCredentialPath   = verifiableOperationID + "/credential"
-	verifiablePresentationPath = verifiableOperationID + "/presentation"
+	VerifiableOperationID      = "/verifiable"
+	verifiableCredentialPath   = VerifiableOperationID + "/credential"
+	verifiablePresentationPath = VerifiableOperationID + "/presentation"
 
 	// credential paths
-	validateCredentialPath  = verifiableCredentialPath + "/validate"
-	saveCredentialPath      = verifiableCredentialPath
-	getCredentialPath       = verifiableCredentialPath + "/{id}"
-	getCredentialByNamePath = verifiableCredentialPath + "/name" + "/{name}"
-	getCredentialsPath      = verifiableOperationID + "/credentials"
-	signCredentialsPath     = verifiableOperationID + "/signcredential"
+	ValidateCredentialPath  = verifiableCredentialPath + "/validate"
+	SaveCredentialPath      = verifiableCredentialPath
+	GetCredentialPath       = verifiableCredentialPath + "/{id}"
+	GetCredentialByNamePath = verifiableCredentialPath + "/name" + "/{name}"
+	GetCredentialsPath      = VerifiableOperationID + "/credentials"
+	SignCredentialsPath     = VerifiableOperationID + "/signcredential"
 
 	// presentation paths
-	generatePresentationPath     = verifiablePresentationPath + "/generate"
-	generatePresentationByIDPath = verifiablePresentationPath + "/generatebyid"
-	savePresentationPath         = verifiablePresentationPath
-	getPresentationPath          = verifiablePresentationPath + "/{id}"
-	getPresentationsPath         = verifiableOperationID + "/presentations"
+	GeneratePresentationPath     = verifiablePresentationPath + "/generate"
+	GeneratePresentationByIDPath = verifiablePresentationPath + "/generatebyid"
+	SavePresentationPath         = verifiablePresentationPath
+	GetPresentationPath          = verifiablePresentationPath + "/{id}"
+	GetPresentationsPath         = VerifiableOperationID + "/presentations"
 )
 
 // provider contains dependencies for the verifiable command and is typically created by using aries.Context().
@@ -80,17 +81,17 @@ func (o *Operation) GetRESTHandlers() []rest.Handler {
 // registerHandler register handlers to be exposed from this protocol service as REST API endpoints
 func (o *Operation) registerHandler() {
 	o.handlers = []rest.Handler{
-		cmdutil.NewHTTPHandler(validateCredentialPath, http.MethodPost, o.ValidateCredential),
-		cmdutil.NewHTTPHandler(saveCredentialPath, http.MethodPost, o.SaveCredential),
-		cmdutil.NewHTTPHandler(getCredentialPath, http.MethodGet, o.GetCredential),
-		cmdutil.NewHTTPHandler(getCredentialByNamePath, http.MethodGet, o.GetCredentialByName),
-		cmdutil.NewHTTPHandler(getCredentialsPath, http.MethodGet, o.GetCredentials),
-		cmdutil.NewHTTPHandler(signCredentialsPath, http.MethodPost, o.SignCredential),
-		cmdutil.NewHTTPHandler(generatePresentationPath, http.MethodPost, o.GeneratePresentation),
-		cmdutil.NewHTTPHandler(generatePresentationByIDPath, http.MethodPost, o.GeneratePresentationByID),
-		cmdutil.NewHTTPHandler(savePresentationPath, http.MethodPost, o.SavePresentation),
-		cmdutil.NewHTTPHandler(getPresentationPath, http.MethodGet, o.GetPresentation),
-		cmdutil.NewHTTPHandler(getPresentationsPath, http.MethodGet, o.GetPresentations),
+		cmdutil.NewHTTPHandler(ValidateCredentialPath, http.MethodPost, o.ValidateCredential),
+		cmdutil.NewHTTPHandler(SaveCredentialPath, http.MethodPost, o.SaveCredential),
+		cmdutil.NewHTTPHandler(GetCredentialPath, http.MethodGet, o.GetCredential),
+		cmdutil.NewHTTPHandler(GetCredentialByNamePath, http.MethodGet, o.GetCredentialByName),
+		cmdutil.NewHTTPHandler(GetCredentialsPath, http.MethodGet, o.GetCredentials),
+		cmdutil.NewHTTPHandler(SignCredentialsPath, http.MethodPost, o.SignCredential),
+		cmdutil.NewHTTPHandler(GeneratePresentationPath, http.MethodPost, o.GeneratePresentation),
+		cmdutil.NewHTTPHandler(GeneratePresentationByIDPath, http.MethodPost, o.GeneratePresentationByID),
+		cmdutil.NewHTTPHandler(SavePresentationPath, http.MethodPost, o.SavePresentation),
+		cmdutil.NewHTTPHandler(GetPresentationPath, http.MethodGet, o.GetPresentation),
+		cmdutil.NewHTTPHandler(GetPresentationsPath, http.MethodGet, o.GetPresentations),
 	}
 }
 

--- a/pkg/controller/rest/verifiable/operation_test.go
+++ b/pkg/controller/rest/verifiable/operation_test.go
@@ -234,7 +234,7 @@ func TestValidateVC(t *testing.T) {
 		jsonStr, err := json.Marshal(vcReq)
 		require.NoError(t, err)
 
-		handler := lookupHandler(t, cmd, validateCredentialPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, ValidateCredentialPath, http.MethodPost)
 		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
 		require.NoError(t, err)
 
@@ -256,7 +256,7 @@ func TestValidateVC(t *testing.T) {
 		var jsonStr = []byte(`{
 		}`)
 
-		handler := lookupHandler(t, cmd, validateCredentialPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, ValidateCredentialPath, http.MethodPost)
 		buf, code, err := sendRequestToHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
 		require.NoError(t, err)
 		require.NotEmpty(t, buf)
@@ -281,7 +281,7 @@ func TestSaveVC(t *testing.T) {
 		jsonStr, err := json.Marshal(vcReq)
 		require.NoError(t, err)
 
-		handler := lookupHandler(t, cmd, saveCredentialPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, SaveCredentialPath, http.MethodPost)
 		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
 		require.NoError(t, err)
 
@@ -304,7 +304,7 @@ func TestSaveVC(t *testing.T) {
 			"name" : "sample"
 		}`)
 
-		handler := lookupHandler(t, cmd, saveCredentialPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, SaveCredentialPath, http.MethodPost)
 		buf, code, err := sendRequestToHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
 		require.NoError(t, err)
 		require.NotEmpty(t, buf)
@@ -326,7 +326,7 @@ func TestGetVC(t *testing.T) {
 		require.NotNil(t, cmd)
 		fmt.Println(base64.StdEncoding.EncodeToString([]byte("http://example.edu/credentials/1989")))
 
-		handler := lookupHandler(t, cmd, getCredentialPath, http.MethodGet)
+		handler := lookupHandler(t, cmd, GetCredentialPath, http.MethodGet)
 		buf, err := getSuccessResponseFromHandler(handler, nil, fmt.Sprintf(`%s/%s`,
 			verifiableCredentialPath, base64.StdEncoding.EncodeToString([]byte("http://example.edu/credentials/1989"))))
 		require.NoError(t, err)
@@ -349,7 +349,7 @@ func TestGetVC(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
 
-		handler := lookupHandler(t, cmd, getCredentialPath, http.MethodGet)
+		handler := lookupHandler(t, cmd, GetCredentialPath, http.MethodGet)
 		buf, code, err := sendRequestToHandler(handler, nil, fmt.Sprintf(`%s/%s`, verifiableCredentialPath, "abc"))
 		require.NoError(t, err)
 		require.NotEmpty(t, buf)
@@ -374,12 +374,12 @@ func TestGetCredentialByName(t *testing.T) {
 		jsonStr, err := json.Marshal(vcReq)
 		require.NoError(t, err)
 
-		handler := lookupHandler(t, cmd, saveCredentialPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, SaveCredentialPath, http.MethodPost)
 		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
 		require.NoError(t, err)
 		require.NotEmpty(t, buf)
 
-		handler = lookupHandler(t, cmd, getCredentialByNamePath, http.MethodGet)
+		handler = lookupHandler(t, cmd, GetCredentialByNamePath, http.MethodGet)
 		buf, err = getSuccessResponseFromHandler(handler, nil, fmt.Sprintf(`%s/name/%s`,
 			verifiableCredentialPath, sampleCredentialName))
 		require.NoError(t, err)
@@ -401,7 +401,7 @@ func TestGetCredentialByName(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
 
-		handler := lookupHandler(t, cmd, getCredentialByNamePath, http.MethodGet)
+		handler := lookupHandler(t, cmd, GetCredentialByNamePath, http.MethodGet)
 		buf, code, err := sendRequestToHandler(handler, nil, fmt.Sprintf(`%s/name/%s`,
 			verifiableCredentialPath, sampleCredentialName))
 		require.NoError(t, err)
@@ -427,13 +427,13 @@ func TestGetCredentials(t *testing.T) {
 		jsonStr, err := json.Marshal(vcReq)
 		require.NoError(t, err)
 
-		handler := lookupHandler(t, cmd, saveCredentialPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, SaveCredentialPath, http.MethodPost)
 		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
 		require.NoError(t, err)
 		require.NotEmpty(t, buf)
 
-		handler = lookupHandler(t, cmd, getCredentialsPath, http.MethodGet)
-		buf, err = getSuccessResponseFromHandler(handler, nil, getCredentialsPath)
+		handler = lookupHandler(t, cmd, GetCredentialsPath, http.MethodGet)
+		buf, err = getSuccessResponseFromHandler(handler, nil, GetCredentialsPath)
 		require.NoError(t, err)
 
 		var response credentialRecordResult
@@ -484,7 +484,7 @@ func TestGeneratePresentation(t *testing.T) {
 		presReqBytes, err := json.Marshal(presReq)
 		require.NoError(t, err)
 
-		handler := lookupHandler(t, cmd, generatePresentationPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, GeneratePresentationPath, http.MethodPost)
 		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer(presReqBytes), handler.Path())
 		require.NoError(t, err, err)
 
@@ -510,7 +510,7 @@ func TestGeneratePresentation(t *testing.T) {
 		presReqBytes, err := json.Marshal(presReq)
 		require.NoError(t, err)
 
-		handler := lookupHandler(t, cmd, generatePresentationPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, GeneratePresentationPath, http.MethodPost)
 		buf, code, err := sendRequestToHandler(handler, bytes.NewBuffer(presReqBytes), handler.Path())
 		require.NoError(t, err)
 		require.NotEmpty(t, buf)
@@ -554,7 +554,7 @@ func TestGeneratePresentation(t *testing.T) {
 		presReqBytes, err := json.Marshal(presReq)
 		require.NoError(t, err)
 
-		handler := lookupHandler(t, cmd, generatePresentationPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, GeneratePresentationPath, http.MethodPost)
 		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer(presReqBytes), handler.Path())
 		require.NoError(t, err)
 
@@ -597,7 +597,7 @@ func TestGeneratePresentation(t *testing.T) {
 		presReqBytes, err := json.Marshal(presReq)
 		require.NoError(t, err)
 
-		handler := lookupHandler(t, cmd, generatePresentationPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, GeneratePresentationPath, http.MethodPost)
 		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer(presReqBytes), handler.Path())
 		require.NoError(t, err)
 
@@ -628,7 +628,7 @@ func TestGeneratePresentation(t *testing.T) {
             "did"  : "did:peer:21tDAKCERh95uGgKbJNHYp"
 		}`)
 
-		handler := lookupHandler(t, cmd, generatePresentationPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, GeneratePresentationPath, http.MethodPost)
 		buf, code, err := sendRequestToHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
 		require.NoError(t, err)
 		require.NotEmpty(t, buf)
@@ -674,7 +674,7 @@ func TestGeneratePresentationByID(t *testing.T) {
 		presReqBytes, err := json.Marshal(presReqByID)
 		require.NoError(t, err)
 
-		handler := lookupHandler(t, cmd, generatePresentationByIDPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, GeneratePresentationByIDPath, http.MethodPost)
 		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer(presReqBytes), handler.Path())
 		require.NoError(t, err)
 
@@ -693,7 +693,7 @@ func TestGeneratePresentationByID(t *testing.T) {
      		"did": "testDID"
 		}`)
 
-		handler := lookupHandler(t, cmd, generatePresentationByIDPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, GeneratePresentationByIDPath, http.MethodPost)
 		buf, code, err := sendRequestToHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
 		require.NoError(t, err)
 		require.NotEmpty(t, buf)
@@ -708,7 +708,7 @@ func TestGeneratePresentationByID(t *testing.T) {
      		"dids": "testDID"
 		}`)
 
-		handler := lookupHandler(t, cmd, generatePresentationByIDPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, GeneratePresentationByIDPath, http.MethodPost)
 		buf, code, err := sendRequestToHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
 		require.NoError(t, err)
 		require.NotEmpty(t, buf)
@@ -727,7 +727,7 @@ func TestSaveVP(t *testing.T) {
 		require.NotNil(t, cmd)
 
 		presentations := []string{udPresentation, udVerifiablePresentation}
-		handler := lookupHandler(t, cmd, savePresentationPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, SavePresentationPath, http.MethodPost)
 
 		for i, presentation := range presentations {
 			vpReq := verifiable.PresentationExt{
@@ -760,7 +760,7 @@ func TestSaveVP(t *testing.T) {
 			"name" : "sample"
 		}`)
 
-		handler := lookupHandler(t, cmd, savePresentationPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, SavePresentationPath, http.MethodPost)
 		buf, code, err := sendRequestToHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
 		require.NoError(t, err)
 		require.NotEmpty(t, buf)
@@ -781,7 +781,7 @@ func TestGetVP(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
 
-		handler := lookupHandler(t, cmd, savePresentationPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, SavePresentationPath, http.MethodPost)
 
 		vpReq := verifiable.PresentationExt{
 			Presentation: verifiable.Presentation{VerifiablePresentation: stringToJSONRaw(udPresentation)},
@@ -800,7 +800,7 @@ func TestGetVP(t *testing.T) {
 		// verify response
 		require.Empty(t, response)
 
-		handler = lookupHandler(t, cmd, getPresentationPath, http.MethodGet)
+		handler = lookupHandler(t, cmd, GetPresentationPath, http.MethodGet)
 
 		buf, err = getSuccessResponseFromHandler(handler, nil, fmt.Sprintf(`%s/%s`,
 			verifiablePresentationPath, base64.StdEncoding.EncodeToString([]byte(sampleVPID))))
@@ -824,7 +824,7 @@ func TestGetVP(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
 
-		handler := lookupHandler(t, cmd, getPresentationPath, http.MethodGet)
+		handler := lookupHandler(t, cmd, GetPresentationPath, http.MethodGet)
 		buf, code, err := sendRequestToHandler(handler, nil, fmt.Sprintf(`%s/%s`, verifiablePresentationPath, "abc"))
 		require.NoError(t, err)
 		require.NotEmpty(t, buf)
@@ -843,7 +843,7 @@ func TestGetPresentations(t *testing.T) {
 		require.NotNil(t, cmd)
 
 		presentations := []string{udPresentation, udVerifiablePresentation}
-		handler := lookupHandler(t, cmd, savePresentationPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, SavePresentationPath, http.MethodPost)
 
 		for i, presentation := range presentations {
 			vpReq := verifiable.PresentationExt{
@@ -864,8 +864,8 @@ func TestGetPresentations(t *testing.T) {
 			require.Empty(t, response)
 		}
 
-		handler = lookupHandler(t, cmd, getPresentationsPath, http.MethodGet)
-		buf, err := getSuccessResponseFromHandler(handler, nil, getPresentationsPath)
+		handler = lookupHandler(t, cmd, GetPresentationsPath, http.MethodGet)
+		buf, err := getSuccessResponseFromHandler(handler, nil, GetPresentationsPath)
 		require.NoError(t, err)
 
 		var response presentationRecordResult
@@ -915,7 +915,7 @@ func TestSignCredential(t *testing.T) {
 		reqBytes, err := json.Marshal(req)
 		require.NoError(t, err)
 
-		handler := lookupHandler(t, cmd, signCredentialsPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, SignCredentialsPath, http.MethodPost)
 		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer(reqBytes), handler.Path())
 		require.NoError(t, err, err)
 
@@ -944,7 +944,7 @@ func TestSignCredential(t *testing.T) {
 		reqBytes, err := json.Marshal(req)
 		require.NoError(t, err)
 
-		handler := lookupHandler(t, cmd, signCredentialsPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, SignCredentialsPath, http.MethodPost)
 		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer(reqBytes), handler.Path())
 		require.NoError(t, err)
 
@@ -985,7 +985,7 @@ func TestSignCredential(t *testing.T) {
 		reqBytes, err := json.Marshal(req)
 		require.NoError(t, err)
 
-		handler := lookupHandler(t, cmd, signCredentialsPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, SignCredentialsPath, http.MethodPost)
 		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer(reqBytes), handler.Path())
 		require.NoError(t, err)
 
@@ -1016,7 +1016,7 @@ func TestSignCredential(t *testing.T) {
             "did"  : "did:peer:21tDAKCERh95uGgKbJNHYp"
 		}`)
 
-		handler := lookupHandler(t, cmd, signCredentialsPath, http.MethodPost)
+		handler := lookupHandler(t, cmd, SignCredentialsPath, http.MethodPost)
 		buf, code, err := sendRequestToHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
 		require.NoError(t, err)
 		require.NotEmpty(t, buf)

--- a/test/bdd/pkg/outofband/outofband_controller_steps.go
+++ b/test/bdd/pkg/outofband/outofband_controller_steps.go
@@ -233,7 +233,7 @@ func (s *ControllerSteps) acceptRequestAndConnect(receiverID, senderID string) e
 func (s *ControllerSteps) constructOOBRequestWithNoAttachments(agentID string) error {
 	req, err := s.NewRequest(agentID)
 	if err != nil {
-		return fmt.Errorf("failed to create an out-of-bound request : %w", err)
+		return fmt.Errorf("failed to create an out-of-band request : %w", err)
 	}
 
 	s.pendingRequests[agentID] = req

--- a/test/bdd/pkg/outofband/outofband_sdk_steps.go
+++ b/test/bdd/pkg/outofband/outofband_sdk_steps.go
@@ -70,7 +70,7 @@ func (sdk *SDKSteps) constructOOBRequestWithNoAttachments(agentID string) error 
 
 	req, err := sdk.newRequest(agentID)
 	if err != nil {
-		return fmt.Errorf("failed to create an out-of-bound request : %w", err)
+		return fmt.Errorf("failed to create an out-of-band request : %w", err)
 	}
 
 	sdk.pendingRequests[agentID] = req


### PR DESCRIPTION
Signed-off-by: Tomisin Jenrola <tomisin.jenrola@securekey.com>

**Title:**
Added mobile binding wrappers for the Verifiable controller

**Description:**
Part of https://github.com/hyperledger/aries-framework-go/issues/1958
Part of https://github.com/hyperledger/aries-framework-go/issues/2005

Summary:

1. Added Verifiable controller interface with local and remote agent implementations
2. Added some documentation for Introduce, Verifiable and terminologies
3. Update code snippet in README
4. Added config options wrapper for Aries framework `Option`
5. Other minor changes and cleanups
