### PR TITLE
feat: Fixes BDD test (router not registered)

### DIFF
--- a/test/aries-js-worker/test/introduce/introduce.js
+++ b/test/aries-js-worker/test/introduce/introduce.js
@@ -115,11 +115,12 @@ async function proposalWithRequest(mode) {
     it("Carol wants to know Bob and sends introduce response with approve", async function () {
         let outofbandAction = getOutofbandAction(carol)
 
+        let checked = checkConnection(mode, bob, carol, request.request['@id'])
+
         await carol.introduce.acceptProposal({
             piid: (await carolAction).Properties.piid,
         })
 
-        let checked = checkConnection(mode, bob, carol, request.request['@id'])
         await carol.outofband.actionContinue({
             piid: (await outofbandAction).Message['@id'],
             label: "Bob",
@@ -181,11 +182,11 @@ async function proposal(mode) {
     it("Carol wants to know Bob and sends introduce response with approve", async function () {
         let outofbandAction = getOutofbandAction(carol)
 
+        let checked = checkConnection(mode, bob, carol, request.request['@id'])
+
         await carol.introduce.acceptProposal({
             piid: (await carolAction).Properties.piid,
         })
-
-        let checked = checkConnection(mode, bob, carol, request.request['@id'])
 
         await carol.outofband.actionContinue({
             piid: (await outofbandAction).Message['@id'],
@@ -238,11 +239,11 @@ async function skipProposalWithRequest(mode) {
     it("Bob wants to know Carol and sends introduce response with approve", async function () {
         let outofbandAction = getOutofbandAction(bob)
 
+        let checked = checkConnection(mode, carol, bob, request.request['@id'])
+
         await bob.introduce.acceptProposal({
             piid: (await bobAction).Properties.piid,
         })
-
-        let checked = checkConnection(mode, carol, bob, request.request['@id'])
 
         await bob.outofband.actionContinue({
             piid: (await outofbandAction).Message['@id'],
@@ -290,11 +291,11 @@ async function skipProposal(mode) {
     it("Bob wants to know Carol and sends introduce response with approve", async function () {
         let outofbandAction = getOutofbandAction(bob)
 
+        let checked = checkConnection(mode, carol, bob, request.request['@id'])
+
         await bob.introduce.acceptProposal({
             piid: (await bobAction).Properties.piid,
         })
-
-        let checked = checkConnection(mode, carol, bob, request.request['@id'])
 
         await bob.outofband.actionContinue({
             piid: (await outofbandAction).Message['@id'],

--- a/test/bdd/pkg/redeemableroutes/redeemable_routes.go
+++ b/test/bdd/pkg/redeemableroutes/redeemable_routes.go
@@ -28,7 +28,7 @@ import (
 	oobSteps "github.com/hyperledger/aries-framework-go/test/bdd/pkg/outofband"
 )
 
-const timeout = 2 * time.Second
+const timeout = 5 * time.Second
 
 // BDDSteps for this feature.
 type BDDSteps struct {


### PR DESCRIPTION
BDD test sometimes fails due to error `routing config : failed to fetch routing configuration : router not registered`. See https://github.com/hyperledger/aries-framework-go/runs/993989706#step:5:3248
This PR increase timeout from 2 to 5 seconds.

The second issue was with the JS test.
This PR also fixes it.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>