### PR TITLE
refactor: add ECDH-1PU to crypto Wrap/Unwrap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 // indirect
-	google.golang.org/protobuf v1.25.0
 	nhooyr.io/websocket v1.8.3
 )
 

--- a/pkg/crypto/api.go
+++ b/pkg/crypto/api.go
@@ -41,8 +41,12 @@ type Crypto interface {
 	VerifyMAC(mac, data []byte, kh interface{}) error
 
 	// WrapKey will execute key wrapping of cek using apu, apv and recipient public key found in kh.
-	WrapKey(cek, apu, apv []byte, kh interface{}) (*composite.RecipientWrappedKey, error)
+	// 'opts' allows setting the option sender key handle using WithSenderKH() option. It allows ECDH-1PU key wrapping
+	// (aka Authcrypt). The absence of this option uses ECDH-ES key wrapping (aka Anoncrypt).
+	WrapKey(cek, apu, apv []byte, kh interface{}, opts ...WrapKeyOpts) (*composite.RecipientWrappedKey, error)
 
 	// UnwrapKey unwraps a key in recWK using recipient private key kh.
-	UnwrapKey(recWK *composite.RecipientWrappedKey, kh interface{}) ([]byte, error)
+	// 'opts' allows setting the option sender key handle using WithSenderKH() option. It allows ECDH-1PU key unwrapping
+	// (aka Authcrypt). The absence of this option uses ECDH-ES key unwrapping (aka Anoncrypt).
+	UnwrapKey(recWK *composite.RecipientWrappedKey, kh interface{}, opts ...WrapKeyOpts) ([]byte, error)
 }

