### PR TITLE
fix: #2078 #2112

### DIFF
--- a/cmd/aries-js-worker/go.sum
+++ b/cmd/aries-js-worker/go.sum
@@ -3,6 +3,9 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=

--- a/pkg/doc/signature/suite/ed25519signature2018/suite.go
+++ b/pkg/doc/signature/suite/ed25519signature2018/suite.go
@@ -26,7 +26,8 @@ type Suite struct {
 }
 
 const (
-	signatureType = "Ed25519Signature2018"
+	// SignatureType is the signature type for ed25519 keys.
+	SignatureType = "Ed25519Signature2018"
 	rdfDataSetAlg = "URDNA2015"
 )
 
@@ -53,5 +54,5 @@ func (s *Suite) GetDigest(doc []byte) []byte {
 
 // Accept will accept only ed25519 signature type.
 func (s *Suite) Accept(t string) bool {
-	return t == signatureType
+	return t == SignatureType
 }

--- a/pkg/kms/legacykms/kms.go
+++ b/pkg/kms/legacykms/kms.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/btcsuite/btcutil/base58"
 	chacha "golang.org/x/crypto/chacha20poly1305"
@@ -180,7 +181,7 @@ func (w *BaseKMS) Close() error {
 
 // getKeyPairSet get encryption & signature key pairs combo.
 func (w *BaseKMS) getKeyPairSet(verKey string) (*cryptoutil.MessagingKeys, error) {
-	bytes, err := w.keystore.Get(verKey)
+	bytes, err := w.keystore.Get(strings.TrimPrefix(verKey, "#"))
 	if err != nil {
 		if errors.Is(storage.ErrDataNotFound, err) {
 			return nil, cryptoutil.ErrKeyNotFound

--- a/pkg/vdri/registry.go
+++ b/pkg/vdri/registry.go
@@ -110,7 +110,7 @@ func (r *Registry) Create(didMethod string, opts ...vdriapi.DocOpts) (*diddoc.Do
 			return nil, fmt.Errorf("failed to create DID: %w", err)
 		}
 
-		id = ""
+		id = fmt.Sprintf("#%s", base58PubKey)
 	} else {
 		id, _, err = r.kms.Create(kms.ED25519Type)
 		if err != nil {

--- a/pkg/vdri/verifiable_compat_test.go
+++ b/pkg/vdri/verifiable_compat_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vdri_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ed25519signature2018"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdri"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/context"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
+	"github.com/hyperledger/aries-framework-go/pkg/storage/mem"
+)
+
+func Test_LDProofs_Compatibility(t *testing.T) {
+	t.Run("did:peer", func(t *testing.T) {
+		alice := agent(t)
+		alicePeerDID := createPeerDIDLikeDIDExchangeService(t, alice)
+		require.NotEmpty(t, alicePeerDID.Authentication)
+
+		verKey := alicePeerDID.Authentication[0].PublicKey
+		require.NotNil(t, verKey)
+
+		// alice self-issues a VC
+		expectedVC := universityDegreeVC()
+
+		now := time.Now()
+
+		err := expectedVC.AddLinkedDataProof(
+			&verifiable.LinkedDataProofContext{
+				SignatureType: ed25519signature2018.SignatureType,
+				Suite: ed25519signature2018.New(suite.WithSigner(
+					&legacySigner{
+						verkey: verKey.ID,
+						ks:     alice.Signer(),
+					},
+				)),
+				SignatureRepresentation: verifiable.SignatureJWS,
+				Created:                 &now,
+				VerificationMethod:      fmt.Sprintf("%s%s", alicePeerDID.ID, verKey.ID),
+				Challenge:               uuid.New().String(),
+				Domain:                  uuid.New().String(),
+				Purpose:                 "authentication",
+			},
+		)
+		require.NoError(t, err)
+
+		// alice encloses her VC in a VP
+		expectedVP, err := expectedVC.Presentation()
+		require.NoError(t, err)
+
+		err = expectedVP.AddLinkedDataProof(&verifiable.LinkedDataProofContext{
+			SignatureType: ed25519signature2018.SignatureType,
+			Suite: ed25519signature2018.New(suite.WithSigner(
+				&legacySigner{
+					verkey: verKey.ID,
+					ks:     alice.Signer(),
+				},
+			)),
+			SignatureRepresentation: verifiable.SignatureJWS,
+			Created:                 &now,
+			VerificationMethod:      fmt.Sprintf("%s%s", alicePeerDID.ID, verKey.ID),
+			Challenge:               uuid.New().String(),
+			Domain:                  uuid.New().String(),
+			Purpose:                 "authentication",
+		})
+		require.NoError(t, err)
+
+		// alice wires her VP and DID to Bob
+		aliceVPBits, err := json.Marshal(expectedVP)
+		require.NoError(t, err)
+
+		alicePeerDIDBits, err := alicePeerDID.JSONBytes()
+		require.NoError(t, err)
+
+		bob := agent(t)
+
+		// bob parses and stores alice's DID
+		actualPeerDID, err := did.ParseDocument(alicePeerDIDBits)
+		require.NoError(t, err)
+
+		err = bob.VDRIRegistry().Store(actualPeerDID)
+		require.NoError(t, err)
+
+		// bob parses alice's VP
+		actualVP, err := verifiable.ParsePresentation(
+			aliceVPBits,
+			verifiable.WithPresPublicKeyFetcher(verifiable.NewDIDKeyResolver(bob.VDRIRegistry()).PublicKeyFetcher()))
+		require.NoError(t, err)
+
+		require.Equal(t, expectedVP.Context, actualVP.Context)
+		require.Equal(t, expectedVP.Type, actualVP.Type)
+
+		actualVCBits, err := actualVP.MarshalledCredentials()
+		require.NoError(t, err)
+		require.Len(t, actualVCBits, 1)
+
+		// bob parses the VCs enclosed in alice's VP
+		actualVC, err := verifiable.ParseCredential(
+			actualVCBits[0],
+			verifiable.WithPublicKeyFetcher(verifiable.NewDIDKeyResolver(bob.VDRIRegistry()).PublicKeyFetcher()))
+		require.NoError(t, err)
+
+		require.Equal(t, expectedVC.Context, actualVC.Context)
+		require.Equal(t, expectedVC.Types, actualVC.Types)
+	})
+}
+
+func agent(t *testing.T) *context.Provider {
+	t.Helper()
+
+	a, err := aries.New(
+		aries.WithStoreProvider(mem.NewProvider()),
+		aries.WithProtocolStateStoreProvider(mem.NewProvider()),
+	)
+	require.NoError(t, err)
+
+	ctx, err := a.Context()
+	require.NoError(t, err)
+
+	return ctx
+}
+
+func createPeerDIDLikeDIDExchangeService(t *testing.T, a *context.Provider) *did.Doc {
+	t.Helper()
+
+	peerDID, err := a.VDRIRegistry().Create(
+		"peer",
+		vdri.WithServiceEndpoint("http://example.com/didcomm"),
+	)
+	require.NoError(t, err)
+
+	return peerDID
+}
+
+func universityDegreeVC() *verifiable.Credential {
+	return &verifiable.Credential{
+		Context: []string{
+			"https://www.w3.org/2018/credentials/v1",
+			"https://www.w3.org/2018/credentials/examples/v1",
+		},
+		Types: []string{
+			"VerifiableCredential",
+			"UniversityDegreeCredential",
+		},
+		ID: "http://example.gov/credentials/ff98f978-588f-4eb0-b17b-60c18e1dac2c",
+		Issuer: verifiable.Issuer{
+			ID: "did:web:vc.transmute.world",
+			CustomFields: map[string]interface{}{
+				"name": "Transmute University",
+			},
+		},
+		Issued: &util.TimeWithTrailingZeroMsec{Time: time.Now()},
+		Subject: &verifiable.Subject{
+			ID: "did:example:ebfeb1f712ebc6f1c276e12ec21",
+			CustomFields: map[string]interface{}{
+				"degree": map[string]string{
+					"type":   "BachelorDegree",
+					"degree": "MIT",
+				},
+				"name":   "Jayden Doe",
+				"spouse": "Bob Doe",
+			},
+		},
+	}
+}
+
+type legacySigner struct {
+	verkey string
+	ks     legacykms.Signer
+}
+
+func (s *legacySigner) Sign(message []byte) ([]byte, error) {
+	return s.ks.SignMessage(message, s.verkey)
+}


### PR DESCRIPTION
fixes #2078 
fixes #2112

----

Set public key id to base58(pubSigKey) in vdri.Registry.Create() when using legacy KMS. This sets the key's ID in the resulting did.Doc in the proper format. This enables compatibility with the DID public key fetcher from the `verifiable` package (format must be "<did#keyID>").

Strip a leading "#" (if any) when searching for public sig keys in the BaseKMS' keystore to account for the above change.

Both these changes are done in code paths where legacy KMS is used and will (presumably) be eliminated once we deprecate it.

---

Whereas before this change peer DID docs were unmarshalled like this (note `authentication`):

<details><summary>Click</summary>

```json
{                                                                                                                                                                                                                  
    "@context": [
        "https://w3id.org/did/v1"
    ],  
    "authentication": [
        ""
    ],  
    "created": "2020-08-10T16:13:22.45194098-04:00",
    "id": "did:peer:1zQmRtJYm9vMdFd4sedav1nyLjaMQp2BozhvTWkiWNSjbFq3",
    "publicKey": [
        {
            "controller": "#id",
            "id": "#CkPGqALPjt8PFWbYd4WmcNX4Qq3iXdUVq67s3yeh9vxe",
            "publicKeyBase58": "CkPGqALPjt8PFWbYd4WmcNX4Qq3iXdUVq67s3yeh9vxe",
            "type": "Ed25519VerificationKey2018"
        }
    ],  
    "service": [
        {
            "id": "#agent",
            "priority": 0,
            "recipientKeys": [
                "CkPGqALPjt8PFWbYd4WmcNX4Qq3iXdUVq67s3yeh9vxe"
            ],
            "routingKeys": null,
            "serviceEndpoint": "http://example.com/didcomm",
            "type": "did-communication"
        }
    ],  
    "updated": "2020-08-10T16:13:22.45194098-04:00"
}
```

</details>

They are now unmarshalled like this (note `authentication`):

<details><summary>Click</summary>

```json
{                                                                                                                                                                                                                  
    "@context": [
        "https://w3id.org/did/v1"
    ],
    "authentication": [
        "#CkPGqALPjt8PFWbYd4WmcNX4Qq3iXdUVq67s3yeh9vxe"
    ],
    "created": "2020-08-10T16:13:22.45194098-04:00",
    "id": "did:peer:1zQmRtJYm9vMdFd4sedav1nyLjaMQp2BozhvTWkiWNSjbFq3",
    "publicKey": [
        {
            "controller": "#id",
            "id": "#CkPGqALPjt8PFWbYd4WmcNX4Qq3iXdUVq67s3yeh9vxe",
            "publicKeyBase58": "CkPGqALPjt8PFWbYd4WmcNX4Qq3iXdUVq67s3yeh9vxe",
            "type": "Ed25519VerificationKey2018"
        }
    ],
    "service": [
        {
            "id": "#agent",
            "priority": 0,
            "recipientKeys": [
                "CkPGqALPjt8PFWbYd4WmcNX4Qq3iXdUVq67s3yeh9vxe"
            ],
            "routingKeys": null,
            "serviceEndpoint": "http://example.com/didcomm",
            "type": "did-communication"
        }
    ],
    "updated": "2020-08-10T16:13:22.45194098-04:00"
}
```

</details>

----

Regarding how to set the verification method, see the example test included:

```go
		err = expectedVP.AddLinkedDataProof(&verifiable.LinkedDataProofContext{
			SignatureType: ed25519signature2018.SignatureType,
			Suite: ed25519signature2018.New(suite.WithSigner(
				&legacySigner{
					verkey: verKey.ID,
					ks:     alice.Signer(),
				},
			)),
			SignatureRepresentation: verifiable.SignatureJWS,
			Created:                 &now,
			VerificationMethod:      fmt.Sprintf("%s%s", alicePeerDID.ID, verKey.ID),
			Challenge:               uuid.New().String(),
			Domain:                  uuid.New().String(),
			Purpose:                 "authentication",
		})
```

Signed-off-by: George Aristy <george.aristy@securekey.com>
