### PR TITLE
feat: Adds possibility to inject logger (mobile)

### DIFF
--- a/cmd/aries-agent-mobile/main.go
+++ b/cmd/aries-agent-mobile/main.go
@@ -12,12 +12,17 @@ import (
 	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/api"
 	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/command"
 	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/config"
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/logger"
 	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/wrappers/rest"
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 )
 
 // New initializes and returns an implementation of the AriesController.
 func New(opts *config.Options) (api.AriesController, error) {
+	if opts.Logger != nil {
+		log.Initialize(logger.New(opts.Logger))
+	}
+
 	if err := setLogLevel(opts.LogLevel); err != nil {
 		return nil, err
 	}

--- a/cmd/aries-agent-mobile/pkg/api/logger.go
+++ b/cmd/aries-agent-mobile/pkg/api/logger.go
@@ -1,0 +1,22 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+// Logger - logger interface.
+type Logger interface {
+	Fatal(msg string)
+	Panic(msg string)
+	Debug(msg string)
+	Info(msg string)
+	Warn(msg string)
+	Error(msg string)
+}
+
+// LoggerProvider is a factory for moduled loggers.
+type LoggerProvider interface {
+	GetLogger(module string) Logger
+}

--- a/cmd/aries-agent-mobile/pkg/wrappers/config/options.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/config/options.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package config
 
+import "github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/api"
+
 // Options represents configurations for Aries.
 type Options struct {
 	UseLocalAgent bool
@@ -22,8 +24,8 @@ type Options struct {
 	// not intended to be used by golang code
 	HTTPResolvers     []string
 	OutboundTransport []string
-
-	WebsocketURL string
+	Logger            api.LoggerProvider
+	WebsocketURL      string
 }
 
 // New returns an instance of Options which can be used to configure an aries controller instance.

--- a/cmd/aries-agent-mobile/pkg/wrappers/logger/logger.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/logger/logger.go
@@ -1,0 +1,58 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package logger is not expected to be used by the mobile app.
+package logger
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/cmd/aries-agent-mobile/pkg/api"
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+)
+
+// New returns new Logger.
+func New(l api.LoggerProvider) *Logger {
+	return &Logger{l: l}
+}
+
+// Logger describes logger structure.
+type Logger struct {
+	l api.LoggerProvider
+}
+
+// GetLogger returns logger implementation.
+func (l *Logger) GetLogger(module string) log.Logger {
+	return loggerWrapper{l.l.GetLogger(module)}
+}
+
+type loggerWrapper struct {
+	api.Logger
+}
+
+func (w loggerWrapper) Fatalf(msg string, args ...interface{}) {
+	w.Fatal(fmt.Sprintf(msg, args...))
+}
+
+func (w loggerWrapper) Panicf(msg string, args ...interface{}) {
+	w.Panic(fmt.Sprintf(msg, args...))
+}
+
+func (w loggerWrapper) Debugf(msg string, args ...interface{}) {
+	w.Debug(fmt.Sprintf(msg, args...))
+}
+
+func (w loggerWrapper) Infof(msg string, args ...interface{}) {
+	w.Info(fmt.Sprintf(msg, args...))
+}
+
+func (w loggerWrapper) Warnf(msg string, args ...interface{}) {
+	w.Warn(fmt.Sprintf(msg, args...))
+}
+
+func (w loggerWrapper) Errorf(msg string, args ...interface{}) {
+	w.Error(fmt.Sprintf(msg, args...))
+}


### PR DESCRIPTION
To inject the logger client must implement `LoggerProvider` with one method `GetLogger`.  GetLogger should return the Logger interface.  GetLogger function receives `module` name e.g `aries-framework/introduce/service`. The client might have additional logic based on module name e.g disable/enable.
```
type LoggerProvider interface {
	GetLogger(module string) Logger
}

type Logger interface {
	Fatal(msg string)
	Panic(msg string)
	Debug(msg string)
	Info(msg string)
	Warn(msg string)
	Error(msg string)
}
```

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>
