### PR TITLE
refactor: Go BDD tests improvements

### DIFF
--- a/test/bdd/features/aries_mediator_e2e_sdk.feature
+++ b/test/bdd/features/aries_mediator_e2e_sdk.feature
@@ -61,11 +61,11 @@ Feature: DIDComm Transport between two Agents through DIDComm Routers [SDK]
       And   "Bob" verifies that the router connection id is set to "bob-router-connID"
 
      # DIDExchange between Alice and Bob through routers
-    When   "Alice" creates invitation
+    When   "Alice" creates invitation with router "alice-router-connID"
       And   "Alice" validates that invitation service endpoint of type "ws"
       And   "Bob" receives invitation from "Alice"
-      And   "Bob" approves invitation request
-      And   "Alice" approves did exchange request
+      And   "Bob" approves invitation request with router "bob-router-connID"
+      And   "Alice" approves did exchange request with router "alice-router-connID"
       And   "Alice,Bob" waits for post state event "completed"
 
     Then   "Alice,Bob" retrieves connection record and validates that connection state is "completed"
@@ -122,11 +122,11 @@ Feature: DIDComm Transport between two Agents through DIDComm Routers [SDK]
       And   "Bob" verifies that the router connection id is set to "bob-router-connID"
 
      # DIDExchange between Alice and Bob through routers
-    When   "Alice" creates invitation
+    When   "Alice" creates invitation with router "alice-router-connID"
       And   "Alice" validates that invitation service endpoint of type "http"
       And   "Bob" receives invitation from "Alice"
-      And   "Bob" approves invitation request
-      And   "Alice" approves did exchange request
+      And   "Bob" approves invitation request with router "bob-router-connID"
+      And   "Alice" approves did exchange request with router "alice-router-connID"
       And   "Alice,Bob" waits for post state event "completed"
 
     Then   "Alice,Bob" retrieves connection record and validates that connection state is "completed"

--- a/test/bdd/pkg/didexchange/didexchange_sdk_steps.go
+++ b/test/bdd/pkg/didexchange/didexchange_sdk_steps.go
@@ -50,25 +50,8 @@ func (d *SDKSteps) createInvitationWithRouter(inviterAgentID, router string) err
 	return d.createInvitation(inviterAgentID, connection)
 }
 
