### PR TITLE
feat: Present proof - fixes abandoned state transition to done

### DIFF
--- a/cmd/aries-agent-rest/startcmd/start_test.go
+++ b/cmd/aries-agent-rest/startcmd/start_test.go
@@ -7,7 +7,6 @@ package startcmd
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -129,7 +128,7 @@ func listenFor(host string) error {
 	for {
 		select {
 		case <-timeout:
-			return errors.New("timeout: server is not available")
+			return fmt.Errorf("timeout: %s is not available", host)
 		default:
 			conn, err := net.Dial("tcp", host)
 			if err != nil {

--- a/pkg/didcomm/protocol/presentproof/service.go
+++ b/pkg/didcomm/protocol/presentproof/service.go
@@ -309,7 +309,7 @@ func (s *Service) startInternalListener() {
 
 		logger.Errorf("failed to handle msgID=%s : %s", msg.Msg.ID(), msg.err)
 
-		msg.state = &abandoning{Code: codeInternalError}
+		msg.state = &abandoned{Code: codeInternalError}
 
 		if err := s.handle(msg); err != nil {
 			logger.Errorf("listener handle: %s", err)
@@ -397,8 +397,8 @@ func stateFromName(name string) state {
 	switch name {
 	case stateNameStart:
 		return &start{}
-	case stateNameAbandoning:
-		return &abandoning{}
+	case stateNameAbandoned:
+		return &abandoned{}
 	case stateNameDone:
 		return &done{}
 	case stateNameRequestSent:
@@ -438,7 +438,7 @@ func nextState(msg service.DIDCommMsgMap) (state, error) {
 	case PresentationMsgType:
 		return &presentationReceived{}, nil
 	case ProblemReportMsgType:
-		return &abandoning{}, nil
+		return &abandoned{}, nil
 	case AckMsgType:
 		return &done{}, nil
 	default:

--- a/pkg/didcomm/protocol/presentproof/states_test.go
+++ b/pkg/didcomm/protocol/presentproof/states_test.go
@@ -26,7 +26,7 @@ func TestStart_CanTransitionTo(t *testing.T) {
 	require.Equal(t, stateNameStart, st.Name())
 	// common states
 	require.False(t, st.CanTransitionTo(&start{}))
-	require.False(t, st.CanTransitionTo(&abandoning{}))
+	require.False(t, st.CanTransitionTo(&abandoned{}))
 	require.False(t, st.CanTransitionTo(&done{}))
 	require.False(t, st.CanTransitionTo(&noOp{}))
 	// states for Verifier
@@ -47,12 +47,12 @@ func TestStart_Execute(t *testing.T) {
 }
 
 func TestAbandoning_CanTransitionTo(t *testing.T) {
-	st := &abandoning{}
-	require.Equal(t, stateNameAbandoning, st.Name())
+	st := &abandoned{}
+	require.Equal(t, stateNameAbandoned, st.Name())
 	// common states
 	require.False(t, st.CanTransitionTo(&start{}))
-	require.False(t, st.CanTransitionTo(&abandoning{}))
-	require.True(t, st.CanTransitionTo(&done{}))
+	require.False(t, st.CanTransitionTo(&abandoned{}))
+	require.False(t, st.CanTransitionTo(&done{}))
 	require.False(t, st.CanTransitionTo(&noOp{}))
 	// states for Verifier
 	require.False(t, st.CanTransitionTo(&requestSent{}))
@@ -72,9 +72,9 @@ func TestAbandoning_Execute(t *testing.T) {
 		thID := uuid.New().String()
 		require.NoError(t, md.Msg.SetID(thID))
 
-		followup, action, err := (&abandoning{Code: codeInternalError}).Execute(md)
+		followup, action, err := (&abandoned{Code: codeInternalError}).Execute(md)
 		require.NoError(t, err)
-		require.Equal(t, &done{}, followup)
+		require.Equal(t, &noOp{}, followup)
 		require.NotNil(t, action)
 
 		ctrl := gomock.NewController(t)
@@ -96,7 +96,7 @@ func TestAbandoning_Execute(t *testing.T) {
 	})
 
 	t.Run("Invalid message", func(t *testing.T) {
-		followup, action, err := (&abandoning{Code: codeInternalError}).Execute(&metaData{})
+		followup, action, err := (&abandoned{Code: codeInternalError}).Execute(&metaData{})
 		require.EqualError(t, errors.Unwrap(err), service.ErrInvalidMessage.Error())
 		require.Nil(t, followup)
 		require.Nil(t, action)
@@ -109,9 +109,9 @@ func TestAbandoning_Execute(t *testing.T) {
 		thID := uuid.New().String()
 		require.NoError(t, md.Msg.SetID(thID))
 
-		followup, action, err := (&abandoning{Code: codeInternalError}).Execute(md)
+		followup, action, err := (&abandoned{Code: codeInternalError}).Execute(md)
 		require.NoError(t, err)
-		require.Equal(t, &done{}, followup)
+		require.Equal(t, &noOp{}, followup)
 		require.NotNil(t, action)
 
 		ctrl := gomock.NewController(t)
@@ -138,9 +138,9 @@ func TestAbandoning_Execute(t *testing.T) {
 
 		require.NoError(t, md.Msg.SetID(uuid.New().String()))
 
-		followup, action, err := (&abandoning{}).Execute(md)
+		followup, action, err := (&abandoned{}).Execute(md)
 		require.NoError(t, err)
-		require.Equal(t, &done{}, followup)
+		require.Equal(t, &noOp{}, followup)
 		require.NotNil(t, action)
 
 		require.NoError(t, action(nil))
@@ -178,7 +178,7 @@ func TestRequestReceived_CanTransitionTo(t *testing.T) {
 	require.Equal(t, stateNameRequestReceived, st.Name())
 	// common states
 	require.False(t, st.CanTransitionTo(&start{}))
-	require.True(t, st.CanTransitionTo(&abandoning{}))
+	require.True(t, st.CanTransitionTo(&abandoned{}))
 	require.False(t, st.CanTransitionTo(&done{}))
 	require.False(t, st.CanTransitionTo(&noOp{}))
 	// states for Verifier
@@ -242,7 +242,7 @@ func TestRequestSent_CanTransitionTo(t *testing.T) {
 	require.Equal(t, stateNameRequestSent, st.Name())
 	// common states
 	require.False(t, st.CanTransitionTo(&start{}))
-	require.True(t, st.CanTransitionTo(&abandoning{}))
+	require.True(t, st.CanTransitionTo(&abandoned{}))
 	require.False(t, st.CanTransitionTo(&done{}))
 	require.False(t, st.CanTransitionTo(&noOp{}))
 	// states for Verifier
@@ -329,7 +329,7 @@ func TestPresentationSent_CanTransitionTo(t *testing.T) {
 	require.Equal(t, stateNamePresentationSent, st.Name())
 	// common states
 	require.False(t, st.CanTransitionTo(&start{}))
-	require.True(t, st.CanTransitionTo(&abandoning{}))
+	require.True(t, st.CanTransitionTo(&abandoned{}))
 	require.True(t, st.CanTransitionTo(&done{}))
 	require.False(t, st.CanTransitionTo(&noOp{}))
 	// states for Verifier
@@ -371,7 +371,7 @@ func TestPresentationReceived_CanTransitionTo(t *testing.T) {
 	require.Equal(t, stateNamePresentationReceived, st.Name())
 	// common states
 	require.False(t, st.CanTransitionTo(&start{}))
-	require.True(t, st.CanTransitionTo(&abandoning{}))
+	require.True(t, st.CanTransitionTo(&abandoned{}))
 	require.True(t, st.CanTransitionTo(&done{}))
 	require.False(t, st.CanTransitionTo(&noOp{}))
 	// states for Verifier
@@ -420,7 +420,7 @@ func TestProposePresentationSent_CanTransitionTo(t *testing.T) {
 	require.Equal(t, stateNameProposalSent, st.Name())
 	// common states
 	require.False(t, st.CanTransitionTo(&start{}))
-	require.True(t, st.CanTransitionTo(&abandoning{}))
+	require.True(t, st.CanTransitionTo(&abandoned{}))
 	require.False(t, st.CanTransitionTo(&done{}))
 	require.False(t, st.CanTransitionTo(&noOp{}))
 	// states for Verifier
@@ -482,7 +482,7 @@ func TestProposePresentationReceived_CanTransitionTo(t *testing.T) {
 	require.Equal(t, stateNameProposalReceived, st.Name())
 	// common states
 	require.False(t, st.CanTransitionTo(&start{}))
-	require.True(t, st.CanTransitionTo(&abandoning{}))
+	require.True(t, st.CanTransitionTo(&abandoned{}))
 	require.False(t, st.CanTransitionTo(&done{}))
 	require.False(t, st.CanTransitionTo(&noOp{}))
 	// states for Verifier
@@ -507,7 +507,7 @@ func notTransition(t *testing.T, st state) {
 
 	var allState = [...]state{
 		// common states
-		&start{}, &abandoning{}, &done{}, &noOp{},
+		&start{}, &abandoned{}, &done{}, &noOp{},
 		// states for Verifier
 		&requestSent{}, &presentationReceived{}, &proposalReceived{},
 		// states for Prover

--- a/test/bdd/features/presentproof.feature
+++ b/test/bdd/features/presentproof.feature
@@ -21,15 +21,15 @@ Feature: Present Proof protocol
     Then "Thomas" sends a request presentation to the "Paul"
     And "Paul" accepts a request and sends a presentation to the "Thomas"
     And "Thomas" declines presentation
-    Then "Paul" checks the history of events "request-received,request-received,presentation-sent,presentation-sent,abandoning,abandoning,done,done"
-    And "Thomas" checks the history of events "request-sent,request-sent,abandoning,abandoning,done,done"
+    Then "Paul" checks the history of events "request-received,request-received,presentation-sent,presentation-sent,abandoned,abandoned"
+    And "Thomas" checks the history of events "request-sent,request-sent,abandoned,abandoned"
   @decline_request_presentation
   Scenario: The Prover declines a request presentation
     Given "Liam" exchange DIDs with "Samuel"
     Then "Liam" sends a request presentation to the "Samuel"
     And "Samuel" declines a request presentation
-    Then "Samuel" checks the history of events "abandoning,abandoning,done,done"
-    And "Liam" checks the history of events "request-sent,request-sent,abandoning,abandoning,done,done"
+    Then "Samuel" checks the history of events "abandoned,abandoned"
+    And "Liam" checks the history of events "request-sent,request-sent,abandoned,abandoned"
   @begin_with_propose_presentation
   Scenario: The Prover begins with a proposal
     Given "Carol" exchange DIDs with "Andrew"
@@ -44,8 +44,8 @@ Feature: Present Proof protocol
     Given "Michael" exchange DIDs with "David"
     Then "Michael" sends a propose presentation to the "David"
     And "David" declines a propose presentation
-    Then "Michael" checks the history of events "proposal-sent,proposal-sent,abandoning,abandoning,done,done"
-    And "David" checks the history of events "abandoning,abandoning,done,done"
+    Then "Michael" checks the history of events "proposal-sent,proposal-sent,abandoned,abandoned"
+    And "David" checks the history of events "abandoned,abandoned"
   @begin_with_request_presentation_negotiation
   Scenario: The Verifier begins with a request presentation (negotiation)
     Given "William" exchange DIDs with "Felix"


### PR DESCRIPTION
`Abandoned` state now cannot transit to the `done` state.
See [0454-present-proof-v2#states](https://github.com/hyperledger/aries-rfcs/tree/master/features/0454-present-proof-v2#states)

> The final states for both the prover and verifier are done or abandoned, and once reached, no further updates to the protocol instance are expected.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>