### PR TITLE
feat:  Verifiable - saves participant`s DIDs.

### DIFF
--- a/cmd/aries-js-worker/main.go
+++ b/cmd/aries-js-worker/main.go
@@ -78,7 +78,10 @@ type ariesStartOpts struct {
 // main registers the 'handleMsg' function in the JS context's global scope to receive commands.
 // results are posted back to the 'handleResult' JS function.
 func main() {
-	input := make(chan *command)
+	// TODO: capacity was added due to deadlock. Looks like js worker are not able to pick up 'output chan *result'.
+	//  Another fix for that is to wrap 'in <- cmd' in a goroutine. e.g go func() { in <- cmd }()
+	//  We need to figure out what is the root cause of deadlock and fix it properly.
+	input := make(chan *command, 10)
 	output := make(chan *result)
 
 	go pipe(input, output)

--- a/pkg/didcomm/protocol/issuecredential/service.go
+++ b/pkg/didcomm/protocol/issuecredential/service.go
@@ -622,6 +622,8 @@ func (s *Service) execute(next state, md *metaData) (state, stateAction, error) 
 
 	defer s.sendMsgEvents(md, next.Name(), service.PostState)
 
+	md.properties = newEventProps(md).All()
+
 	if err := s.middleware.Handle(md); err != nil {
 		return nil, nil, fmt.Errorf("middleware: %w", err)
 	}

--- a/pkg/didcomm/protocol/middleware/presentproof/middlewares_test.go
+++ b/pkg/didcomm/protocol/middleware/presentproof/middlewares_test.go
@@ -34,6 +34,8 @@ var pubKey = did.PublicKey{
 	},
 }
 
+const vpJWS = "eyJhbGciOiJFZERTQSIsImtpZCI6ImtleS0xIiwidHlwIjoiSldUIn0.eyJpc3MiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJqdGkiOiJ1cm46dXVpZDozOTc4MzQ0Zi04NTk2LTRjM2EtYTk3OC04ZmNhYmEzOTAzYzUiLCJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiIsIlVuaXZlcnNpdHlEZWdyZWVDcmVkZW50aWFsIl0sInZlcmlmaWFibGVDcmVkZW50aWFsIjpbeyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sImNyZWRlbnRpYWxTY2hlbWEiOltdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwidW5pdmVyc2l0eSI6Ik1JVCJ9LCJpZCI6ImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSIsIm5hbWUiOiJKYXlkZW4gRG9lIiwic3BvdXNlIjoiZGlkOmV4YW1wbGU6YzI3NmUxMmVjMjFlYmZlYjFmNzEyZWJjNmYxIn0sImV4cGlyYXRpb25EYXRlIjoiMjAyMC0wMS0wMVQxOToyMzoyNFoiLCJpZCI6Imh0dHA6Ly9leGFtcGxlLmVkdS9jcmVkZW50aWFscy8xODcyIiwiaXNzdWFuY2VEYXRlIjoiMjAxMC0wMS0wMVQxOToyMzoyNFoiLCJpc3N1ZXIiOnsiaWQiOiJkaWQ6ZXhhbXBsZTo3NmUxMmVjNzEyZWJjNmYxYzIyMWViZmViMWYiLCJuYW1lIjoiRXhhbXBsZSBVbml2ZXJzaXR5In0sInJlZmVyZW5jZU51bWJlciI6OC4zMjk0ODQ3ZSswNywidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIlVuaXZlcnNpdHlEZWdyZWVDcmVkZW50aWFsIl19XX19.RlO_1B-7qhQNwo2mmOFUWSa8A6hwaJrtq3q7yJDkKq4k6B-EJ-oyLNM6H_g2_nko2Yg9Im1CiROFm6nK12U_AQ" //nolint:lll
+
 func TestSavePresentation(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -108,11 +110,13 @@ func TestSavePresentation(t *testing.T) {
 			errMsg = "error message"
 		)
 
-		vpJWS := "eyJhbGciOiJFZERTQSIsImtpZCI6ImtleS0xIiwidHlwIjoiSldUIn0.eyJpc3MiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJqdGkiOiJ1cm46dXVpZDozOTc4MzQ0Zi04NTk2LTRjM2EtYTk3OC04ZmNhYmEzOTAzYzUiLCJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiIsIlVuaXZlcnNpdHlEZWdyZWVDcmVkZW50aWFsIl0sInZlcmlmaWFibGVDcmVkZW50aWFsIjpbeyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sImNyZWRlbnRpYWxTY2hlbWEiOltdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwidW5pdmVyc2l0eSI6Ik1JVCJ9LCJpZCI6ImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSIsIm5hbWUiOiJKYXlkZW4gRG9lIiwic3BvdXNlIjoiZGlkOmV4YW1wbGU6YzI3NmUxMmVjMjFlYmZlYjFmNzEyZWJjNmYxIn0sImV4cGlyYXRpb25EYXRlIjoiMjAyMC0wMS0wMVQxOToyMzoyNFoiLCJpZCI6Imh0dHA6Ly9leGFtcGxlLmVkdS9jcmVkZW50aWFscy8xODcyIiwiaXNzdWFuY2VEYXRlIjoiMjAxMC0wMS0wMVQxOToyMzoyNFoiLCJpc3N1ZXIiOnsiaWQiOiJkaWQ6ZXhhbXBsZTo3NmUxMmVjNzEyZWJjNmYxYzIyMWViZmViMWYiLCJuYW1lIjoiRXhhbXBsZSBVbml2ZXJzaXR5In0sInJlZmVyZW5jZU51bWJlciI6OC4zMjk0ODQ3ZSswNywidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIlVuaXZlcnNpdHlEZWdyZWVDcmVkZW50aWFsIl19XX19.RlO_1B-7qhQNwo2mmOFUWSa8A6hwaJrtq3q7yJDkKq4k6B-EJ-oyLNM6H_g2_nko2Yg9Im1CiROFm6nK12U_AQ" //nolint:lll
-
 		metadata := mocks.NewMockMetadata(ctrl)
 		metadata.EXPECT().StateName().Return(stateNamePresentationReceived)
 		metadata.EXPECT().PresentationNames().Return([]string{vcName}).Times(2)
+		metadata.EXPECT().Properties().Return(map[string]interface{}{
+			myDIDKey:    myDIDKey,
+			theirDIDKey: theirDIDKey,
+		})
 		metadata.EXPECT().Message().Return(service.NewDIDCommMsgMap(presentproof.Presentation{
 			Type: presentproof.PresentationMsgType,
 			PresentationsAttach: []decorator.Attachment{
@@ -121,7 +125,8 @@ func TestSavePresentation(t *testing.T) {
 		}))
 
 		verifiableStore := mocksstore.NewMockStore(ctrl)
-		verifiableStore.EXPECT().SavePresentation(gomock.Any(), gomock.Any()).Return(errors.New(errMsg))
+		verifiableStore.EXPECT().SavePresentation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(errors.New(errMsg))
 
 		registry := mocksvdri.NewMockRegistry(ctrl)
 		registry.EXPECT().Resolve("did:example:ebfeb1f712ebc6f1c276e12ec21").Return(&did.Doc{
@@ -135,10 +140,36 @@ func TestSavePresentation(t *testing.T) {
 		require.EqualError(t, SavePresentation(provider)(next).Handle(metadata), "save presentation: "+errMsg)
 	})
 
+	t.Run("No DIDs", func(t *testing.T) {
+		metadata := mocks.NewMockMetadata(ctrl)
+		metadata.EXPECT().StateName().Return(stateNamePresentationReceived)
+		metadata.EXPECT().Properties().Return(map[string]interface{}{})
+		metadata.EXPECT().Message().Return(service.NewDIDCommMsgMap(presentproof.Presentation{
+			Type: presentproof.PresentationMsgType,
+			PresentationsAttach: []decorator.Attachment{
+				{Data: decorator.AttachmentData{Base64: base64.StdEncoding.EncodeToString([]byte(vpJWS))}},
+			},
+		}))
+
+		registry := mocksvdri.NewMockRegistry(ctrl)
+		registry.EXPECT().Resolve("did:example:ebfeb1f712ebc6f1c276e12ec21").Return(&did.Doc{
+			PublicKey: []did.PublicKey{pubKey},
+		}, nil)
+
+		provider := mocks.NewMockProvider(ctrl)
+		provider.EXPECT().VDRIRegistry().Return(registry).AnyTimes()
+		provider.EXPECT().VerifiableStore().Return(mocksstore.NewMockStore(ctrl))
+
+		require.EqualError(t, SavePresentation(provider)(next).Handle(metadata), "myDID or theirDID is absent")
+	})
+
 	t.Run("Success (no ID)", func(t *testing.T) {
 		vpJWSNoID := "eyJhbGciOiJFZERTQSIsImtpZCI6IiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJkaWQ6ZXhhbXBsZTo0YTU3NTQ2OTczNDM2ZjZmNmM0YTRhNTc1NzMiLCJpc3MiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiIsIlVuaXZlcnNpdHlEZWdyZWVDcmVkZW50aWFsIl0sInZlcmlmaWFibGVDcmVkZW50aWFsIjpbeyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sImNyZWRlbnRpYWxTY2hlbWEiOltdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwidW5pdmVyc2l0eSI6Ik1JVCJ9LCJpZCI6ImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSIsIm5hbWUiOiJKYXlkZW4gRG9lIiwic3BvdXNlIjoiZGlkOmV4YW1wbGU6YzI3NmUxMmVjMjFlYmZlYjFmNzEyZWJjNmYxIn0sImV4cGlyYXRpb25EYXRlIjoiMjAyMC0wMS0wMVQxOToyMzoyNFoiLCJpZCI6Imh0dHA6Ly9leGFtcGxlLmVkdS9jcmVkZW50aWFscy8xODcyIiwiaXNzdWFuY2VEYXRlIjoiMjAxMC0wMS0wMVQxOToyMzoyNFoiLCJpc3N1ZXIiOnsiaWQiOiJkaWQ6ZXhhbXBsZTo3NmUxMmVjNzEyZWJjNmYxYzIyMWViZmViMWYiLCJuYW1lIjoiRXhhbXBsZSBVbml2ZXJzaXR5In0sInJlZmVyZW5jZU51bWJlciI6ODMyOTQ4NDcsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJVbml2ZXJzaXR5RGVncmVlQ3JlZGVudGlhbCJdfV19fQ.VaULMC_bFEI46jPLX7T8BW9liQ88JfCu0BeAxUkEIqjk-K2GFAbrP1WOJyJIXZZ-5J_nM7LNZX6mxbmhcj--Dw" //nolint:lll
 
-		props := map[string]interface{}{}
+		props := map[string]interface{}{
+			myDIDKey:    myDIDKey,
+			theirDIDKey: theirDIDKey,
+		}
 
 		metadata := mocks.NewMockMetadata(ctrl)
 		metadata.EXPECT().StateName().Return(stateNamePresentationReceived)
@@ -152,7 +183,8 @@ func TestSavePresentation(t *testing.T) {
 		}))
 
 		verifiableStore := mocksstore.NewMockStore(ctrl)
-		verifiableStore.EXPECT().SavePresentation(gomock.Any(), gomock.Any()).Return(nil)
+		verifiableStore.EXPECT().SavePresentation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil)
 
 		registry := mocksvdri.NewMockRegistry(ctrl)
 		registry.EXPECT().Resolve("did:example:ebfeb1f712ebc6f1c276e12ec21").Return(&did.Doc{
@@ -171,9 +203,10 @@ func TestSavePresentation(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		const vcName = "vc-name"
 
-		vpJWS := "eyJhbGciOiJFZERTQSIsImtpZCI6ImtleS0xIiwidHlwIjoiSldUIn0.eyJpc3MiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJqdGkiOiJ1cm46dXVpZDozOTc4MzQ0Zi04NTk2LTRjM2EtYTk3OC04ZmNhYmEzOTAzYzUiLCJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiIsIlVuaXZlcnNpdHlEZWdyZWVDcmVkZW50aWFsIl0sInZlcmlmaWFibGVDcmVkZW50aWFsIjpbeyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sImNyZWRlbnRpYWxTY2hlbWEiOltdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwidW5pdmVyc2l0eSI6Ik1JVCJ9LCJpZCI6ImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSIsIm5hbWUiOiJKYXlkZW4gRG9lIiwic3BvdXNlIjoiZGlkOmV4YW1wbGU6YzI3NmUxMmVjMjFlYmZlYjFmNzEyZWJjNmYxIn0sImV4cGlyYXRpb25EYXRlIjoiMjAyMC0wMS0wMVQxOToyMzoyNFoiLCJpZCI6Imh0dHA6Ly9leGFtcGxlLmVkdS9jcmVkZW50aWFscy8xODcyIiwiaXNzdWFuY2VEYXRlIjoiMjAxMC0wMS0wMVQxOToyMzoyNFoiLCJpc3N1ZXIiOnsiaWQiOiJkaWQ6ZXhhbXBsZTo3NmUxMmVjNzEyZWJjNmYxYzIyMWViZmViMWYiLCJuYW1lIjoiRXhhbXBsZSBVbml2ZXJzaXR5In0sInJlZmVyZW5jZU51bWJlciI6OC4zMjk0ODQ3ZSswNywidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIlVuaXZlcnNpdHlEZWdyZWVDcmVkZW50aWFsIl19XX19.RlO_1B-7qhQNwo2mmOFUWSa8A6hwaJrtq3q7yJDkKq4k6B-EJ-oyLNM6H_g2_nko2Yg9Im1CiROFm6nK12U_AQ" //nolint:lll
-
-		props := map[string]interface{}{}
+		props := map[string]interface{}{
+			myDIDKey:    myDIDKey,
+			theirDIDKey: theirDIDKey,
+		}
 
 		metadata := mocks.NewMockMetadata(ctrl)
 		metadata.EXPECT().StateName().Return(stateNamePresentationReceived)
@@ -187,7 +220,8 @@ func TestSavePresentation(t *testing.T) {
 		}))
 
 		verifiableStore := mocksstore.NewMockStore(ctrl)
-		verifiableStore.EXPECT().SavePresentation(gomock.Any(), gomock.Any()).Return(nil)
+		verifiableStore.EXPECT().SavePresentation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil)
 
 		registry := mocksvdri.NewMockRegistry(ctrl)
 		registry.EXPECT().Resolve("did:example:ebfeb1f712ebc6f1c276e12ec21").Return(&did.Doc{

--- a/pkg/didcomm/protocol/presentproof/service.go
+++ b/pkg/didcomm/protocol/presentproof/service.go
@@ -610,6 +610,8 @@ func (s *Service) execute(next state, md *metaData) (state, stateAction, error) 
 
 	defer s.sendMsgEvents(md, next.Name(), service.PostState)
 
+	md.properties = newEventProps(md).All()
+
 	if err := s.middleware.Handle(md); err != nil {
 		return nil, nil, fmt.Errorf("middleware: %w", err)
 	}

--- a/pkg/internal/gomocks/store/verifiable/mocks.go
+++ b/pkg/internal/gomocks/store/verifiable/mocks.go
@@ -153,29 +153,39 @@ func (mr *MockStoreMockRecorder) RemovePresentationByName(arg0 interface{}) *gom
 }
 
 // SaveCredential mocks base method
-func (m *MockStore) SaveCredential(arg0 string, arg1 *verifiable.Credential) error {
+func (m *MockStore) SaveCredential(arg0 string, arg1 *verifiable.Credential, arg2 ...verifiable0.Opt) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveCredential", arg0, arg1)
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SaveCredential", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SaveCredential indicates an expected call of SaveCredential
-func (mr *MockStoreMockRecorder) SaveCredential(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) SaveCredential(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveCredential", reflect.TypeOf((*MockStore)(nil).SaveCredential), arg0, arg1)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveCredential", reflect.TypeOf((*MockStore)(nil).SaveCredential), varargs...)
 }
 
 // SavePresentation mocks base method
-func (m *MockStore) SavePresentation(arg0 string, arg1 *verifiable.Presentation) error {
+func (m *MockStore) SavePresentation(arg0 string, arg1 *verifiable.Presentation, arg2 ...verifiable0.Opt) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SavePresentation", arg0, arg1)
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SavePresentation", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SavePresentation indicates an expected call of SavePresentation
-func (mr *MockStoreMockRecorder) SavePresentation(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) SavePresentation(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SavePresentation", reflect.TypeOf((*MockStore)(nil).SavePresentation), arg0, arg1)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SavePresentation", reflect.TypeOf((*MockStore)(nil).SavePresentation), varargs...)
 }

--- a/pkg/store/verifiable/models.go
+++ b/pkg/store/verifiable/models.go
@@ -13,4 +13,8 @@ type Record struct {
 	Context   []string `json:"context,omitempty"`
 	Type      []string `json:"type,omitempty"`
 	SubjectID string   `json:"subjectId,omitempty"`
+	// MyDID and TheirDID contains information about participants who were involved in the process
+	// of issuing a credential or presentation.
+	MyDID    string `json:"my_did,omitempty"`
+	TheirDID string `json:"their_did,omitempty"`
 }

--- a/pkg/store/verifiable/store_test.go
+++ b/pkg/store/verifiable/store_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package verifiable
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"testing"
@@ -290,6 +291,26 @@ func TestSaveVC(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "credential name already exists")
 	})
+
+	t.Run("test save vc - with options", func(t *testing.T) {
+		const (
+			MyDID    = "MyDID"
+			TheirDID = "TheirDID"
+		)
+		s, err := New(&mockprovider.Provider{
+			StorageProviderValue: mockstore.NewMockStoreProvider(),
+		})
+		require.NoError(t, err)
+		require.NoError(t, s.SaveCredential(sampleCredentialName, &verifiable.Credential{ID: "vc1"},
+			WithMyDID(MyDID), WithTheirDID(TheirDID)))
+
+		records, err := s.GetCredentials()
+		require.NoError(t, err)
+		require.Equal(t, 1, len(records))
+
+		require.Equal(t, MyDID, records[0].MyDID)
+		require.Equal(t, TheirDID, records[0].TheirDID)
+	})
 }
 
 func TestGetVC(t *testing.T) {
@@ -364,7 +385,13 @@ func TestGetVC(t *testing.T) {
 
 func TestGetCredentialIDBasedOnName(t *testing.T) {
 	t.Run("test get credential based on name - success", func(t *testing.T) {
-		rbytes, err := getRecord(sampleCredentialID, "", nil, nil)
+		rbytes, err := json.Marshal(&Record{
+			ID:        sampleCredentialID,
+			Name:      "",
+			Context:   nil,
+			Type:      nil,
+			SubjectID: ""},
+		)
 		require.NoError(t, err)
 
 		store := make(map[string][]byte)
@@ -501,6 +528,26 @@ func TestSaveVP(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "presentation name already exists")
 	})
+
+	t.Run("test save vp - with options", func(t *testing.T) {
+		const (
+			MyDID    = "MyDID"
+			TheirDID = "TheirDID"
+		)
+		s, err := New(&mockprovider.Provider{
+			StorageProviderValue: mockstore.NewMockStoreProvider(),
+		})
+		require.NoError(t, err)
+		require.NoError(t, s.SavePresentation(samplePresentationName, &verifiable.Presentation{ID: "vp1"},
+			WithMyDID(MyDID), WithTheirDID(TheirDID)))
+
+		records, err := s.GetPresentations()
+		require.NoError(t, err)
+		require.Equal(t, 1, len(records))
+
+		require.Equal(t, MyDID, records[0].MyDID)
+		require.Equal(t, TheirDID, records[0].TheirDID)
+	})
 }
 
 func TestGetVP(t *testing.T) {
@@ -579,7 +626,13 @@ func TestGetVP(t *testing.T) {
 
 func TestGetPresentationIDBasedOnName(t *testing.T) {
 	t.Run("test get presentation based on name - success", func(t *testing.T) {
-		rbytes, err := getRecord(samplePresentationID, "", nil, nil)
+		rbytes, err := json.Marshal(&Record{
+			ID:        samplePresentationID,
+			Name:      "",
+			Context:   nil,
+			Type:      nil,
+			SubjectID: ""},
+		)
 		require.NoError(t, err)
 
 		store := make(map[string][]byte)

--- a/test/aries-js-worker/test/presentproof/presentproof.js
+++ b/test/aries-js-worker/test/presentproof/presentproof.js
@@ -63,12 +63,14 @@ async function presentProof(mode) {
     })
 
     let proverAction;
+    let verifierConn;
+
     it("Verifier sends a request presentation to the Prover", async function() {
         proverAction = getAction(prover)
-        let conn = await connection(verifier, connections[0])
+        verifierConn = await connection(verifier, connections[0])
         return verifier.presentproof.sendRequestPresentation({
-            my_did: conn.MyDID,
-            their_did: conn.TheirDID,
+            my_did: verifierConn.MyDID,
+            their_did: verifierConn.TheirDID,
             request_presentation: {will_confirm:true},
         })
     })
@@ -92,7 +94,10 @@ async function presentProof(mode) {
     })
 
     it("Verifier checks presentation", async function () {
-        await getPresentation(verifier, name)
+        let presentation = await getPresentation(verifier, name)
+
+        assert.equal(presentation.my_did, verifierConn.MyDID)
+        assert.equal(presentation.their_did, verifierConn.TheirDID)
     })
 }
 
@@ -106,7 +111,7 @@ async function getPresentation(agent, name) {
     if (res.result) {
         for (let j = 0; j < res.result.length; j++) {
             if (res.result[j].name === name) {
-                return
+                return res.result[j]
             }
         }
     }


### PR DESCRIPTION
We did not have a possibility to correlate `credentials` or `presentations` that were issued through the protocols with did-connections (participants who were involved in the process of issuing).
This PR fixes it by introducing two new fields in `verifiable.Record` structure. Those fields are not part of credentials/presentations and they do not have any impact on original VC/VP. Fields are being used as `other fields of interest.` according to `Record` structure.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>