-func (d *SDKSteps) createInvitationDefaultRouter(inviterAgentID string) error {
-	var connections []string
-
-	if _, ok := d.bddContext.RouteClients[inviterAgentID]; ok {
-		var err error
-
-		connections, err = d.bddContext.RouteClients[inviterAgentID].GetConnections()
-		if err != nil {
-			return err
-		}
-	}
-
-	var connection string
-
-	if len(connections) > 0 {
-		connection = connections[0]
-	}
-
-	return d.createInvitation(inviterAgentID, connection)
+func (d *SDKSteps) createInvitationWithoutRouter(inviterAgentID string) error {
+	return d.createInvitation(inviterAgentID, "")
 }
 
 func (d *SDKSteps) createInvitation(inviterAgentID, connection string) error {
@@ -262,19 +245,8 @@ func (d *SDKSteps) ApproveRequest(agentID string) error {
 		return fmt.Errorf("%s is not registered for request approval", agentID)
 	}
 
-	var connections []string
-
-	if _, ok := d.bddContext.RouteClients[agentID]; ok {
-		var err error
-
-		connections, err = d.bddContext.RouteClients[agentID].GetConnections()
-		if err != nil {
-			return err
-		}
-	}
-
 	// sends the signal which automatically handles events
-	c <- struct{ connections []string }{connections: connections}
+	c <- struct{ connections []string }{connections: nil}
 
 	return nil
 }
@@ -385,7 +357,7 @@ func (d *SDKSteps) performDIDExchange(inviter, invitee string) error {
 	}
 
 	// create invitation
-	err := d.createInvitationDefaultRouter(inviter)
+	err := d.createInvitationWithoutRouter(inviter)
 	if err != nil {
 		return err
 	}
@@ -504,7 +476,7 @@ func (d *SDKSteps) SetContext(ctx *context.BDDContext) {
 
 // RegisterSteps registers did exchange steps.
 func (d *SDKSteps) RegisterSteps(s *godog.Suite) {
-	s.Step(`^"([^"]*)" creates invitation$`, d.createInvitationDefaultRouter)
+	s.Step(`^"([^"]*)" creates invitation$`, d.createInvitationWithoutRouter)
 	s.Step(`^"([^"]*)" creates invitation with router "([^"]*)"$`, d.createInvitationWithRouter)
 	s.Step(`^"([^"]*)" validates that invitation service endpoint of type "([^"]*)"$`, d.validateInvitationEndpointScheme)
 	s.Step(`^"([^"]*)" creates invitation with public DID$`, d.CreateInvitationWithDID)
@@ -517,8 +489,8 @@ func (d *SDKSteps) RegisterSteps(s *godog.Suite) {
 	s.Step(`^"([^"]*)" retrieves connection record and validates that connection state is "([^"]*)"$`,
 		d.ValidateConnection)
 	s.Step(`^"([^"]*)" creates did exchange client$`, d.CreateDIDExchangeClient)
-	s.Step(`^"([^"]*)" approves did exchange request`, d.ApproveRequest)
-	s.Step(`^"([^"]*)" approves invitation request`, d.ApproveRequest)
+	s.Step(`^"([^"]*)" approves did exchange request$`, d.ApproveRequest)
+	s.Step(`^"([^"]*)" approves invitation request$`, d.ApproveRequest)
 	s.Step(`^"([^"]*)" approves invitation request with router "([^"]*)"$`, d.ApproveRequestWithRouter)
 	s.Step(`^"([^"]*)" approves did exchange request with router "([^"]*)"$`, d.ApproveRequestWithRouter)
 	s.Step(`^"([^"]*)" registers to receive notification for post state event "([^"]*)"$`, d.RegisterPostMsgEvent)

--- a/test/bdd/pkg/introduce/introduce_controller_steps.go
+++ b/test/bdd/pkg/introduce/introduce_controller_steps.go
@@ -18,7 +18,6 @@ import (
 
 	client "github.com/hyperledger/aries-framework-go/pkg/client/introduce"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/command/introduce"
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	protocol "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/introduce"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/context"
 	bddoutofband "github.com/hyperledger/aries-framework-go/test/bdd/pkg/outofband"
@@ -359,7 +358,7 @@ func (s *ControllerSteps) tryOutofbandContinue(agent string) error {
 		return fmt.Errorf("pull events from WebSocket: %w", err)
 	}
 
-	piid, err := service.DIDCommMsgMap(msg.Message.Message).ThreadID()
+	piid, err := msg.Message.Message.ThreadID()
 	if err != nil {
 		return fmt.Errorf("thread id: %w", err)
 	}

--- a/test/bdd/pkg/outofband/outofband_sdk_steps.go
+++ b/test/bdd/pkg/outofband/outofband_sdk_steps.go
@@ -221,7 +221,7 @@ func (sdk *SDKSteps) ConfirmConnections(senderID, receiverID, status string) err
 		return fmt.Errorf("failed to wait for post events : %w", err)
 	}
 
-	connSender, err := sdk.getConnection(senderID, receiverID)
+	connSender, err := sdk.GetConnection(senderID, receiverID)
 	if err != nil {
 		return err
 	}
@@ -233,7 +233,7 @@ func (sdk *SDKSteps) ConfirmConnections(senderID, receiverID, status string) err
 		)
 	}
 
-	connReceiver, err := sdk.getConnection(receiverID, senderID)
+	connReceiver, err := sdk.GetConnection(receiverID, senderID)
 	if err != nil {
 		return err
 	}
@@ -248,7 +248,8 @@ func (sdk *SDKSteps) ConfirmConnections(senderID, receiverID, status string) err
 	return nil
 }
 
-func (sdk *SDKSteps) getConnection(from, to string) (*didexClient.Connection, error) {
+// GetConnection returns connection between agents.
+func (sdk *SDKSteps) GetConnection(from, to string) (*didexClient.Connection, error) {
 	connections, err := sdk.context.DIDExchangeClients[from].QueryConnections(&didexClient.QueryConnectionsParams{})
 	if err != nil {
 		return nil, fmt.Errorf("%s failed to fetch their connections : %w", from, err)

--- a/test/bdd/pkg/redeemableroutes/redeemable_routes.go
+++ b/test/bdd/pkg/redeemableroutes/redeemable_routes.go
@@ -38,6 +38,7 @@ type BDDSteps struct {
 	routeSdk       *bddroute.SDKSteps
 	proposals      map[string]*introClient.Recipient
 	goalCode       string
+	connectionID   string
 	redeemableCode string
 	redeemableOpts *mediator.Options
 	introClients   map[string]*introClient.Client
@@ -240,6 +241,13 @@ func (b *BDDSteps) bobConnectsWithRouterAndRequestsRoute(bob, router string) err
 		return fmt.Errorf("failed to confirm connection status between %s and %s : %w", router, bob, err)
 	}
 
+	conn, err := b.oobSdk.GetConnection(bob, router)
+	if err != nil {
+		return fmt.Errorf("failed to get connection between %s and %s : %w", router, bob, err)
+	}
+
+	b.connectionID = conn.ConnectionID
+
 	return nil
 }
 
@@ -266,7 +274,7 @@ func (b *BDDSteps) routerConfirmsCodeAndApprovesRequest(router string) error {
 }
 
 func (b *BDDSteps) bobConfirmsGrant(bob, serviceEndpoint, routingKey string) error {
-	config, err := b.routeSdk.GetRoutingConfig(bob, timeout)
+	config, err := b.routeSdk.GetRoutingConfig(bob, b.connectionID, timeout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR includes:
* improves BDD tests with the router usage
* added one WebSocket listener which saves data to the channel (prevents from missing events)

Note: I have run these tests 100 times 99 of 100 were successful.
The reliability of these tests also depends on https://github.com/hyperledger/aries-framework-go/pull/2226

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>