### PR TITLE
feat: Introduce - added action event support (ProblemReport)

### DIFF
--- a/cmd/aries-js-worker/src/agent-rest-client.js
+++ b/cmd/aries-js-worker/src/agent-rest-client.js
@@ -174,6 +174,11 @@ const pkgs = {
             path: "/introduce/send-proposal",
             method: "POST",
         },
+        AcceptProblemReport: {
+            path: "/introduce/{piid}/accept-problem-report",
+            method: "POST",
+            pathParam:"piid"
+        },
         SendProposalWithOOBRequest: {
             path: "/introduce/send-proposal-with-oob-request",
             method: "POST",

--- a/cmd/aries-js-worker/src/aries.js
+++ b/cmd/aries-js-worker/src/aries.js
@@ -219,6 +219,16 @@ const Aries = function (opts) {
             },
 
             /**
+             * Accepts a problem report.
+             *
+             * @param req - json document
+             * @returns {Promise<Object>}
+             */
+            acceptProblemReport: function (req) {
+                return invoke(aw, pending, this.pkgname, "AcceptProblemReport", req, "timeout while accepting a problem report")
+            },
+
+            /**
              * SendProposal sends a proposal to the introducees (the client has not published an out-of-band message).
              *
              * @param req - json document

--- a/pkg/client/introduce/client.go
+++ b/pkg/client/introduce/client.go
@@ -144,6 +144,11 @@ func (c *Client) DeclineRequest(piID, reason string) error {
 	return c.service.ActionStop(piID, errors.New(reason))
 }
 
+// AcceptProblemReport accepts problem report action.
+func (c *Client) AcceptProblemReport(piID string) error {
+	return c.service.ActionContinue(piID, nil)
+}
+
 // Actions returns unfinished actions for the async usage.
 func (c *Client) Actions() ([]Action, error) {
 	actions, err := c.service.Actions()

--- a/pkg/client/introduce/client_test.go
+++ b/pkg/client/introduce/client_test.go
@@ -288,3 +288,19 @@ func TestClient_DeclineRequest(t *testing.T) {
 
 	require.NoError(t, client.DeclineRequest("PIID", "the reason"))
 }
+
+func TestClient_AcceptProblemReport(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	provider := mocksintroduce.NewMockProvider(ctrl)
+
+	svc := mocksintroduce.NewMockProtocolService(ctrl)
+	svc.EXPECT().ActionContinue("PIID", gomock.Any()).Return(nil)
+
+	provider.EXPECT().Service(gomock.Any()).Return(svc, nil)
+	client, err := New(provider)
+	require.NoError(t, err)
+
+	require.NoError(t, client.AcceptProblemReport("PIID"))
+}

--- a/pkg/controller/command/introduce/command_test.go
+++ b/pkg/controller/command/introduce/command_test.go
@@ -971,6 +971,86 @@ func TestCommand_DeclineRequest(t *testing.T) {
 	})
 }
 
+func TestCommand_AcceptProblemReport(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service := mocks.NewMockProtocolService(ctrl)
+	service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil).AnyTimes()
+	service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil).AnyTimes()
+
+	provider := mocks.NewMockProvider(ctrl)
+	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+
+	t.Run("Decode error", func(t *testing.T) {
+		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptProblemReport(&b, bytes.NewBufferString("}"))
+
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("Empty PIID", func(t *testing.T) {
+		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptProblemReport(&b, bytes.NewBufferString("{}"))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errEmptyPIID)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("AcceptProblemReport (error)", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionContinue(gomock.Any(), gomock.Any()).Return(errors.New("some error message"))
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		const jsonPayload = `{"piid":"piid"}`
+		cmdErr := cmd.AcceptProblemReport(&b, bytes.NewBufferString(jsonPayload))
+
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), "some error message")
+		require.Equal(t, AcceptProblemReportErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		service := mocks.NewMockProtocolService(ctrl)
+		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
+		service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
+		service.EXPECT().ActionContinue(gomock.Any(), gomock.Any())
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+
+		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		const jsonPayload = `{"piid":"piid"}`
+		require.NoError(t, cmd.AcceptProblemReport(&b, bytes.NewBufferString(jsonPayload)))
+	})
+}
+
 func toProtocolActions(actions []introduce.Action) []protocol.Action {
 	res := make([]protocol.Action, len(actions))
 	for i, action := range actions {

--- a/pkg/controller/command/introduce/models.go
+++ b/pkg/controller/command/introduce/models.go
@@ -182,3 +182,18 @@ type AcceptProposalArgs struct {
 // Represents a AcceptProposal response message
 //
 type AcceptProposalResponse struct{}
+
+// AcceptProblemReportArgs model
+//
+// This is used for accepting a problem report
+//
+type AcceptProblemReportArgs struct {
+	// PIID Protocol instance ID
+	PIID string `json:"piid"`
+}
+
+// AcceptProblemReportResponse model
+//
+// Represents a AcceptProblemReport response message
+//
+type AcceptProblemReportResponse struct{}

--- a/pkg/controller/rest/introduce/models.go
+++ b/pkg/controller/rest/introduce/models.go
@@ -280,3 +280,26 @@ type introduceAcceptProposalResponse struct { // nolint: unused,deadcode
 	// in: body
 	Body struct{}
 }
+
+// introduceAcceptProblemReportRequest model
+//
+// This is used for operation to accept a problem report.
+//
+// swagger:parameters introduceAcceptProblemReport
+type introduceAcceptProblemReportRequest struct { // nolint: unused,deadcode
+	// Protocol instance ID
+	//
+	// in: path
+	// required: true
+	PIID string `json:"piid"`
+}
+
+// introduceAcceptProblemReportResponse model
+//
+// Represents a AcceptProblemReport response message
+//
+// swagger:response introduceAcceptProblemReportResponse
+type introduceAcceptProblemReportResponse struct { // nolint: unused,deadcode
+	// in: body
+	Body struct{}
+}

--- a/pkg/controller/rest/introduce/operation.go
+++ b/pkg/controller/rest/introduce/operation.go
@@ -37,6 +37,7 @@ const (
 	AcceptRequestWithRecipients       = OperationID + "/{piid}/accept-request-with-recipients"
 	DeclineProposal                   = OperationID + "/{piid}/decline-proposal"
 	DeclineRequest                    = OperationID + "/{piid}/decline-request"
+	AcceptProblemReport               = OperationID + "/{piid}/accept-problem-report"
 )
 
 // Operation is controller REST service controller for the introduce.
@@ -77,6 +78,7 @@ func (c *Operation) registerHandler() {
 		cmdutil.NewHTTPHandler(AcceptRequestWithRecipients, http.MethodPost, c.AcceptRequestWithRecipients),
 		cmdutil.NewHTTPHandler(DeclineProposal, http.MethodPost, c.DeclineProposal),
 		cmdutil.NewHTTPHandler(DeclineRequest, http.MethodPost, c.DeclineRequest),
+		cmdutil.NewHTTPHandler(AcceptProblemReport, http.MethodPost, c.AcceptProblemReport),
 	}
 }
 
@@ -201,6 +203,19 @@ func (c *Operation) DeclineRequest(rw http.ResponseWriter, req *http.Request) {
 		"piid":%q,
 		"reason":%q
 	}`, mux.Vars(req)["piid"], req.URL.Query().Get("reason"))))
+}
+
+// AcceptProblemReport swagger:route POST /introduce/{piid}/accept-problem-report introduce introduceAcceptProblemReport
+//
+// Accepts a problem report.
+//
+// Responses:
+//    default: genericError
+//        200: introduceAcceptProblemReportResponse
+func (c *Operation) AcceptProblemReport(rw http.ResponseWriter, req *http.Request) {
+	rest.Execute(c.command.AcceptProblemReport, rw, bytes.NewBufferString(fmt.Sprintf(`{
+		"piid":%q
+	}`, mux.Vars(req)["piid"])))
 }
 
 func toCommandRequest(rw http.ResponseWriter, req *http.Request) (bool, io.Reader) {

--- a/pkg/controller/rest/introduce/operation_test.go
+++ b/pkg/controller/rest/introduce/operation_test.go
@@ -286,6 +286,25 @@ func TestOperation_DeclineProposal(t *testing.T) {
 	})
 }
 
+func TestOperation_AcceptProblemReport(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("Success", func(t *testing.T) {
+		operation, err := New(provider(ctrl), mocknotifier.NewMockNotifier(nil))
+		require.NoError(t, err)
+
+		_, code, err := sendRequestToHandler(
+			handlerLookup(t, operation, AcceptProblemReport),
+			nil,
+			strings.Replace(AcceptProblemReport, `{piid}`, "1234", 1),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+	})
+}
+
 func handlerLookup(t *testing.T, op *Operation, lookup string) rest.Handler {
 	t.Helper()
 

--- a/pkg/didcomm/protocol/introduce/service.go
+++ b/pkg/didcomm/protocol/introduce/service.go
@@ -568,7 +568,7 @@ func stateFromName(name string) state {
 // canTriggerActionEvents checks if the incoming message can trigger an action event.
 func canTriggerActionEvents(msg service.DIDCommMsg) bool {
 	switch msg.Type() {
-	case ProposalMsgType, RequestMsgType:
+	case ProposalMsgType, RequestMsgType, ProblemReportMsgType:
 		return true
 	}
 

--- a/pkg/didcomm/protocol/introduce/service_test.go
+++ b/pkg/didcomm/protocol/introduce/service_test.go
@@ -565,14 +565,16 @@ func TestService_ProposalNoInvitation(t *testing.T) {
 		"waiting", "waiting",
 		"abandoning", "abandoning",
 		"done", "done",
-	), checkDIDCommAction(t, Bob, action{Expected: introduce.ProposalMsgType}))
+	), checkDIDCommAction(t, Bob, action{Expected: introduce.ProposalMsgType},
+		action{Expected: introduce.ProblemReportMsgType}))
 
 	handle(t, Carol, done, agentSetup(Carol, t, ctrl, transport), checkStateMsg(t, Carol,
 		"deciding", "deciding",
 		"waiting", "waiting",
 		"abandoning", "abandoning",
 		"done", "done",
-	), checkDIDCommAction(t, Carol, action{Expected: introduce.ProposalMsgType}))
+	), checkDIDCommAction(t, Carol, action{Expected: introduce.ProposalMsgType},
+		action{Expected: introduce.ProblemReportMsgType}))
 
 	proposal1 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Carol}})
 	proposal2 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Bob}})
@@ -731,7 +733,8 @@ func TestService_ProposalStopIntroduceeFirst(t *testing.T) {
 		"waiting", "waiting",
 		"abandoning", "abandoning",
 		"done", "done",
-	), checkDIDCommAction(t, Carol, action{Expected: introduce.ProposalMsgType}))
+	), checkDIDCommAction(t, Carol, action{Expected: introduce.ProposalMsgType},
+		action{Expected: introduce.ProblemReportMsgType}))
 
 	proposal1 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Carol}})
 	proposal2 := introduce.CreateProposal(&introduce.Recipient{To: &introduce.To{Name: Bob}})
@@ -779,7 +782,8 @@ func TestService_ProposalStopIntroduceeSecond(t *testing.T) {
 		"waiting", "waiting",
 		"abandoning", "abandoning",
 		"done", "done",
-	), checkDIDCommAction(t, Bob, action{Expected: introduce.ProposalMsgType}))
+	), checkDIDCommAction(t, Bob, action{Expected: introduce.ProposalMsgType},
+		action{Expected: introduce.ProblemReportMsgType}))
 
 	handle(t, Carol, done, agentSetup(Carol, t, ctrl, transport), checkStateMsg(t, Carol,
 		"deciding", "deciding",
@@ -843,7 +847,8 @@ func TestService_ProposalActionStopIntroduceeSecond(t *testing.T) {
 		"waiting", "waiting",
 		"abandoning", "abandoning",
 		"done", "done",
-	), checkDIDCommAction(t, Bob, action{Expected: introduce.ProposalMsgType}))
+	), checkDIDCommAction(t, Bob, action{Expected: introduce.ProposalMsgType},
+		action{Expected: introduce.ProblemReportMsgType}))
 
 	handle(t, Carol, done, carol, checkStateMsg(t, Carol,
 		"deciding", "deciding",
@@ -1169,7 +1174,8 @@ func TestService_ProposalWithRequestStopIntroduceeFirst(t *testing.T) {
 		"waiting", "waiting",
 		"abandoning", "abandoning",
 		"done", "done",
-	), checkDIDCommAction(t, Carol, action{Expected: introduce.ProposalMsgType}))
+	), checkDIDCommAction(t, Carol, action{Expected: introduce.ProposalMsgType},
+		action{Expected: introduce.ProblemReportMsgType}))
 
 	_, err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
 		Type: introduce.RequestMsgType,
@@ -1228,7 +1234,8 @@ func TestService_ProposalWithRequestStopIntroduceeSecond(t *testing.T) {
 		"waiting", "waiting",
 		"abandoning", "abandoning",
 		"done", "done",
-	), checkDIDCommAction(t, Bob, action{Expected: introduce.ProposalMsgType}))
+	), checkDIDCommAction(t, Bob, action{Expected: introduce.ProposalMsgType},
+		action{Expected: introduce.ProblemReportMsgType}))
 
 	handle(t, Carol, done, agentSetup(Carol, t, ctrl, transport), checkStateMsg(t, Carol,
 		"deciding", "deciding",
@@ -1288,7 +1295,7 @@ func TestService_ProposalWithRequestIntroducerStop(t *testing.T) {
 		"requesting", "requesting",
 		"abandoning", "abandoning",
 		"done", "done",
-	), nil)
+	), checkDIDCommAction(t, Bob, action{Expected: introduce.ProblemReportMsgType}))
 
 	_, err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
 		Type: introduce.RequestMsgType,
@@ -1434,7 +1441,7 @@ func TestService_ProposalWithRequestNoRecipients(t *testing.T) {
 		"requesting", "requesting",
 		"abandoning", "abandoning",
 		"done", "done",
-	), nil)
+	), checkDIDCommAction(t, Bob, action{Expected: introduce.ProblemReportMsgType}))
 
 	_, err := bob.HandleOutbound(service.NewDIDCommMsgMap(&introduce.Request{
 		Type: introduce.RequestMsgType,

--- a/pkg/didcomm/protocol/introduce/states.go
+++ b/pkg/didcomm/protocol/introduce/states.go
@@ -353,9 +353,11 @@ func (s *abandoning) CanTransitionTo(next state) bool {
 	return next.Name() == stateNameDone
 }
 
+// nolint: funlen
 func (s *abandoning) ExecuteInbound(messenger service.Messenger, md *metaData) (state, stateAction, error) {
-	// if code is not provided it means we do not need to notify participants about it
-	if s.Code == "" {
+	// if code is not provided it means we do not need to notify participants about it.
+	// if we received ProblemReport message no need to answer.
+	if s.Code == "" || md.Msg.Type() == ProblemReportMsgType {
 		return &done{}, zeroAction, nil
 	}
 

--- a/test/bdd/features/introduce.feature
+++ b/test/bdd/features/introduce.feature
@@ -108,6 +108,8 @@ Feature: Introduce protocol
     And   "Alice" sends introduce proposal to the "Bob" and "Carol"
     And   "Bob" wants to know "Carol" and sends introduce response with approve
     And   "Carol" wants to know "Bob" and sends introduce response with approve
+    Then "Bob" receives problem report message (Introduce)
+    Then "Carol" receives problem report message (Introduce)
     Then   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,arranging,arranging,arranging,arranging,delivering,delivering,abandoning,abandoning,done,done"
     And   "Bob" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
     And   "Carol" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,abandoning,abandoning,done,done" and stop
@@ -119,6 +121,8 @@ Feature: Introduce protocol
     Then   "Alice" sends introduce proposal back to the "Bob" and requested introduce
     And   "Bob" wants to know "Carol" and sends introduce response with approve
     And   "Carol" wants to know "Bob" and sends introduce response with approve
+    Then "Bob" receives problem report message (Introduce)
+    Then "Carol" receives problem report message (Introduce)
     Then   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,arranging,arranging,delivering,delivering,abandoning,abandoning,done,done"
     And   "Bob" checks the history of introduce protocol events "requesting,requesting,deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
     And   "Carol" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,abandoning,abandoning,done,done" and stop
@@ -129,6 +133,7 @@ Feature: Introduce protocol
     When   "Alice" sends introduce proposal to the "Bob" and "Carol"
     And   "Bob" doesn't want to know "Carol" and sends introduce response
     And   "Carol" wants to know "Bob" and sends introduce response with approve
+    Then "Carol" receives problem report message (Introduce)
     Then   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,arranging,arranging,arranging,arranging,abandoning,abandoning,done,done"
     And   "Bob" checks the history of introduce protocol events "deciding,deciding,abandoning,abandoning,done,done"
     And   "Carol" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,abandoning,abandoning,done,done" and stop
@@ -140,6 +145,7 @@ Feature: Introduce protocol
     Then   "Alice" sends introduce proposal back to the "Bob" and requested introduce
     And   "Bob" doesn't want to know "Carol" and sends introduce response
     And   "Carol" wants to know "Bob" and sends introduce response with approve
+    Then "Carol" receives problem report message (Introduce)
     Then   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,arranging,arranging,abandoning,abandoning,done,done"
     And   "Bob" checks the history of introduce protocol events "requesting,requesting,deciding,deciding,abandoning,abandoning,done,done"
     And   "Carol" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,abandoning,abandoning,done,done" and stop
@@ -150,6 +156,7 @@ Feature: Introduce protocol
     When   "Alice" sends introduce proposal to the "Bob" and "Carol"
     And   "Bob" wants to know "Carol" and sends introduce response with approve
     And   "Carol" doesn't want to know "Bob" and sends introduce response
+    Then "Bob" receives problem report message (Introduce)
     Then   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,arranging,arranging,arranging,arranging,abandoning,abandoning,done,done"
     And   "Bob" checks the history of introduce protocol events "deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
     And   "Carol" checks the history of introduce protocol events "deciding,deciding,abandoning,abandoning,done,done" and stop
@@ -161,6 +168,7 @@ Feature: Introduce protocol
     Then   "Alice" sends introduce proposal back to the "Bob" and requested introduce
     And   "Bob" wants to know "Carol" and sends introduce response with approve
     And   "Carol" doesn't want to know "Bob" and sends introduce response
+    Then "Bob" receives problem report message (Introduce)
     Then   "Alice" checks the history of introduce protocol events "arranging,arranging,arranging,arranging,arranging,arranging,abandoning,abandoning,done,done"
     And   "Bob" checks the history of introduce protocol events "requesting,requesting,deciding,deciding,waiting,waiting,abandoning,abandoning,done,done"
     And   "Carol" checks the history of introduce protocol events "deciding,deciding,abandoning,abandoning,done,done" and stop
@@ -170,5 +178,6 @@ Feature: Introduce protocol
     Given   "Bob" exchange DIDs with "Alice"
     When   "Bob" sends introduce request to the "Alice" asking about "Carol"
     And   "Alice" stops the introduce protocol
+    Then "Bob" receives problem report message (Introduce)
     Then   "Alice" checks the history of introduce protocol events "abandoning,abandoning,done,done"
     And   "Bob" checks the history of introduce protocol events "requesting,requesting,abandoning,abandoning,done,done" and stop


### PR DESCRIPTION
Adds action event support for the Introduce protocol. Now, if the protocol receives `ProblemReport` message an action event will be triggered.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>