### PR TITLE
test: Fixes local KMS writer test

### DIFF
--- a/pkg/kms/localkms/localkms_writer_test.go
+++ b/pkg/kms/localkms/localkms_writer_test.go
@@ -101,8 +101,6 @@ func TestLocalKMSWriter(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, len(someKey), n)
 		require.Equal(t, maxKeyIDLen, len(l.KeysetID))
-		// keysetID must not start with _
-		require.NotEqual(t, uint8('_'), l.KeysetID[0])
 		retrievedKey, ok := storeMap[l.KeysetID]
 		require.True(t, ok)
 		require.Equal(t, retrievedKey, someKey)


### PR DESCRIPTION
Sometimes the test is failing randomly.
```
    --- FAIL: TestLocalKMSWriter/error_case_-_import_duplicate_keysetID (0.00s)
        localkms_writer_test.go:105: 
            	Error Trace:	localkms_writer_test.go:105
            	Error:      	Should not be: 0x5f
            	Test:       	TestLocalKMSWriter/error_case_-_import_duplicate_keysetID
```

According to the code, we are generating bytes randomly e.g `base64.RawURLEncoding.EncodeToString(random.GetRandomBytes(uint32(keySetIDLength)))`
Then we are checking that the first byte is not equal to `uint8('_')`.
Since `_` (underscore) is a character that can be used for base64 there is no guarantee that `_` will not be the first character.
This is the reason why the test is failing randomly.

Conclusion:
The test is redundant.


Signed-off-by: Andrii Soluk <isoluchok@gmail.com>