### PR TITLE
refactor: revert KID encoding back to base64URL and introduce base58 store wrapper

### DIFF
--- a/pkg/didcomm/packer/authcrypt/pack.go
+++ b/pkg/didcomm/packer/authcrypt/pack.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/storage/base58wrapper"
 )
 
 // Package authcrypt includes a Packer implementation to build and parse JWE messages using Authcrypt. It allows sending
@@ -68,7 +69,7 @@ func New(ctx packer.Provider, encAlg jose.EncAlg) (*Packer, error) {
 	return &Packer{
 		kms:    k,
 		encAlg: encAlg,
-		store:  store,
+		store:  base58wrapper.NewBase58StoreWrapper(store),
 	}, nil
 }
 

--- a/pkg/didcomm/packer/authcrypt/pack_test.go
+++ b/pkg/didcomm/packer/authcrypt/pack_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/btcsuite/btcutil/base58"
 	"github.com/google/tink/go/keyset"
 	"github.com/stretchr/testify/require"
 
@@ -42,7 +43,8 @@ func TestAuthryptPackerSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// add sender key in store (prep step before Authcrypt.Pack()/Unpack())
-	mockStoreMap[skid] = senderKey
+	b58SKID := base58.Encode([]byte(skid))
+	mockStoreMap[b58SKID] = senderKey
 
 	origMsg := []byte("secret message")
 	ct, err := authPacker.Pack(origMsg, []byte(skid), recipientsKeys)

