### PR TITLE
fix: #2178 CouchDB setup in BDD tests

### DIFF
--- a/pkg/storage/base58wrapper/base58wrapper_test.go
+++ b/pkg/storage/base58wrapper/base58wrapper_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	couchDBURL = "localhost:5984"
+	couchDBURL = "admin:password@localhost:5984"
 )
 
 // For these unit tests to run, you must ensure you have a CouchDB instance running at the URL specified in couchDBURL.

--- a/pkg/storage/couchdb/couchdbstore_test.go
+++ b/pkg/storage/couchdb/couchdbstore_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	couchDBURL = "localhost:5984"
+	couchDBURL = "admin:password@localhost:5984"
 )
 
 // For these unit tests to run, you must ensure you have a CouchDB instance running at the URL specified in couchDBURL.

--- a/pkg/storage/providers_test.go
+++ b/pkg/storage/providers_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	couchDBURL    = "localhost:5984"
+	couchDBURL    = "admin:password@localhost:5984"
 	sqlStoreDBURL = "root:my-secret-pw@tcp(127.0.0.1:3306)/"
 )
 
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		fmt.Printf(err.Error() +
 			". Make sure you start a couchDB instance using" +
-			" 'docker run -p 5984:5984 couchdb:2.3.1' before running the unit tests")
+			" 'docker run -p 5984:5984 couchdb:<tag>' before running the unit tests")
 		os.Exit(0)
 	}
 
@@ -43,7 +43,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		fmt.Printf(err.Error() +
 			". Make sure you start a sqlStoreDB instance using" +
-			" 'docker run -p 3306:3306 mysql:8.0.20' before running the unit tests")
+			" 'docker run -p 3306:3306 mysql:<tag>' before running the unit tests")
 		os.Exit(0)
 	}
 

--- a/scripts/check_js_integration.sh
+++ b/scripts/check_js_integration.sh
@@ -31,11 +31,11 @@ echo ""
 echo "----> executing aries-js-worker tests"
 echo ""
 cd $ROOT/test/aries-js-worker
-# capture exit code if it fails
 command=$1
 if [ -z "$command" ]; then
     command=test
 fi
+# capture exit code if it fails
 npm run "$command" || code=$?
 if [ -z ${code+x} ]; then
   # set exit code because it did not fail

--- a/scripts/check_unit.sh
+++ b/scripts/check_unit.sh
@@ -30,8 +30,11 @@ docker rm MYSQLStoreTest >/dev/null 2>&1 || true
 
 remove_docker_container
 
