### PR TITLE
fix: Fixes mem store

### DIFF
--- a/pkg/storage/mem/mem_store.go
+++ b/pkg/storage/mem/mem_store.go
@@ -146,7 +146,7 @@ func (s *memStore) Iterator(start, limit string) storage.StoreIterator {
 	sort.Strings(keys)
 
 	var (
-		sIDx, eIDx = 0, len(keys)
+		sIDx, eIDx = -1, len(keys)
 		skip       bool
 	)
 
@@ -165,6 +165,10 @@ func (s *memStore) Iterator(start, limit string) storage.StoreIterator {
 
 			eIDx++
 		}
+	}
+
+	if sIDx == -1 {
+		return newMemIterator(nil)
 	}
 
 	for _, k := range keys[sIDx:eIDx] {

--- a/pkg/storage/mem/mem_store_test.go
+++ b/pkg/storage/mem/mem_store_test.go
@@ -217,6 +217,9 @@ func TestMemStore(t *testing.T) {
 
 		itr = store.Iterator("abc_", "mno_123")
 		verifyItr(t, itr, 6, "")
+
+		itr = store.Iterator("t_", "t_"+storage.EndKeySuffix)
+		verifyItr(t, itr, 0, "")
 	})
 }
 

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -163,6 +163,9 @@ func TestStore(t *testing.T) {
 
 			itr = store.Iterator("abc_", "mno_123")
 			verifyItr(t, itr, 6, "")
+
+			itr = store.Iterator("t_", "t_"+storage.EndKeySuffix)
+			verifyItr(t, itr, 0, "")
 		})
 
 		t.Run("Delete "+provider.Name, func(t *testing.T) {


### PR DESCRIPTION
The current implementation of `mem` storage has a bug in the `Iterator` method.
This bug can be reproduced only when storage is populated with the data.
The issue comes out when we are iterating over keys and the start key doesn't match.
In that case, the start index is equal to `0`. Which means that the iterator will return data starting from 0 index. e.g data[0:end_idx_match].

This PR fixes it by introducing zero index as a -1.
PR includes:
* Bugfix 
* Common test case (for all DBs)
* Test case for `mem` implementation.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>