--- a/pkg/kms/localkms/kid_creator.go
+++ b/pkg/kms/localkms/kid_creator.go
@@ -12,11 +12,11 @@ import (
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math/big"
 
-	"github.com/btcsuite/btcutil/base58"
 	hybrid "github.com/google/tink/go/hybrid/subtle"
 
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite"
@@ -27,7 +27,7 @@ import (
 // CreateKID creates a KID value based on the marshalled keyBytes of type kt. This function should be called for
 // asymmetric public keys only (ECDSA DER or IEEE1363, ED25519).
 // returns:
-//  - base58 encoded KID
+//  - base64 raw (no padding) URL encoded KID
 //  - error in case of error
 func CreateKID(keyBytes []byte, kt kms.KeyType) (string, error) {
 	jwk, err := buildJWK(keyBytes, kt)
@@ -40,7 +40,7 @@ func CreateKID(keyBytes []byte, kt kms.KeyType) (string, error) {
 		return "", fmt.Errorf("createKID: failed to get jwk Thumbprint: %w", err)
 	}
 
-	return base58.Encode(tp), nil
+	return base64.RawURLEncoding.EncodeToString(tp), nil
 }
 
 func buildJWK(keyBytes []byte, kt kms.KeyType) (*jose.JWK, error) {

--- a/pkg/kms/localkms/localkms.go
+++ b/pkg/kms/localkms/localkms.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms/internal/keywrapper"
 	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/storage/base58wrapper"
 )
 
 const (
@@ -57,9 +58,18 @@ type LocalKMS struct {
 	masterKeyEnvAEAD *aead.KMSEnvelopeAEAD
 }
 
+func newKeyIDWrapperStore(provider storage.Provider) (storage.Store, error) {
+	s, err := provider.OpenStore(Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return base58wrapper.NewBase58StoreWrapper(s), nil
+}
+
 // New will create a new (local) KMS service.
 func New(masterKeyURI string, p kms.Provider) (*LocalKMS, error) {
-	store, err := p.StorageProvider().OpenStore(Namespace)
+	store, err := newKeyIDWrapperStore(p.StorageProvider())
 	if err != nil {
 		return nil, fmt.Errorf("new: failed to ceate local kms: %w", err)
 	}
@@ -78,7 +88,8 @@ func New(masterKeyURI string, p kms.Provider) (*LocalKMS, error) {
 			store:            store,
 			secretLock:       secretLock,
 			masterKeyURI:     masterKeyURI,
-			masterKeyEnvAEAD: masterKeyEnvAEAD},
+			masterKeyEnvAEAD: masterKeyEnvAEAD,
+		},
 		nil
 }
 

--- a/pkg/kms/localkms/localkms_test.go
+++ b/pkg/kms/localkms/localkms_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/btcsuite/btcutil/base58"
 	"github.com/google/tink/go/keyset"
 	"github.com/google/tink/go/subtle/random"
 	"github.com/stretchr/testify/require"
@@ -275,7 +276,9 @@ func TestLocalKMS_Success(t *testing.T) {
 		require.NoError(t, e)
 		require.NotEmpty(t, newKeyHandle)
 		require.NotEmpty(t, keyID)
-		ks, ok := storeDB[keyID]
+
+		b58KID := base58.Encode([]byte(keyID))
+		ks, ok := storeDB[b58KID]
 		require.True(t, ok)
 		require.NotEmpty(t, ks)
 

--- a/pkg/kms/localkms/localkms_writer.go
+++ b/pkg/kms/localkms/localkms_writer.go
@@ -7,17 +7,17 @@
 package localkms
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 
-	"github.com/btcsuite/btcutil/base58"
 	"github.com/google/tink/go/subtle/random"
 
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
-const maxKeyIDLen = 36
+const maxKeyIDLen = 50
 
 // newWriter creates a new instance of local storage key storeWriter in the given store and for masterKeyURI.
 func newWriter(kmsStore storage.Store, opts ...kms.PrivateKeyOpts) *storeWriter {
@@ -84,11 +84,12 @@ func (l *storeWriter) verifyRequestedID() (string, error) {
 }
 
 func (l *storeWriter) newKeysetID() (string, error) {
+	keySetIDLength := base64.RawURLEncoding.DecodedLen(maxKeyIDLen)
 	ksID := ""
 
 	for {
-		// generate random ID, maxKeyIDLen of 36 bytes gives 48 to 50 bytes encoded ID (the closest length to max 50)
-		ksID = base58.Encode(random.GetRandomBytes(uint32(maxKeyIDLen)))
+		// generate random ID
+		ksID = base64.RawURLEncoding.EncodeToString(random.GetRandomBytes(uint32(keySetIDLength)))
 
 		// ensure ksID is not already used
 		_, err := l.storage.Get(ksID)

--- a/pkg/kms/localkms/localkms_writer_test.go
+++ b/pkg/kms/localkms/localkms_writer_test.go
@@ -30,9 +30,7 @@ func TestLocalKMSWriter(t *testing.T) {
 			n, err := l.Write(someKey)
 			require.NoError(t, err)
 			require.Equal(t, len(someKey), n)
-			require.Contains(t, []int{50, 49, 48}, len(l.KeysetID), "for key creation iteration %d", i)
-			// keysetID must not start with _
-			require.NotEqual(t, uint8('_'), l.KeysetID[0])
+			require.Equal(t, maxKeyIDLen, len(l.KeysetID), "for key creation iteration %d", i)
 			retrievedKey, ok := storeMap[l.KeysetID]
 			require.True(t, ok)
 			require.Equal(t, retrievedKey, someKey)
@@ -102,7 +100,7 @@ func TestLocalKMSWriter(t *testing.T) {
 		n, err := l.Write(someKey)
 		require.NoError(t, err)
 		require.Equal(t, len(someKey), n)
-		require.Contains(t, []int{50, 49, 48}, len(l.KeysetID))
+		require.Equal(t, maxKeyIDLen, len(l.KeysetID))
 		// keysetID must not start with _
 		require.NotEqual(t, uint8('_'), l.KeysetID[0])
 		retrievedKey, ok := storeMap[l.KeysetID]

--- a/pkg/storage/base58wrapper/base58wrapper.go
+++ b/pkg/storage/base58wrapper/base58wrapper.go
@@ -1,0 +1,73 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package base58wrapper
+
+import (
+	"github.com/btcsuite/btcutil/base58"
+
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+// package base58wrapper offers provider.Store wrappers for stores with certain constraints on key values such as
+// reserved prefix values (eg key IDs starting with underscore) by wrapping key values in another format supported by
+// the store.
+
+// NewBase58StoreWrapper creates a new Base58StoreWrapper of store.
+func NewBase58StoreWrapper(store storage.Store) storage.Store {
+	return &Base58StoreWrapper{store: store}
+}
+
+// Base58StoreWrapper is a wrapper store that converts key IDs from base64 to base58 encoded values.
+// Keys IDs will be stored in the embedded store base58 encoded while the user of this wrapper store will interact with
+// the wrapper store using key IDs base64 raw (no padding) URL encoded.
+type Base58StoreWrapper struct {
+	store storage.Store
+}
+
+func convert(k string) string {
+	b58k := base58.Encode([]byte(k))
+
+	return b58k
+}
+
+// Put stores the key and the record by converting the key from base64 to base58 encoded value first.
+func (b *Base58StoreWrapper) Put(k string, v []byte) error {
+	b58k := convert(k)
+
+	return b.store.Put(b58k, v)
+}
+
+// Get fetches the record based on key by converting the key ID from base58 to base64 encoded value first.
+func (b *Base58StoreWrapper) Get(k string) ([]byte, error) {
+	b58k := convert(k)
+
+	return b.store.Get(b58k)
+}
+
+// Iterator returns an iterator for the latest snapshot of the underlying store.
+//
+// Args:
+//
+// startKey: Start of the key range, include in the range by converting it from base64 to base58 encoded value first.
+// endKey: End of the key range, not include in the range by converting it from base64 to base58 encoded value first.
+//
+// Returns:
+//
+// StoreIterator: a wrapped iterator for result range.
+func (b *Base58StoreWrapper) Iterator(startKey, endKey string) storage.StoreIterator {
+	// base58 encoding doesn't maintain the same prefix for values using the same prefix,
+	// eg `abc_123` encoded is "4h3c6pUcw4" and `abc_` encoded "3VNr6J" which is not the prefix of `abc_123` base58
+	// encoded.  This means StoreIterator cannot iterate through base58 encoded keys.
+	// For this reason, this wrapper doesn't support the iterator.
+	return nil
+}
+
+// Delete will delete a record with k by converting it from base64 to base58 encoded value first.
+func (b *Base58StoreWrapper) Delete(k string) error {
+	b58k := convert(k)
+
+	return b.store.Delete(b58k)
+}

--- a/pkg/storage/base58wrapper/base58wrapper_test.go
+++ b/pkg/storage/base58wrapper/base58wrapper_test.go
@@ -1,0 +1,231 @@
+// +build !js,!wasm
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package base58wrapper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/go-kivik/kivik"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+	couchdbstore "github.com/hyperledger/aries-framework-go/pkg/storage/couchdb"
+)
+
+const (
+	couchDBURL = "localhost:5984"
+)
+
+// For these unit tests to run, you must ensure you have a CouchDB instance running at the URL specified in couchDBURL.
+// 'make unit-test' from the terminal will take care of this for you.
+// To run the tests manually, start an instance by running docker run -p 5984:5984 couchdb:2.3.1 from a terminal.
+
+func TestMain(m *testing.M) {
+	err := prepareCouchDB()
+	if err != nil {
+		fmt.Printf(err.Error() +
+			". Make sure you start a couchDB instance using" +
+			" 'docker run -p 5984:5984 couchdb:2.3.1' before running the unit tests")
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}
+
+func prepareCouchDB() error {
+	client, err := kivik.New("couch", couchDBURL)
+	if err != nil {
+		return err
+	}
+
+	dbs, err := client.AllDBs(context.Background())
+	if err != nil {
+		return err
+	}
+
+	for _, v := range dbs {
+		if err := client.DestroyDB(context.Background(), v); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func TestCouchDBStore(t *testing.T) {
+	t.Run("Test couchdb store put and get", func(t *testing.T) {
+		prov, err := couchdbstore.NewProvider(couchDBURL, couchdbstore.WithDBPrefix("dbprefix"))
+		require.NoError(t, err)
+		couchdbStore, err := prov.OpenStore("test")
+		require.NoError(t, err)
+
+		store := NewBase58StoreWrapper(couchdbStore)
+
+		const key = "ZGlkOmV4YW1wbGU6MTIz" // "did:example:123" base64 RAW URL encoded
+		data := []byte("value")
+
+		err = store.Put(key, data)
+		require.NoError(t, err)
+
+		doc, err := store.Get(key)
+		require.NoError(t, err)
+		require.NotEmpty(t, doc)
+		require.Equal(t, data, doc)
+
+		// test update
+		data = []byte(`{"key1":"value1"}`)
+		err = store.Put(key, data)
+		require.NoError(t, err)
+
+		doc, err = store.Get(key)
+		require.NoError(t, err)
+		require.NotEmpty(t, doc)
+		require.Equal(t, data, doc)
+
+		// test update
+		update := []byte(`{"_key1":"value1"}`)
+		err = store.Put(key, update)
+		require.NoError(t, err)
+
+		doc, err = store.Get(key)
+		require.NoError(t, err)
+		require.NotEmpty(t, doc)
+		require.Equal(t, update, doc)
+
+		did2 := "ZGlkOmV4YW1wbGU6Nzg5" // "did:example:789" base64 RAW URL encoded
+		_, err = store.Get(did2)
+		require.True(t, errors.Is(err, storage.ErrDataNotFound))
+
+		// nil key
+		_, err = store.Get("")
+		require.Error(t, err)
+
+		// nil value
+		err = store.Put(key, nil)
+		require.Error(t, err)
+
+		// nil key
+		err = store.Put("", data)
+		require.Error(t, err)
+
+		err = prov.Close()
+		require.NoError(t, err)
+	})
+
+	t.Run("Test couchdb multi store close by name", func(t *testing.T) {
+		prov, err := couchdbstore.NewProvider(couchDBURL, couchdbstore.WithDBPrefix("dbprefix"))
+		require.NoError(t, err)
+
+		const commonKey = "ZGlkOmV4YW1wbGU6MQ" // "did:example:1" base64 RAW URL encoded
+
+		data := []byte("value1")
+
+		storeNames := []string{"store_1", "store_2", "store_3", "store_4", "store_5"}
+		storesToClose := []string{"store_1", "store_3", "store_5"}
+
+		for _, name := range storeNames {
+			couchdbStore, e := prov.OpenStore(name)
+			require.NoError(t, e)
+
+			store := NewBase58StoreWrapper(couchdbStore)
+			require.NotNil(t, store)
+
+			e = store.Put(commonKey, data)
+			require.NoError(t, e)
+		}
+
+		for _, name := range storeNames {
+			couchdbStore, e := prov.OpenStore(name)
+			require.NoError(t, e)
+
+			store := NewBase58StoreWrapper(couchdbStore)
+			require.NotNil(t, store)
+
+			dataRead, e := store.Get(commonKey)
+			require.NoError(t, e)
+			require.Equal(t, data, dataRead)
+		}
+
+		// verify store length
+		// require.Len(t, prov.dbs, 5) // not available in the wrapper provider
+
+		for _, name := range storesToClose {
+			store, e := prov.OpenStore(name)
+			require.NoError(t, e)
+			require.NotNil(t, store)
+
+			e = prov.CloseStore(name)
+			require.NoError(t, e)
+		}
+
+		// verify store length
+		// require.Len(t, prov.dbs, 2) // not available in the wrapper provider
+
+		// try to close non existing db
+		err = prov.CloseStore("store_x")
+		require.NoError(t, err)
+
+		// verify store length
+		// require.Len(t, prov.dbs, 2) // not available in the wrapper provider
+
+		err = prov.Close()
+		require.NoError(t, err)
+
+		// verify store length
+		// require.Empty(t, prov.dbs) // not available in the wrapper provider
+
+		// try close all again
+		err = prov.Close()
+		require.NoError(t, err)
+	})
+}
+
+func TestCouchDBStore_Delete(t *testing.T) {
+	const commonKey = "ZGlkOmV4YW1wbGU6MTIzNA" // "did:example:1234" base64 RAW URL encoded
+
+	prov, err := couchdbstore.NewProvider(couchDBURL)
+	require.NoError(t, err)
+
+	data := []byte("value1")
+
+	// create store 1 & store 2
+	couchdbStore, err := prov.OpenStore("store1")
+	require.NoError(t, err)
+
+	store1 := NewBase58StoreWrapper(couchdbStore)
+
+	// put in store 1
+	err = store1.Put(commonKey, data)
+	require.NoError(t, err)
+
+	// get in store 1 - found
+	doc, err := store1.Get(commonKey)
+	require.NoError(t, err)
+	require.NotEmpty(t, doc)
+	require.Equal(t, data, doc)
+
+	// now try Delete with an empty key - should fail
+	err = store1.Delete("")
+	require.EqualError(t, err, "key is mandatory")
+
+	err = store1.Delete("k1")
+	require.NoError(t, err)
+
+	// finally test Delete an existing key
+	err = store1.Delete(commonKey)
+	require.NoError(t, err)
+
+	doc, err = store1.Get(commonKey)
+	require.EqualError(t, err, storage.ErrDataNotFound.Error())
+	require.Empty(t, doc)
+}

--- a/pkg/storage/couchdb/couchdbstore.go
+++ b/pkg/storage/couchdb/couchdbstore.go
@@ -50,6 +50,8 @@ func WithDBPrefix(dbPrefix string) Option {
 }
 
 // NewProvider instantiates Provider.
+// Certain stores like couchdb cannot accept key IDs with '_' prefix, to avoid getting errors with such values, key ID
+// need to be base58 encoded for these stores. In order to do so, the store must be wrapped using base58wrapper.
 func NewProvider(hostURL string, opts ...Option) (*Provider, error) {
 	if hostURL == "" {
 		return nil, errors.New(blankHostErrMsg)


### PR DESCRIPTION
closes #2137

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
