### PR TITLE
fix: unit tests depending on docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,10 @@ jobs:
 
     - uses: actions/checkout@v2
 
+    - name: Skip tests using docker on macOS (issue-2183)
+      if: matrix.os == 'macOS-10.15'
+      run: echo '::set-env name=SKIP_DOCKER::true'
+
     - name: Run unit test
       timeout-minutes: 15
       run: make unit-test

--- a/pkg/storage/base58wrapper/base58wrapper_test.go
+++ b/pkg/storage/base58wrapper/base58wrapper_test.go
@@ -1,4 +1,4 @@
-// +build !js,!wasm
+// +build !js,!wasm,!ISSUE2183
 
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
@@ -9,13 +9,11 @@ SPDX-License-Identifier: Apache-2.0
 package base58wrapper
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
 	"testing"
 
-	"github.com/go-kivik/kivik"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
@@ -32,26 +30,13 @@ const (
 // To run the tests manually, start an instance by running docker run -p 5984:5984 couchdb:2.3.1 from a terminal.
 
 func TestMain(m *testing.M) {
-	err := checkCouchDB()
+	err := couchdbstore.PingCouchDB(couchDBURL)
 	if err != nil {
-		fmt.Printf(err.Error() +
-			". Make sure you start a couchDB instance using" +
-			" 'docker run -p 5984:5984 couchdb:2.3.1' before running the unit tests")
-		os.Exit(0)
+		fmt.Printf(err.Error() + ". Make sure CouchDB is running.\n")
+		os.Exit(1)
 	}
 
 	os.Exit(m.Run())
-}
-
-func checkCouchDB() error {
-	client, err := kivik.New("couch", couchDBURL)
-	if err != nil {
-		return err
-	}
-
-	_, err = client.Ping(context.Background())
-
-	return err
 }
 
 func TestCouchDBStore(t *testing.T) {

--- a/pkg/storage/couchdb/couchdbstore_test.go
+++ b/pkg/storage/couchdb/couchdbstore_test.go
@@ -1,4 +1,4 @@
-// +build !js,!wasm
+// +build !js,!wasm,!ISSUE2183
 
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
@@ -9,14 +9,12 @@ SPDX-License-Identifier: Apache-2.0
 package couchdbstore
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
 
-	"github.com/go-kivik/kivik"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
@@ -32,26 +30,13 @@ const (
 // To run the tests manually, start an instance by running docker run -p 5984:5984 couchdb:2.3.1 from a terminal.
 
 func TestMain(m *testing.M) {
-	err := checkCouchDB()
+	err := PingCouchDB(couchDBURL)
 	if err != nil {
-		fmt.Printf(err.Error() +
-			". Make sure you start a couchDB instance using" +
-			" 'docker run -p 5984:5984 couchdb:2.3.1' before running the unit tests")
-		os.Exit(0)
+		fmt.Printf(err.Error() + ". Make sure CouchDB is running.\n")
+		os.Exit(1)
 	}
 
 	os.Exit(m.Run())
-}
-
-func checkCouchDB() error {
-	client, err := kivik.New("couch", couchDBURL)
-	if err != nil {
-		return err
-	}
-
-	_, err = client.Ping(context.Background())
-
-	return err
 }
 
 func TestCouchDBStore(t *testing.T) {

--- a/pkg/storage/mysql/mysqlstore_test.go
+++ b/pkg/storage/mysql/mysqlstore_test.go
@@ -1,3 +1,5 @@
+// +build !ISSUE2183
+
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
@@ -33,10 +35,8 @@ const (
 func TestMain(m *testing.M) {
 	err := checkMySQL()
 	if err != nil {
-		fmt.Printf(err.Error() +
-			". Make sure you start a sqlStoreDB instance using" +
-			" 'docker run -p 3306:3306 mysql:8.0.20' before running the unit tests")
-		os.Exit(0)
+		fmt.Printf(err.Error() + " . Make sure MySQL is running.\n")
+		os.Exit(1)
 	}
 
 	os.Exit(m.Run())

--- a/pkg/storage/providers_test.go
+++ b/pkg/storage/providers_test.go
@@ -1,4 +1,4 @@
-// +build !js,!wasm
+// +build !js,!wasm,!ISSUE2183
 
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
@@ -9,14 +9,12 @@ SPDX-License-Identifier: Apache-2.0
 package storage_test
 
 import (
-	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
 
-	"github.com/go-kivik/kivik"
 	"github.com/stretchr/testify/require"
 
 	couchdbstore "github.com/hyperledger/aries-framework-go/pkg/storage/couchdb"
@@ -31,20 +29,16 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	err := checkMySQL()
+	err := couchdbstore.PingCouchDB(couchDBURL)
 	if err != nil {
-		fmt.Printf(err.Error() +
-			". Make sure you start a couchDB instance using" +
-			" 'docker run -p 5984:5984 couchdb:<tag>' before running the unit tests")
-		os.Exit(0)
+		fmt.Printf(err.Error() + ". Make sure CouchDB is running.\n")
+		os.Exit(1)
 	}
 
-	err = checkCouchDB()
+	err = checkMySQL()
 	if err != nil {
-		fmt.Printf(err.Error() +
-			". Make sure you start a sqlStoreDB instance using" +
-			" 'docker run -p 3306:3306 mysql:<tag>' before running the unit tests")
-		os.Exit(0)
+		fmt.Printf(err.Error() + ". Make sure MySQL is running.\n")
+		os.Exit(1)
 	}
 
 	os.Exit(m.Run())
@@ -57,17 +51,6 @@ func checkMySQL() error {
 	}
 
 	return db.Ping()
-}
-
-func checkCouchDB() error {
-	client, err := kivik.New("couch", couchDBURL)
-	if err != nil {
-		return err
-	}
-
-	_, err = client.Ping(context.Background())
-
-	return err
 }
 
 func setUpProviders(t *testing.T) []Provider {

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1,3 +1,5 @@
+// +build !ISSUE2183
+
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0

--- a/scripts/check_unit.sh
+++ b/scripts/check_unit.sh
@@ -8,47 +8,57 @@ set -e
 
 echo "Running $0"
 
+GO_TEST_CMD="go test"
+
 go generate ./...
-pwd=`pwd`
-echo "" > "$pwd"/coverage.txt
+ROOT=$(pwd)
+echo "" > "$ROOT"/coverage.txt
 
 amend_coverage_file () {
 if [ -f profile.out ]; then
-     cat profile.out >> "$pwd"/coverage.txt
+     cat profile.out >> "$ROOT"/coverage.txt
      rm profile.out
 fi
 }
 
-# docker rm returns 1 if the image isn't found. This is OK and expected, so we suppress it
-# Any return status other than 0 or 1 is unusual and so we exit
+# docker rm returns 1 if the image isn't found. This is OK and expected, so we suppress it.
 remove_docker_container () {
-docker kill CouchDBStoreTest >/dev/null 2>&1 || true
-docker rm CouchDBStoreTest >/dev/null 2>&1 || true
-docker kill MYSQLStoreTest >/dev/null 2>&1 || true
-docker rm MYSQLStoreTest >/dev/null 2>&1 || true
+  echo "Removing CouchDBStoreTest docker image..."
+  docker kill CouchDBStoreTest >/dev/null 2>&1 || true
+  docker rm CouchDBStoreTest >/dev/null 2>&1 || true
+  echo "Removing MYSQLStoreTest docker image..."
+  docker kill MYSQLStoreTest >/dev/null 2>&1 || true
+  docker rm MYSQLStoreTest >/dev/null 2>&1 || true
 }
 
-remove_docker_container
+cleanup() {
+  remove_docker_container
+}
 
-docker run -p 5984:5984 -d --name CouchDBStoreTest \
-           -v $(pwd)/couchdb-config/10-single-node.ini:/opt/couchdb/etc/local.d/10-single-node.ini \
-           -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password couchdb:3.1.0 >/dev/null || true
-docker run -p 3306:3306 -d --name MYSQLStoreTest \
-           -e MYSQL_ROOT_PASSWORD=my-secret-pw mysql:8.0.20 >/dev/null || true
+trap cleanup EXIT
+
+if [ -z ${SKIP_DOCKER+x} ]; then
+  remove_docker_container
+
+  echo "Starting CouchDBStoreTest docker image..."
+  docker run -p 5984:5984 -d --name CouchDBStoreTest \
+             -v $ROOT/scripts/couchdb-config/10-single-node.ini:/opt/couchdb/etc/local.d/10-single-node.ini \
+             -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password couchdb:3.1.0 >/dev/null
+  echo "Starting MYSQLStoreTest docker image..."
+  docker run -p 3306:3306 -d --name MYSQLStoreTest \
+             -e MYSQL_ROOT_PASSWORD=my-secret-pw mysql:8.0.20 >/dev/null
+else
+  GO_TEST_CMD="$GO_TEST_CMD --tags=ISSUE2183"
+fi
 
 # Running aries-framework-go unit test
-PKGS=`go list github.com/hyperledger/aries-framework-go/... 2> /dev/null | \
-                                                 grep -v /mocks | \
-                                                 grep -v /aries-js-worker`
-go test $PKGS -count=1 -race -coverprofile=profile.out -covermode=atomic -timeout=10m
+PKGS=$(go list github.com/hyperledger/aries-framework-go/... 2> /dev/null | grep -v /mocks | grep -v /aries-js-worker)
+$GO_TEST_CMD $PKGS -count=1 -race -coverprofile=profile.out -covermode=atomic -timeout=10m
 amend_coverage_file
-
-remove_docker_container
 
 # Running aries-agent-rest unit test
 cd cmd/aries-agent-rest
-PKGS=`go list github.com/hyperledger/aries-framework-go/cmd/aries-agent-rest/... 2> /dev/null | \
-                                                 grep -v /mocks`
-go test $PKGS -count=1 -race -coverprofile=profile.out -covermode=atomic -timeout=10m
+PKGS=$(go list github.com/hyperledger/aries-framework-go/cmd/aries-agent-rest/... 2> /dev/null | grep -v /mocks)
+$GO_TEST_CMD $PKGS -count=1 -race -coverprofile=profile.out -covermode=atomic -timeout=10m
 amend_coverage_file
-cd "$pwd" || exit
+cd "$ROOT" || exit


### PR DESCRIPTION
Depends on #2180

Unit tests for storages were all ignoring failures (such as CouchDB or MySQL not running). This completely undermined confidence in any of these tests... a real mess.

This patch only ignores these tests when running in GitHub actions using the 'macOS-10.15' virtual environment. Issue #2183 was opened to track the problem of not running these tests in the macOS CI in the first place.

Signed-off-by: George Aristy <george.aristy@securekey.com>