### PR TITLE
fix: Fixes deadline in BDD test

### DIFF
--- a/test/bdd/pkg/introduce/introduce_sdk_steps.go
+++ b/test/bdd/pkg/introduce/introduce_sdk_steps.go
@@ -33,7 +33,7 @@ import (
 	outofbandbdd "github.com/hyperledger/aries-framework-go/test/bdd/pkg/outofband"
 )
 
-const timeout = time.Second * 2
+const timeout = time.Second * 10
 
 // SDKSteps is steps for introduce using client SDK.
 type SDKSteps struct {


### PR DESCRIPTION
BDD test was failing due to the deadline. It happens because of the missing event.
This PR fixes it by moving the listener before action.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>