### PR TITLE
docs: added PresentProof protocol summary and related terms

### DIFF
--- a/docs/concepts/00_what_is_hl_aries.md
+++ b/docs/concepts/00_what_is_hl_aries.md
@@ -43,6 +43,10 @@ This protocol enables an [issuer](./01_terminologies.md#issuer) to provide a [ho
 
 ### 8. PresentProof Protocol
 
+This protocol enables a [verifier](./01_terminologies.md#verifier) to request a presentation of a proof from a [holder/prover](./01_terminologies.md#holder).
+
+It focuses on the exchange of [verifiable presentations](./01_terminologies.md#verifiable-presentation) and does not concern itself with the structure of the documents which are being exchanged. _(7)_
+
 ### 9. VDRI
 
 ### 10. Verifiable
@@ -58,3 +62,4 @@ This controller allows for the creation, retrieval, validation and signing of [v
 4. [Aries RFCs - DIDExchange](https://github.com/hyperledger/aries-rfcs/tree/master/features/0023-did-exchange)
 5. [Aries RFCs - Introduce](https://github.com/hyperledger/aries-rfcs/tree/master/features/0028-introduce)
 6. [Aries RFCs - IssueCredential Choreography Diagram](https://github.com/hyperledger/aries-rfcs/tree/master/features/0453-issue-credential-v2#choreography-diagram)
+7. [Aries RFCs - Present Proof](https://github.com/hyperledger/aries-rfcs/tree/master/features/0454-present-proof-v2)

--- a/docs/concepts/01_terminologies.md
+++ b/docs/concepts/01_terminologies.md
@@ -22,7 +22,9 @@ _Reference: https://www.w3.org/TR/did-core/#dfn-did-documents_
 
 ### Holder
 
-This is the entity to whom an [issuer](#issuer) issues a credential. Although the holder can request or propose that a credential be issued to them, they may not always be the subjects of a credential.
+Also known as a prover, a holder is the entity to whom an [issuer](#issuer) issues a credential. Although the holder can request or propose that a credential be issued to them, they may not always be the subjects of a credential. 
+
+In the [PresentProof](./00_what_is_hl_aries.md#8-presentproof-protocol) flow, the prover prepares the proof and presents it to the [verifier](#verifier).
 
 ### Issuer
 The entity that issues a [credential](#verifiable-credential) to a holder.
@@ -41,3 +43,8 @@ A verifiable presentation expresses data from one or more verifiable credentials
 
 _Reference: https://www.w3.org/TR/vc-data-model/#presentations_
 
+### Verifier
+
+This is the entity who makes a request for a [credential](#verifiable-credential) or proof from a [holder](#holder) and verifies it.
+
+_Reference: https://github.com/hyperledger/aries-rfcs/tree/master/features/0454-present-proof-v2#roles_


### PR DESCRIPTION
Signed-off-by: Tomisin Jenrola <tomisin.jenrola@securekey.com>

**Title:**
Added docs for PresentProof protocol

**Description:**
Closes https://github.com/hyperledger/aries-framework-go/issues/2040

**Summary:**
Brief explanation of the protocol and its related terminologies.
