### PR TITLE
renamed transient store to protocol state store and appropriate usages

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -40,7 +40,7 @@ type provider interface {
 	LegacyKMS() legacykms.KeyManager
 	ServiceEndpoint() string
 	StorageProvider() storage.Provider
-	TransientStorageProvider() storage.Provider
+	ProtocolStateStorageProvider() storage.Provider
 }
 
 // Client enable access to didexchange api

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -47,8 +47,8 @@ func TestNew(t *testing.T) {
 		require.NotNil(t, svc)
 
 		_, err = New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -71,8 +71,8 @@ func TestNew(t *testing.T) {
 
 	t.Run("test route service cast error", func(t *testing.T) {
 		_, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: &mocksvc.MockDIDExchangeSvc{},
 				mediator.Coordination:   &mocksvc.MockDIDExchangeSvc{},
@@ -92,7 +92,7 @@ func TestNew(t *testing.T) {
 		require.NotNil(t, svc)
 
 		_, err = New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			StorageProviderValue: &mockstore.MockStoreProvider{
 				ErrOpenStoreHandle: fmt.Errorf("failed to open store")},
 			ServiceMap: map[string]interface{}{
@@ -104,7 +104,7 @@ func TestNew(t *testing.T) {
 		require.Contains(t, err.Error(), "failed to open store")
 	})
 
-	t.Run("test error from open transient store", func(t *testing.T) {
+	t.Run("test error from open protocol state store", func(t *testing.T) {
 		svc, err := didexchange.New(&mockprotocol.MockProvider{
 			ServiceMap: map[string]interface{}{
 				mediator.Coordination: &mockroute.MockMediatorSvc{},
@@ -115,15 +115,15 @@ func TestNew(t *testing.T) {
 
 		_, err = New(&mockprovider.Provider{
 			StorageProviderValue: mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: &mockstore.MockStoreProvider{
-				ErrOpenStoreHandle: fmt.Errorf("failed to open transient store")},
+			ProtocolStateStorageProviderValue: &mockstore.MockStoreProvider{
+				ErrOpenStoreHandle: fmt.Errorf("failed to open protocol state store")},
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
 			},
 			ServiceEndpointValue: "endpoint"})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to open transient store")
+		require.Contains(t, err.Error(), "failed to open protocol state store")
 	})
 }
 
@@ -138,8 +138,8 @@ func TestClient_CreateInvitation(t *testing.T) {
 		require.NotNil(t, svc)
 
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -167,8 +167,8 @@ func TestClient_CreateInvitation(t *testing.T) {
 		require.NotNil(t, svc)
 
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -196,8 +196,8 @@ func TestClient_CreateInvitation(t *testing.T) {
 		require.NotNil(t, svc)
 
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewCustomMockStoreProvider(store),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewCustomMockStoreProvider(store),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -222,8 +222,8 @@ func TestClient_CreateInvitation(t *testing.T) {
 		require.NotNil(t, svc)
 
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{RoutingKeys: routingKeys, RouterEndpoint: endpoint},
@@ -252,8 +252,8 @@ func TestClient_CreateInvitation(t *testing.T) {
 		require.NotNil(t, svc)
 
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{ConfigErr: errors.New("router config error")},
@@ -282,8 +282,8 @@ func TestClient_CreateInvitation(t *testing.T) {
 		require.NotNil(t, svc)
 
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination: &mockroute.MockMediatorSvc{
@@ -315,8 +315,8 @@ func TestClient_CreateInvitationWithDID(t *testing.T) {
 		require.NotNil(t, svc)
 
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -351,8 +351,8 @@ func TestClient_CreateInvitationWithDID(t *testing.T) {
 		require.NotNil(t, svc)
 
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewCustomMockStoreProvider(store),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewCustomMockStoreProvider(store),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -382,8 +382,8 @@ func TestClient_QueryConnectionByID(t *testing.T) {
 		require.NotNil(t, svc)
 
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -418,8 +418,8 @@ func TestClient_QueryConnectionByID(t *testing.T) {
 		}
 
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewCustomMockStoreProvider(store),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewCustomMockStoreProvider(store),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -447,8 +447,8 @@ func TestClient_QueryConnectionByID(t *testing.T) {
 		require.NotNil(t, svc)
 
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -478,8 +478,8 @@ func TestClient_GetConnection(t *testing.T) {
 		require.NotNil(t, svc)
 		s := &mockstore.MockStore{Store: make(map[string][]byte), ErrGet: ErrConnectionNotFound}
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -508,8 +508,8 @@ func TestClientGetConnectionAtState(t *testing.T) {
 
 	// create client
 	c, err := New(&mockprovider.Provider{
-		TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-		StorageProviderValue:          mockstore.NewMockStoreProvider(),
+		ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+		StorageProviderValue:              mockstore.NewMockStoreProvider(),
 		ServiceMap: map[string]interface{}{
 			didexchange.DIDExchange: svc,
 			mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -534,12 +534,12 @@ func TestClient_CreateConnection(t *testing.T) {
 		invitationDID := newPeerDID(t).ID
 		implicit := true
 		storageProvider := &mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 		}
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: storageProvider.TransientStorageProvider(),
-			StorageProviderValue:          storageProvider.StorageProvider(),
+			ProtocolStateStorageProviderValue: storageProvider.ProtocolStateStorageProvider(),
+			StorageProviderValue:              storageProvider.StorageProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: &mocksvc.MockDIDExchangeSvc{
 					CreateConnRecordFunc: func(r *connection.Record, td *did.Doc) error {
@@ -577,8 +577,8 @@ func TestClient_CreateConnection(t *testing.T) {
 
 	t.Run("test create connection - error", func(t *testing.T) {
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: &mocksvc.MockDIDExchangeSvc{
 					CreateConnRecordFunc: func(*connection.Record, *did.Doc) error {
@@ -611,8 +611,8 @@ func TestClient_RemoveConnection(t *testing.T) {
 		require.NotNil(t, svc)
 
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -644,8 +644,8 @@ func TestClient_RemoveConnection(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, svc)
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -662,8 +662,8 @@ func TestClient_RemoveConnection(t *testing.T) {
 func TestClient_HandleInvitation(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: &mocksvc.MockDIDExchangeSvc{},
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -682,8 +682,8 @@ func TestClient_HandleInvitation(t *testing.T) {
 
 	t.Run("test error from handle msg", func(t *testing.T) {
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: &mocksvc.MockDIDExchangeSvc{HandleFunc: func(msg service.DIDCommMsg) (string, error) {
 					return "", fmt.Errorf("handle error")
@@ -705,8 +705,8 @@ func TestClient_HandleInvitation(t *testing.T) {
 func TestClient_CreateImplicitInvitation(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: &mocksvc.MockDIDExchangeSvc{},
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -722,8 +722,8 @@ func TestClient_CreateImplicitInvitation(t *testing.T) {
 
 	t.Run("test error from service", func(t *testing.T) {
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: &mocksvc.MockDIDExchangeSvc{
 					ImplicitInvitationErr: errors.New("implicit error")},
@@ -746,8 +746,8 @@ func TestClient_CreateImplicitInvitationWithDID(t *testing.T) {
 
 	t.Run("test success", func(t *testing.T) {
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: &mocksvc.MockDIDExchangeSvc{},
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -763,8 +763,8 @@ func TestClient_CreateImplicitInvitationWithDID(t *testing.T) {
 
 	t.Run("test error from service", func(t *testing.T) {
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: &mocksvc.MockDIDExchangeSvc{
 					ImplicitInvitationErr: errors.New("implicit with DID error")},
@@ -782,8 +782,8 @@ func TestClient_CreateImplicitInvitationWithDID(t *testing.T) {
 
 	t.Run("test missing required DID info", func(t *testing.T) {
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: &mocksvc.MockDIDExchangeSvc{},
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -816,8 +816,8 @@ func TestClient_QueryConnectionsByParams(t *testing.T) {
 
 		storageProvider := mockstore.NewMockStoreProvider()
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          storageProvider,
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              storageProvider,
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -856,8 +856,8 @@ func TestClient_QueryConnectionsByParams(t *testing.T) {
 
 		storageProvider := mockstore.NewMockStoreProvider()
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          storageProvider,
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              storageProvider,
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -946,8 +946,8 @@ func TestClient_QueryConnectionsByParams(t *testing.T) {
 
 		storageProvider := mockstore.NewMockStoreProvider()
 		c, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			StorageProviderValue:          storageProvider,
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              storageProvider,
 			ServiceMap: map[string]interface{}{
 				didexchange.DIDExchange: svc,
 				mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -964,11 +964,11 @@ func TestClient_QueryConnectionsByParams(t *testing.T) {
 }
 
 func TestServiceEvents(t *testing.T) {
-	transientStore := mockstore.NewMockStoreProvider()
+	protocolStateStore := mockstore.NewMockStoreProvider()
 	store := mockstore.NewMockStoreProvider()
 	didExSvc, err := didexchange.New(&mockprotocol.MockProvider{
-		TransientStoreProvider: transientStore,
-		StoreProvider:          store,
+		ProtocolStateStoreProvider: protocolStateStore,
+		StoreProvider:              store,
 		ServiceMap: map[string]interface{}{
 			mediator.Coordination: &mockroute.MockMediatorSvc{},
 		},
@@ -977,8 +977,8 @@ func TestServiceEvents(t *testing.T) {
 
 	// create the client
 	c, err := New(&mockprovider.Provider{
-		TransientStorageProviderValue: transientStore,
-		StorageProviderValue:          store,
+		ProtocolStateStorageProviderValue: protocolStateStore,
+		StorageProviderValue:              store,
 		ServiceMap: map[string]interface{}{
 			didexchange.DIDExchange: didExSvc,
 			mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -1068,8 +1068,8 @@ func TestAcceptExchangeRequest(t *testing.T) {
 
 	// create the client
 	c, err := New(&mockprovider.Provider{
-		TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-		StorageProviderValue:          store,
+		ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+		StorageProviderValue:              store,
 		ServiceMap: map[string]interface{}{
 			didexchange.DIDExchange: didExSvc,
 			mediator.Coordination:   &mockroute.MockMediatorSvc{},
@@ -1161,8 +1161,8 @@ func TestAcceptInvitation(t *testing.T) {
 
 	// create the client
 	c, err := New(&mockprovider.Provider{
-		TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-		StorageProviderValue:          store,
+		ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+		StorageProviderValue:              store,
 		ServiceMap: map[string]interface{}{
 			didexchange.DIDExchange: didExSvc,
 			mediator.Coordination:   &mockroute.MockMediatorSvc{},

--- a/pkg/client/didexchange/example_test.go
+++ b/pkg/client/didexchange/example_test.go
@@ -122,11 +122,11 @@ func ExampleClient_CreateInvitationWithDID() {
 }
 
 func mockContext() provider {
-	transientStoreProvider := mockstore.NewMockStoreProvider()
+	protocolStateStoreProvider := mockstore.NewMockStoreProvider()
 	storeProvider := mockstore.NewMockStoreProvider()
 	mockProvider := &mockprotocol.MockProvider{
-		TransientStoreProvider: transientStoreProvider,
-		StoreProvider:          storeProvider,
+		ProtocolStateStoreProvider: protocolStateStoreProvider,
+		StoreProvider:              storeProvider,
 		ServiceMap: map[string]interface{}{
 			mediator.Coordination: &mockroute.MockMediatorSvc{},
 		},
@@ -138,9 +138,9 @@ func mockContext() provider {
 	}
 
 	context := &mockprovider.Provider{
-		LegacyKMSValue:                &mockkms.CloseableKMS{CreateSigningKeyValue: "sample-key"},
-		TransientStorageProviderValue: transientStoreProvider,
-		StorageProviderValue:          storeProvider,
+		LegacyKMSValue:                    &mockkms.CloseableKMS{CreateSigningKeyValue: "sample-key"},
+		ProtocolStateStorageProviderValue: protocolStateStoreProvider,
+		StorageProviderValue:              storeProvider,
 		ServiceMap: map[string]interface{}{
 			didexchange.DIDExchange: svc,
 			mediator.Coordination:   &mockroute.MockMediatorSvc{},

--- a/pkg/client/mediator/example_test.go
+++ b/pkg/client/mediator/example_test.go
@@ -101,11 +101,11 @@ func performDIDExchangeWithRouter(client *didexClient.Client) string {
 }
 
 func didClientMockContext() *mockprovider.Provider {
-	transientStoreProvider := mockstore.NewMockStoreProvider()
+	protocolStateStoreProvider := mockstore.NewMockStoreProvider()
 	storeProvider := mockstore.NewMockStoreProvider()
 	mockProvider := &mockprotocol.MockProvider{
-		TransientStoreProvider: transientStoreProvider,
-		StoreProvider:          storeProvider,
+		ProtocolStateStoreProvider: protocolStateStoreProvider,
+		StoreProvider:              storeProvider,
 		ServiceMap: map[string]interface{}{
 			mediator.Coordination: &mockroute.MockMediatorSvc{},
 		},
@@ -117,9 +117,9 @@ func didClientMockContext() *mockprovider.Provider {
 	}
 
 	context := &mockprovider.Provider{
-		LegacyKMSValue:                &mockkms.CloseableKMS{CreateSigningKeyValue: "sample-key"},
-		TransientStorageProviderValue: transientStoreProvider,
-		StorageProviderValue:          storeProvider,
+		LegacyKMSValue:                    &mockkms.CloseableKMS{CreateSigningKeyValue: "sample-key"},
+		ProtocolStateStorageProviderValue: protocolStateStoreProvider,
+		StorageProviderValue:              storeProvider,
 		ServiceMap: map[string]interface{}{
 			didexchange.DIDExchange: svc,
 			mediator.Coordination:   routeService(),

--- a/pkg/client/outofband/client_test.go
+++ b/pkg/client/outofband/client_test.go
@@ -512,9 +512,9 @@ type didcommMsg struct {
 
 func withTestProvider() *mockprovider.Provider {
 	return &mockprovider.Provider{
-		TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-		StorageProviderValue:          mockstore.NewMockStoreProvider(),
-		LegacyKMSValue:                &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
+		ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+		StorageProviderValue:              mockstore.NewMockStoreProvider(),
+		LegacyKMSValue:                    &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
 		ServiceMap: map[string]interface{}{
 			mediator.Coordination: &mockroute.MockMediatorSvc{},
 			outofband.Name:        &stubOOBService{},

--- a/pkg/client/outofband/example_test.go
+++ b/pkg/client/outofband/example_test.go
@@ -293,9 +293,9 @@ func ExampleClient_AcceptInvitation() { //nolint:gocyclo,gocognit
 
 func getContext(agent string) *mockprovider.Provider {
 	return &mockprovider.Provider{
-		LegacyKMSValue:                &mocklegacykms.CloseableKMS{},
-		StorageProviderValue:          mem.NewProvider(),
-		TransientStorageProviderValue: mem.NewProvider(),
+		LegacyKMSValue:                    &mocklegacykms.CloseableKMS{},
+		StorageProviderValue:              mem.NewProvider(),
+		ProtocolStateStorageProviderValue: mem.NewProvider(),
 		ServiceMap: map[string]interface{}{
 			outofband.Name: &stubOOBService{
 				Event: nil,

--- a/pkg/controller/command/didexchange/command.go
+++ b/pkg/controller/command/didexchange/command.go
@@ -90,7 +90,7 @@ type provider interface {
 	LegacyKMS() legacykms.KeyManager
 	ServiceEndpoint() string
 	StorageProvider() storage.Provider
-	TransientStorageProvider() storage.Provider
+	ProtocolStateStorageProvider() storage.Provider
 }
 
 // New returns new DID Exchange controller command instance

--- a/pkg/controller/command/didexchange/command_test.go
+++ b/pkg/controller/command/didexchange/command_test.go
@@ -500,7 +500,7 @@ func TestCommand_AcceptInvitation(t *testing.T) {
 	t.Run("test accept invitation complete flow", func(t *testing.T) {
 		store := mockstore.NewMockStoreProvider()
 		didExSvc, err := didexsvc.New(&protocol.MockProvider{
-			TransientStoreProvider: store,
+			ProtocolStateStoreProvider: store,
 			ServiceMap: map[string]interface{}{
 				mediator.Coordination: &mockroute.MockMediatorSvc{},
 			},
@@ -513,8 +513,8 @@ func TestCommand_AcceptInvitation(t *testing.T) {
 
 		// create the client
 		cmd, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: store,
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: store,
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
 			ServiceMap: map[string]interface{}{
 				didexsvc.DIDExchange:  didExSvc,
 				mediator.Coordination: &mockroute.MockMediatorSvc{},
@@ -721,11 +721,11 @@ func TestCommand_AcceptExchangeRequest(t *testing.T) {
 	})
 
 	t.Run("test accept exchange request complete flow", func(t *testing.T) {
-		transientStore := mockstore.NewMockStoreProvider()
+		protocolStateStore := mockstore.NewMockStoreProvider()
 		store := mockstore.NewMockStoreProvider()
 		didExSvc, err := didexsvc.New(
 			&protocol.MockProvider{
-				TransientStoreProvider: transientStore, StoreProvider: store,
+				ProtocolStateStoreProvider: protocolStateStore, StoreProvider: store,
 				ServiceMap: map[string]interface{}{
 					mediator.Coordination: &mockroute.MockMediatorSvc{},
 				},
@@ -739,8 +739,8 @@ func TestCommand_AcceptExchangeRequest(t *testing.T) {
 
 		// create the client
 		cmd, err := New(&mockprovider.Provider{
-			TransientStorageProviderValue: transientStore,
-			StorageProviderValue:          store,
+			ProtocolStateStorageProviderValue: protocolStateStore,
+			StorageProviderValue:              store,
 			ServiceMap: map[string]interface{}{
 				didexsvc.DIDExchange:  didExSvc,
 				mediator.Coordination: &mockroute.MockMediatorSvc{},
@@ -930,8 +930,8 @@ func TestCommand_RemoveConnection(t *testing.T) {
 
 func mockProvider() *mockprovider.Provider {
 	return &mockprovider.Provider{
-		TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-		StorageProviderValue:          mockstore.NewMockStoreProvider(),
+		ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+		StorageProviderValue:              mockstore.NewMockStoreProvider(),
 		ServiceMap: map[string]interface{}{
 			didexsvc.DIDExchange:  &mockdidexchange.MockDIDExchangeSvc{},
 			mediator.Coordination: &mockroute.MockMediatorSvc{},

--- a/pkg/controller/command/messaging/command.go
+++ b/pkg/controller/command/messaging/command.go
@@ -84,7 +84,7 @@ var errConnForDIDNotFound = fmt.Errorf(errMsgConnectionMatchingDIDNotFound)
 type provider interface {
 	VDRIRegistry() vdri.Registry
 	Messenger() service.Messenger
-	TransientStorageProvider() storage.Provider
+	ProtocolStateStorageProvider() storage.Provider
 	StorageProvider() storage.Provider
 	LegacyKMS() legacykms.KeyManager
 }

--- a/pkg/controller/rest/didexchange/operation.go
+++ b/pkg/controller/rest/didexchange/operation.go
@@ -42,7 +42,7 @@ type provider interface {
 	LegacyKMS() legacykms.KeyManager
 	ServiceEndpoint() string
 	StorageProvider() storage.Provider
-	TransientStorageProvider() storage.Provider
+	ProtocolStateStorageProvider() storage.Provider
 }
 
 // New returns new DID Exchange rest client protocol instance

--- a/pkg/controller/rest/didexchange/operation_test.go
+++ b/pkg/controller/rest/didexchange/operation_test.go
@@ -43,8 +43,8 @@ import (
 
 func TestOperation_GetAPIHandlers(t *testing.T) {
 	svc, err := New(&mockprovider.Provider{
-		TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-		StorageProviderValue:          mockstore.NewMockStoreProvider(),
+		ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+		StorageProviderValue:              mockstore.NewMockStoreProvider(),
 		ServiceMap: map[string]interface{}{
 			didexsvc.DIDExchange:  &mockdidexchange.MockDIDExchangeSvc{},
 			mediator.Coordination: &mockroute.MockMediatorSvc{},
@@ -409,8 +409,8 @@ func TestEmptyID(t *testing.T) {
 	const response = `{"code":2000,"message":"empty connection ID"}`
 
 	prov := &mockprovider.Provider{
-		TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-		StorageProviderValue:          mockstore.NewMockStoreProvider(),
+		ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+		StorageProviderValue:              mockstore.NewMockStoreProvider(),
 		ServiceMap: map[string]interface{}{
 			didexsvc.DIDExchange:  &mockdidexchange.MockDIDExchangeSvc{},
 			mediator.Coordination: &mockroute.MockMediatorSvc{},
@@ -477,7 +477,7 @@ type fails struct {
 }
 
 func getHandlerWithError(t *testing.T, lookup string, f *fails) rest.Handler {
-	transientStore := mockstore.MockStore{Store: make(map[string][]byte)}
+	protocolStateStore := mockstore.MockStore{Store: make(map[string][]byte)}
 	store := mockstore.MockStore{Store: make(map[string][]byte)}
 	connRec := &connection.Record{State: "complete", ConnectionID: "1234", ThreadID: "th1234"}
 
@@ -508,10 +508,10 @@ func getHandlerWithError(t *testing.T, lookup string, f *fails) rest.Handler {
 			},
 			mediator.Coordination: &mockroute.MockMediatorSvc{},
 		},
-		LegacyKMSValue:                &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
-		ServiceEndpointValue:          "endpoint",
-		TransientStorageProviderValue: &mockstore.MockStoreProvider{Store: &transientStore},
-		StorageProviderValue:          &mockstore.MockStoreProvider{Store: &store}},
+		LegacyKMSValue:                    &mockkms.CloseableKMS{CreateEncryptionKeyValue: "sample-key"},
+		ServiceEndpointValue:              "endpoint",
+		ProtocolStateStorageProviderValue: &mockstore.MockStoreProvider{Store: &protocolStateStore},
+		StorageProviderValue:              &mockstore.MockStoreProvider{Store: &store}},
 		webnotifier.NewHTTPNotifier(nil),
 		"", true,
 	)

--- a/pkg/controller/rest/messaging/operation.go
+++ b/pkg/controller/rest/messaging/operation.go
@@ -39,7 +39,7 @@ const (
 type provider interface {
 	VDRIRegistry() vdri.Registry
 	Messenger() service.Messenger
-	TransientStorageProvider() storage.Provider
+	ProtocolStateStorageProvider() storage.Provider
 	StorageProvider() storage.Provider
 	LegacyKMS() legacykms.KeyManager
 }

--- a/pkg/didcomm/protocol/didexchange/persistence_test.go
+++ b/pkg/didcomm/protocol/didexchange/persistence_test.go
@@ -68,7 +68,7 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 	t.Run("save connection record error", func(t *testing.T) {
 		const errMsg = "get error"
 		record, err := newConnectionStore(&protocol.MockProvider{
-			TransientStoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
+			ProtocolStateStoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
 				Store:  make(map[string][]byte),
 				ErrPut: fmt.Errorf(errMsg),
 			}),
@@ -82,7 +82,7 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 	t.Run("save connection record error", func(t *testing.T) {
 		const errMsg = "get error"
 		record, err := newConnectionStore(&protocol.MockProvider{
-			TransientStoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
+			ProtocolStateStoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
 				Store:  make(map[string][]byte),
 				ErrPut: fmt.Errorf(errMsg),
 			}),

--- a/pkg/didcomm/protocol/mediator/service.go
+++ b/pkg/didcomm/protocol/mediator/service.go
@@ -89,7 +89,7 @@ var ErrRouterNotRegistered = errors.New("router not registered")
 type provider interface {
 	OutboundDispatcher() dispatcher.Outbound
 	StorageProvider() storage.Provider
-	TransientStorageProvider() storage.Provider
+	ProtocolStateStorageProvider() storage.Provider
 	RouterEndpoint() string
 	LegacyKMS() legacykms.KeyManager
 	VDRIRegistry() vdri.Registry

--- a/pkg/didcomm/protocol/mediator/service_test.go
+++ b/pkg/didcomm/protocol/mediator/service_test.go
@@ -48,8 +48,8 @@ func TestServiceNew(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 		})
 		require.NoError(t, err)
 		require.Equal(t, Coordination, svc.Name())
@@ -82,8 +82,8 @@ func TestServiceHandleInbound(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 		})
 		require.NoError(t, err)
 
@@ -104,9 +104,9 @@ func TestServiceHandleOutbound(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
+			StorageProviderValue:              &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					require.Equal(t, myDID, MYDID)
@@ -165,8 +165,8 @@ func TestServiceHandleOutbound(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 		})
 		require.NoError(t, err)
 		s.connectionLookup = &connectionsStub{
@@ -188,8 +188,8 @@ func TestServiceHandleOutbound(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 		})
 		require.NoError(t, err)
 		s.connectionLookup = &connectionsStub{
@@ -212,10 +212,10 @@ func TestServiceRequestMsg(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		err = svc.RegisterActionEvent(make(chan service.DIDCommAction))
@@ -233,10 +233,10 @@ func TestServiceRequestMsg(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		msg := &service.DIDCommMsgMap{"@id": map[int]int{}}
@@ -256,10 +256,10 @@ func TestServiceRequestMsg(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			ServiceEndpointValue:          endpoint,
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			ServiceEndpointValue:              endpoint,
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSend: func(msg interface{}, senderVerKey string, des *service.Destination) error {
 					res, err := json.Marshal(msg)
@@ -295,8 +295,8 @@ func TestServiceRequestMsg(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			LegacyKMSValue: &mockkms.CloseableKMS{
 				CreateKeyErr: expected,
 			},
@@ -321,10 +321,10 @@ func TestEvents(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		events := make(chan service.DIDCommAction)
@@ -353,9 +353,9 @@ func TestEvents(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					dispatched <- struct{}{}
@@ -392,9 +392,9 @@ func TestEvents(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					dispatched <- struct{}{}
@@ -430,10 +430,10 @@ func TestEvents(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		_, err = svc.HandleInbound(generateRequestMsgPayload(t, "123"), "", "")
@@ -448,10 +448,10 @@ func TestEvents(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			ServiceEndpointValue:          "http://other.com",
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			ServiceEndpointValue:              "http://other.com",
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					res, err := json.Marshal(msg)
@@ -526,10 +526,10 @@ func TestServiceGrantMsg(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		msgID := randomID()
@@ -544,10 +544,10 @@ func TestServiceGrantMsg(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		msg := &service.DIDCommMsgMap{"@id": map[int]int{}}
@@ -564,10 +564,10 @@ func TestServiceUpdateKeyListMsg(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		msgID := randomID()
@@ -585,10 +585,10 @@ func TestServiceUpdateKeyListMsg(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		msg := &service.DIDCommMsgMap{"@id": map[int]int{}}
@@ -608,9 +608,9 @@ func TestServiceUpdateKeyListMsg(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSend: func(msg interface{}, senderVerKey string, des *service.Destination) error {
 					res, err := json.Marshal(msg)
@@ -654,10 +654,10 @@ func TestServiceKeylistUpdateResponseMsg(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		msgID := randomID()
@@ -676,10 +676,10 @@ func TestServiceKeylistUpdateResponseMsg(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		msg := &service.DIDCommMsgMap{"@id": map[int]int{}}
@@ -697,10 +697,10 @@ func TestServiceForwardMsg(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		err = svc.routeStore.Put(to, []byte("did:example:123"))
@@ -718,10 +718,10 @@ func TestServiceForwardMsg(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		msg := &service.DIDCommMsgMap{"@id": map[int]int{}}
@@ -739,10 +739,10 @@ func TestServiceForwardMsg(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		err = svc.handleForward(generateForwardMsgPayload(t, msgID, to, nil))
@@ -769,9 +769,9 @@ func TestServiceForwardMsg(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateForward: func(msg interface{}, des *service.Destination) error {
 					require.Equal(t, content, msg)
@@ -825,9 +825,9 @@ func TestMessagePickup(t *testing.T) {
 							require.Equal(t, content, message)
 							return nil
 						}}},
-				StorageProviderValue:          mockstore.NewMockStoreProvider(),
-				TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-				LegacyKMSValue:                &mockkms.CloseableKMS{},
+				StorageProviderValue:              mockstore.NewMockStoreProvider(),
+				ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+				LegacyKMSValue:                    &mockkms.CloseableKMS{},
 				OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 					ValidateForward: func(_ interface{}, _ *service.Destination) error {
 						return errors.New("websocket connection failed")
@@ -867,9 +867,9 @@ func TestMessagePickup(t *testing.T) {
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{
 					AddMessageErr: errors.New("add error"),
 				}},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateForward: func(_ interface{}, _ *service.Destination) error {
 					return errors.New("websocket connection failed")
@@ -904,9 +904,9 @@ func TestRegister(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
+			StorageProviderValue:              &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					require.Equal(t, myDID, MYDID)
@@ -950,8 +950,8 @@ func TestRegister(t *testing.T) {
 			StorageProviderValue: &mockstore.MockStoreProvider{
 				Store: &mockstore.MockStore{Store: s, ErrPut: errors.New("save error")},
 			},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					request, ok := msg.(*Request)
@@ -984,10 +984,10 @@ func TestRegister(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		connRec := &connection.Record{
@@ -1007,10 +1007,10 @@ func TestRegister(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		connRec := &connection.Record{
@@ -1032,9 +1032,9 @@ func TestRegister(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					return fmt.Errorf("error send")
@@ -1053,8 +1053,8 @@ func TestRegister(t *testing.T) {
 			},
 			StorageProviderValue: &mockstore.MockStoreProvider{
 				Store: &mockstore.MockStore{ErrGet: fmt.Errorf("get error")}},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					return fmt.Errorf("error send")
@@ -1075,8 +1075,8 @@ func TestUnregister(t *testing.T) {
 				ServiceMap: map[string]interface{}{
 					messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 				},
-				StorageProviderValue:          &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
-				TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+				StorageProviderValue:              &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
+				ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			},
 		)
 		require.NoError(t, err)
@@ -1097,7 +1097,7 @@ func TestUnregister(t *testing.T) {
 				StorageProviderValue: &mockstore.MockStoreProvider{
 					Store: &mockstore.MockStore{Store: s},
 				},
-				TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+				ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			},
 		)
 		require.NoError(t, err)
@@ -1117,7 +1117,7 @@ func TestUnregister(t *testing.T) {
 				StorageProviderValue: &mockstore.MockStoreProvider{
 					Store: &mockstore.MockStore{Store: s, ErrGet: errors.New("get error")},
 				},
-				TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+				ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			},
 		)
 		require.NoError(t, err)
@@ -1138,9 +1138,9 @@ func TestKeylistUpdate(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
+			StorageProviderValue:              &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					require.Equal(t, myDID, MYDID)
@@ -1191,9 +1191,9 @@ func TestKeylistUpdate(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
+			StorageProviderValue:              &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					require.Equal(t, myDID, MYDID)
@@ -1252,10 +1252,10 @@ func TestKeylistUpdate(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		connRec := &connection.Record{
@@ -1279,9 +1279,9 @@ func TestKeylistUpdate(t *testing.T) {
 			StorageProviderValue: &mockstore.MockStoreProvider{
 				Store: &mockstore.MockStore{Store: s, ErrGet: errors.New("get error")},
 			},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		err = svc.AddKey("recKey")
@@ -1299,10 +1299,10 @@ func TestConfig(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		require.NoError(t, svc.saveRouterConnectionID("connID-123"))
@@ -1323,10 +1323,10 @@ func TestConfig(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		conf, err := svc.Config()
@@ -1341,10 +1341,10 @@ func TestConfig(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		require.NoError(t, svc.saveRouterConnectionID("connID-123"))
@@ -1361,10 +1361,10 @@ func TestConfig(t *testing.T) {
 			ServiceMap: map[string]interface{}{
 				messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 			},
-			StorageProviderValue:          &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			StorageProviderValue:              &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		require.NoError(t, svc.saveRouterConnectionID("connID-123"))
@@ -1385,9 +1385,9 @@ func TestConfig(t *testing.T) {
 			StorageProviderValue: &mockstore.MockStoreProvider{
 				Store: &mockstore.MockStore{Store: s, ErrGet: errors.New("get error")},
 			},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			LegacyKMSValue:                &mockkms.CloseableKMS{},
-			OutboundDispatcherValue:       &mockdispatcher.MockOutbound{}})
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			LegacyKMSValue:                    &mockkms.CloseableKMS{},
+			OutboundDispatcherValue:           &mockdispatcher.MockOutbound{}})
 		require.NoError(t, err)
 
 		require.NoError(t, svc.saveRouterConnectionID("connID-123"))
@@ -1410,8 +1410,8 @@ func TestGetConnection(t *testing.T) {
 				ServiceMap: map[string]interface{}{
 					messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 				},
-				StorageProviderValue:          &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
-				TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+				StorageProviderValue:              &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
+				ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			},
 		)
 		require.NoError(t, err)
@@ -1430,8 +1430,8 @@ func TestGetConnection(t *testing.T) {
 				ServiceMap: map[string]interface{}{
 					messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 				},
-				StorageProviderValue:          &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
-				TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+				StorageProviderValue:              &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
+				ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			},
 		)
 		require.NoError(t, err)
@@ -1449,8 +1449,8 @@ func TestGetConnection(t *testing.T) {
 				ServiceMap: map[string]interface{}{
 					messagepickup.MessagePickup: &mockmessagep.MockMessagePickupSvc{},
 				},
-				StorageProviderValue:          &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
-				TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+				StorageProviderValue:              &mockstore.MockStoreProvider{Store: &mockstore.MockStore{Store: s}},
+				ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			},
 		)
 		require.NoError(t, err)
@@ -1473,7 +1473,7 @@ func TestGetConnection(t *testing.T) {
 				StorageProviderValue: &mockstore.MockStoreProvider{
 					Store: &mockstore.MockStore{Store: s, ErrGet: errors.New("get error")},
 				},
-				TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+				ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			},
 		)
 		require.NoError(t, err)

--- a/pkg/didcomm/protocol/messagepickup/service.go
+++ b/pkg/didcomm/protocol/messagepickup/service.go
@@ -57,7 +57,7 @@ var logger = log.New("aries-framework/messagepickup")
 type provider interface {
 	OutboundDispatcher() dispatcher.Outbound
 	StorageProvider() storage.Provider
-	TransientStorageProvider() storage.Provider
+	ProtocolStateStorageProvider() storage.Provider
 }
 
 type connections interface {

--- a/pkg/didcomm/protocol/messagepickup/service_test.go
+++ b/pkg/didcomm/protocol/messagepickup/service_test.go
@@ -42,8 +42,8 @@ func TestServiceNew(t *testing.T) {
 		svc, err := New(&mockprovider.Provider{
 			StorageProviderValue: &mockstore.MockStoreProvider{
 				ErrOpenStoreHandle: fmt.Errorf("error opening the store")},
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			OutboundDispatcherValue:       nil,
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			OutboundDispatcherValue:           nil,
 		}, &mockTransportProvider{
 			packagerValue: &mockPackager{},
 		})
@@ -139,8 +139,8 @@ func TestHandleInbound(t *testing.T) {
 		require.NoError(t, err)
 
 		svc, err := New(&mockprovider.Provider{
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					require.Equal(t, myDID, MYDID)
@@ -231,8 +231,8 @@ func TestHandleInbound(t *testing.T) {
 		require.NoError(t, err)
 
 		svc, err := New(&mockprovider.Provider{
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					require.Equal(t, myDID, MYDID)
@@ -302,9 +302,9 @@ func TestHandleInbound(t *testing.T) {
 	t.Run("test MessagePickupService.HandleInbound() - BatchPickup - get error", func(t *testing.T) {
 		mockStore := mockstore.NewMockStoreProvider()
 		svc, err := New(&mockprovider.Provider{
-			StorageProviderValue:          mockStore,
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			OutboundDispatcherValue:       nil,
+			StorageProviderValue:              mockStore,
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			OutboundDispatcherValue:           nil,
 		}, &mockTransportProvider{
 			packagerValue: &mockPackager{},
 		})
@@ -328,9 +328,9 @@ func TestHandleInbound(t *testing.T) {
 	t.Run("test MessagePickupService.pullMessages() - put inbox error", func(t *testing.T) {
 		mockStore := mockstore.NewMockStoreProvider()
 		svc, err := New(&mockprovider.Provider{
-			StorageProviderValue:          mockStore,
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			OutboundDispatcherValue:       nil,
+			StorageProviderValue:              mockStore,
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			OutboundDispatcherValue:           nil,
 		}, &mockTransportProvider{
 			packagerValue: &mockPackager{},
 		})
@@ -451,9 +451,9 @@ func TestAddMessage(t *testing.T) {
 	t.Run("test MessagePickupService.AddMessage() - success", func(t *testing.T) {
 		mockStore := mockstore.NewMockStoreProvider()
 		svc, err := New(&mockprovider.Provider{
-			StorageProviderValue:          mockStore,
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			OutboundDispatcherValue:       nil,
+			StorageProviderValue:              mockStore,
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			OutboundDispatcherValue:           nil,
 		}, &mockTransportProvider{
 			packagerValue: &mockPackager{},
 		})
@@ -500,9 +500,9 @@ func TestAddMessage(t *testing.T) {
 	t.Run("test MessagePickupService.AddMessage() - put error", func(t *testing.T) {
 		mockStore := mockstore.NewMockStoreProvider()
 		svc, err := New(&mockprovider.Provider{
-			StorageProviderValue:          mockStore,
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			OutboundDispatcherValue:       nil,
+			StorageProviderValue:              mockStore,
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			OutboundDispatcherValue:           nil,
 		}, &mockTransportProvider{
 			packagerValue: &mockPackager{},
 		})
@@ -529,9 +529,9 @@ func TestAddMessage(t *testing.T) {
 	t.Run("test MessagePickupService.AddMessage() - get error", func(t *testing.T) {
 		mockStore := mockstore.NewMockStoreProvider()
 		svc, err := New(&mockprovider.Provider{
-			StorageProviderValue:          mockStore,
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-			OutboundDispatcherValue:       nil,
+			StorageProviderValue:              mockStore,
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			OutboundDispatcherValue:           nil,
 		}, &mockTransportProvider{
 			packagerValue: &mockPackager{},
 		})
@@ -553,8 +553,8 @@ func TestStatusRequest(t *testing.T) {
 		s := make(map[string][]byte)
 
 		provider := &mockprovider.Provider{
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					require.Equal(t, myDID, MYDID)
@@ -629,8 +629,8 @@ func TestStatusRequest(t *testing.T) {
 		s := make(map[string][]byte)
 
 		provider := &mockprovider.Provider{
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					return errors.New("send error")
@@ -666,8 +666,8 @@ func TestBatchPickup(t *testing.T) {
 		s := make(map[string][]byte)
 
 		provider := &mockprovider.Provider{
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					require.Equal(t, myDID, MYDID)
@@ -746,8 +746,8 @@ func TestBatchPickup(t *testing.T) {
 		s := make(map[string][]byte)
 
 		provider := &mockprovider.Provider{
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					return errors.New("send error")
@@ -819,8 +819,8 @@ func TestNoop(t *testing.T) {
 		s := make(map[string][]byte)
 
 		provider := &mockprovider.Provider{
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					require.Equal(t, myDID, MYDID)
@@ -858,8 +858,8 @@ func TestNoop(t *testing.T) {
 		s := make(map[string][]byte)
 
 		provider := &mockprovider.Provider{
-			StorageProviderValue:          mockstore.NewMockStoreProvider(),
-			TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
 			OutboundDispatcherValue: &mockdispatcher.MockOutbound{
 				ValidateSendToDID: func(msg interface{}, myDID, theirDID string) error {
 					return errors.New("send error")
@@ -924,9 +924,9 @@ func TestGetConnection(t *testing.T) {
 
 func getService() (*Service, error) {
 	svc, err := New(&mockprovider.Provider{
-		StorageProviderValue:          mockstore.NewMockStoreProvider(),
-		TransientStorageProviderValue: mockstore.NewMockStoreProvider(),
-		OutboundDispatcherValue:       nil,
+		StorageProviderValue:              mockstore.NewMockStoreProvider(),
+		ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+		OutboundDispatcherValue:           nil,
 	}, &mockTransportProvider{
 		packagerValue: &mockPackager{},
 	})

--- a/pkg/didcomm/protocol/outofband/service.go
+++ b/pkg/didcomm/protocol/outofband/service.go
@@ -108,7 +108,7 @@ type transitionalPayload struct {
 type Provider interface {
 	Service(id string) (interface{}, error)
 	StorageProvider() storage.Provider
-	TransientStorageProvider() storage.Provider
+	ProtocolStateStorageProvider() storage.Provider
 	OutboundMessageHandler() service.OutboundHandler
 }
 
@@ -124,7 +124,7 @@ func New(p Provider) (*Service, error) {
 		return nil, errors.New("failed to cast the didexchange service to satisfy our dependency")
 	}
 
-	store, err := p.TransientStorageProvider().OpenStore(Name)
+	store, err := p.ProtocolStateStorageProvider().OpenStore(Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open the store : %w", err)
 	}

--- a/pkg/didcomm/protocol/outofband/service_test.go
+++ b/pkg/didcomm/protocol/outofband/service_test.go
@@ -52,10 +52,10 @@ func TestNew(t *testing.T) {
 		_, err := New(provider)
 		require.Error(t, err)
 	})
-	t.Run("wraps error thrown from transient store when it cannot be opened", func(t *testing.T) {
+	t.Run("wraps error thrown from protocol state store when it cannot be opened", func(t *testing.T) {
 		expected := errors.New("test")
 		provider := testProvider()
-		provider.TransientStoreProvider = &mockstore.MockStoreProvider{
+		provider.ProtocolStateStoreProvider = &mockstore.MockStoreProvider{
 			ErrOpenStoreHandle: expected,
 		}
 		_, err := New(provider)
@@ -414,10 +414,10 @@ func TestHandleRequestCallback(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, errors.Is(err, expected))
 	})
-	t.Run("wraps error returned by the transient store", func(t *testing.T) {
+	t.Run("wraps error returned by the protocol state store", func(t *testing.T) {
 		expected := errors.New("test")
 		provider := testProvider()
-		provider.TransientStoreProvider = &mockstore.MockStoreProvider{
+		provider.ProtocolStateStoreProvider = &mockstore.MockStoreProvider{
 			Store: &mockstore.MockStore{
 				ErrPut: expected,
 			},
@@ -478,11 +478,11 @@ func TestHandleDIDEvent(t *testing.T) {
 			t.Error("timeout")
 		}
 	})
-	t.Run("wraps error returned by the transient store", func(t *testing.T) {
+	t.Run("wraps error returned by the protocol state store", func(t *testing.T) {
 		expected := errors.New("test")
 		const connID = "123"
 		provider := testProvider()
-		provider.TransientStoreProvider = &mockstore.MockStoreProvider{
+		provider.ProtocolStateStoreProvider = &mockstore.MockStoreProvider{
 			Store: &mockstore.MockStore{
 				Store:  make(map[string][]byte),
 				ErrGet: expected,
@@ -605,7 +605,7 @@ func TestHandleDIDEvent(t *testing.T) {
 			))
 
 		s.store = &mockstore.MockStore{
-			Store:  provider.TransientStoreProvider.Store.Store,
+			Store:  provider.ProtocolStateStoreProvider.Store.Store,
 			ErrPut: expected,
 		}
 
@@ -1115,8 +1115,8 @@ func TestChooseTarget(t *testing.T) {
 
 func testProvider() *protocol.MockProvider {
 	return &protocol.MockProvider{
-		StoreProvider:          mockstore.NewMockStoreProvider(),
-		TransientStoreProvider: mockstore.NewMockStoreProvider(),
+		StoreProvider:              mockstore.NewMockStoreProvider(),
+		ProtocolStateStoreProvider: mockstore.NewMockStoreProvider(),
 		ServiceMap: map[string]interface{}{
 			didexchange.DIDExchange: &mockdidexchange.MockDIDExchangeSvc{},
 		},

--- a/pkg/framework/aries/api/protocol.go
+++ b/pkg/framework/aries/api/protocol.go
@@ -40,7 +40,7 @@ type Provider interface {
 	RouterEndpoint() string
 	VDRIRegistry() vdriapi.Registry
 	Signer() legacykms.Signer
-	TransientStorageProvider() storage.Provider
+	ProtocolStateStorageProvider() storage.Provider
 	InboundMessageHandler() didcommtransport.InboundMessageHandler
 	OutboundMessageHandler() service.OutboundHandler
 	VerifiableStore() verifiable.Store

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -191,9 +191,9 @@ func setAdditionalDefaultOpts(frameworkOpts *Aries) error {
 		}
 	}
 
-	if frameworkOpts.transientStoreProvider == nil {
+	if frameworkOpts.protocolStateStoreProvider == nil {
 		var err error
-		frameworkOpts.transientStoreProvider, err = transientStoreProvider()
+		frameworkOpts.protocolStateStoreProvider, err = protocolStateStoreProvider()
 
 		if err != nil {
 			return err

--- a/pkg/framework/aries/default_js_wasm.go
+++ b/pkg/framework/aries/default_js_wasm.go
@@ -22,7 +22,7 @@ func storeProvider() (storage.Provider, error) {
 	return storeProv, nil
 }
 
-func transientStoreProvider() (storage.Provider, error) {
+func protocolStateStoreProvider() (storage.Provider, error) {
 	storeProv, err := jsindexeddb.NewProvider("temp")
 	if err != nil {
 		return nil, fmt.Errorf("js indexeddb  provider initialization failed : %w", err)

--- a/pkg/framework/aries/default_srv.go
+++ b/pkg/framework/aries/default_srv.go
@@ -24,6 +24,6 @@ func storeProvider() (storage.Provider, error) {
 	return leveldb.NewProvider(dbPath), nil
 }
 
-func transientStoreProvider() (storage.Provider, error) {
+func protocolStateStoreProvider() (storage.Provider, error) {
 	return mem.NewProvider(), nil
 }

--- a/pkg/framework/aries/example_test.go
+++ b/pkg/framework/aries/example_test.go
@@ -18,7 +18,7 @@ func Example() {
 	framework, err := New(
 		WithInboundTransport(newMockInTransport()),
 		WithStoreProvider(newMockDBProvider()),
-		WithTransientStoreProvider(newMockDBProvider()),
+		WithProtocolStateStoreProvider(newMockDBProvider()),
 	)
 	if err != nil {
 		fmt.Println("failed to create framework")

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -39,33 +39,32 @@ const (
 
 // Aries provides access to the context being managed by the framework. The context can be used to create aries clients.
 type Aries struct {
-	storeProvider storage.Provider
-	// TODO Rename transient store to protocol state store https://github.com/hyperledger/aries-framework-go/issues/835
-	transientStoreProvider storage.Provider
-	protocolSvcCreators    []api.ProtocolSvcCreator
-	services               []dispatcher.ProtocolService
-	msgSvcProvider         api.MessageServiceProvider
-	outboundDispatcher     dispatcher.Outbound
-	messenger              service.MessengerHandler
-	outboundTransports     []transport.OutboundTransport
-	inboundTransports      []transport.InboundTransport
-	legacyKMSCreator       api.KMSCreator
-	legacyKMS              api.CloseableKMS
-	kms                    kms.KeyManager
-	kmsCreator             kms.Creator
-	secretLock             secretlock.Service
-	crypto                 crypto.Crypto
-	packagerCreator        packager.Creator
-	packager               commontransport.Packager
-	packerCreator          packer.LegacyCreator
-	packerCreators         []packer.LegacyCreator
-	primaryPacker          packer.Packer
-	packers                []packer.Packer
-	vdriRegistry           vdriapi.Registry
-	vdri                   []vdriapi.VDRI
-	verifiableStore        verifiable.Store
-	transportReturnRoute   string
-	id                     string
+	storeProvider              storage.Provider
+	protocolStateStoreProvider storage.Provider
+	protocolSvcCreators        []api.ProtocolSvcCreator
+	services                   []dispatcher.ProtocolService
+	msgSvcProvider             api.MessageServiceProvider
+	outboundDispatcher         dispatcher.Outbound
+	messenger                  service.MessengerHandler
+	outboundTransports         []transport.OutboundTransport
+	inboundTransports          []transport.InboundTransport
+	legacyKMSCreator           api.KMSCreator
+	legacyKMS                  api.CloseableKMS
+	kms                        kms.KeyManager
+	kmsCreator                 kms.Creator
+	secretLock                 secretlock.Service
+	crypto                     crypto.Crypto
+	packagerCreator            packager.Creator
+	packager                   commontransport.Packager
+	packerCreator              packer.LegacyCreator
+	packerCreators             []packer.LegacyCreator
+	primaryPacker              packer.Packer
+	packers                    []packer.Packer
+	vdriRegistry               vdriapi.Registry
+	vdri                       []vdriapi.VDRI
+	verifiableStore            verifiable.Store
+	transportReturnRoute       string
+	id                         string
 }
 
 // Option configures the framework.
@@ -196,10 +195,10 @@ func WithStoreProvider(prov storage.Provider) Option {
 	}
 }
 
-// WithTransientStoreProvider injects a transient storage provider to the Aries framework.
-func WithTransientStoreProvider(prov storage.Provider) Option {
+// WithProtocolStateStoreProvider injects a protocol state storage provider to the Aries framework.
+func WithProtocolStateStoreProvider(prov storage.Provider) Option {
 	return func(opts *Aries) error {
-		opts.transientStoreProvider = prov
+		opts.protocolStateStoreProvider = prov
 		return nil
 	}
 }
@@ -296,7 +295,7 @@ func (a *Aries) Context() (*context.Provider, error) {
 		context.WithServiceEndpoint(serviceEndpoint(a)),
 		context.WithRouterEndpoint(routingEndpoint(a)),
 		context.WithStorageProvider(a.storeProvider),
-		context.WithTransientStorageProvider(a.transientStoreProvider),
+		context.WithProtocolStateStorageProvider(a.protocolStateStoreProvider),
 		context.WithPacker(a.primaryPacker, a.packers...),
 		context.WithPackager(a.packager),
 		context.WithVDRIRegistry(a.vdriRegistry),
@@ -329,8 +328,8 @@ func (a *Aries) Close() error {
 		}
 	}
 
-	if a.transientStoreProvider != nil {
-		err := a.transientStoreProvider.Close()
+	if a.protocolStateStoreProvider != nil {
+		err := a.protocolStateStoreProvider.Close()
 		if err != nil {
 			return fmt.Errorf("failed to close the store: %w", err)
 		}
@@ -495,7 +494,7 @@ func loadServices(frameworkOpts *Aries) error {
 		context.WithOutboundDispatcher(frameworkOpts.outboundDispatcher),
 		context.WithMessengerHandler(frameworkOpts.messenger),
 		context.WithStorageProvider(frameworkOpts.storeProvider),
-		context.WithTransientStorageProvider(frameworkOpts.transientStoreProvider),
+		context.WithProtocolStateStorageProvider(frameworkOpts.protocolStateStoreProvider),
 		context.WithLegacyKMS(frameworkOpts.legacyKMS),
 		context.WithCrypto(frameworkOpts.crypto),
 		context.WithPackager(frameworkOpts.packager),

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -544,16 +544,16 @@ func TestFramework(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("test transient store - with user provided transient store", func(t *testing.T) {
+	t.Run("test protocol state store - with user provided protocol state store", func(t *testing.T) {
 		path, cleanup := generateTempDir(t)
 		defer cleanup()
 		dbPath = path
 		s := storage.NewMockStoreProvider()
 
-		aries, err := New(WithInboundTransport(&mockInboundTransport{}), WithTransientStoreProvider(s))
+		aries, err := New(WithInboundTransport(&mockInboundTransport{}), WithProtocolStateStoreProvider(s))
 		require.NoError(t, err)
 		require.NotEmpty(t, aries)
-		require.Equal(t, s, aries.transientStoreProvider)
+		require.Equal(t, s, aries.protocolStateStoreProvider)
 	})
 
 	t.Run("test new with outbound transport service", func(t *testing.T) {

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -29,26 +29,26 @@ import (
 
 // Provider supplies the framework configuration to client objects.
 type Provider struct {
-	services               []dispatcher.ProtocolService
-	msgSvcProvider         api.MessageServiceProvider
-	storeProvider          storage.Provider
-	transientStoreProvider storage.Provider
-	legacyKMS              legacykms.KMS
-	kms                    kms.KeyManager
-	secretLock             secretlock.Service
-	crypto                 crypto.Crypto
-	packager               commontransport.Packager
-	primaryPacker          packer.Packer
-	packers                []packer.Packer
-	serviceEndpoint        string
-	routerEndpoint         string
-	outboundDispatcher     dispatcher.Outbound
-	messenger              service.MessengerHandler
-	outboundTransports     []transport.OutboundTransport
-	vdriRegistry           vdriapi.Registry
-	verifiableStore        verifiable.Store
-	transportReturnRoute   string
-	frameworkID            string
+	services                   []dispatcher.ProtocolService
+	msgSvcProvider             api.MessageServiceProvider
+	storeProvider              storage.Provider
+	protocolStateStoreProvider storage.Provider
+	legacyKMS                  legacykms.KMS
+	kms                        kms.KeyManager
+	secretLock                 secretlock.Service
+	crypto                     crypto.Crypto
+	packager                   commontransport.Packager
+	primaryPacker              packer.Packer
+	packers                    []packer.Packer
+	serviceEndpoint            string
+	routerEndpoint             string
+	outboundDispatcher         dispatcher.Outbound
+	messenger                  service.MessengerHandler
+	outboundTransports         []transport.OutboundTransport
+	vdriRegistry               vdriapi.Registry
+	verifiableStore            verifiable.Store
+	transportReturnRoute       string
+	frameworkID                string
 }
 
 type outboundHandler struct {
@@ -218,9 +218,9 @@ func (p *Provider) StorageProvider() storage.Provider {
 	return p.storeProvider
 }
 
-// TransientStorageProvider return a transient storage provider.
-func (p *Provider) TransientStorageProvider() storage.Provider {
-	return p.transientStoreProvider
+// ProtocolStateStorageProvider return a protocol state storage provider.
+func (p *Provider) ProtocolStateStorageProvider() storage.Provider {
+	return p.protocolStateStoreProvider
 }
 
 // VDRIRegistry returns a vdri registry
@@ -350,10 +350,10 @@ func WithStorageProvider(s storage.Provider) ProviderOption {
 	}
 }
 
-// WithTransientStorageProvider injects a transient storage provider into the context.
-func WithTransientStorageProvider(s storage.Provider) ProviderOption {
+// WithProtocolStateStorageProvider injects a protocol state storage provider into the context.
+func WithProtocolStateStorageProvider(s storage.Provider) ProviderOption {
 	return func(opts *Provider) error {
-		opts.transientStoreProvider = s
+		opts.protocolStateStoreProvider = s
 		return nil
 	}
 }

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -340,11 +340,11 @@ func TestNewProvider(t *testing.T) {
 		require.Equal(t, s, prov.StorageProvider())
 	})
 
-	t.Run("test new with transient storage provider", func(t *testing.T) {
+	t.Run("test new with protocol state storage provider", func(t *testing.T) {
 		s := storage.NewMockStoreProvider()
-		prov, err := New(WithTransientStorageProvider(s))
+		prov, err := New(WithProtocolStateStorageProvider(s))
 		require.NoError(t, err)
-		require.Equal(t, s, prov.TransientStorageProvider())
+		require.Equal(t, s, prov.ProtocolStateStorageProvider())
 	})
 
 	t.Run("test new with vdri", func(t *testing.T) {

--- a/pkg/mock/didcomm/protocol/didexchange/mock_didexchange.go
+++ b/pkg/mock/didcomm/protocol/didexchange/mock_didexchange.go
@@ -171,9 +171,9 @@ func (m *MockDIDExchangeSvc) CreateConnection(r *connection.Record, theirDID *di
 
 // MockProvider is provider for DIDExchange Service
 type MockProvider struct {
-	StoreProvider          *mockstore.MockStoreProvider
-	TransientStoreProvider *mockstore.MockStoreProvider
-	CustomVDRI             vdriapi.Registry
+	StoreProvider              *mockstore.MockStoreProvider
+	ProtocolStateStoreProvider *mockstore.MockStoreProvider
+	CustomVDRI                 vdriapi.Registry
 }
 
 // OutboundDispatcher is mock outbound dispatcher for DID exchange service
@@ -190,10 +190,10 @@ func (p *MockProvider) StorageProvider() storage.Provider {
 	return mockstore.NewMockStoreProvider()
 }
 
-// TransientStorageProvider is mock transient storage provider for DID exchange service
-func (p *MockProvider) TransientStorageProvider() storage.Provider {
-	if p.TransientStoreProvider != nil {
-		return p.TransientStoreProvider
+// ProtocolStateStorageProvider is mock protocol state storage provider for DID exchange service
+func (p *MockProvider) ProtocolStateStorageProvider() storage.Provider {
+	if p.ProtocolStateStoreProvider != nil {
+		return p.ProtocolStateStoreProvider
 	}
 
 	return mockstore.NewMockStoreProvider()

--- a/pkg/mock/didcomm/protocol/mock_protocol.go
+++ b/pkg/mock/didcomm/protocol/mock_protocol.go
@@ -22,16 +22,16 @@ import (
 
 // MockProvider is provider for DIDExchange Service
 type MockProvider struct {
-	StoreProvider          *mockstore.MockStoreProvider
-	TransientStoreProvider *mockstore.MockStoreProvider
-	CustomVDRI             vdriapi.Registry
-	CustomOutbound         *mockdispatcher.MockOutbound
-	CustomMessenger        *mockservice.MockMessenger
-	CustomKMS              *mockkms.CloseableKMS
-	ServiceErr             error
-	ServiceMap             map[string]interface{}
-	InboundMsgHandler      transport.InboundMessageHandler
-	OutboundMsgHandler     service.OutboundHandler
+	StoreProvider              *mockstore.MockStoreProvider
+	ProtocolStateStoreProvider *mockstore.MockStoreProvider
+	CustomVDRI                 vdriapi.Registry
+	CustomOutbound             *mockdispatcher.MockOutbound
+	CustomMessenger            *mockservice.MockMessenger
+	CustomKMS                  *mockkms.CloseableKMS
+	ServiceErr                 error
+	ServiceMap                 map[string]interface{}
+	InboundMsgHandler          transport.InboundMessageHandler
+	OutboundMsgHandler         service.OutboundHandler
 }
 
 // OutboundDispatcher is mock outbound dispatcher for DID exchange service
@@ -52,10 +52,10 @@ func (p *MockProvider) StorageProvider() storage.Provider {
 	return mockstore.NewMockStoreProvider()
 }
 
-// TransientStorageProvider is mock transient storage provider for DID exchange service
-func (p *MockProvider) TransientStorageProvider() storage.Provider {
-	if p.TransientStoreProvider != nil {
-		return p.TransientStoreProvider
+// ProtocolStateStorageProvider is mock protocol state storage provider for DID exchange service
+func (p *MockProvider) ProtocolStateStorageProvider() storage.Provider {
+	if p.ProtocolStateStoreProvider != nil {
+		return p.ProtocolStateStoreProvider
 	}
 
 	return mockstore.NewMockStoreProvider()

--- a/pkg/mock/provider/mock_provider.go
+++ b/pkg/mock/provider/mock_provider.go
@@ -17,19 +17,19 @@ import (
 
 // Provider mocks provider needed for did exchange service initialization
 type Provider struct {
-	ServiceValue                  interface{}
-	ServiceErr                    error
-	ServiceMap                    map[string]interface{}
-	KMSValue                      kms.KeyManager
-	LegacyKMSValue                legacykms.KMS
-	ServiceEndpointValue          string
-	StorageProviderValue          storage.Provider
-	TransientStorageProviderValue storage.Provider
-	PackerList                    []packer.Packer
-	PackerValue                   packer.Packer
-	OutboundDispatcherValue       dispatcher.Outbound
-	VDRIRegistryValue             vdriapi.Registry
-	CryptoValue                   crypto.Crypto
+	ServiceValue                      interface{}
+	ServiceErr                        error
+	ServiceMap                        map[string]interface{}
+	KMSValue                          kms.KeyManager
+	LegacyKMSValue                    legacykms.KMS
+	ServiceEndpointValue              string
+	StorageProviderValue              storage.Provider
+	ProtocolStateStorageProviderValue storage.Provider
+	PackerList                        []packer.Packer
+	PackerValue                       packer.Packer
+	OutboundDispatcherValue           dispatcher.Outbound
+	VDRIRegistryValue                 vdriapi.Registry
+	CryptoValue                       crypto.Crypto
 }
 
 // Service return service
@@ -75,9 +75,9 @@ func (p *Provider) StorageProvider() storage.Provider {
 	return p.StorageProviderValue
 }
 
-// TransientStorageProvider returns the transient storage provider
-func (p *Provider) TransientStorageProvider() storage.Provider {
-	return p.TransientStorageProviderValue
+// ProtocolStateStorageProvider returns the protocol state storage provider
+func (p *Provider) ProtocolStateStorageProvider() storage.Provider {
+	return p.ProtocolStateStorageProviderValue
 }
 
 // Packers returns the available Packer services


### PR DESCRIPTION
Signed-off-by: Kevin Griffin <griffin.kev@gmail.com>

**Title:**
rename transient store to protocol state store

**Description:**
cleaned up naming and usages

Summary:

closes #835 

