### PR TITLE
feat: updated mobile bindings for IssueCredential protocol

### DIFF
--- a/cmd/aries-agent-mobile/pkg/api/issuecredential.go
+++ b/cmd/aries-agent-mobile/pkg/api/issuecredential.go
@@ -35,6 +35,9 @@ type IssueCredentialController interface {
 	// AcceptOffer is used when the Holder is willing to accept the offer.
 	AcceptOffer(request *models.RequestEnvelope) *models.ResponseEnvelope
 
+	// AcceptProblemReport is used for accepting problem report.
+	AcceptProblemReport(request *models.RequestEnvelope) *models.ResponseEnvelope
+
 	// DeclineOffer is used when the Holder does not want to accept the offer.
 	DeclineOffer(request *models.RequestEnvelope) *models.ResponseEnvelope
 

--- a/cmd/aries-agent-mobile/pkg/wrappers/command/issuecredential.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/command/issuecredential.go
@@ -141,6 +141,22 @@ func (ic *IssueCredential) AcceptOffer(request *models.RequestEnvelope) *models.
 	return &models.ResponseEnvelope{Payload: response}
 }
 
+// AcceptProblemReport is used for accepting problem report.
+func (ic *IssueCredential) AcceptProblemReport(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	args := cmdisscred.AcceptProblemReportArgs{}
+
+	if err := json.Unmarshal(request.Payload, &args); err != nil {
+		return &models.ResponseEnvelope{Error: &models.CommandError{Message: err.Error()}}
+	}
+
+	response, cmdErr := exec(ic.handlers[cmdisscred.AcceptProblemReport], args)
+	if cmdErr != nil {
+		return &models.ResponseEnvelope{Error: cmdErr}
+	}
+
+	return &models.ResponseEnvelope{Payload: response}
+}
+
 // DeclineOffer is used when the Holder does not want to accept the offer.
 func (ic *IssueCredential) DeclineOffer(request *models.RequestEnvelope) *models.ResponseEnvelope {
 	args := cmdisscred.DeclineOfferArgs{}

--- a/cmd/aries-agent-mobile/pkg/wrappers/command/issuecredential_test.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/command/issuecredential_test.go
@@ -194,6 +194,26 @@ func TestIssueCredential_AcceptOffer(t *testing.T) {
 	})
 }
 
+func TestIssueCredential_AcceptProblemReport(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		ic := getIssueCredentialController(t)
+
+		mockResponse := emptyResponse
+		fakeHandler := mockCommandRunner{data: []byte(mockResponse)}
+		ic.handlers[cmdisscred.AcceptProblemReport] = fakeHandler.exec
+
+		payload := mockPIID
+
+		req := &models.RequestEnvelope{Payload: []byte(payload)}
+		resp := ic.AcceptProblemReport(req)
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t,
+			mockResponse,
+			string(resp.Payload))
+	})
+}
+
 func TestIssueCredential_DeclineOffer(t *testing.T) {
 	t.Run("test it performs an decline offer operation", func(t *testing.T) {
 		ic := getIssueCredentialController(t)

--- a/cmd/aries-agent-mobile/pkg/wrappers/rest/endpoints.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/rest/endpoints.go
@@ -214,6 +214,10 @@ func getIssueCredentialEndpoints() map[string]*endpoint {
 			Path:   opisscred.AcceptOffer,
 			Method: http.MethodPost,
 		},
+		cmdisscred.AcceptProblemReport: {
+			Path:   opisscred.AcceptProblemReport,
+			Method: http.MethodPost,
+		},
 		cmdisscred.DeclineOffer: {
 			Path:   opisscred.DeclineOffer,
 			Method: http.MethodPost,

--- a/cmd/aries-agent-mobile/pkg/wrappers/rest/issuecredential.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/rest/issuecredential.go
@@ -60,6 +60,11 @@ func (ic *IssueCredential) AcceptOffer(request *models.RequestEnvelope) *models.
 	return ic.createRespEnvelope(request, cmdisscred.AcceptOffer)
 }
 
+// AcceptProblemReport is used for accepting problem report.
+func (ic *IssueCredential) AcceptProblemReport(request *models.RequestEnvelope) *models.ResponseEnvelope {
+	return ic.createRespEnvelope(request, cmdisscred.AcceptProblemReport)
+}
+
 // DeclineOffer is used when the Holder does not want to accept the offer.
 func (ic *IssueCredential) DeclineOffer(request *models.RequestEnvelope) *models.ResponseEnvelope {
 	return ic.createRespEnvelope(request, cmdisscred.DeclineOffer)

--- a/cmd/aries-agent-mobile/pkg/wrappers/rest/issuecredential_test.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/rest/issuecredential_test.go
@@ -192,6 +192,27 @@ func TestIssueCredential_AcceptOffer(t *testing.T) {
 	})
 }
 
+func TestIssueCredential_AcceptProblemReport(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		ic := getIssueCredentialController(t)
+
+		reqData := fmt.Sprintf(`{"piid": "%s"}`, mockPIID)
+		mockURL, err := parseURL(mockAgentURL, opisscred.AcceptProblemReport, reqData)
+		require.NoError(t, err, "failed to parse test url")
+
+		mockResponse := emptyResponse
+		ic.httpClient = &mockHTTPClient{data: mockResponse,
+			method: http.MethodPost, url: mockURL}
+
+		req := &models.RequestEnvelope{Payload: []byte(reqData)}
+		resp := ic.AcceptProblemReport(req)
+
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.Equal(t, mockResponse, string(resp.Payload))
+	})
+}
+
 func TestIssueCredential_DeclineOffer(t *testing.T) {
 	t.Run("test it makes a decline offer request", func(t *testing.T) {
 		ic := getIssueCredentialController(t)


### PR DESCRIPTION
Signed-off-by: Tomisin Jenrola <tomisin.jenrola@securekey.com>

**Title:**
Add new methods to the IssueCredential mobile wrappers

**Description:**
Closes https://github.com/hyperledger/aries-framework-go/issues/2061

**Summary:**

Adds the new `AcceptProblemReport` method introduced by https://github.com/hyperledger/aries-framework-go/pull/2057.

