### PR TITLE
fix: Mediator - replacing a channel sync with the database sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
   bddTest:
     name: BDD test
     runs-on: ubuntu-18.04
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
 
       - name: Setup Go 1.15
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run BDD test
-        timeout-minutes: 20
+        timeout-minutes: 25
         run: |
           function logout {
             docker logout docker.pkg.github.com


### PR DESCRIPTION
Currently, we are using the `go channel` to synchronize whether the `mediate-grant` message was received.
The problem here is that the `mediate-grant` message can be received on the different `node`. Which means we will fail due to timeout. This PR fixes it by saving data to DB.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>