### PR TITLE
docs: added issue credential protocol and related terminologies

### DIFF
--- a/docs/concepts/00_what_is_hl_aries.md
+++ b/docs/concepts/00_what_is_hl_aries.md
@@ -31,6 +31,8 @@ _(5)_
 
 ### 3. IssueCredential Protocol
 
+This protocol enables an [issuer](./01_terminologies.md#issuer) to provide a [holder](./01_terminologies.md#holder) with a [verifiable credential](./01_terminologies.md#verifiable-credential). This process can be initiated by the issuer or holder. _(6)_
+
 ### 4. KMS
 
 ### 5. Mediator
@@ -55,3 +57,4 @@ This controller allows for the creation, retrieval, validation and signing of [v
 3. [Hyperledger Aries Wiki](https://wiki.hyperledger.org/display/ARIES/Hyperledger+Aries)
 4. [Aries RFCs - DIDExchange](https://github.com/hyperledger/aries-rfcs/tree/master/features/0023-did-exchange)
 5. [Aries RFCs - Introduce](https://github.com/hyperledger/aries-rfcs/tree/master/features/0028-introduce)
+6. [Aries RFCs - IssueCredential Choreography Diagram](https://github.com/hyperledger/aries-rfcs/tree/master/features/0453-issue-credential-v2#choreography-diagram)

--- a/docs/concepts/01_terminologies.md
+++ b/docs/concepts/01_terminologies.md
@@ -20,6 +20,13 @@ A DID document may also contain other attributes or claims describing the DID su
 
 _Reference: https://www.w3.org/TR/did-core/#dfn-did-documents_
 
+### Holder
+
+This is the entity to whom an [issuer](#issuer) issues a credential. Although the holder can request or propose that a credential be issued to them, they may not always be the subjects of a credential.
+
+### Issuer
+The entity that issues a [credential](#verifiable-credential) to a holder.
+
 ### Verifiable Credential
 
 A verifiable credential can represent all of the same information that a physical credential represents. It is a tamper-evident credential that has authorship that can be cryptographically verified.


### PR DESCRIPTION
Signed-off-by: Tomisin Jenrola <tomisin.jenrola@securekey.com>

**Title:**
Add docs for IssueCredential

**Description:**
Closes https://github.com/hyperledger/aries-framework-go/issues/2031

**Summary**:
Added:
- protocol defintion
- terminologies

