### PR TITLE
feat: add HeadersOpt optional function to remoteKMS New()

### DIFF
--- a/pkg/kms/webkms/headers_opts.go
+++ b/pkg/kms/webkms/headers_opts.go
@@ -1,0 +1,34 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package webkms
+
+import "net/http"
+
+// addHeaders function supports adding custom http headers.
+type addHeaders func(req *http.Request) (*http.Header, error)
+
+type headersOpts struct {
+	headersFunc addHeaders
+}
+
+// NewOpt creates a new empty additional http headers option.
+// Not to be used directly. It's intended for implementations of remoteKMS.
+// Use WithHeaders() option function below instead.
+func NewOpt() *headersOpts { // nolint // unexported type doesn't need to be used outside of remotekms package
+	return &headersOpts{}
+}
+
+// HeadersOpt are the remoteKMS headers option.
+type HeadersOpt func(opts *headersOpts)
+
+// WithHeaders option is for setting additional http request headers (since it's a function, it can call a remote
+// authorization server to fetch the necessary info needed in these headers).
+func WithHeaders(addHeadersFunc addHeaders) HeadersOpt {
+	return func(opts *headersOpts) {
+		opts.headersFunc = addHeadersFunc
+	}
+}


### PR DESCRIPTION
This change introduced a new optional function passed to remotekms.New()
This new option allows calling a function to potentially call an
authorization server and setup auth info as http headers. This function
should be created by the user of the framework. The absence of this option
means the remoteKMS is not setting any authorization info in the headers.

This change also removed 'secret' and 'controller' http headers as these
should not be dictated by the framework.

It also includes some minor refactoring like placing CreateKeystore()
above New() as a keystore is required before creating a new remoteKMS instance.

part of #2307

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
