### PR TITLE
test: Increases timeout

### DIFF
--- a/pkg/didcomm/transport/http/support_test.go
+++ b/pkg/didcomm/transport/http/support_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const certPrefix = "testdata/crypto/"
-const clientTimeout = 1 * time.Second
+const clientTimeout = 5 * time.Second
 
 func addCertsToCertPool(pool *x509.CertPool) error {
 	var rawCerts []string


### PR DESCRIPTION
Sometimes test is failed due to a timeout issue.
See https://github.com/hyperledger/aries-framework-go/runs/916239512#step:4:130

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>