### PR TITLE
feat: Added TheirLabel to the record when request received

### DIFF
--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -677,6 +677,7 @@ func (s *Service) requestMsgRecord(msg service.DIDCommMsg) (*connection.Record, 
 	}
 
 	connRecord := &connection.Record{
+		TheirLabel:   request.Label,
 		ConnectionID: generateRandomID(),
 		ThreadID:     request.ID,
 		State:        stateNameNull,


### PR DESCRIPTION
We missed adding `TheirLabel` to the connection record. This PR fixes it by adding `TheirLabel` to the record when requests received.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>