### PR TITLE
fix: incorrect content type in agent rest

### DIFF
--- a/cmd/aries-agent-rest/main.go
+++ b/cmd/aries-agent-rest/main.go
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
 // Terms Of Service:
 //
 //
-//     Schemes: http, https
+//     Schemes: https
 //     Version: 0.1.0
 //     License: SPDX-License-Identifier: Apache-2.0
 //

--- a/docs/rest/openapi_demo.md
+++ b/docs/rest/openapi_demo.md
@@ -5,6 +5,8 @@ Please go through the [prerequisites](../test/build.md#Prerequisites-(for-runnin
 
 `make run-openapi-demo`
 
+Note: Since this open api demo makes API calls in https make sure you import tls certs generated while running above target. Generated certs can be found in `test/bdd/fixtures/keys/tls`.
+
 Once both agents are up, click on the agent specific urls to launch the OpenAPI interface.
 
 [Alice OpenAPI Interface](http://localhost:8089/openapi/)

--- a/pkg/controller/rest/rest.go
+++ b/pkg/controller/rest/rest.go
@@ -27,12 +27,12 @@ type Handler interface {
 // Execute executes given command with args provided and writes error to
 // response writer.
 func Execute(exec command.Exec, rw http.ResponseWriter, req io.Reader) {
+	rw.Header().Set("Content-Type", "application/json")
+
 	err := exec(rw, req)
 	if err != nil {
 		SendError(rw, err)
 	}
-
-	rw.Header().Set("Content-Type", "application/json")
 }
 
 // genericError is aries rest api error response


### PR DESCRIPTION
- open api demo schema changed to 'https' from 'http,https'
- closes #2239

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
