### PR TITLE
feat: updated verifiable controllers with the new methods

### DIFF
--- a/pkg/controller/command/verifiable/models.go
+++ b/pkg/controller/command/verifiable/models.go
@@ -111,3 +111,11 @@ type RecordResult struct {
 type Presentation struct {
 	VerifiablePresentation json.RawMessage `json:"verifiablePresentation,omitempty"`
 }
+
+// RemoveCredentialByNameResponse is a response model for removing a vc by name
+// from the verifiable store
+type RemoveCredentialByNameResponse struct{}
+
+// RemovePresentationByNameResponse is a response model for removing a vp by name
+// from the verifiable store
+type RemovePresentationByNameResponse struct{}

--- a/pkg/controller/rest/verifiable/models.go
+++ b/pkg/controller/rest/verifiable/models.go
@@ -28,7 +28,14 @@ type validateCredentialReq struct { // nolint: unused,deadcode
 // emptyRes model
 //
 // swagger:response emptyRes
-type emptyRes struct {
+type emptyRes struct{}
+
+// emptyResponse model
+//
+// swagger:response emptyResponse
+type emptyResponse struct { // nolint:unused,deadcode
+	// in: body
+	Body emptyRes
 }
 
 // saveCredentialReq model
@@ -97,6 +104,32 @@ type getPresentationReq struct { // nolint: unused,deadcode
 //
 // swagger:parameters getCredentialByNameReq
 type getCredentialByNameReq struct { // nolint: unused,deadcode
+	// VC Name
+	//
+	// in: path
+	// required: true
+	Name string `json:"name"`
+}
+
+// removeCredentialByNameReq model
+//
+// This is used to remove the verifiable credential by name.
+//
+// swagger:parameters removeCredentialByNameReq
+type removeCredentialByNameReq struct { // nolint: unused,deadcode
+	// VC Name
+	//
+	// in: path
+	// required: true
+	Name string `json:"name"`
+}
+
+// removePersentationByNameReq model
+//
+// This is used to remove the verifiable persentation by name.
+//
+// swagger:parameters removePersentationByNameReq
+type removePersentationByNameReq struct { // nolint: unused,deadcode
 	// VC Name
 	//
 	// in: path

--- a/pkg/controller/rest/verifiable/operation.go
+++ b/pkg/controller/rest/verifiable/operation.go
@@ -31,12 +31,13 @@ const (
 	verifiablePresentationPath = VerifiableOperationID + "/presentation"
 
 	// credential paths
-	ValidateCredentialPath  = verifiableCredentialPath + "/validate"
-	SaveCredentialPath      = verifiableCredentialPath
-	GetCredentialPath       = verifiableCredentialPath + "/{id}"
-	GetCredentialByNamePath = verifiableCredentialPath + "/name" + "/{name}"
-	GetCredentialsPath      = VerifiableOperationID + "/credentials"
-	SignCredentialsPath     = VerifiableOperationID + "/signcredential"
+	ValidateCredentialPath     = verifiableCredentialPath + "/validate"
+	SaveCredentialPath         = verifiableCredentialPath
+	GetCredentialPath          = verifiableCredentialPath + "/{id}"
+	GetCredentialByNamePath    = verifiableCredentialPath + "/name" + "/{name}"
+	GetCredentialsPath         = VerifiableOperationID + "/credentials"
+	SignCredentialsPath        = VerifiableOperationID + "/signcredential"
+	RemoveCredentialByNamePath = verifiableCredentialPath + "/remove/name" + "/{name}"
 
 	// presentation paths
 	GeneratePresentationPath     = verifiablePresentationPath + "/generate"
@@ -44,6 +45,7 @@ const (
 	SavePresentationPath         = verifiablePresentationPath
 	GetPresentationPath          = verifiablePresentationPath + "/{id}"
 	GetPresentationsPath         = VerifiableOperationID + "/presentations"
+	RemovePresentationByNamePath = verifiablePresentationPath + "/remove/name" + "/{name}"
 )
 
 // provider contains dependencies for the verifiable command and is typically created by using aries.Context().
@@ -92,6 +94,8 @@ func (o *Operation) registerHandler() {
 		cmdutil.NewHTTPHandler(SavePresentationPath, http.MethodPost, o.SavePresentation),
 		cmdutil.NewHTTPHandler(GetPresentationPath, http.MethodGet, o.GetPresentation),
 		cmdutil.NewHTTPHandler(GetPresentationsPath, http.MethodGet, o.GetPresentations),
+		cmdutil.NewHTTPHandler(RemoveCredentialByNamePath, http.MethodPost, o.RemoveCredentialByName),
+		cmdutil.NewHTTPHandler(RemovePresentationByNamePath, http.MethodPost, o.RemovePresentationByName),
 	}
 }
 
@@ -239,4 +243,34 @@ func (o *Operation) GeneratePresentation(rw http.ResponseWriter, req *http.Reque
 //        200: presentationRes
 func (o *Operation) GeneratePresentationByID(rw http.ResponseWriter, req *http.Request) {
 	rest.Execute(o.command.GeneratePresentationByID, rw, req.Body)
+}
+
+// RemoveCredentialByName swagger:route POST /verifiable/credential/remove/name/{name} verifiable removeCredentialByNameReq
+//
+// Removes a verifiable credential by name.
+//
+// Responses:
+//    default: genericError
+//        200: emptyResponse
+func (o *Operation) RemoveCredentialByName(rw http.ResponseWriter, req *http.Request) {
+	name := mux.Vars(req)["name"]
+
+	request := fmt.Sprintf(`{"name":"%s"}`, name)
+
+	rest.Execute(o.command.RemoveCredentialByName, rw, bytes.NewBufferString(request))
+}
+
+// RemovePresentationByName swagger:route POST /verifiable/presentation/remove/name/{name} verifiable removePersentationByNameReq
+//
+// Removes a verifiable presentation by name.
+//
+// Responses:
+//    default: genericError
+//        200: emptyResponse
+func (o *Operation) RemovePresentationByName(rw http.ResponseWriter, req *http.Request) {
+	name := mux.Vars(req)["name"]
+
+	request := fmt.Sprintf(`{"name":"%s"}`, name)
+
+	rest.Execute(o.command.RemovePresentationByName, rw, bytes.NewBufferString(request))
 }


### PR DESCRIPTION
Signed-off-by: Tomisin Jenrola <tomisin.jenrola@securekey.com>

**Title:**
Update verifiable controllers

**Description:**
Closes https://github.com/hyperledger/aries-framework-go/issues/2034

Summary:
- Implement the two methods recently added to the verifiable store.
- updated the command controller
- updated the rest controller

