### PR TITLE
chore(make): add stop-openapi-demo target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,8 @@ run-openapi-demo: generate-test-keys generate-openapi-demo-specs
         scripts/run-openapi-demo.sh
 
 .PHONY: stop-openapi-demo
-stop-openapi-demo: generate-test-keys generate-openapi-demo-specs
-	@echo "Starting demo agent rest containers ..."
+stop-openapi-demo:
+	@echo "Stopping demo agent rest containers ..."
 	@DEMO_COMPOSE_PATH=test/bdd/fixtures/demo/openapi SIDETREE_COMPOSE_PATH=test/bdd/fixtures/sidetree-mock AGENT_REST_COMPOSE_PATH=test/bdd/fixtures/agent-rest  \
         DEMO_COMPOSE_OP=down scripts/run-openapi-demo.sh
 

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,12 @@ run-openapi-demo: generate-test-keys generate-openapi-demo-specs
 	@DEMO_COMPOSE_PATH=test/bdd/fixtures/demo/openapi SIDETREE_COMPOSE_PATH=test/bdd/fixtures/sidetree-mock AGENT_REST_COMPOSE_PATH=test/bdd/fixtures/agent-rest  \
         scripts/run-openapi-demo.sh
 
+.PHONY: stop-openapi-demo
+stop-openapi-demo: generate-test-keys generate-openapi-demo-specs
+	@echo "Starting demo agent rest containers ..."
+	@DEMO_COMPOSE_PATH=test/bdd/fixtures/demo/openapi SIDETREE_COMPOSE_PATH=test/bdd/fixtures/sidetree-mock AGENT_REST_COMPOSE_PATH=test/bdd/fixtures/agent-rest  \
+        DEMO_COMPOSE_OP=down scripts/run-openapi-demo.sh
+
 .PHONY: agent-rest
 agent-rest:
 	@echo "Building aries-agent-rest"

--- a/scripts/run-openapi-demo.sh
+++ b/scripts/run-openapi-demo.sh
@@ -6,7 +6,7 @@
 #
 set -e
 
-DEMO_COMPOSE_OP="${DEMO_COMPOSE_OP:-up --force-recreate}"
+DEMO_COMPOSE_OP="${DEMO_COMPOSE_OP:-up --force-recreate -d}"
 COMPOSE_FILES="${DEMO_COMPOSE_FILES}"
 DEMO_PATH="$PWD/${DEMO_COMPOSE_PATH}"
 AGENT_PATH="${AGENT_REST_COMPOSE_PATH}"
@@ -27,8 +27,8 @@ set -o allexport
 set +o allexport
 
 cd $AGENT_COMPOSE_FILE
-docker-compose -f docker-compose.yml  ${DEMO_COMPOSE_OP} -d
+docker-compose -f docker-compose.yml  ${DEMO_COMPOSE_OP}
 cd $SIDETREE_COMPOSE_FILE
-docker-compose -f docker-compose.yml ${DEMO_COMPOSE_OP} -d
+docker-compose -f docker-compose.yml ${DEMO_COMPOSE_OP}
 cd $DEMO_PATH
-docker-compose -f docker-compose.yml ${DEMO_COMPOSE_OP} -d
+docker-compose -f docker-compose.yml ${DEMO_COMPOSE_OP}


### PR DESCRIPTION
Signed-off-by: Jan Christoph Ebersbach <jan-christoph.eberbach@41ppl.com>

**Title:**
Add stop-openapi-demo target

**Description:**
Currently, there's only a target to start the demo but none to shut it down. Since stopping the demo by hand involves multiple commands executed in multiple directories, this new target should reduce the effort to stop the demo.

**Summary:**
Extended the Makefile with a stop-openapi-demo target.