-docker run -p 5984:5984 -d --name CouchDBStoreTest couchdb:2.3.1 >/dev/null || true
-docker run -p 3306:3306 --name MYSQLStoreTest -e MYSQL_ROOT_PASSWORD=my-secret-pw -d mysql:8.0.20 >/dev/null || true
+docker run -p 5984:5984 -d --name CouchDBStoreTest \
+           -v $(pwd)/couchdb-config/10-single-node.ini:/opt/couchdb/etc/local.d/10-single-node.ini \
+           -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password couchdb:3.1.0 >/dev/null || true
+docker run -p 3306:3306 -d --name MYSQLStoreTest \
+           -e MYSQL_ROOT_PASSWORD=my-secret-pw mysql:8.0.20 >/dev/null || true
 
 # Running aries-framework-go unit test
 PKGS=`go list github.com/hyperledger/aries-framework-go/... 2> /dev/null | \

--- a/scripts/couchdb-config/10-single-node.ini
+++ b/scripts/couchdb-config/10-single-node.ini
@@ -1,0 +1,14 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Explicitly set single_node=true when not in cluster mode.
+# This ensures our single CouchDB node creates all system databases for our tests, including _users.
+# References:
+#  - https://docs.couchdb.org/en/3.1.0/config/couchdb.html#couchdb/single_node
+#  - https://github.com/apache/couchdb-docker#no-system-databases-until-the-installation-is-finalized
+#  - https://github.com/apache/couchdb-docker/issues/54#issuecomment-643818998
+[couchdb]
+single_node=true

--- a/test/bdd/fixtures/agent-rest/couchdb-config/10-single-node.ini
+++ b/test/bdd/fixtures/agent-rest/couchdb-config/10-single-node.ini
@@ -1,0 +1,14 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Explicitly set single_node=true when not in cluster mode.
+# This ensures our single CouchDB node creates all system databases for our tests, including _users.
+# References:
+#  - https://docs.couchdb.org/en/3.1.0/config/couchdb.html#couchdb/single_node
+#  - https://github.com/apache/couchdb-docker#no-system-databases-until-the-installation-is-finalized
+#  - https://github.com/apache/couchdb-docker/issues/54#issuecomment-643818998
+[couchdb]
+single_node=true

--- a/test/bdd/fixtures/agent-rest/docker-compose.yml
+++ b/test/bdd/fixtures/agent-rest/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - ARIESD_DATABASE_TYPE=couchdb
       - ARIESD_DATABASE_URL=admin:password@couchdb.example.com:5984
       - ARIESD_DATABASE_PREFIX=alice
+      - ARIESD_DATABASE_TIMEOUT=60
       - ARIESD_HTTP_RESOLVER=${HTTP_DID_RESOLVER}
       - TLS_CERT_FILE=/etc/tls/ec-pubCert.pem
       - TLS_KEY_FILE=/etc/tls/ec-key.pem
@@ -29,6 +30,8 @@ services:
       - ${ALICE_API_PORT}:${ALICE_API_PORT}
     entrypoint: ""
     command:  /bin/sh -c "cp /etc/tls/* /usr/local/share/ca-certificates/;update-ca-certificates; aries-agent-rest start"
+    depends_on:
+      - couchdb.example.com
     networks:
       - bdd_net
 
@@ -44,6 +47,7 @@ services:
       - ARIESD_DATABASE_TYPE=couchdb
       - ARIESD_DATABASE_URL=admin:password@couchdb.example.com:5984
       - ARIESD_DATABASE_PREFIX=erin
+      - ARIESD_DATABASE_TIMEOUT=60
       - ARIESD_HTTP_RESOLVER=${HTTP_DID_RESOLVER}
       - TLS_CERT_FILE=/etc/tls/ec-pubCert.pem
       - TLS_KEY_FILE=/etc/tls/ec-key.pem
@@ -54,6 +58,8 @@ services:
       - ${ERIN_API_PORT}:${ERIN_API_PORT}
     entrypoint: ""
     command:  /bin/sh -c "cp /etc/tls/* /usr/local/share/ca-certificates/;update-ca-certificates; aries-agent-rest start"
+    depends_on:
+      - couchdb.example.com
     networks:
       - bdd_net
 
@@ -68,6 +74,7 @@ services:
       - ARIESD_DATABASE_TYPE=couchdb
       - ARIESD_DATABASE_URL=admin:password@couchdb.example.com:5984
       - ARIESD_DATABASE_PREFIX=bob
+      - ARIESD_DATABASE_TIMEOUT=60
       - ARIESD_DEFAULT_LABEL=bob-agent
       - ARIESD_HTTP_RESOLVER=${HTTP_DID_RESOLVER}
       - TLS_CERT_FILE=/etc/tls/ec-pubCert.pem
@@ -79,6 +86,8 @@ services:
       - ${BOB_API_PORT}:${BOB_API_PORT}
     entrypoint: ""
     command:  /bin/sh -c "cp /etc/tls/* /usr/local/share/ca-certificates/;update-ca-certificates; aries-agent-rest start"
+    depends_on:
+      - couchdb.example.com
     networks:
       - bdd_net
 
@@ -122,6 +131,7 @@ services:
       - ARIESD_DATABASE_TYPE=mysql
       - ARIESD_DATABASE_URL=aries:aries-secret-pw@tcp(mysql:3306)/
       - ARIESD_DATABASE_PREFIX=carl
+      - ARIESD_DATABASE_TIMEOUT=60
       - ARIESD_OUTBOUND_TRANSPORT=${HTTP_SCHEME},${WS_SCHEME}
       - ARIESD_TRANSPORT_RETURN_ROUTE=${TRANSPORT_RETURN_OPTION_ALL}
       - TLS_CERT_FILE=/etc/tls/ec-pubCert.pem
@@ -132,6 +142,8 @@ services:
       - ${CARL_API_PORT}:${CARL_API_PORT}
     entrypoint: ""
     command:  /bin/sh -c "cp /etc/tls/* /usr/local/share/ca-certificates/;update-ca-certificates; aries-agent-rest start"
+    depends_on:
+      - mysql
     networks:
       - bdd_net
 
@@ -156,6 +168,7 @@ services:
       - ARIESD_DATABASE_TYPE=mysql
       - ARIESD_DATABASE_URL=aries:aries-secret-pw@tcp(mysql:3306)/
       - ARIESD_DATABASE_PREFIX=carl_router
+      - ARIESD_DATABASE_TIMEOUT=60
       - ARIESD_DEFAULT_LABEL=carl-router-agent
       - ARIESD_OUTBOUND_TRANSPORT=${HTTP_SCHEME},${WS_SCHEME}
       - ARIESD_HTTP_RESOLVER=${HTTP_DID_RESOLVER}
@@ -169,6 +182,8 @@ services:
       - ${CARL_ROUTER_API_PORT}:${CARL_ROUTER_API_PORT}
     entrypoint: ""
     command:  /bin/sh -c "cp /etc/tls/* /usr/local/share/ca-certificates/;update-ca-certificates; aries-agent-rest start"
+    depends_on:
+      - mysql
     networks:
       - bdd_net
 
@@ -192,6 +207,7 @@ services:
       - ARIESD_DATABASE_TYPE=mysql
       - ARIESD_DATABASE_URL=aries:aries-secret-pw@tcp(mysql:3306)/
       - ARIESD_DATABASE_PREFIX=dave
+      - ARIESD_DATABASE_TIMEOUT=60
       - ARIESD_OUTBOUND_TRANSPORT=${HTTP_SCHEME},${WS_SCHEME}
       - ARIESD_TRANSPORT_RETURN_ROUTE=${TRANSPORT_RETURN_OPTION_ALL}
       - TLS_CERT_FILE=/etc/tls/ec-pubCert.pem
@@ -202,6 +218,8 @@ services:
       - ${DAVE_API_PORT}:${DAVE_API_PORT}
     entrypoint: ""
     command:  /bin/sh -c "cp /etc/tls/* /usr/local/share/ca-certificates/;update-ca-certificates; aries-agent-rest start"
+    depends_on:
+      - mysql
     networks:
       - bdd_net
 
@@ -226,6 +244,7 @@ services:
       - ARIESD_DATABASE_TYPE=mysql
       - ARIESD_DATABASE_URL=aries:aries-secret-pw@tcp(mysql:3306)/
       - ARIESD_DATABASE_PREFIX=dave_router
+      - ARIESD_DATABASE_TIMEOUT=60
       - ARIESD_DEFAULT_LABEL=dave-router-agent
       - ARIESD_OUTBOUND_TRANSPORT=${HTTP_SCHEME},${WS_SCHEME}
       - ARIESD_HTTP_RESOLVER=${HTTP_DID_RESOLVER}
@@ -239,6 +258,8 @@ services:
       - ${DAVE_ROUTER_API_PORT}:${DAVE_ROUTER_API_PORT}
     entrypoint: ""
     command:  /bin/sh -c "cp /etc/tls/* /usr/local/share/ca-certificates/;update-ca-certificates; aries-agent-rest start"
+    depends_on:
+      - mysql
     networks:
       - bdd_net
 
@@ -274,6 +295,8 @@ services:
     environment:
       - COUCHDB_USER=admin
       - COUCHDB_PASSWORD=password
+    volumes:
+      - ./couchdb-config/10-single-node.ini:/opt/couchdb/etc/local.d/10-single-node.ini
     networks:
       - bdd_net
 


### PR DESCRIPTION
part of #2178 

**Summary**

Since v3, CouchDB does not create system databases (eg. `_users`) by default. This means that pinging the `_up` endpoint is not a sufficient smoke test, which means the CouchDB storage provider's constructor returns successfully. However, CouchDB might still not be fully ready by the time the framework wants to create a database (eg. the verifiable store) and this call fails because `_users` is still not there, which means the request is not authenticated.

-----

**Changes**

* Explicitly set CouchDB on single-node mode in our tests as per their documentation
* CouchDB provider now checks for availability of `_users` as a smoke test instead of querying `_up`.
* Upgraded CouchDB version in unit tests

----

**References**

* [Single mode config](https://docs.couchdb.org/en/3.1.0/config/couchdb.html#couchdb/single_node)
* [CouchDB no longer creates system databases by default](https://github.com/apache/couchdb-docker#no-system-databases-until-the-installation-is-finalized)
* [Admin privileges required to create databases](https://docs.couchdb.org/en/latest/api/database/common.html#put--db)

----

Signed-off-by: George Aristy <george.aristy@securekey.com>
