### PR TITLE
feat: flexible cache for jsonld.Processor DocumentLoader

### DIFF
--- a/pkg/doc/signature/jsonld/processor_test.go
+++ b/pkg/doc/signature/jsonld/processor_test.go
@@ -80,6 +80,68 @@ func TestGetCanonicalDocument(t *testing.T) {
 				},
 			},
 			{
+				name:   "canonizing sample document with extra cached dummy context",
+				doc:    jsonLDMultipleInvalidRDFs,
+				result: canonizedSampleVP_extraContext,
+				opts: []ProcessorOpts{
+					WithRemoveAllInvalidRDF(), WithExternalContext("http://localhost:8652/dummy.jsonld"),
+					WithDocumentLoaderCache(createContextCache("http://localhost:8652/dummy.jsonld", extraJSONLDContext)),
+				},
+			},
+			{
+				name:   "canonizing sample document with extra cached dummy context and cached document loader",
+				doc:    jsonLDMultipleInvalidRDFs,
+				result: canonizedSampleVP_extraContext,
+				opts: []ProcessorOpts{
+					WithRemoveAllInvalidRDF(), WithExternalContext("http://localhost:8652/dummy.jsonld"),
+					WithDocumentLoaderCache(createContextCache("http://localhost:8652/dummy.jsonld", extraJSONLDContext)),
+					WithDocumentLoader(ld.NewCachingDocumentLoader(ld.NewRFC7324CachingDocumentLoader(&http.Client{}))),
+				},
+			},
+			{
+				name:   "canonizing sample document with extra cached dummy context and non caching document loader",
+				doc:    jsonLDMultipleInvalidRDFs,
+				result: canonizedSampleVP_extraContext,
+				opts: []ProcessorOpts{
+					WithRemoveAllInvalidRDF(), WithExternalContext("http://localhost:8652/dummy.jsonld"),
+					WithDocumentLoaderCache(createContextCache("http://localhost:8652/dummy.jsonld", extraJSONLDContext)),
+					WithDocumentLoader(ld.NewRFC7324CachingDocumentLoader(&http.Client{})),
+				},
+			},
+			{
+				name:   "canonizing sample document with extra byte cached dummy context",
+				doc:    jsonLDMultipleInvalidRDFs,
+				result: canonizedSampleVP_extraContext,
+				opts: []ProcessorOpts{
+					WithRemoveAllInvalidRDF(), WithExternalContext("http://localhost:8652/dummy.jsonld"),
+					WithDocumentLoaderCache(map[string]interface{}{
+						"http://localhost:8652/dummy.jsonld": []byte(extraJSONLDContext),
+					}),
+				},
+			},
+			{
+				name:   "canonizing sample document with extra map cached dummy context",
+				doc:    jsonLDMultipleInvalidRDFs,
+				result: canonizedSampleVP_extraContext,
+				opts: []ProcessorOpts{
+					WithRemoveAllInvalidRDF(), WithExternalContext("http://localhost:8652/dummy.jsonld"),
+					WithDocumentLoaderCache(map[string]interface{}{
+						"http://localhost:8652/dummy.jsonld": stringToMap(t, extraJSONLDContext),
+					}),
+				},
+			},
+			{
+				name:   "canonizing sample document with extra io.Reader cached dummy context",
+				doc:    jsonLDMultipleInvalidRDFs,
+				result: canonizedSampleVP_extraContext,
+				opts: []ProcessorOpts{
+					WithRemoveAllInvalidRDF(), WithExternalContext("http://localhost:8652/dummy.jsonld"),
+					WithDocumentLoaderCache(map[string]interface{}{
+						"http://localhost:8652/dummy.jsonld": strings.NewReader(extraJSONLDContext),
+					}),
+				},
+			},
+			{
 				name:   "canonizing sample document with multiple incorrect RDFs 3",
 				doc:    jsonLDMultipleInvalidRDFs,
 				result: canonizedSampleVP,
@@ -155,7 +217,8 @@ func TestGetCanonicalDocument(t *testing.T) {
 				err := json.Unmarshal([]byte(tc.doc), &jsonldDoc)
 				require.NoError(t, err)
 
-				response, err := NewProcessor(defaultAlgorithm).GetCanonicalDocument(jsonldDoc, tc.opts...)
+				response, err := NewProcessor(defaultAlgorithm).GetCanonicalDocument(jsonldDoc,
+					append([]ProcessorOpts{jsonldCache}, tc.opts...)...)
 				if tc.err != "" {
 					require.Error(t, err)
 					require.Contains(t, err.Error(), tc.err)
@@ -212,6 +275,21 @@ func createInMemoryDocumentLoader(url, inMemoryContext string) *ld.CachingDocume
 	loader.AddDocument(url, reader)
 
 	return loader
+}
+
+func createContextCache(url, inMemoryContext string) map[string]interface{} {
+	return map[string]interface{}{
+		url: inMemoryContext,
+	}
+}
+
+func stringToMap(t *testing.T, s string) map[string]interface{} {
+	var m map[string]interface{}
+
+	err := json.Unmarshal([]byte(s), &m)
+	require.NoError(t, err)
+
+	return m
 }
 
 const (
@@ -709,6 +787,702 @@ const extraJSONLDContext = `
       "type": "@type",
       
       "ex": "https://example.org/examples#",
+
+      "CredentialStatusList2017": "ex:CredentialStatusList2017",
+      "DocumentVerification": "ex:DocumentVerification",
+      "SupportingActivity": "ex:SupportingActivity"
+    }
+}
+`
+
+//nolint:gochecknoglobals
+var jsonldCache = WithDocumentLoaderCache(
+	map[string]interface{}{
+		"https://www.w3.org/2018/credentials/v1":                       vcDoc,
+		"https://www.w3.org/2018/credentials/examples/v1":              vcExampleDoc,
+		"https://www.w3.org/ns/odrl.jsonld":                            odrlDoc,
+		"https://w3id.org/security/v1":                                 securityV1Doc,
+		"https://w3id.org/security/v2":                                 securityV2Doc,
+		"https://trustbloc.github.io/context/vc/credentials-v1.jsonld": trustblocDoc,
+		"https://trustbloc.github.io/context/vc/examples-v1.jsonld":    trustblocExampleDoc,
+	})
+
+const vcDoc = `
+
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+
+    "id": "@id",
+    "type": "@type",
+
+    "VerifiableCredential": {
+      "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "cred": "https://www.w3.org/2018/credentials#",
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "credentialSchema": {
+          "@id": "cred:credentialSchema",
+          "@type": "@id",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "cred": "https://www.w3.org/2018/credentials#",
+
+            "JsonSchemaValidator2018": "cred:JsonSchemaValidator2018"
+          }
+        },
+        "credentialStatus": {"@id": "cred:credentialStatus", "@type": "@id"},
+        "credentialSubject": {"@id": "cred:credentialSubject", "@type": "@id"},
+        "evidence": {"@id": "cred:evidence", "@type": "@id"},
+        "expirationDate": {"@id": "cred:expirationDate", "@type": "xsd:dateTime"},
+        "holder": {"@id": "cred:holder", "@type": "@id"},
+        "issued": {"@id": "cred:issued", "@type": "xsd:dateTime"},
+        "issuer": {"@id": "cred:issuer", "@type": "@id"},
+        "issuanceDate": {"@id": "cred:issuanceDate", "@type": "xsd:dateTime"},
+        "proof": {"@id": "sec:proof", "@type": "@id", "@container": "@graph"},
+        "refreshService": {
+          "@id": "cred:refreshService",
+          "@type": "@id",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "cred": "https://www.w3.org/2018/credentials#",
+
+            "ManualRefreshService2018": "cred:ManualRefreshService2018"
+          }
+        },
+        "termsOfUse": {"@id": "cred:termsOfUse", "@type": "@id"},
+        "validFrom": {"@id": "cred:validFrom", "@type": "xsd:dateTime"},
+        "validUntil": {"@id": "cred:validUntil", "@type": "xsd:dateTime"}
+      }
+    },
+
+    "VerifiablePresentation": {
+      "@id": "https://www.w3.org/2018/credentials#VerifiablePresentation",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "cred": "https://www.w3.org/2018/credentials#",
+        "sec": "https://w3id.org/security#",
+
+        "holder": {"@id": "cred:holder", "@type": "@id"},
+        "proof": {"@id": "sec:proof", "@type": "@id", "@container": "@graph"},
+        "verifiableCredential": {"@id": "cred:verifiableCredential", "@type": "@id", "@container": "@graph"}
+      }
+    },
+
+    "EcdsaSecp256k1Signature2019": {
+      "@id": "https://w3id.org/security#EcdsaSecp256k1Signature2019",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "challenge": "sec:challenge",
+        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
+        "domain": "sec:domain",
+        "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
+
+            "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
+            "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
+      }
+    },
+
+    "EcdsaSecp256r1Signature2019": {
+      "@id": "https://w3id.org/security#EcdsaSecp256r1Signature2019",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "challenge": "sec:challenge",
+        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
+        "domain": "sec:domain",
+        "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
+
+            "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
+            "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
+      }
+    },
+
+    "Ed25519Signature2018": {
+      "@id": "https://w3id.org/security#Ed25519Signature2018",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "challenge": "sec:challenge",
+        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
+        "domain": "sec:domain",
+        "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
+
+            "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
+            "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
+      }
+    },
+
+    "RsaSignature2018": {
+      "@id": "https://w3id.org/security#RsaSignature2018",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "challenge": "sec:challenge",
+        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
+        "domain": "sec:domain",
+        "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
+
+            "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
+            "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
+      }
+    },
+
+    "proof": {"@id": "https://w3id.org/security#proof", "@type": "@id", "@container": "@graph"}
+  }
+}
+`
+
+const vcExampleDoc = `
+{
+  "@context": [{
+    "@version": 1.1
+  },"https://www.w3.org/ns/odrl.jsonld", {
+    "ex": "https://example.org/examples#",
+    "schema": "http://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+
+    "3rdPartyCorrelation": "ex:3rdPartyCorrelation",
+    "AllVerifiers": "ex:AllVerifiers",
+    "Archival": "ex:Archival",
+    "BachelorDegree": "ex:BachelorDegree",
+    "Child": "ex:Child",
+    "CLCredentialDefinition2019": "ex:CLCredentialDefinition2019",
+    "CLSignature2019": "ex:CLSignature2019",
+    "IssuerPolicy": "ex:IssuerPolicy",
+    "HolderPolicy": "ex:HolderPolicy",
+    "Mother": "ex:Mother",
+    "RelationshipCredential": "ex:RelationshipCredential",
+    "UniversityDegreeCredential": "ex:UniversityDegreeCredential",
+    "ZkpExampleSchema2018": "ex:ZkpExampleSchema2018",
+
+    "issuerData": "ex:issuerData",
+    "attributes": "ex:attributes",
+    "signature": "ex:signature",
+    "signatureCorrectnessProof": "ex:signatureCorrectnessProof",
+    "primaryProof": "ex:primaryProof",
+    "nonRevocationProof": "ex:nonRevocationProof",
+
+    "alumniOf": {"@id": "schema:alumniOf", "@type": "rdf:HTML"},
+    "child": {"@id": "ex:child", "@type": "@id"},
+    "degree": "ex:degree",
+    "degreeType": "ex:degreeType",
+    "degreeSchool": "ex:degreeSchool",
+    "college": "ex:college",
+    "name": {"@id": "schema:name", "@type": "rdf:HTML"},
+    "givenName": "schema:givenName",
+    "familyName": "schema:familyName",
+    "parent": {"@id": "ex:parent", "@type": "@id"},
+    "referenceId": "ex:referenceId",
+    "documentPresence": "ex:documentPresence",
+    "evidenceDocument": "ex:evidenceDocument",
+    "spouse": "schema:spouse",
+    "subjectPresence": "ex:subjectPresence",
+    "verifier": {"@id": "ex:verifier", "@type": "@id"}
+  }]
+}
+`
+
+const odrlDoc = `
+{
+ "@context": {
+    "odrl":    "http://www.w3.org/ns/odrl/2/",
+    "rdf":     "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs":    "http://www.w3.org/2000/01/rdf-schema#",
+    "owl":     "http://www.w3.org/2002/07/owl#",
+    "skos":    "http://www.w3.org/2004/02/skos/core#",
+    "dct":     "http://purl.org/dc/terms/",
+    "xsd":     "http://www.w3.org/2001/XMLSchema#",
+    "vcard":   "http://www.w3.org/2006/vcard/ns#",
+    "foaf":    "http://xmlns.com/foaf/0.1/",
+    "schema":  "http://schema.org/",
+    "cc":      "http://creativecommons.org/ns#",
+
+    "uid":     "@id",
+    "type":    "@type",
+
+    "Policy":           "odrl:Policy",
+    "Rule":             "odrl:Rule",
+    "profile":          {"@type": "@id", "@id": "odrl:profile"},
+
+    "inheritFrom":      {"@type": "@id", "@id": "odrl:inheritFrom"},
+
+    "ConflictTerm":     "odrl:ConflictTerm",
+    "conflict":         {"@type": "@vocab", "@id": "odrl:conflict"},
+    "perm":             "odrl:perm",
+    "prohibit":         "odrl:prohibit",
+    "invalid":          "odrl:invalid",
+
+    "Agreement":           "odrl:Agreement",
+    "Assertion":           "odrl:Assertion",
+    "Offer":               "odrl:Offer",
+    "Privacy":             "odrl:Privacy",
+    "Request":             "odrl:Request",
+    "Set":                 "odrl:Set",
+    "Ticket":              "odrl:Ticket",
+
+    "Asset":               "odrl:Asset",
+    "AssetCollection":     "odrl:AssetCollection",
+    "relation":            {"@type": "@id", "@id": "odrl:relation"},
+    "hasPolicy":           {"@type": "@id", "@id": "odrl:hasPolicy"},
+
+    "target":             {"@type": "@id", "@id": "odrl:target"},
+    "output":             {"@type": "@id", "@id": "odrl:output"},
+
+    "partOf":            {"@type": "@id", "@id": "odrl:partOf"},
+	"source":            {"@type": "@id", "@id": "odrl:source"},
+
+    "Party":              "odrl:Party",
+    "PartyCollection":    "odrl:PartyCollection",
+    "function":           {"@type": "@vocab", "@id": "odrl:function"},
+    "PartyScope":         "odrl:PartyScope",
+
+    "assignee":             {"@type": "@id", "@id": "odrl:assignee"},
+    "assigner":             {"@type": "@id", "@id": "odrl:assigner"},
+	"assigneeOf":           {"@type": "@id", "@id": "odrl:assigneeOf"},
+    "assignerOf":           {"@type": "@id", "@id": "odrl:assignerOf"},
+    "attributedParty":      {"@type": "@id", "@id": "odrl:attributedParty"},
+	"attributingParty":     {"@type": "@id", "@id": "odrl:attributingParty"},
+    "compensatedParty":     {"@type": "@id", "@id": "odrl:compensatedParty"},
+    "compensatingParty":    {"@type": "@id", "@id": "odrl:compensatingParty"},
+    "consentingParty":      {"@type": "@id", "@id": "odrl:consentingParty"},
+	"consentedParty":       {"@type": "@id", "@id": "odrl:consentedParty"},
+    "informedParty":        {"@type": "@id", "@id": "odrl:informedParty"},
+	"informingParty":       {"@type": "@id", "@id": "odrl:informingParty"},
+    "trackingParty":        {"@type": "@id", "@id": "odrl:trackingParty"},
+	"trackedParty":         {"@type": "@id", "@id": "odrl:trackedParty"},
+	"contractingParty":     {"@type": "@id", "@id": "odrl:contractingParty"},
+	"contractedParty":      {"@type": "@id", "@id": "odrl:contractedParty"},
+
+    "Action":                "odrl:Action",
+    "action":                {"@type": "@vocab", "@id": "odrl:action"},
+    "includedIn":            {"@type": "@id", "@id": "odrl:includedIn"},
+    "implies":               {"@type": "@id", "@id": "odrl:implies"},
+
+    "Permission":            "odrl:Permission",
+    "permission":            {"@type": "@id", "@id": "odrl:permission"},
+
+    "Prohibition":           "odrl:Prohibition",
+    "prohibition":           {"@type": "@id", "@id": "odrl:prohibition"},
+
+    "obligation":            {"@type": "@id", "@id": "odrl:obligation"},
+
+    "use":                   "odrl:use",
+    "grantUse":              "odrl:grantUse",
+    "aggregate":             "odrl:aggregate",
+    "annotate":              "odrl:annotate",
+    "anonymize":             "odrl:anonymize",
+    "archive":               "odrl:archive",
+    "concurrentUse":         "odrl:concurrentUse",
+    "derive":                "odrl:derive",
+    "digitize":              "odrl:digitize",
+    "display":               "odrl:display",
+    "distribute":            "odrl:distribute",
+    "execute":               "odrl:execute",
+    "extract":               "odrl:extract",
+    "give":                  "odrl:give",
+    "index":                 "odrl:index",
+    "install":               "odrl:install",
+    "modify":                "odrl:modify",
+    "move":                  "odrl:move",
+    "play":                  "odrl:play",
+    "present":               "odrl:present",
+    "print":                 "odrl:print",
+    "read":                  "odrl:read",
+    "reproduce":             "odrl:reproduce",
+    "sell":                  "odrl:sell",
+    "stream":                "odrl:stream",
+    "textToSpeech":          "odrl:textToSpeech",
+    "transfer":              "odrl:transfer",
+    "transform":             "odrl:transform",
+    "translate":             "odrl:translate",
+
+    "Duty":                 "odrl:Duty",
+    "duty":                 {"@type": "@id", "@id": "odrl:duty"},
+    "consequence":          {"@type": "@id", "@id": "odrl:consequence"},
+	"remedy":               {"@type": "@id", "@id": "odrl:remedy"},
+
+    "acceptTracking":       "odrl:acceptTracking",
+    "attribute":            "odrl:attribute",
+    "compensate":           "odrl:compensate",
+    "delete":               "odrl:delete",
+    "ensureExclusivity":    "odrl:ensureExclusivity",
+    "include":              "odrl:include",
+    "inform":               "odrl:inform",
+    "nextPolicy":           "odrl:nextPolicy",
+    "obtainConsent":        "odrl:obtainConsent",
+    "reviewPolicy":         "odrl:reviewPolicy",
+    "uninstall":            "odrl:uninstall",
+    "watermark":            "odrl:watermark",
+
+    "Constraint":           "odrl:Constraint",
+	"LogicalConstraint":    "odrl:LogicalConstraint",
+    "constraint":           {"@type": "@id", "@id": "odrl:constraint"},
+	"refinement":           {"@type": "@id", "@id": "odrl:refinement"},
+    "Operator":             "odrl:Operator",
+    "operator":             {"@type": "@vocab", "@id": "odrl:operator"},
+    "RightOperand":         "odrl:RightOperand",
+    "rightOperand":         "odrl:rightOperand",
+    "rightOperandReference":{"@type": "xsd:anyURI", "@id": "odrl:rightOperandReference"},
+    "LeftOperand":          "odrl:LeftOperand",
+    "leftOperand":          {"@type": "@vocab", "@id": "odrl:leftOperand"},
+    "unit":                 "odrl:unit",
+    "dataType":             {"@type": "xsd:anyType", "@id": "odrl:datatype"},
+    "status":               "odrl:status",
+
+    "absolutePosition":        "odrl:absolutePosition",
+    "absoluteSpatialPosition": "odrl:absoluteSpatialPosition",
+    "absoluteTemporalPosition":"odrl:absoluteTemporalPosition",
+    "absoluteSize":            "odrl:absoluteSize",
+    "count":                   "odrl:count",
+    "dateTime":                "odrl:dateTime",
+    "delayPeriod":             "odrl:delayPeriod",
+    "deliveryChannel":         "odrl:deliveryChannel",
+    "elapsedTime":             "odrl:elapsedTime",
+    "event":                   "odrl:event",
+    "fileFormat":              "odrl:fileFormat",
+    "industry":                "odrl:industry:",
+    "language":                "odrl:language",
+    "media":                   "odrl:media",
+    "meteredTime":             "odrl:meteredTime",
+    "payAmount":               "odrl:payAmount",
+    "percentage":              "odrl:percentage",
+    "product":                 "odrl:product",
+    "purpose":                 "odrl:purpose",
+    "recipient":               "odrl:recipient",
+    "relativePosition":        "odrl:relativePosition",
+    "relativeSpatialPosition": "odrl:relativeSpatialPosition",
+    "relativeTemporalPosition":"odrl:relativeTemporalPosition",
+    "relativeSize":            "odrl:relativeSize",
+    "resolution":              "odrl:resolution",
+    "spatial":                 "odrl:spatial",
+    "spatialCoordinates":      "odrl:spatialCoordinates",
+    "systemDevice":            "odrl:systemDevice",
+    "timeInterval":            "odrl:timeInterval",
+    "unitOfCount":             "odrl:unitOfCount",
+    "version":                 "odrl:version",
+    "virtualLocation":         "odrl:virtualLocation",
+
+    "eq":                   "odrl:eq",
+    "gt":                   "odrl:gt",
+    "gteq":                 "odrl:gteq",
+    "lt":                   "odrl:lt",
+    "lteq":                 "odrl:lteq",
+    "neq":                  "odrl:neg",
+    "isA":                  "odrl:isA",
+    "hasPart":              "odrl:hasPart",
+    "isPartOf":             "odrl:isPartOf",
+    "isAllOf":              "odrl:isAllOf",
+    "isAnyOf":              "odrl:isAnyOf",
+    "isNoneOf":             "odrl:isNoneOf",
+    "or":                   "odrl:or",
+    "xone":                 "odrl:xone",
+    "and":                  "odrl:and",
+    "andSequence":          "odrl:andSequence",
+
+    "policyUsage":                "odrl:policyUsage"
+
+    }
+}
+`
+
+const securityV1Doc = `
+{
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+
+    "dc": "http://purl.org/dc/terms/",
+    "sec": "https://w3id.org/security#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "EcdsaKoblitzSignature2016": "sec:EcdsaKoblitzSignature2016",
+    "Ed25519Signature2018": "sec:Ed25519Signature2018",
+    "EncryptedMessage": "sec:EncryptedMessage",
+    "GraphSignature2012": "sec:GraphSignature2012",
+    "LinkedDataSignature2015": "sec:LinkedDataSignature2015",
+    "LinkedDataSignature2016": "sec:LinkedDataSignature2016",
+    "CryptographicKey": "sec:Key",
+
+    "authenticationTag": "sec:authenticationTag",
+    "canonicalizationAlgorithm": "sec:canonicalizationAlgorithm",
+    "cipherAlgorithm": "sec:cipherAlgorithm",
+    "cipherData": "sec:cipherData",
+    "cipherKey": "sec:cipherKey",
+    "created": {"@id": "dc:created", "@type": "xsd:dateTime"},
+    "creator": {"@id": "dc:creator", "@type": "@id"},
+    "digestAlgorithm": "sec:digestAlgorithm",
+    "digestValue": "sec:digestValue",
+    "domain": "sec:domain",
+    "encryptionKey": "sec:encryptionKey",
+    "expiration": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+    "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+    "initializationVector": "sec:initializationVector",
+    "iterationCount": "sec:iterationCount",
+    "nonce": "sec:nonce",
+    "normalizationAlgorithm": "sec:normalizationAlgorithm",
+    "owner": {"@id": "sec:owner", "@type": "@id"},
+    "password": "sec:password",
+    "privateKey": {"@id": "sec:privateKey", "@type": "@id"},
+    "privateKeyPem": "sec:privateKeyPem",
+    "publicKey": {"@id": "sec:publicKey", "@type": "@id"},
+    "publicKeyBase58": "sec:publicKeyBase58",
+    "publicKeyPem": "sec:publicKeyPem",
+    "publicKeyWif": "sec:publicKeyWif",
+    "publicKeyService": {"@id": "sec:publicKeyService", "@type": "@id"},
+    "revoked": {"@id": "sec:revoked", "@type": "xsd:dateTime"},
+    "salt": "sec:salt",
+    "signature": "sec:signature",
+    "signatureAlgorithm": "sec:signingAlgorithm",
+    "signatureValue": "sec:signatureValue"
+  }
+}`
+
+const securityV2Doc = `
+{
+  "@context": [{
+    "@version": 1.1
+  }, "https://w3id.org/security/v1", {
+    "AesKeyWrappingKey2019": "sec:AesKeyWrappingKey2019",
+    "DeleteKeyOperation": "sec:DeleteKeyOperation",
+    "DeriveSecretOperation": "sec:DeriveSecretOperation",
+    "EcdsaSecp256k1Signature2019": "sec:EcdsaSecp256k1Signature2019",
+    "EcdsaSecp256r1Signature2019": "sec:EcdsaSecp256r1Signature2019",
+    "EcdsaSecp256k1VerificationKey2019": "sec:EcdsaSecp256k1VerificationKey2019",
+    "EcdsaSecp256r1VerificationKey2019": "sec:EcdsaSecp256r1VerificationKey2019",
+    "Ed25519Signature2018": "sec:Ed25519Signature2018",
+    "Ed25519VerificationKey2018": "sec:Ed25519VerificationKey2018",
+    "EquihashProof2018": "sec:EquihashProof2018",
+    "ExportKeyOperation": "sec:ExportKeyOperation",
+    "GenerateKeyOperation": "sec:GenerateKeyOperation",
+    "KmsOperation": "sec:KmsOperation",
+    "RevokeKeyOperation": "sec:RevokeKeyOperation",
+    "RsaSignature2018": "sec:RsaSignature2018",
+    "RsaVerificationKey2018": "sec:RsaVerificationKey2018",
+    "Sha256HmacKey2019": "sec:Sha256HmacKey2019",
+    "SignOperation": "sec:SignOperation",
+    "UnwrapKeyOperation": "sec:UnwrapKeyOperation",
+    "VerifyOperation": "sec:VerifyOperation",
+    "WrapKeyOperation": "sec:WrapKeyOperation",
+    "X25519KeyAgreementKey2019": "sec:X25519KeyAgreementKey2019",
+
+    "allowedAction": "sec:allowedAction",
+    "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
+    "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"},
+    "capability": {"@id": "sec:capability", "@type": "@id"},
+    "capabilityAction": "sec:capabilityAction",
+    "capabilityChain": {"@id": "sec:capabilityChain", "@type": "@id", "@container": "@list"},
+    "capabilityDelegation": {"@id": "sec:capabilityDelegationMethod", "@type": "@id", "@container": "@set"},
+    "capabilityInvocation": {"@id": "sec:capabilityInvocationMethod", "@type": "@id", "@container": "@set"},
+    "caveat": {"@id": "sec:caveat", "@type": "@id", "@container": "@set"},
+    "challenge": "sec:challenge",
+    "ciphertext": "sec:ciphertext",
+    "controller": {"@id": "sec:controller", "@type": "@id"},
+    "delegator": {"@id": "sec:delegator", "@type": "@id"},
+    "equihashParameterK": {"@id": "sec:equihashParameterK", "@type": "xsd:integer"},
+    "equihashParameterN": {"@id": "sec:equihashParameterN", "@type": "xsd:integer"},
+    "invocationTarget": {"@id": "sec:invocationTarget", "@type": "@id"},
+    "invoker": {"@id": "sec:invoker", "@type": "@id"},
+    "jws": "sec:jws",
+    "keyAgreement": {"@id": "sec:keyAgreementMethod", "@type": "@id", "@container": "@set"},
+    "kmsModule": {"@id": "sec:kmsModule"},
+    "parentCapability": {"@id": "sec:parentCapability", "@type": "@id"},
+    "plaintext": "sec:plaintext",
+    "proof": {"@id": "sec:proof", "@type": "@id", "@container": "@graph"},
+    "proofPurpose": {"@id": "sec:proofPurpose", "@type": "@vocab"},
+    "proofValue": "sec:proofValue",
+    "referenceId": "sec:referenceId",
+    "unwrappedKey": "sec:unwrappedKey",
+    "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"},
+    "verifyData": "sec:verifyData",
+    "wrappedKey": "sec:wrappedKey"
+  }]
+}`
+
+const trustblocDoc = `
+{
+  "@context": {
+    "@version": 1.1,
+
+    "id": "@id",
+    "type": "@type",
+
+    "trustbloc": "https://trustbloc.github.io/context#",
+    "ldssk": "https://w3c-ccg.github.io/lds-jws2020/contexts/#",
+    "sec": "https://w3id.org/security#",
+
+    "publicKeyJwk": {
+      "@id": "sec:publicKeyJwk",
+      "@type": "@json"
+    },
+
+    "JsonWebSignature2020": {
+      "@id": "https://w3c-ccg.github.io/lds-jws2020/contexts/#JsonWebSignature2020",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "challenge": "sec:challenge",
+        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
+        "domain": "sec:domain",
+        "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
+
+            "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
+            "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
+      }
+    }
+  }
+}`
+
+const trustblocExampleDoc = `
+{
+    "@context": {
+      "@version": 1.1,
+
+      "id": "@id",
+      "type": "@type",
+
+      "ex": "https://example.org/examples#",
+
+      "image": {"@id": "http://schema.org/image", "@type": "@id"},
 
       "CredentialStatusList2017": "ex:CredentialStatusList2017",
       "DocumentVerification": "ex:DocumentVerification",

--- a/pkg/doc/signature/proof/cache.go
+++ b/pkg/doc/signature/proof/cache.go
@@ -1,0 +1,184 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package proof
+
+//nolint:gochecknoglobals
+var jsonldCache = map[string]interface{}{
+	"https://w3id.org/security/v1":                                 securityV1Doc,
+	"https://w3id.org/security/v2":                                 securityV2Doc,
+	"https://trustbloc.github.io/context/vc/credentials-v1.jsonld": trustblocContext,
+}
+
+const securityV1Doc = `
+{
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+
+    "dc": "http://purl.org/dc/terms/",
+    "sec": "https://w3id.org/security#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "EcdsaKoblitzSignature2016": "sec:EcdsaKoblitzSignature2016",
+    "Ed25519Signature2018": "sec:Ed25519Signature2018",
+    "EncryptedMessage": "sec:EncryptedMessage",
+    "GraphSignature2012": "sec:GraphSignature2012",
+    "LinkedDataSignature2015": "sec:LinkedDataSignature2015",
+    "LinkedDataSignature2016": "sec:LinkedDataSignature2016",
+    "CryptographicKey": "sec:Key",
+
+    "authenticationTag": "sec:authenticationTag",
+    "canonicalizationAlgorithm": "sec:canonicalizationAlgorithm",
+    "cipherAlgorithm": "sec:cipherAlgorithm",
+    "cipherData": "sec:cipherData",
+    "cipherKey": "sec:cipherKey",
+    "created": {"@id": "dc:created", "@type": "xsd:dateTime"},
+    "creator": {"@id": "dc:creator", "@type": "@id"},
+    "digestAlgorithm": "sec:digestAlgorithm",
+    "digestValue": "sec:digestValue",
+    "domain": "sec:domain",
+    "encryptionKey": "sec:encryptionKey",
+    "expiration": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+    "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+    "initializationVector": "sec:initializationVector",
+    "iterationCount": "sec:iterationCount",
+    "nonce": "sec:nonce",
+    "normalizationAlgorithm": "sec:normalizationAlgorithm",
+    "owner": {"@id": "sec:owner", "@type": "@id"},
+    "password": "sec:password",
+    "privateKey": {"@id": "sec:privateKey", "@type": "@id"},
+    "privateKeyPem": "sec:privateKeyPem",
+    "publicKey": {"@id": "sec:publicKey", "@type": "@id"},
+    "publicKeyBase58": "sec:publicKeyBase58",
+    "publicKeyPem": "sec:publicKeyPem",
+    "publicKeyWif": "sec:publicKeyWif",
+    "publicKeyService": {"@id": "sec:publicKeyService", "@type": "@id"},
+    "revoked": {"@id": "sec:revoked", "@type": "xsd:dateTime"},
+    "salt": "sec:salt",
+    "signature": "sec:signature",
+    "signatureAlgorithm": "sec:signingAlgorithm",
+    "signatureValue": "sec:signatureValue"
+  }
+}`
+
+const securityV2Doc = `
+{
+  "@context": [{
+    "@version": 1.1
+  }, "https://w3id.org/security/v1", {
+    "AesKeyWrappingKey2019": "sec:AesKeyWrappingKey2019",
+    "DeleteKeyOperation": "sec:DeleteKeyOperation",
+    "DeriveSecretOperation": "sec:DeriveSecretOperation",
+    "EcdsaSecp256k1Signature2019": "sec:EcdsaSecp256k1Signature2019",
+    "EcdsaSecp256r1Signature2019": "sec:EcdsaSecp256r1Signature2019",
+    "EcdsaSecp256k1VerificationKey2019": "sec:EcdsaSecp256k1VerificationKey2019",
+    "EcdsaSecp256r1VerificationKey2019": "sec:EcdsaSecp256r1VerificationKey2019",
+    "Ed25519Signature2018": "sec:Ed25519Signature2018",
+    "Ed25519VerificationKey2018": "sec:Ed25519VerificationKey2018",
+    "EquihashProof2018": "sec:EquihashProof2018",
+    "ExportKeyOperation": "sec:ExportKeyOperation",
+    "GenerateKeyOperation": "sec:GenerateKeyOperation",
+    "KmsOperation": "sec:KmsOperation",
+    "RevokeKeyOperation": "sec:RevokeKeyOperation",
+    "RsaSignature2018": "sec:RsaSignature2018",
+    "RsaVerificationKey2018": "sec:RsaVerificationKey2018",
+    "Sha256HmacKey2019": "sec:Sha256HmacKey2019",
+    "SignOperation": "sec:SignOperation",
+    "UnwrapKeyOperation": "sec:UnwrapKeyOperation",
+    "VerifyOperation": "sec:VerifyOperation",
+    "WrapKeyOperation": "sec:WrapKeyOperation",
+    "X25519KeyAgreementKey2019": "sec:X25519KeyAgreementKey2019",
+
+    "allowedAction": "sec:allowedAction",
+    "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
+    "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"},
+    "capability": {"@id": "sec:capability", "@type": "@id"},
+    "capabilityAction": "sec:capabilityAction",
+    "capabilityChain": {"@id": "sec:capabilityChain", "@type": "@id", "@container": "@list"},
+    "capabilityDelegation": {"@id": "sec:capabilityDelegationMethod", "@type": "@id", "@container": "@set"},
+    "capabilityInvocation": {"@id": "sec:capabilityInvocationMethod", "@type": "@id", "@container": "@set"},
+    "caveat": {"@id": "sec:caveat", "@type": "@id", "@container": "@set"},
+    "challenge": "sec:challenge",
+    "ciphertext": "sec:ciphertext",
+    "controller": {"@id": "sec:controller", "@type": "@id"},
+    "delegator": {"@id": "sec:delegator", "@type": "@id"},
+    "equihashParameterK": {"@id": "sec:equihashParameterK", "@type": "xsd:integer"},
+    "equihashParameterN": {"@id": "sec:equihashParameterN", "@type": "xsd:integer"},
+    "invocationTarget": {"@id": "sec:invocationTarget", "@type": "@id"},
+    "invoker": {"@id": "sec:invoker", "@type": "@id"},
+    "jws": "sec:jws",
+    "keyAgreement": {"@id": "sec:keyAgreementMethod", "@type": "@id", "@container": "@set"},
+    "kmsModule": {"@id": "sec:kmsModule"},
+    "parentCapability": {"@id": "sec:parentCapability", "@type": "@id"},
+    "plaintext": "sec:plaintext",
+    "proof": {"@id": "sec:proof", "@type": "@id", "@container": "@graph"},
+    "proofPurpose": {"@id": "sec:proofPurpose", "@type": "@vocab"},
+    "proofValue": "sec:proofValue",
+    "referenceId": "sec:referenceId",
+    "unwrappedKey": "sec:unwrappedKey",
+    "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"},
+    "verifyData": "sec:verifyData",
+    "wrappedKey": "sec:wrappedKey"
+  }]
+}`
+
+const trustblocContext = `
+{
+  "@context": {
+    "@version": 1.1,
+
+    "id": "@id",
+    "type": "@type",
+
+    "trustbloc": "https://trustbloc.github.io/context#",
+    "ldssk": "https://w3c-ccg.github.io/lds-jws2020/contexts/#",
+    "sec": "https://w3id.org/security#",
+
+    "publicKeyJwk": {
+      "@id": "sec:publicKeyJwk",
+      "@type": "@json"
+    },
+
+    "JsonWebSignature2020": {
+      "@id": "https://w3c-ccg.github.io/lds-jws2020/contexts/#JsonWebSignature2020",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "challenge": "sec:challenge",
+        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
+        "domain": "sec:domain",
+        "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
+
+            "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
+            "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
+      }
+    }
+  }
+}`

--- a/pkg/doc/signature/proof/data.go
+++ b/pkg/doc/signature/proof/data.go
@@ -100,6 +100,8 @@ func prepareCanonicalProofOptions(suite signatureSuite, proofOptions map[string]
 	}
 
 	if suite.CompactProof() {
+		opts = append(opts, jsonld.WithDocumentLoaderCache(jsonldCache))
+
 		docCompacted, err := getCompactedWithSecuritySchema(proofOptionsCopy, opts...)
 		if err != nil {
 			return nil, err

--- a/pkg/doc/signature/proof/data_test.go
+++ b/pkg/doc/signature/proof/data_test.go
@@ -28,13 +28,13 @@ func TestCreateVerifyHashAlgorithm(t *testing.T) {
 	err := json.Unmarshal([]byte(validDoc), &doc)
 	require.NoError(t, err)
 
-	normalizedDoc, err := CreateVerifyHash(&mockSignatureSuite{}, doc, proofOptions)
+	normalizedDoc, err := CreateVerifyHash(&mockSignatureSuite{}, doc, proofOptions, jsonldDidCache)
 	require.NoError(t, err)
 	require.NotEmpty(t, normalizedDoc)
 
 	// test error due to missing proof option
 	delete(proofOptions, jsonldCreated)
-	normalizedDoc, err = CreateVerifyHash(&mockSignatureSuite{}, doc, proofOptions)
+	normalizedDoc, err = CreateVerifyHash(&mockSignatureSuite{}, doc, proofOptions, jsonldDidCache)
 	require.NotNil(t, err)
 	require.Nil(t, normalizedDoc)
 	require.Contains(t, err.Error(), "created is missing")
@@ -61,13 +61,13 @@ func TestPrepareCanonicalProofOptions(t *testing.T) {
 		"nonce":    "nonce",
 	}
 
-	canonicalProofOptions, err := prepareCanonicalProofOptions(&mockSignatureSuite{}, proofOptions)
+	canonicalProofOptions, err := prepareCanonicalProofOptions(&mockSignatureSuite{}, proofOptions, jsonldDidCache)
 	require.NoError(t, err)
 	require.NotEmpty(t, canonicalProofOptions)
 
 	// test missing created
 	delete(proofOptions, jsonldCreated)
-	canonicalProofOptions, err = prepareCanonicalProofOptions(&mockSignatureSuite{}, proofOptions)
+	canonicalProofOptions, err = prepareCanonicalProofOptions(&mockSignatureSuite{}, proofOptions, jsonldDidCache)
 	require.NotNil(t, err)
 	require.Nil(t, canonicalProofOptions)
 	require.Contains(t, err.Error(), "created is missing")
@@ -88,24 +88,24 @@ func TestCreateVerifyData(t *testing.T) {
 	require.NoError(t, err)
 
 	p.SignatureRepresentation = SignatureProofValue
-	normalizedDoc, err := CreateVerifyData(&mockSignatureSuite{}, doc, p)
+	normalizedDoc, err := CreateVerifyData(&mockSignatureSuite{}, doc, p, jsonldDidCache)
 	require.NoError(t, err)
 	require.NotEmpty(t, normalizedDoc)
 
 	p.SignatureRepresentation = SignatureProofValue
-	normalizedDoc, err = CreateVerifyData(&mockSignatureSuite{compactProof: true}, doc, p)
+	normalizedDoc, err = CreateVerifyData(&mockSignatureSuite{compactProof: true}, doc, p, jsonldDidCache)
 	require.NoError(t, err)
 	require.NotEmpty(t, normalizedDoc)
 
 	p.SignatureRepresentation = SignatureJWS
 	p.JWS = "jws header.."
-	normalizedDoc, err = CreateVerifyData(&mockSignatureSuite{}, doc, p)
+	normalizedDoc, err = CreateVerifyData(&mockSignatureSuite{}, doc, p, jsonldDidCache)
 	require.NoError(t, err)
 	require.NotEmpty(t, normalizedDoc)
 
 	// unsupported signature representation
 	p.SignatureRepresentation = SignatureRepresentation(-1)
-	signature, err := CreateVerifyData(&mockSignatureSuite{}, doc, p)
+	signature, err := CreateVerifyData(&mockSignatureSuite{}, doc, p, jsonldDidCache)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported signature representation")

--- a/pkg/doc/signature/proof/jws.go
+++ b/pkg/doc/signature/proof/jws.go
@@ -120,7 +120,7 @@ func prepareJWSProof(suite signatureSuite, proofOptions map[string]interface{},
 	delete(proofOptionsCopy, jsonldJWS)
 	delete(proofOptionsCopy, jsonldProofValue)
 
-	return suite.GetCanonicalDocument(proofOptionsCopy, opts...)
+	return suite.GetCanonicalDocument(proofOptionsCopy, append(opts, jsonld.WithDocumentLoaderCache(jsonldCache))...)
 }
 
 func prepareDocumentForJWS(suite signatureSuite, jsonldObject map[string]interface{},
@@ -129,6 +129,8 @@ func prepareDocumentForJWS(suite signatureSuite, jsonldObject map[string]interfa
 	doc := GetCopyWithoutProof(jsonldObject)
 
 	if suite.CompactProof() {
+		opts = append(opts, jsonld.WithDocumentLoaderCache(jsonldCache))
+
 		docCompacted, err := getCompactedWithSecuritySchema(doc, opts...)
 		if err != nil {
 			return nil, err
@@ -147,7 +149,5 @@ func getCompactedWithSecuritySchema(docMap map[string]interface{},
 		"@context": securityContext,
 	}
 
-	// TODO pass JSON-LD document loader with loaded security context
-	//  (https://github.com/hyperledger/aries-framework-go/issues/2253)
 	return jsonld.Default().Compact(docMap, contextMap, opts...)
 }

--- a/pkg/doc/signature/proof/jws_test.go
+++ b/pkg/doc/signature/proof/jws_test.go
@@ -43,18 +43,18 @@ func Test_createVerifyJWS(t *testing.T) {
 	require.NoError(t, err)
 
 	// happy path - no proof compaction
-	proofVerifyData, err := createVerifyJWS(&mockSignatureSuite{}, doc, p)
+	proofVerifyData, err := createVerifyJWS(&mockSignatureSuite{}, doc, p, jsonldDidCache)
 	require.NoError(t, err)
 	require.NotEmpty(t, proofVerifyData)
 
 	// happy path - with proof compaction
-	proofVerifyData, err = createVerifyJWS(&mockSignatureSuite{compactProof: true}, doc, p)
+	proofVerifyData, err = createVerifyJWS(&mockSignatureSuite{compactProof: true}, doc, p, jsonldDidCache)
 	require.NoError(t, err)
 	require.NotEmpty(t, proofVerifyData)
 
 	// artificial example - failure of doc canonization
 	doc["type"] = 777
-	proofVerifyData, err = createVerifyJWS(&mockSignatureSuite{}, doc, p)
+	proofVerifyData, err = createVerifyJWS(&mockSignatureSuite{}, doc, p, jsonldDidCache)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid type value")
 	require.Empty(t, proofVerifyData)
@@ -62,7 +62,7 @@ func Test_createVerifyJWS(t *testing.T) {
 	// invalid JWT passed (we need to read a header from it to prepare verify data)
 	doc["type"] = "Ed25519Signature2018"
 	p.JWS = "invalid jws"
-	proofVerifyData, err = createVerifyJWS(&mockSignatureSuite{}, doc, p)
+	proofVerifyData, err = createVerifyJWS(&mockSignatureSuite{}, doc, p, jsonldDidCache)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid JWT")
 	require.Empty(t, proofVerifyData)

--- a/pkg/doc/signature/proof/support_test.go
+++ b/pkg/doc/signature/proof/support_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package proof
+
+import "github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
+
+//nolint:gochecknoglobals
+var jsonldDidCache = jsonld.WithDocumentLoaderCache(
+	map[string]interface{}{
+		"https://w3id.org/did/v1": didDoc,
+	})
+
+const didDoc = `
+{
+  "@context": {
+    "@version": 1.1,
+    "id": "@id",
+    "type": "@type",
+
+    "dc": "http://purl.org/dc/terms/",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "schema": "http://schema.org/",
+    "sec": "https://w3id.org/security#",
+    "didv": "https://w3id.org/did#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "AuthenticationSuite": "sec:AuthenticationSuite",
+    "CryptographicKey": "sec:Key",
+    "EquihashProof2017": "sec:EquihashProof2017",
+    "GraphSignature2012": "sec:GraphSignature2012",
+    "IssueCredential": "didv:IssueCredential",
+    "LinkedDataSignature2015": "sec:LinkedDataSignature2015",
+    "LinkedDataSignature2016": "sec:LinkedDataSignature2016",
+    "RsaCryptographicKey": "sec:RsaCryptographicKey",
+    "RsaSignatureAuthentication2018": "sec:RsaSignatureAuthentication2018",
+    "RsaSigningKey2018": "sec:RsaSigningKey",
+    "RsaSignature2015": "sec:RsaSignature2015",
+    "RsaSignature2017": "sec:RsaSignature2017",
+    "UpdateDidDescription": "didv:UpdateDidDescription",
+
+    "authentication": "sec:authenticationMethod",
+    "authenticationCredential": "sec:authenticationCredential",
+    "authorizationCapability": "sec:authorizationCapability",
+    "canonicalizationAlgorithm": "sec:canonicalizationAlgorithm",
+    "capability": "sec:capability",
+    "comment": "rdfs:comment",
+    "created": {"@id": "dc:created", "@type": "xsd:dateTime"},
+    "creator": {"@id": "dc:creator", "@type": "@id"},
+    "description": "schema:description",
+    "digestAlgorithm": "sec:digestAlgorithm",
+    "digestValue": "sec:digestValue",
+    "domain": "sec:domain",
+    "entity": "sec:entity",
+    "equihashParameterAlgorithm": "sec:equihashParameterAlgorithm",
+    "equihashParameterK": {"@id": "sec:equihashParameterK", "@type": "xsd:integer"},
+    "equihashParameterN": {"@id": "sec:equihashParameterN", "@type": "xsd:integer"},
+    "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+    "field": {"@id": "didv:field", "@type": "@id"},
+    "label": "rdfs:label",
+    "minimumProofsRequired": "sec:minimumProofsRequired",
+    "minimumSignaturesRequired": "sec:minimumSignaturesRequired",
+    "name": "schema:name",
+    "nonce": "sec:nonce",
+    "normalizationAlgorithm": "sec:normalizationAlgorithm",
+    "owner": {"@id": "sec:owner", "@type": "@id"},
+    "permission": "sec:permission",
+    "permittedProofType": "sec:permittedProofType",
+    "privateKey": {"@id": "sec:privateKey", "@type": "@id"},
+    "privateKeyPem": "sec:privateKeyPem",
+    "proof": "sec:proof",
+    "proofAlgorithm": "sec:proofAlgorithm",
+    "proofType": "sec:proofType",
+    "proofValue": "sec:proofValue",
+    "publicKey": {"@id": "sec:publicKey", "@type": "@id", "@container": "@set"},
+    "publicKeyPem": "sec:publicKeyPem",
+    "requiredProof": "sec:requiredProof",
+    "revoked": {"@id": "sec:revoked", "@type": "xsd:dateTime"},
+    "seeAlso": {"@id": "rdfs:seeAlso", "@type": "@id"},
+    "signature": "sec:signature",
+    "signatureAlgorithm": "sec:signatureAlgorithm",
+    "signatureValue": "sec:signatureValue"
+  }
+}`

--- a/pkg/doc/signature/signer/signer_test.go
+++ b/pkg/doc/signature/signer/signer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/proof"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ed25519signature2018"
@@ -32,12 +33,12 @@ func TestDocumentSigner_Sign(t *testing.T) {
 	require.NoError(t, err)
 
 	s := New(ed25519signature2018.New(suite.WithSigner(signer)))
-	signedDoc, err := s.Sign(context, []byte(validDoc))
+	signedDoc, err := s.Sign(context, []byte(validDoc), jsonldCache)
 	require.NoError(t, err)
 	require.NotNil(t, signedDoc)
 
 	context.SignatureRepresentation = proof.SignatureJWS
-	signedJWSDoc, err := s.Sign(context, []byte(validDoc))
+	signedJWSDoc, err := s.Sign(context, []byte(validDoc), jsonldCache)
 	require.NoError(t, err)
 	require.NotNil(t, signedJWSDoc)
 
@@ -70,7 +71,7 @@ func TestDocumentSigner_SignErrors(t *testing.T) {
 	s := New(ed25519signature2018.New(suite.WithSigner(signer)))
 
 	// test invalid json
-	signedDoc, err := s.Sign(context, []byte("not json"))
+	signedDoc, err := s.Sign(context, []byte("not json"), jsonldCache)
 	require.NotNil(t, err)
 	require.Nil(t, signedDoc)
 	require.Contains(t, err.Error(), "failed to unmarshal json ld document")
@@ -78,7 +79,7 @@ func TestDocumentSigner_SignErrors(t *testing.T) {
 	// test for signature suite not supported
 	context = getSignatureContext()
 	context.SignatureType = "non-existent"
-	signedDoc, err = s.Sign(context, []byte(validDoc))
+	signedDoc, err = s.Sign(context, []byte(validDoc), jsonldCache)
 	require.NotNil(t, err)
 	require.Nil(t, signedDoc)
 	require.Contains(t, err.Error(), "signature type non-existent not supported")
@@ -94,7 +95,7 @@ func TestDocumentSigner_SignErrors(t *testing.T) {
 	require.NoError(t, err)
 
 	context = getSignatureContext()
-	signedDoc, err = s.Sign(context, invalidDocBytes)
+	signedDoc, err = s.Sign(context, invalidDocBytes, jsonldCache)
 	require.NotNil(t, err)
 	require.Nil(t, signedDoc)
 	require.Contains(t, err.Error(), "invalid context")
@@ -103,7 +104,7 @@ func TestDocumentSigner_SignErrors(t *testing.T) {
 	context = getSignatureContext()
 	s = New(ed25519signature2018.New(
 		suite.WithSigner(signature.GetEd25519Signer([]byte("invalid"), nil))))
-	signedDoc, err = s.Sign(context, []byte(validDoc))
+	signedDoc, err = s.Sign(context, []byte(validDoc), jsonldCache)
 	require.NotNil(t, err)
 	require.Nil(t, signedDoc)
 	require.Contains(t, err.Error(), "bad private key length")
@@ -114,7 +115,7 @@ func TestDocumentSigner_isValidContext(t *testing.T) {
 
 	context := getSignatureContext()
 	context.SignatureType = ""
-	signedDoc, err := s.Sign(context, []byte(validDoc))
+	signedDoc, err := s.Sign(context, []byte(validDoc), jsonldCache)
 	require.NotNil(t, err)
 	require.Nil(t, signedDoc)
 	require.Contains(t, err.Error(), "signature type is missing")
@@ -163,3 +164,196 @@ const validDoc = `{
   ],
   "created": "2002-10-10T17:00:00Z"
 }`
+
+const didDoc = `
+{
+  "@context": {
+    "@version": 1.1,
+    "id": "@id",
+    "type": "@type",
+
+    "dc": "http://purl.org/dc/terms/",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "schema": "http://schema.org/",
+    "sec": "https://w3id.org/security#",
+    "didv": "https://w3id.org/did#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "AuthenticationSuite": "sec:AuthenticationSuite",
+    "CryptographicKey": "sec:Key",
+    "EquihashProof2017": "sec:EquihashProof2017",
+    "GraphSignature2012": "sec:GraphSignature2012",
+    "IssueCredential": "didv:IssueCredential",
+    "LinkedDataSignature2015": "sec:LinkedDataSignature2015",
+    "LinkedDataSignature2016": "sec:LinkedDataSignature2016",
+    "RsaCryptographicKey": "sec:RsaCryptographicKey",
+    "RsaSignatureAuthentication2018": "sec:RsaSignatureAuthentication2018",
+    "RsaSigningKey2018": "sec:RsaSigningKey",
+    "RsaSignature2015": "sec:RsaSignature2015",
+    "RsaSignature2017": "sec:RsaSignature2017",
+    "UpdateDidDescription": "didv:UpdateDidDescription",
+
+    "authentication": "sec:authenticationMethod",
+    "authenticationCredential": "sec:authenticationCredential",
+    "authorizationCapability": "sec:authorizationCapability",
+    "canonicalizationAlgorithm": "sec:canonicalizationAlgorithm",
+    "capability": "sec:capability",
+    "comment": "rdfs:comment",
+    "created": {"@id": "dc:created", "@type": "xsd:dateTime"},
+    "creator": {"@id": "dc:creator", "@type": "@id"},
+    "description": "schema:description",
+    "digestAlgorithm": "sec:digestAlgorithm",
+    "digestValue": "sec:digestValue",
+    "domain": "sec:domain",
+    "entity": "sec:entity",
+    "equihashParameterAlgorithm": "sec:equihashParameterAlgorithm",
+    "equihashParameterK": {"@id": "sec:equihashParameterK", "@type": "xsd:integer"},
+    "equihashParameterN": {"@id": "sec:equihashParameterN", "@type": "xsd:integer"},
+    "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+    "field": {"@id": "didv:field", "@type": "@id"},
+    "label": "rdfs:label",
+    "minimumProofsRequired": "sec:minimumProofsRequired",
+    "minimumSignaturesRequired": "sec:minimumSignaturesRequired",
+    "name": "schema:name",
+    "nonce": "sec:nonce",
+    "normalizationAlgorithm": "sec:normalizationAlgorithm",
+    "owner": {"@id": "sec:owner", "@type": "@id"},
+    "permission": "sec:permission",
+    "permittedProofType": "sec:permittedProofType",
+    "privateKey": {"@id": "sec:privateKey", "@type": "@id"},
+    "privateKeyPem": "sec:privateKeyPem",
+    "proof": "sec:proof",
+    "proofAlgorithm": "sec:proofAlgorithm",
+    "proofType": "sec:proofType",
+    "proofValue": "sec:proofValue",
+    "publicKey": {"@id": "sec:publicKey", "@type": "@id", "@container": "@set"},
+    "publicKeyPem": "sec:publicKeyPem",
+    "requiredProof": "sec:requiredProof",
+    "revoked": {"@id": "sec:revoked", "@type": "xsd:dateTime"},
+    "seeAlso": {"@id": "rdfs:seeAlso", "@type": "@id"},
+    "signature": "sec:signature",
+    "signatureAlgorithm": "sec:signatureAlgorithm",
+    "signatureValue": "sec:signatureValue"
+  }
+}`
+
+const securityV1Doc = `
+{
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+
+    "dc": "http://purl.org/dc/terms/",
+    "sec": "https://w3id.org/security#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "EcdsaKoblitzSignature2016": "sec:EcdsaKoblitzSignature2016",
+    "Ed25519Signature2018": "sec:Ed25519Signature2018",
+    "EncryptedMessage": "sec:EncryptedMessage",
+    "GraphSignature2012": "sec:GraphSignature2012",
+    "LinkedDataSignature2015": "sec:LinkedDataSignature2015",
+    "LinkedDataSignature2016": "sec:LinkedDataSignature2016",
+    "CryptographicKey": "sec:Key",
+
+    "authenticationTag": "sec:authenticationTag",
+    "canonicalizationAlgorithm": "sec:canonicalizationAlgorithm",
+    "cipherAlgorithm": "sec:cipherAlgorithm",
+    "cipherData": "sec:cipherData",
+    "cipherKey": "sec:cipherKey",
+    "created": {"@id": "dc:created", "@type": "xsd:dateTime"},
+    "creator": {"@id": "dc:creator", "@type": "@id"},
+    "digestAlgorithm": "sec:digestAlgorithm",
+    "digestValue": "sec:digestValue",
+    "domain": "sec:domain",
+    "encryptionKey": "sec:encryptionKey",
+    "expiration": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+    "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+    "initializationVector": "sec:initializationVector",
+    "iterationCount": "sec:iterationCount",
+    "nonce": "sec:nonce",
+    "normalizationAlgorithm": "sec:normalizationAlgorithm",
+    "owner": {"@id": "sec:owner", "@type": "@id"},
+    "password": "sec:password",
+    "privateKey": {"@id": "sec:privateKey", "@type": "@id"},
+    "privateKeyPem": "sec:privateKeyPem",
+    "publicKey": {"@id": "sec:publicKey", "@type": "@id"},
+    "publicKeyBase58": "sec:publicKeyBase58",
+    "publicKeyPem": "sec:publicKeyPem",
+    "publicKeyWif": "sec:publicKeyWif",
+    "publicKeyService": {"@id": "sec:publicKeyService", "@type": "@id"},
+    "revoked": {"@id": "sec:revoked", "@type": "xsd:dateTime"},
+    "salt": "sec:salt",
+    "signature": "sec:signature",
+    "signatureAlgorithm": "sec:signingAlgorithm",
+    "signatureValue": "sec:signatureValue"
+  }
+}`
+
+const securityV2Doc = `
+{
+  "@context": [{
+    "@version": 1.1
+  }, "https://w3id.org/security/v1", {
+    "AesKeyWrappingKey2019": "sec:AesKeyWrappingKey2019",
+    "DeleteKeyOperation": "sec:DeleteKeyOperation",
+    "DeriveSecretOperation": "sec:DeriveSecretOperation",
+    "EcdsaSecp256k1Signature2019": "sec:EcdsaSecp256k1Signature2019",
+    "EcdsaSecp256r1Signature2019": "sec:EcdsaSecp256r1Signature2019",
+    "EcdsaSecp256k1VerificationKey2019": "sec:EcdsaSecp256k1VerificationKey2019",
+    "EcdsaSecp256r1VerificationKey2019": "sec:EcdsaSecp256r1VerificationKey2019",
+    "Ed25519Signature2018": "sec:Ed25519Signature2018",
+    "Ed25519VerificationKey2018": "sec:Ed25519VerificationKey2018",
+    "EquihashProof2018": "sec:EquihashProof2018",
+    "ExportKeyOperation": "sec:ExportKeyOperation",
+    "GenerateKeyOperation": "sec:GenerateKeyOperation",
+    "KmsOperation": "sec:KmsOperation",
+    "RevokeKeyOperation": "sec:RevokeKeyOperation",
+    "RsaSignature2018": "sec:RsaSignature2018",
+    "RsaVerificationKey2018": "sec:RsaVerificationKey2018",
+    "Sha256HmacKey2019": "sec:Sha256HmacKey2019",
+    "SignOperation": "sec:SignOperation",
+    "UnwrapKeyOperation": "sec:UnwrapKeyOperation",
+    "VerifyOperation": "sec:VerifyOperation",
+    "WrapKeyOperation": "sec:WrapKeyOperation",
+    "X25519KeyAgreementKey2019": "sec:X25519KeyAgreementKey2019",
+
+    "allowedAction": "sec:allowedAction",
+    "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
+    "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"},
+    "capability": {"@id": "sec:capability", "@type": "@id"},
+    "capabilityAction": "sec:capabilityAction",
+    "capabilityChain": {"@id": "sec:capabilityChain", "@type": "@id", "@container": "@list"},
+    "capabilityDelegation": {"@id": "sec:capabilityDelegationMethod", "@type": "@id", "@container": "@set"},
+    "capabilityInvocation": {"@id": "sec:capabilityInvocationMethod", "@type": "@id", "@container": "@set"},
+    "caveat": {"@id": "sec:caveat", "@type": "@id", "@container": "@set"},
+    "challenge": "sec:challenge",
+    "ciphertext": "sec:ciphertext",
+    "controller": {"@id": "sec:controller", "@type": "@id"},
+    "delegator": {"@id": "sec:delegator", "@type": "@id"},
+    "equihashParameterK": {"@id": "sec:equihashParameterK", "@type": "xsd:integer"},
+    "equihashParameterN": {"@id": "sec:equihashParameterN", "@type": "xsd:integer"},
+    "invocationTarget": {"@id": "sec:invocationTarget", "@type": "@id"},
+    "invoker": {"@id": "sec:invoker", "@type": "@id"},
+    "jws": "sec:jws",
+    "keyAgreement": {"@id": "sec:keyAgreementMethod", "@type": "@id", "@container": "@set"},
+    "kmsModule": {"@id": "sec:kmsModule"},
+    "parentCapability": {"@id": "sec:parentCapability", "@type": "@id"},
+    "plaintext": "sec:plaintext",
+    "proof": {"@id": "sec:proof", "@type": "@id", "@container": "@graph"},
+    "proofPurpose": {"@id": "sec:proofPurpose", "@type": "@vocab"},
+    "proofValue": "sec:proofValue",
+    "referenceId": "sec:referenceId",
+    "unwrappedKey": "sec:unwrappedKey",
+    "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"},
+    "verifyData": "sec:verifyData",
+    "wrappedKey": "sec:wrappedKey"
+  }]
+}`
+
+//nolint:gochecknoglobals
+var jsonldCache = jsonld.WithDocumentLoaderCache(
+	map[string]interface{}{
+		"https://w3id.org/did/v1":      didDoc,
+		"https://w3id.org/security/v1": securityV1Doc,
+		"https://w3id.org/security/v2": securityV2Doc,
+	})


### PR DESCRIPTION
Added `jsonld. WithDocumentLoaderCache()` which can be used to pass cached JSON-LD contexts as pairs of URLs and JSON-LD context content (e.g. as string or `io.Reader`).
It can be used in combination with actively used `jsonld. WithDocumentLoader()`.

Current logic:
- if neither `DocumentLoader` nor `DocumentLoaderCache` is defined - do not set `DocumentLoader`JSON-LD option;
- if `DocumentLoader` is not defined - create it using `ld.NewCachingDocumentLoader()`;
- otherwise, check if `DocumentLoader` is caching one, if not, cteate a wrapping caching loader.
- apply cached contexts from `DocumentLoaderCache` to the cached document loader.

Checked that the tests from `signature` package can be run off-line (so there is no dependency on any online available JSON-LD contexts). This is achieved by passing the cached document loader and context maps in the tests.

closes #2253

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>