### PR TITLE
fix: Generate openapi spec

### DIFF
--- a/scripts/generate-openapi-spec.sh
+++ b/scripts/generate-openapi-spec.sh
@@ -7,19 +7,18 @@
 set -e
 
 SPEC_LOC="${SPEC_LOC}"
-SPEC_META="${SPEC_META:-cmd/aries-agent-rest}"
-OUTPUT="$PWD/$SPEC_LOC/openAPI.yml"
+SPEC_DIR="cmd/aries-agent-rest"
+WORKING_DIR="/opt"
+OUTPUT="$SPEC_LOC/openAPI.yml"
 IMAGE="${DOCKER_IMAGE:-quay.io/goswagger/swagger}"
 IMAGE_VERSION="${DOCKER_IMAGE_VERSION:-latest}"
 
-cd $SPEC_META
-
 # generate and validate commands
-GENERATE_COMMAND="generate spec main.go -o $OUTPUT"
+GENERATE_COMMAND="generate spec -w $SPEC_DIR -o $OUTPUT"
 VALIDATE_COMMAND="validate $OUTPUT"
 
 echo "Generating Open API spec"
-docker run --rm -v $HOME:$HOME -w $(pwd) ${IMAGE}:${IMAGE_VERSION} $GENERATE_COMMAND
+docker run --rm -v $(pwd):$WORKING_DIR -w $WORKING_DIR ${IMAGE}:${IMAGE_VERSION} $GENERATE_COMMAND
 
 echo "Validating generated spec"
-docker run --rm -v $HOME:$HOME -w $(pwd) ${IMAGE}:${IMAGE_VERSION} $VALIDATE_COMMAND
+docker run --rm -v $(pwd):$WORKING_DIR -w $WORKING_DIR ${IMAGE}:${IMAGE_VERSION} $VALIDATE_COMMAND


### PR DESCRIPTION
Allows generating openAPI spec outside the home directory.

for #2015 

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>