### PR TITLE
fix: EDV REST provider store indexed attribute creation

### DIFF
--- a/pkg/storage/edv/restprovider.go
+++ b/pkg/storage/edv/restprovider.go
@@ -275,7 +275,7 @@ func (r *restStore) createIndexedAttributes(keyName string) ([]models.IndexedAtt
 	storeIndexedAttribute := models.IndexedAttribute{
 		Name:   r.storeIndexNameMACBase64Encoded,
 		Value:  base64.URLEncoding.EncodeToString([]byte(storeIndexValueMAC)),
-		Unique: true,
+		Unique: false,
 	}
 
 	storeAndKeyIndexValueMACBase64Encoded, err := r.computeStoreAndKeyIndexValueMACBase64Encoded(keyName)


### PR DESCRIPTION
The unique property of the "store name" indexed attribute was incorrectly set to true, which was preventing multiple documents from storing successfully.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>