### PR TITLE
refactor: add Wrap/Unwrap crypto functions

### DIFF
--- a/pkg/crypto/api.go
+++ b/pkg/crypto/api.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package crypto
 
+import "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite"
+
 // package crypto contains the Crypto interface to be used by the framework.
 // it will be created via Options creation in pkg/framework/context.Provider
 
@@ -37,4 +39,10 @@ type Crypto interface {
 	// VerifyMAC determines if mac is a correct authentication code (MAC) for data
 	// using a matching MAC primitive in kh key handle and returns nil if so, otherwise it returns an error.
 	VerifyMAC(mac, data []byte, kh interface{}) error
+
+	// WrapKey will execute key wrapping of cek using apu, apv and recipient public key found in kh.
+	WrapKey(cek, apu, apv []byte, kh interface{}) (*composite.RecipientWrappedKey, error)
+
+	// UnwrapKey unwraps a key in recWK using recipient private key kh.
+	UnwrapKey(recWK *composite.RecipientWrappedKey, kh interface{}) ([]byte, error)
 }

--- a/pkg/crypto/tinkcrypto/crypto.go
+++ b/pkg/crypto/tinkcrypto/crypto.go
@@ -11,8 +11,10 @@ SPDX-License-Identifier: Apache-2.0
 package tinkcrypto
 
 import (
+	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/google/tink/go/aead"
 	aeadsubtle "github.com/google/tink/go/aead/subtle"
@@ -20,7 +22,18 @@ import (
 	"github.com/google/tink/go/keyset"
 	"github.com/google/tink/go/mac"
 	"github.com/google/tink/go/signature"
+	josecipher "github.com/square/go-jose/v3/cipher"
 	"golang.org/x/crypto/chacha20poly1305"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite"
+	ecdhessubtle "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/keyio"
+	compositepb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/common_composite_go_proto"
+)
+
+const (
+	ecdhesKWAlg = ecdhessubtle.A256KWAlg
+	keySize     = 32
 )
 
 var errBadKeyHandleFormat = errors.New("bad key handle format")
@@ -32,11 +45,12 @@ var errBadKeyHandleFormat = errors.New("bad key handle format")
 
 // Crypto is the default Crypto SPI implementation using Tink.
 type Crypto struct {
+	kw keyWrapper
 }
 
 // New creates a new Crypto instance.
 func New() (*Crypto, error) {
-	return &Crypto{}, nil
+	return &Crypto{kw: &keyWrapperSupport{}}, nil
 }
 
 // Encrypt will encrypt msg using the implementation's corresponding encryption key and primitive in kh.
@@ -44,6 +58,11 @@ func (t *Crypto) Encrypt(msg, aad []byte, kh interface{}) ([]byte, []byte, error
 	keyHandle, ok := kh.(*keyset.Handle)
 	if !ok {
 		return nil, nil, errBadKeyHandleFormat
+	}
+
+	ps, err := keyHandle.Primitives()
+	if err != nil {
+		return nil, nil, fmt.Errorf("get primitives: %w", err)
 	}
 
 	a, err := aead.New(keyHandle)
@@ -54,11 +73,6 @@ func (t *Crypto) Encrypt(msg, aad []byte, kh interface{}) ([]byte, []byte, error
 	ct, err := a.Encrypt(msg, aad)
 	if err != nil {
 		return nil, nil, fmt.Errorf("encrypt msg: %w", err)
-	}
-
-	ps, err := keyHandle.Primitives()
-	if err != nil {
-		return nil, nil, fmt.Errorf("get primitives: %w", err)
 	}
 
 	// Tink appends a key prefix + nonce to ciphertext, let's remove them to get the raw ciphertext
@@ -92,14 +106,14 @@ func (t *Crypto) Decrypt(cipher, aad, nonce []byte, kh interface{}) ([]byte, err
 		return nil, errBadKeyHandleFormat
 	}
 
-	a, err := aead.New(keyHandle)
-	if err != nil {
-		return nil, fmt.Errorf("create new aead: %w", err)
-	}
-
 	ps, err := keyHandle.Primitives()
 	if err != nil {
 		return nil, fmt.Errorf("get primitives: %w", err)
+	}
+
+	a, err := aead.New(keyHandle)
+	if err != nil {
+		return nil, fmt.Errorf("create new aead: %w", err)
 	}
 
 	// since Tink expects the key prefix + nonce as the ciphertext prefix, prepend them prior to calling its Decrypt()
@@ -186,4 +200,124 @@ func (t *Crypto) VerifyMAC(macBytes, data []byte, kh interface{}) error {
 	}
 
 	return macPrimitive.VerifyMAC(macBytes, data)
+}
+
+// WrapKey will do ECDHES key wrapping of cek using apu, apv and recipient public key found in kh.
+func (t *Crypto) WrapKey(cek, apu, apv []byte, kh interface{}) (*composite.RecipientWrappedKey, error) {
+	// TODO: add support for 25519 key wrapping https://github.com/hyperledger/aries-framework-go/issues/1637
+	keyType := compositepb.KeyType_EC.String()
+
+	pubKH, ok := kh.(*keyset.Handle)
+	if !ok {
+		return nil, fmt.Errorf("wrapKey: %w", errBadKeyHandleFormat)
+	}
+
+	pubKey, err := keyio.ExtractPrimaryPublicKey(pubKH)
+	if err != nil {
+		return nil, fmt.Errorf("wrapKey: failed to extract recipient public key from kh: %w", err)
+	}
+
+	c, err := t.kw.getCurve(pubKey.Curve)
+	if err != nil {
+		return nil, fmt.Errorf("wrapKey: failed to get curve of recipient key: %w", err)
+	}
+
+	recPubKey := &ecdsa.PublicKey{
+		Curve: c,
+		X:     new(big.Int).SetBytes(pubKey.X),
+		Y:     new(big.Int).SetBytes(pubKey.Y),
+	}
+
+	ephemeralPriv, err := t.kw.generateKey(recPubKey.Curve)
+	if err != nil {
+		return nil, fmt.Errorf("wrapKey: failed to generate EPK: %w", err)
+	}
+
+	kek := josecipher.DeriveECDHES(ecdhesKWAlg, apu, apv, ephemeralPriv, recPubKey, keySize)
+
+	block, err := t.kw.createCipher(kek)
+	if err != nil {
+		return nil, fmt.Errorf("wrapKey: failed to create new Cipher: %w", err)
+	}
+
+	wk, err := t.kw.wrap(block, cek)
+	if err != nil {
+		return nil, fmt.Errorf("wrapKey: failed to wrap key: %w", err)
+	}
+
+	return &composite.RecipientWrappedKey{
+		KID:          pubKey.KID,
+		EncryptedCEK: wk,
+		EPK: composite.PublicKey{
+			X:     ephemeralPriv.PublicKey.X.Bytes(),
+			Y:     ephemeralPriv.PublicKey.Y.Bytes(),
+			Curve: ephemeralPriv.PublicKey.Curve.Params().Name,
+			Type:  keyType,
+		},
+		APU: apu,
+		APV: apv,
+		Alg: ecdhesKWAlg,
+	}, nil
+}
+
+// UnwrapKey unwraps a key in recWK using ECDHES with recipient private key kh.
+func (t *Crypto) UnwrapKey(recWK *composite.RecipientWrappedKey, kh interface{}) ([]byte, error) {
+	if recWK == nil {
+		return nil, fmt.Errorf("unwrapKey: RecipientWrappedKey is empty")
+	}
+
+	// only ECDHES KW alg is supported (for now)
+	if recWK.Alg != ecdhesKWAlg {
+		return nil, fmt.Errorf("unwrapKey: unsupported JWE KW Alg '%s'", recWK.Alg)
+	}
+
+	privKey, ok := kh.(*keyset.Handle)
+	if !ok {
+		return nil, fmt.Errorf("unwrapKey: %w", errBadKeyHandleFormat)
+	}
+
+	recipientPrivateKey, err := extractPrivKey(privKey)
+	if err != nil {
+		return nil, fmt.Errorf("unwrapKey: %w", err)
+	}
+
+	// TODO: add support for 25519 key wrapping https://github.com/hyperledger/aries-framework-go/issues/1637
+	recPrivKey := &ecdsa.PrivateKey{
+		PublicKey: ecdsa.PublicKey{
+			Curve: recipientPrivateKey.PublicKey.Curve,
+			X:     recipientPrivateKey.PublicKey.Point.X,
+			Y:     recipientPrivateKey.PublicKey.Point.Y,
+		},
+		D: recipientPrivateKey.D,
+	}
+
+	epkCurve, err := t.kw.getCurve(recWK.EPK.Curve)
+	if err != nil {
+		return nil, fmt.Errorf("unwrapKey: failed to GetCurve: %w", err)
+	}
+
+	if recipientPrivateKey.PublicKey.Curve != epkCurve {
+		return nil, errors.New("unwrapKey: recipient and epk keys are not on the same curve")
+	}
+
+	epkPubKey := &ecdsa.PublicKey{
+		Curve: epkCurve,
+		X:     new(big.Int).SetBytes(recWK.EPK.X),
+		Y:     new(big.Int).SetBytes(recWK.EPK.Y),
+	}
+
+	// DeriveECDHES checks if keys are on the same curve
+	kek := josecipher.DeriveECDHES(recWK.Alg, recWK.APU, recWK.APV, recPrivKey, epkPubKey, keySize)
+
+	block, err := t.kw.createCipher(kek)
+	if err != nil {
+		return nil, fmt.Errorf("unwrapKey: failed to create new Cipher: %w", err)
+	}
+
+	wk, err := t.kw.unwrap(block, recWK.EncryptedCEK)
+	if err != nil {
+		return nil, fmt.Errorf("unwrapKey: failed to unwrap key: %w", err)
+	}
+
+	return wk, nil
 }

--- a/pkg/crypto/tinkcrypto/key_wrapper.go
+++ b/pkg/crypto/tinkcrypto/key_wrapper.go
@@ -1,0 +1,48 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tinkcrypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+
+	hybrid "github.com/google/tink/go/hybrid/subtle"
+	josecipher "github.com/square/go-jose/v3/cipher"
+)
+
+type keyWrapper interface {
+	getCurve(curve string) (elliptic.Curve, error)
+	generateKey(curve elliptic.Curve) (*ecdsa.PrivateKey, error)
+	createCipher(key []byte) (cipher.Block, error)
+	wrap(block cipher.Block, cek []byte) ([]byte, error)
+	unwrap(block cipher.Block, encryptedKey []byte) ([]byte, error)
+}
+
+type keyWrapperSupport struct{}
+
+func (w *keyWrapperSupport) getCurve(curve string) (elliptic.Curve, error) {
+	return hybrid.GetCurve(curve)
+}
+
+func (w *keyWrapperSupport) generateKey(curve elliptic.Curve) (*ecdsa.PrivateKey, error) {
+	return ecdsa.GenerateKey(curve, rand.Reader)
+}
+
+func (w *keyWrapperSupport) createCipher(kek []byte) (cipher.Block, error) {
+	return aes.NewCipher(kek)
+}
+
+func (w *keyWrapperSupport) wrap(block cipher.Block, cek []byte) ([]byte, error) {
+	return josecipher.KeyWrap(block, cek)
+}
+
+func (w *keyWrapperSupport) unwrap(block cipher.Block, encryptedKey []byte) ([]byte, error) {
+	return josecipher.KeyUnwrap(block, encryptedKey)
+}

--- a/pkg/crypto/tinkcrypto/key_wrapper_test.go
+++ b/pkg/crypto/tinkcrypto/key_wrapper_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tinkcrypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
+	"testing"
+
+	"github.com/google/tink/go/keyset"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdhes"
+)
+
+type mockKeyWrapperSupport struct {
+	getCurveVal     elliptic.Curve
+	getCurveErr     error
+	generateKeyVal  *ecdsa.PrivateKey
+	generateKeyErr  error
+	createCipherVal cipher.Block
+	createCipherErr error
+	wrapVal         []byte
+	wrapErr         error
+	unwrapVal       []byte
+	unwrapErr       error
+}
+
+func (w *mockKeyWrapperSupport) getCurve(curve string) (elliptic.Curve, error) {
+	return w.getCurveVal, w.getCurveErr
+}
+
+func (w *mockKeyWrapperSupport) generateKey(curve elliptic.Curve) (*ecdsa.PrivateKey, error) {
+	return w.generateKeyVal, w.generateKeyErr
+}
+
+func (w *mockKeyWrapperSupport) createCipher(kek []byte) (cipher.Block, error) {
+	return w.createCipherVal, w.createCipherErr
+}
+
+func (w *mockKeyWrapperSupport) wrap(block cipher.Block, cek []byte) ([]byte, error) {
+	return w.wrapVal, w.wrapErr
+}
+
+func (w *mockKeyWrapperSupport) unwrap(block cipher.Block, wrappedKey []byte) ([]byte, error) {
+	return w.unwrapVal, w.unwrapErr
+}
+
+func TestWrapKey_Failure(t *testing.T) {
+	recipientKey, err := keyset.NewHandle(ecdhes.ECDHES256KWAES256GCMKeyTemplate())
+	require.NoError(t, err)
+
+	cek := random.GetRandomBytes(uint32(keySize))
+	apu := []byte("sender")
+	apv := []byte("recipient")
+
+	// test WrapKey with mocked getCurve error
+	c := Crypto{kw: &mockKeyWrapperSupport{getCurveErr: errors.New("bad Curve")}}
+
+	_, err = c.WrapKey(cek, apu, apv, recipientKey)
+	require.EqualError(t, err, "wrapKey: failed to get curve of recipient key: bad Curve")
+
+	// test WrapKey with mocked generateKey error
+	c = Crypto{kw: &mockKeyWrapperSupport{generateKeyErr: errors.New("genKey failed")}}
+
+	_, err = c.WrapKey(cek, apu, apv, recipientKey)
+	require.EqualError(t, err, "wrapKey: failed to generate EPK: genKey failed")
+
+	epk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	// test WrapKey with mocked createCipher error
+	c = Crypto{
+		kw: &mockKeyWrapperSupport{
+			createCipherErr: errors.New("createCipher failed"),
+			generateKeyVal:  epk,
+		},
+	}
+
+	_, err = c.WrapKey(cek, apu, apv, recipientKey)
+	require.EqualError(t, err, "wrapKey: failed to create new Cipher: createCipher failed")
+
+	aesCipher, err := aes.NewCipher(random.GetRandomBytes(uint32(keySize)))
+	require.NoError(t, err)
+
+	// test WrapKey with mocked Wrap call error
+	c = Crypto{
+		kw: &mockKeyWrapperSupport{
+			createCipherVal: aesCipher,
+			generateKeyVal:  epk,
+			wrapErr:         errors.New("wrap error"),
+		},
+	}
+
+	_, err = c.WrapKey(cek, apu, apv, recipientKey)
+	require.EqualError(t, err, "wrapKey: failed to wrap key: wrap error")
+}
+
+func TestUnwrapKey_Failure(t *testing.T) {
+	recipientKey, err := keyset.NewHandle(ecdhes.ECDHES256KWAES256GCMKeyTemplate())
+	require.NoError(t, err)
+
+	cek := random.GetRandomBytes(uint32(keySize))
+	apu := []byte("sender")
+	apv := []byte("recipient")
+
+	validCrypter, err := New()
+	require.NoError(t, err)
+
+	wpKey, err := validCrypter.WrapKey(cek, apu, apv, recipientKey)
+	require.NoError(t, err)
+
+	// test UnwrapKey with mocked getCurve error
+	c := Crypto{kw: &mockKeyWrapperSupport{getCurveErr: errors.New("bad Curve")}}
+
+	_, err = c.UnwrapKey(wpKey, recipientKey)
+	require.EqualError(t, err, "unwrapKey: failed to GetCurve: bad Curve")
+
+	// test UnwrapKey with mocked createCipher error
+	c = Crypto{
+		kw: &mockKeyWrapperSupport{
+			createCipherErr: errors.New("createCipher failed"),
+			getCurveVal:     elliptic.P256(),
+		},
+	}
+
+	_, err = c.UnwrapKey(wpKey, recipientKey)
+	require.EqualError(t, err, "unwrapKey: failed to create new Cipher: createCipher failed")
+
+	// test UnwrapKey with mocked unwrap error
+	aesCipher, err := aes.NewCipher(random.GetRandomBytes(uint32(keySize)))
+	require.NoError(t, err)
+
+	c = Crypto{
+		kw: &mockKeyWrapperSupport{
+			createCipherVal: aesCipher,
+			getCurveVal:     elliptic.P256(),
+			unwrapErr:       errors.New("unwrap error"),
+		},
+	}
+
+	_, err = c.UnwrapKey(wpKey, recipientKey)
+	require.EqualError(t, err, "unwrapKey: failed to unwrap key: unwrap error")
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/composite_common.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/composite_common.go
@@ -46,6 +46,8 @@ type RecipientWrappedKey struct {
 	EncryptedCEK []byte    `json:"encryptedcek,omitempty"`
 	EPK          PublicKey `json:"epk,omitempty"`
 	Alg          string    `json:"alg,omitempty"`
+	APU          []byte    `json:"apu,omitempty"`
+	APV          []byte    `json:"apv,omitempty"`
 }
 
 // PublicKey mainly to exchange EPK in RecipientWrappedKey.

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdh1pu/subtle/ecdh1pu_aes_aead_composite_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdh1pu/subtle/ecdh1pu_aes_aead_composite_test.go
@@ -356,7 +356,7 @@ func (m *MockEncHelper) BuildDecData(encData *composite.EncryptedData) []byte {
 	return finalCT
 }
 
-func TestUnWrapUsingKeysOnDifferentCurves(t *testing.T) {
+func TestUnwrapUsingKeysOnDifferentCurves(t *testing.T) {
 	keySize := 32
 	curveP256, err := hybrid.GetCurve(commonpb.EllipticCurveType_NIST_P256.String())
 	require.NoError(t, err)

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_concatkdf_kw_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdhes/subtle/ecdhes_concatkdf_kw_test.go
@@ -56,7 +56,7 @@ func TestWrap(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestUnWrapUsingKeysOnDifferentCurves(t *testing.T) {
+func TestUnwrapUsingKeysOnDifferentCurves(t *testing.T) {
 	keySize := 32
 	curveP256, err := hybrid.GetCurve(commonpb.EllipticCurveType_NIST_P256.String())
 	require.NoError(t, err)

--- a/pkg/crypto/tinkcrypto/unwrap_support.go
+++ b/pkg/crypto/tinkcrypto/unwrap_support.go
@@ -1,0 +1,94 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tinkcrypto
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/golang/protobuf/proto"
+	hybrid "github.com/google/tink/go/hybrid/subtle"
+	"github.com/google/tink/go/keyset"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+
+	ecdhespb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdhes_aead_go_proto"
+)
+
+func extractPrivKey(kh *keyset.Handle) (*hybrid.ECPrivateKey, error) {
+	buf := new(bytes.Buffer)
+	w := &privKeyWriter{w: buf}
+	nAEAD := &noopAEAD{}
+
+	if kh == nil {
+		return nil, fmt.Errorf("extractPrivKey: kh is nil")
+	}
+
+	err := kh.Write(w, nAEAD)
+	if err != nil {
+		return nil, fmt.Errorf("extractPrivKey: retrieving private key failed: %w", err)
+	}
+
+	ks := new(tinkpb.Keyset)
+
+	err = proto.Unmarshal(buf.Bytes(), ks)
+	if err != nil {
+		return nil, errors.New("extractPrivKey: invalid private key")
+	}
+
+	ecdhesAESPrivateKeyTypeURL := "type.hyperledger.org/hyperledger.aries.crypto.tink.EcdhesAesAeadPrivateKey"
+	primaryKey := ks.Key[0]
+
+	if primaryKey.KeyData.TypeUrl != ecdhesAESPrivateKeyTypeURL {
+		return nil, errors.New("extractPrivKey: can't extract unsupported private key")
+	}
+
+	pbKey := new(ecdhespb.EcdhesAeadPrivateKey)
+
+	err = proto.Unmarshal(primaryKey.KeyData.Value, pbKey)
+	if err != nil {
+		return nil, errors.New("extractPrivKey: invalid key in keyset")
+	}
+
+	c, err := hybrid.GetCurve(pbKey.PublicKey.Params.KwParams.CurveType.String())
+	if err != nil {
+		return nil, fmt.Errorf("extractPrivKey: invalid key: %w", err)
+	}
+
+	return hybrid.GetECPrivateKey(c, pbKey.KeyValue), nil
+}
+
+type noopAEAD struct{}
+
+func (n noopAEAD) Encrypt(plaintext, additionalData []byte) ([]byte, error) {
+	return plaintext, nil
+}
+
+func (n noopAEAD) Decrypt(ciphertext, additionalData []byte) ([]byte, error) {
+	return ciphertext, nil
+}
+
+type privKeyWriter struct {
+	w io.Writer
+}
+
+// Write writes the public keyset to the underlying w.Writer. It's not used in this implementation.
+func (p *privKeyWriter) Write(_ *tinkpb.Keyset) error {
+	return fmt.Errorf("privKeyWriter: write function not supported")
+}
+
+// WriteEncrypted writes the encrypted keyset to the underlying w.Writer.
+func (p *privKeyWriter) WriteEncrypted(ks *tinkpb.EncryptedKeyset) error {
+	return write(p.w, ks)
+}
+
+func write(w io.Writer, ks *tinkpb.EncryptedKeyset) error {
+	// we write EncryptedKeyset directly without decryption since noopAEAD was used to write *keyset.Handle
+	_, e := w.Write(ks.EncryptedKeyset)
+	return e
+}

--- a/pkg/crypto/tinkcrypto/unwrap_support_test.go
+++ b/pkg/crypto/tinkcrypto/unwrap_support_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tinkcrypto
+
+import (
+	"testing"
+
+	"github.com/google/tink/go/aead"
+	"github.com/google/tink/go/keyset"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ExtractPrivKey(t *testing.T) {
+	_, err := extractPrivKey(nil)
+	require.EqualError(t, err, "extractPrivKey: kh is nil")
+
+	badKey, err := keyset.NewHandle(aead.AES256GCMKeyTemplate())
+	require.NoError(t, err)
+
+	_, err = extractPrivKey(badKey)
+	require.EqualError(t, err, "extractPrivKey: can't extract unsupported private key")
+
+	_, err = extractPrivKey(&keyset.Handle{})
+	require.EqualError(t, err, "extractPrivKey: retrieving private key failed: keyset.Handle: invalid keyset")
+}
+
+func TestNoopAEAD_Decrypt(t *testing.T) {
+	n := noopAEAD{}
+
+	plainText, err := n.Decrypt([]byte("test"), nil)
+	require.NoError(t, err)
+	require.EqualValues(t, "test", plainText)
+}
+
+func TestPrivKeyWriter_Write(t *testing.T) {
+	p := privKeyWriter{}
+
+	err := p.Write(nil)
+	require.EqualError(t, err, "privKeyWriter: write function not supported")
+}

--- a/pkg/doc/jose/jwe.go
+++ b/pkg/doc/jose/jwe.go
@@ -59,6 +59,7 @@ type Recipient struct {
 type RecipientHeaders struct {
 	Alg string          `json:"alg,omitempty"`
 	APU string          `json:"apu,omitempty"`
+	APV string          `json:"apv,omitempty"`
 	IV  string          `json:"iv,omitempty"`
 	Tag string          `json:"tag,omitempty"`
 	KID string          `json:"kid,omitempty"`

--- a/pkg/mock/crypto/mock_crypto.go
+++ b/pkg/mock/crypto/mock_crypto.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package crypto
 
+import "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite"
+
 // SignFunc mocks Crypto's Sign() function, it useful for executing custom signing with the help of SignKey.
 type SignFunc func([]byte, interface{}) ([]byte, error)
 
@@ -24,6 +26,10 @@ type Crypto struct {
 	ComputeMACValue   []byte
 	ComputeMACErr     error
 	VerifyMACErr      error
+	WrapValue         *composite.RecipientWrappedKey
+	WrapError         error
+	UnwrapValue       []byte
+	UnwrapError       error
 }
 
 // Encrypt returns mocked values and a mocked error.
@@ -58,4 +64,14 @@ func (c *Crypto) ComputeMAC(data []byte, kh interface{}) ([]byte, error) {
 // VerifyMAC returns a mocked value.
 func (c *Crypto) VerifyMAC(mac, data []byte, kh interface{}) error {
 	return c.VerifyMACErr
+}
+
+// WrapKey returns a mocked value.
+func (c *Crypto) WrapKey(cek, apu, apv []byte, kh interface{}) (*composite.RecipientWrappedKey, error) {
+	return c.WrapValue, c.WrapError
+}
+
+// UnwrapKey returns a mocked value.
+func (c *Crypto) UnwrapKey(recWK *composite.RecipientWrappedKey, kh interface{}) ([]byte, error) {
+	return c.UnwrapValue, c.UnwrapError
 }


### PR DESCRIPTION
This change introduces Wrap() and Unwrap() to Cryto api.

The functions work for ECDHES keys only for now. Future keys
(ECDH1PU, Ed25519) can be introduced in a future change.

It also includes setting APU and APV in the key derivation
process (they are set to empty `[]byte{}` in the current JWE
building process).

closes #2257

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>