--- a/pkg/crypto/tinkcrypto/key_wrapper.go
+++ b/pkg/crypto/tinkcrypto/key_wrapper.go
@@ -7,14 +7,24 @@ SPDX-License-Identifier: Apache-2.0
 package tinkcrypto
 
 import (
+	"crypto"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"math/big"
 
 	hybrid "github.com/google/tink/go/hybrid/subtle"
+	"github.com/google/tink/go/keyset"
 	josecipher "github.com/square/go-jose/v3/cipher"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/keyio"
+	compositepb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/common_composite_go_proto"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/cryptoutil"
 )
 
 type keyWrapper interface {
@@ -23,6 +33,10 @@ type keyWrapper interface {
 	createCipher(key []byte) (cipher.Block, error)
 	wrap(block cipher.Block, cek []byte) ([]byte, error)
 	unwrap(block cipher.Block, encryptedKey []byte) ([]byte, error)
+	deriveSender1Pu(kwAlg string, apu, apv []byte, ephemeralPriv, senderPrivKey *ecdsa.PrivateKey,
+		recPubKey *ecdsa.PublicKey, keySize int) ([]byte, error)
+	deriveRecipient1Pu(kwAlg string, apu, apv []byte, ephemeralPub, senderPubKey *ecdsa.PublicKey,
+		recPrivKey *ecdsa.PrivateKey, keySize int) ([]byte, error)
 }
 
 type keyWrapperSupport struct{}
@@ -45,4 +59,171 @@ func (w *keyWrapperSupport) wrap(block cipher.Block, cek []byte) ([]byte, error)
 
 func (w *keyWrapperSupport) unwrap(block cipher.Block, encryptedKey []byte) ([]byte, error) {
 	return josecipher.KeyUnwrap(block, encryptedKey)
+}
+
+func (w *keyWrapperSupport) deriveSender1Pu(alg string, apu, apv []byte, ephemeralPriv, senderPrivKey *ecdsa.PrivateKey,
+	recPubKey *ecdsa.PublicKey, keySize int) ([]byte, error) {
+	ze := josecipher.DeriveECDHES(alg, apu, apv, ephemeralPriv, recPubKey, keySize)
+	zs := josecipher.DeriveECDHES(alg, apu, apv, senderPrivKey, recPubKey, keySize)
+
+	return derive1Pu(alg, ze, zs, apu, apv, keySize)
+}
+
+func (w *keyWrapperSupport) deriveRecipient1Pu(alg string, apu, apv []byte, ephemeralPub, senderPubKey *ecdsa.PublicKey,
+	recPrivKey *ecdsa.PrivateKey, keySize int) ([]byte, error) {
+	// DeriveECDHES checks if keys are on the same curve
+	ze := josecipher.DeriveECDHES(alg, apu, apv, recPrivKey, ephemeralPub, keySize)
+	zs := josecipher.DeriveECDHES(alg, apu, apv, recPrivKey, senderPubKey, keySize)
+
+	return derive1Pu(alg, ze, zs, apu, apv, keySize)
+}
+
+func (t *Crypto) deriveKEKAndWrap(cek, apu, apv []byte, senderKH interface{}, ephemeralPrivKey *ecdsa.PrivateKey,
+	recPubKey *ecdsa.PublicKey, recKID string) (*composite.RecipientWrappedKey, error) {
+	var kek []byte
+
+	// TODO: add support for 25519 key wrapping https://github.com/hyperledger/aries-framework-go/issues/1637
+	keyType := compositepb.KeyType_EC.String()
+	wrappingAlg := ecdhesKWAlg
+
+	if senderKH != nil { // ecdh1pu
+		wrappingAlg = ecdh1puKWAlg
+
+		senderPrivKey, err := ksToPrivateECDSAKey(senderKH)
+		if err != nil {
+			return nil, fmt.Errorf("wrapKey: failed to retrieve sender key: %w", err)
+		}
+
+		kek, err = t.kw.deriveSender1Pu(wrappingAlg, apu, apv, ephemeralPrivKey, senderPrivKey, recPubKey, keySize)
+		if err != nil {
+			return nil, fmt.Errorf("wrapKey: failed to derive key: %w", err)
+		}
+	} else { // ecdhes
+		kek = josecipher.DeriveECDHES(wrappingAlg, apu, apv, ephemeralPrivKey, recPubKey, keySize)
+	}
+
+	block, err := t.kw.createCipher(kek)
+	if err != nil {
+		return nil, fmt.Errorf("wrapKey: failed to create new Cipher: %w", err)
+	}
+
+	wk, err := t.kw.wrap(block, cek)
+	if err != nil {
+		return nil, fmt.Errorf("wrapKey: failed to wrap key: %w", err)
+	}
+
+	return &composite.RecipientWrappedKey{
+		KID:          recKID,
+		EncryptedCEK: wk,
+		EPK: composite.PublicKey{
+			X:     ephemeralPrivKey.PublicKey.X.Bytes(),
+			Y:     ephemeralPrivKey.PublicKey.Y.Bytes(),
+			Curve: ephemeralPrivKey.PublicKey.Curve.Params().Name,
+			Type:  keyType,
+		},
+		APU: apu,
+		APV: apv,
+		Alg: wrappingAlg,
+	}, nil
+}
+
+func (t *Crypto) deriveKEKAndUnwrap(alg string, encCEK, apu, apv []byte, senderKH interface{},
+	epkPubKey *ecdsa.PublicKey, recPrivKey *ecdsa.PrivateKey) ([]byte, error) {
+	var kek []byte
+
+	switch alg {
+	case ecdh1puKWAlg:
+		if senderKH == nil {
+			return nil, fmt.Errorf("unwrap: sender's public keyset handle option is required for '%s'", ecdh1puKWAlg)
+		}
+
+		senderPubKey, err := ksToPublicECDSAKey(senderKH, t.kw)
+		if err != nil {
+			return nil, fmt.Errorf("unwrapKey: failed to retrieve sender key: %w", err)
+		}
+
+		kek, err = t.kw.deriveRecipient1Pu(alg, apu, apv, epkPubKey, senderPubKey, recPrivKey, keySize)
+		if err != nil {
+			return nil, fmt.Errorf("unwrapKey: failed to derive kek: %w", err)
+		}
+	case ecdhesKWAlg:
+		kek = josecipher.DeriveECDHES(alg, apu, apv, recPrivKey, epkPubKey, keySize)
+	default:
+		return nil, fmt.Errorf("unwrapKey: unsupported JWE KW Alg '%s'", alg)
+	}
+
+	block, err := t.kw.createCipher(kek)
+	if err != nil {
+		return nil, fmt.Errorf("unwrapKey: failed to create new Cipher: %w", err)
+	}
+
+	wk, err := t.kw.unwrap(block, encCEK)
+	if err != nil {
+		return nil, fmt.Errorf("unwrapKey: failed to unwrap key: %w", err)
+	}
+
+	return wk, nil
+}
+
+func derive1Pu(kwAlg string, ze, zs, apu, apv []byte, keySize int) ([]byte, error) {
+	z := append(ze, zs...)
+	algID := cryptoutil.LengthPrefix([]byte(kwAlg))
+	ptyUInfo := cryptoutil.LengthPrefix(apu)
+	ptyVInfo := cryptoutil.LengthPrefix(apv)
+
+	supPubLen := 4
+	supPubInfo := make([]byte, supPubLen)
+
+	byteLen := 8
+	binary.BigEndian.PutUint32(supPubInfo, uint32(keySize)*uint32(byteLen))
+
+	reader := josecipher.NewConcatKDF(crypto.SHA256, z, algID, ptyUInfo, ptyVInfo, supPubInfo, []byte{})
+
+	kek := make([]byte, keySize)
+
+	_, err := reader.Read(kek)
+	if err != nil {
+		return nil, err
+	}
+
+	return kek, nil
+}
+
+func ksToPrivateECDSAKey(ks interface{}) (*ecdsa.PrivateKey, error) {
+	senderKH, ok := ks.(*keyset.Handle)
+	if !ok {
+		return nil, fmt.Errorf("ksToPrivateECDSAKey: %w", errBadKeyHandleFormat)
+	}
+
+	senderHPrivKey, err := extractPrivKey(senderKH)
+	if err != nil {
+		return nil, fmt.Errorf("ksToPrivateECDSAKey: failed to extract sender key: %w", err)
+	}
+
+	return hybridECPrivToECDSAKey(senderHPrivKey), nil
+}
+
+func ksToPublicECDSAKey(ks interface{}, kw keyWrapper) (*ecdsa.PublicKey, error) {
+	switch kst := ks.(type) {
+	case *keyset.Handle:
+		sPubKey, err := keyio.ExtractPrimaryPublicKey(kst)
+		if err != nil {
+			return nil, fmt.Errorf("ksToPublicECDSAKey: failed to extract public key from keyset handle: %w", err)
+		}
+
+		sCurve, err := kw.getCurve(sPubKey.Curve)
+		if err != nil {
+			return nil, fmt.Errorf("ksToPublicECDSAKey: failed to GetCurve: %w", err)
+		}
+
+		return &ecdsa.PublicKey{
+			Curve: sCurve,
+			X:     new(big.Int).SetBytes(sPubKey.X),
+			Y:     new(big.Int).SetBytes(sPubKey.Y),
+		}, nil
+	case *ecdsa.PublicKey:
+		return kst, nil
+	default:
+		return nil, fmt.Errorf("ksToPublicECDSAKey: unsupported keyset type %+v", kst)
+	}
 }

--- a/pkg/crypto/tinkcrypto/primitive/composite/keyio/composite_key_export.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/keyio/composite_key_export.go
@@ -35,7 +35,7 @@ const (
 // composite.PublicKey type.
 // The keyset must have a keyURL value equal to `ecdhesAESPublicKeyTypeURL` constant of ecdhes package or
 // `ecdh1puAESPublicKeyTypeURL` constant of ecdh1pu package.
-// Note: This writer should be used only for ECDHES/ECDH1PU public key exports. Other export of public keys should be
+// Note: This writer should be used only for ECDH public key exports. Other export of public keys should be
 //       called via localkms package.
 type PubKeyWriter struct {
 	w io.Writer

--- a/pkg/crypto/tinkcrypto/unwrap_support.go
+++ b/pkg/crypto/tinkcrypto/unwrap_support.go
@@ -8,6 +8,7 @@ package tinkcrypto
 
 import (
 	"bytes"
+	"crypto/ecdsa"
 	"errors"
 	"fmt"
 	"io"
@@ -61,6 +62,17 @@ func extractPrivKey(kh *keyset.Handle) (*hybrid.ECPrivateKey, error) {
 	}
 
 	return hybrid.GetECPrivateKey(c, pbKey.KeyValue), nil
+}
+
+func hybridECPrivToECDSAKey(hybridEcPriv *hybrid.ECPrivateKey) *ecdsa.PrivateKey {
+	return &ecdsa.PrivateKey{
+		PublicKey: ecdsa.PublicKey{
+			Curve: hybridEcPriv.PublicKey.Curve,
+			X:     hybridEcPriv.PublicKey.Point.X,
+			Y:     hybridEcPriv.PublicKey.Point.Y,
+		},
+		D: hybridEcPriv.D,
+	}
 }
 
 type noopAEAD struct{}

--- a/pkg/crypto/wrapkey_opts.go
+++ b/pkg/crypto/wrapkey_opts.go
@@ -1,0 +1,36 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package crypto
+
+type wrapKeyOpts struct {
+	senderKH interface{}
+}
+
+// NewOpt creates a new empty wrap key option.
+// Not to be used directly. It's intended for implementations of Crypto interface
+// Use WithSenderKH() option function below instead.
+func NewOpt() *wrapKeyOpts { // nolint // unexported type doesn't need to be used outside of crypto package
+	return &wrapKeyOpts{}
+}
+
+// SenderKH gets the Sender key handle to be used for kew wrapping with a sender key (authcrypt).
+// Not to be used directly. It's intended for implementations of Crypto interface
+// Use WithSenderKH() option function below instead.
+func (pk *wrapKeyOpts) SenderKH() interface{} {
+	return pk.senderKH
+}
+
+// WrapKeyOpts are the crypto.Wrap key options.
+type WrapKeyOpts func(opts *wrapKeyOpts)
+
+// WithSenderKH option is for setting a sender key handle with crypto wrapping (eg: AuthCrypt). For Anoncrypt,
+// this option must not be set.
+func WithSenderKH(senderKH interface{}) WrapKeyOpts {
+	return func(opts *wrapKeyOpts) {
+		opts.senderKH = senderKH
+	}
+}

--- a/pkg/mock/crypto/mock_crypto.go
+++ b/pkg/mock/crypto/mock_crypto.go
@@ -6,7 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package crypto
 
-import "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite"
+import (
+	cryptoapi "github.com/hyperledger/aries-framework-go/pkg/crypto"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite"
+)
 
 // SignFunc mocks Crypto's Sign() function, it useful for executing custom signing with the help of SignKey.
 type SignFunc func([]byte, interface{}) ([]byte, error)
@@ -67,11 +70,13 @@ func (c *Crypto) VerifyMAC(mac, data []byte, kh interface{}) error {
 }
 
 // WrapKey returns a mocked value.
-func (c *Crypto) WrapKey(cek, apu, apv []byte, kh interface{}) (*composite.RecipientWrappedKey, error) {
+func (c *Crypto) WrapKey(cek, apu, apv []byte, kh interface{},
+	wrapKeyOpts ...cryptoapi.WrapKeyOpts) (*composite.RecipientWrappedKey, error) {
 	return c.WrapValue, c.WrapError
 }
 
 // UnwrapKey returns a mocked value.
-func (c *Crypto) UnwrapKey(recWK *composite.RecipientWrappedKey, kh interface{}) ([]byte, error) {
+func (c *Crypto) UnwrapKey(recWK *composite.RecipientWrappedKey, kh interface{},
+	wrapKeyOpts ...cryptoapi.WrapKeyOpts) ([]byte, error) {
 	return c.UnwrapValue, c.UnwrapError
 }


### PR DESCRIPTION
this change is necessary to consolidate ECDHES and ECDH1PU Tink keys
since key wrapping will not be executed by the Tink primitives.

closes #2271

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
