### PR TITLE
chore: Github - environment variables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Skip tests using docker on macOS (issue-2183)
       if: matrix.os == 'macOS-10.15'
-      run: echo '::set-env name=SKIP_DOCKER::true'
+      run: echo "SKIP_DOCKER=true" >> $GITHUB_ENV
 
     - name: Run unit test
       timeout-minutes: 15
@@ -73,7 +73,7 @@ jobs:
         id: go
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1.4.0
+        uses: actions/setup-node@v1.4.4
         with:
           node-version: 12.14.x
           registry-url: "https://npm.pkg.github.com"


### PR DESCRIPTION
Github is going to depreciate `set-env` functionality.
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This PR fixes it according to new changes.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>