### PR TITLE
feat: add remoteCrypto implementation

### DIFF
--- a/pkg/crypto/api.go
+++ b/pkg/crypto/api.go
@@ -41,14 +41,20 @@ type Crypto interface {
 	VerifyMAC(mac, data []byte, kh interface{}) error
 
 	// WrapKey will execute key wrapping of cek using apu, apv and recipient public key 'recPubKey'.
-	// 'opts' allows setting the option sender key handle using WithSenderKH() option. It allows ECDH-1PU key wrapping
+	// 'opts' allows setting the option sender key handle using WithSender() option. It allows ECDH-1PU key wrapping
 	// (aka Authcrypt). The absence of this option uses ECDH-ES key wrapping (aka Anoncrypt).
+	// returns:
+	// 		RecipientWrappedKey containing the wrapped cek value
+	// 		error in case of errors
 	WrapKey(cek, apu, apv []byte, recPubKey *PublicKey,
 		opts ...WrapKeyOpts) (*RecipientWrappedKey, error)
 
 	// UnwrapKey unwraps a key in recWK using recipient private key kh.
-	// 'opts' allows setting the option sender key handle using WithSenderKH() option. It allows ECDH-1PU key unwrapping
+	// 'opts' allows setting the option sender key handle using WithSender() option. It allows ECDH-1PU key unwrapping
 	// (aka Authcrypt). The absence of this option uses ECDH-ES key unwrapping (aka Anoncrypt).
+	// returns:
+	// 		unwrapped key in raw bytes
+	// 		error in case of errors
 	UnwrapKey(recWK *RecipientWrappedKey, kh interface{}, opts ...WrapKeyOpts) ([]byte, error)
 }
 

--- a/pkg/crypto/tinkcrypto/crypto.go
+++ b/pkg/crypto/tinkcrypto/crypto.go
@@ -205,7 +205,7 @@ func (t *Crypto) VerifyMAC(macBytes, data []byte, kh interface{}) error {
 // WrapKey will do ECDH (ES or 1PU) key wrapping of cek using apu, apv and recipient public key 'recPubKey'.
 // The optional 'wrapKeyOpts' specifies the sender kh for 1PU key wrapping.
 // This function is used with the following parameters:
-//  - Key Wrapping: ECDH-ES (no options)/ECDH-1PU (using crypto.WithSenderKH() option) over A256KW as
+//  - Key Wrapping: ECDH-ES (no options)/ECDH-1PU (using crypto.WithSender() option) over A256KW as
 // 		per https://tools.ietf.org/html/rfc7518#appendix-A.2
 //  - KDF: Concat KDF as per https://tools.ietf.org/html/rfc7518#section-4.6
 // returns the resulting key wrapping info as *composite.RecipientWrappedKey or error in case of wrapping failure.
@@ -237,14 +237,14 @@ func (t *Crypto) WrapKey(cek, apu, apv []byte, recPubKey *cryptoapi.PublicKey,
 		return nil, fmt.Errorf("wrapKey: failed to generate EPK: %w", err)
 	}
 
-	return t.deriveKEKAndWrap(cek, apu, apv, pOpts.SenderKH(), ephemeralPriv, pubKey, recPubKey.KID)
+	return t.deriveKEKAndWrap(cek, apu, apv, pOpts.SenderKey(), ephemeralPriv, pubKey, recPubKey.KID)
 }
 
 // UnwrapKey unwraps a key in recWK using ECDH (ES or 1PU) with recipient private key kh.
 // The optional 'wrapKeyOpts' specifies the sender kh for 1PU key unwrapping.
 // Note, if the option was used in WrapKey(), then it must be set here as well for a successful unwrapping.
 // This function is used with the following parameters:
-//  - Key Unwrapping: ECDH-ES (no options)/ECDH-1PU (using crypto.WithSenderKH() option) over A256KW as
+//  - Key Unwrapping: ECDH-ES (no options)/ECDH-1PU (using crypto.WithSender() option) over A256KW as
 // 		per https://tools.ietf.org/html/rfc7518#appendix-A.2
 //  - KDF: Concat KDF as per https://tools.ietf.org/html/rfc7518#section-4.6
 // returns the resulting unwrapping key or error in case of unwrapping failure.
@@ -288,6 +288,6 @@ func (t *Crypto) UnwrapKey(recWK *cryptoapi.RecipientWrappedKey, kh interface{},
 		Y:     new(big.Int).SetBytes(recWK.EPK.Y),
 	}
 
-	return t.deriveKEKAndUnwrap(recWK.Alg, recWK.EncryptedCEK, recWK.APU, recWK.APV, pOpts.SenderKH(),
+	return t.deriveKEKAndUnwrap(recWK.Alg, recWK.EncryptedCEK, recWK.APU, recWK.APV, pOpts.SenderKey(),
 		epkPubKey, recPrivKey)
 }

--- a/pkg/crypto/tinkcrypto/key_wrapper.go
+++ b/pkg/crypto/tinkcrypto/key_wrapper.go
@@ -224,6 +224,17 @@ func ksToPublicECDSAKey(ks interface{}, kw keyWrapper) (*ecdsa.PublicKey, error)
 			X:     new(big.Int).SetBytes(sPubKey.X),
 			Y:     new(big.Int).SetBytes(sPubKey.Y),
 		}, nil
+	case *cryptoapi.PublicKey:
+		sCurve, err := kw.getCurve(kst.Curve)
+		if err != nil {
+			return nil, fmt.Errorf("ksToPublicECDSAKey: failed to GetCurve: %w", err)
+		}
+
+		return &ecdsa.PublicKey{
+			Curve: sCurve,
+			X:     new(big.Int).SetBytes(kst.X),
+			Y:     new(big.Int).SetBytes(kst.Y),
+		}, nil
 	case *ecdsa.PublicKey:
 		return kst, nil
 	default:

--- a/pkg/crypto/webkms/remotecrypto.go
+++ b/pkg/crypto/webkms/remotecrypto.go
@@ -1,0 +1,527 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package webkms
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto"
+	webkmsimpl "github.com/hyperledger/aries-framework-go/pkg/kms/webkms"
+)
+
+var logger = log.New("aries-framework/crypto/webkms")
+
+type encryptReq struct {
+	Message        string `json:"message,omitempty"`
+	AdditionalData string `json:"aad,omitempty"`
+}
+
+type encryptResp struct {
+	CipherText string `json:"cipherText,omitempty"`
+	Nonce      string `json:"nonce,omitempty"`
+}
+
+type decryptReq struct {
+	CipherText     string `json:"cipherText,omitempty"`
+	AdditionalData string `json:"aad,omitempty"`
+	Nonce          string `json:"nonce,omitempty"`
+}
+
+type decryptResp struct {
+	PlainText string `json:"plainText,omitempty"`
+}
+
+type signReq struct {
+	Message string `json:"message,omitempty"`
+}
+
+type signResp struct {
+	Signature string `json:"signature,omitempty"`
+}
+
+type verifyReq struct {
+	Signature string `json:"signature,omitempty"`
+	Message   string `json:"message,omitempty"`
+}
+
+type computeMACReq struct {
+	Data string `json:"data,omitempty"`
+}
+
+type computeMACResp struct {
+	MAC string `json:"mac,omitempty"`
+}
+
+type verifyMACReq struct {
+	MAC  string `json:"mac,omitempty"`
+	Data string `json:"data,omitempty"`
+}
+
+type marshalFunc func(interface{}) ([]byte, error)
+
+type unmarshalFunc func([]byte, interface{}) error
+
+// RemoteCrypto implementation of kms.KeyManager api.
+type RemoteCrypto struct {
+	httpClient     *http.Client
+	keystoreURL    string
+	marshalFunc    marshalFunc
+	unmarshalFunc  unmarshalFunc
+	addHeadersOpts *webkmsimpl.HeadersOpts
+}
+
+const (
+	keysURI       = "/keys"
+	encryptURI    = "/encrypt"
+	decryptURI    = "/decrypt"
+	signURI       = "/sign"
+	verifyURI     = "/verify"
+	computeMACURI = "/computemac"
+	verifyMACURI  = "/verifymac"
+	wrapURI       = "/wrap"
+	unwrapURI     = "/unwrap"
+)
+
+// New creates a new remoteCrypto instance using http client connecting to keystoreURL.
+func New(keystoreURL string, client *http.Client, headersOpts ...webkmsimpl.HeadersOpt) *RemoteCrypto {
+	hOpts := webkmsimpl.NewOpt()
+
+	for _, opt := range headersOpts {
+		opt(hOpts)
+	}
+
+	return &RemoteCrypto{
+		httpClient:     client,
+		keystoreURL:    keystoreURL,
+		marshalFunc:    json.Marshal,
+		unmarshalFunc:  json.Unmarshal,
+		addHeadersOpts: hOpts,
+	}
+}
+
+func (r *RemoteCrypto) postHTTPRequest(destination string, mReq []byte) (*http.Response, error) {
+	return r.doHTTPRequest(http.MethodPost, destination, mReq)
+}
+
+func (r *RemoteCrypto) doHTTPRequest(method, destination string, mReq []byte) (*http.Response, error) {
+	httpReq, err := http.NewRequest(method, destination, bytes.NewBuffer(mReq))
+	if err != nil {
+		return nil, fmt.Errorf("build request error: %w", err)
+	}
+
+	if method == http.MethodPost {
+		httpReq.Header.Set("Content-Type", webkmsimpl.ContentType)
+	}
+
+	if r.addHeadersOpts.HeadersFunc != nil {
+		httpHeaders, err := r.addHeadersOpts.HeadersFunc(httpReq)
+		if err != nil {
+			return nil, fmt.Errorf("add optional request headers error: %w", err)
+		}
+
+		if httpHeaders != nil {
+			httpReq.Header = httpHeaders.Clone()
+		}
+	}
+
+	return r.httpClient.Do(httpReq)
+}
+
+// Encrypt will remotely encrypt msg and aad using a matching AEAD primitive in a remote key handle at keyURL of
+// a public key.
+// returns:
+// 		cipherText in []byte
+//		nonce in []byte
+//		error in case of errors during encryption
+func (r *RemoteCrypto) Encrypt(msg, aad []byte, keyURL interface{}) ([]byte, []byte, error) {
+	destination := fmt.Sprintf("%s", keyURL) + encryptURI
+
+	eReq := encryptReq{
+		Message:        base64.URLEncoding.EncodeToString(msg),
+		AdditionalData: base64.URLEncoding.EncodeToString(aad),
+	}
+
+	httpReqBytes, err := r.marshalFunc(eReq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal encryption request for Encrypt failed [%s, %w]", destination, err)
+	}
+
+	resp, err := r.postHTTPRequest(destination, httpReqBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("posting Encrypt plaintext failed [%s, %w]", destination, err)
+	}
+
+	// handle response
+	defer closeResponseBody(resp.Body, logger, "Encrypt")
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read encryption response for Encrypt failed [%s, %w]", destination, err)
+	}
+
+	httpResp := &encryptResp{}
+
+	err = r.unmarshalFunc(respBody, httpResp)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unmarshal encryption for Encrypt failed [%s, %w]", destination, err)
+	}
+
+	keyBytes, err := base64.URLEncoding.DecodeString(httpResp.CipherText)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	nonceBytes, err := base64.URLEncoding.DecodeString(httpResp.Nonce)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return keyBytes, nonceBytes, nil
+}
+
+// Decrypt will remotely decrypt cipher with aad and given nonce using a matching AEAD primitive in a remote key handle
+// at keyURL of a private key.
+// returns:
+//		plainText in []byte
+//		error in case of errors
+func (r *RemoteCrypto) Decrypt(cipher, aad, nonce []byte, keyURL interface{}) ([]byte, error) {
+	destination := fmt.Sprintf("%s", keyURL) + decryptURI
+
+	dReq := decryptReq{
+		CipherText:     base64.URLEncoding.EncodeToString(cipher),
+		Nonce:          base64.URLEncoding.EncodeToString(nonce),
+		AdditionalData: base64.URLEncoding.EncodeToString(aad),
+	}
+
+	httpReqBytes, err := r.marshalFunc(dReq)
+	if err != nil {
+		return nil, fmt.Errorf("marshal decryption request for Decrypt failed [%s, %w]", destination, err)
+	}
+
+	resp, err := r.postHTTPRequest(destination, httpReqBytes)
+	if err != nil {
+		return nil, fmt.Errorf("posting Decrypt ciphertext failed [%s, %w]", destination, err)
+	}
+
+	// handle response
+	defer closeResponseBody(resp.Body, logger, "Decrypt")
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read decryption response for Decrypt failed [%s, %w]", destination, err)
+	}
+
+	httpResp := &decryptResp{}
+
+	err = r.unmarshalFunc(respBody, httpResp)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal decryption for Decrypt failed [%s, %w]", destination, err)
+	}
+
+	plaintTextBytes, err := base64.URLEncoding.DecodeString(httpResp.PlainText)
+	if err != nil {
+		return nil, err
+	}
+
+	return plaintTextBytes, nil
+}
+
+// Sign will remotely sign msg using a matching signature primitive in remote kh key handle at keyURL of a private key.
+// returns:
+// 		signature in []byte
+//		error in case of errors
+func (r *RemoteCrypto) Sign(msg []byte, keyURL interface{}) ([]byte, error) {
+	destination := fmt.Sprintf("%s", keyURL) + signURI
+
+	sReq := signReq{
+		Message: base64.URLEncoding.EncodeToString(msg),
+	}
+
+	httpReqBytes, err := r.marshalFunc(sReq)
+	if err != nil {
+		return nil, fmt.Errorf("marshal signature request for Sign failed [%s, %w]", destination, err)
+	}
+
+	resp, err := r.postHTTPRequest(destination, httpReqBytes)
+	if err != nil {
+		return nil, fmt.Errorf("posting Sign message failed [%s, %w]", destination, err)
+	}
+
+	// handle response
+	defer closeResponseBody(resp.Body, logger, "Sign")
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read signature response for Sign failed [%s, %w]", destination, err)
+	}
+
+	httpResp := &signResp{}
+
+	err = r.unmarshalFunc(respBody, httpResp)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal signature for Sign failed [%s, %w]", destination, err)
+	}
+
+	keyBytes, err := base64.URLEncoding.DecodeString(httpResp.Signature)
+	if err != nil {
+		return nil, err
+	}
+
+	return keyBytes, nil
+}
+
+// Verify will remotely verify a signature for the given msg using a matching signature primitive in a remote key
+// handle at keyURL of a public key.
+// returns:
+// 		error in case of errors or nil if signature verification was successful
+func (r *RemoteCrypto) Verify(signature, msg []byte, keyURL interface{}) error {
+	destination := fmt.Sprintf("%s", keyURL) + verifyURI
+
+	vReq := verifyReq{
+		Message:   base64.URLEncoding.EncodeToString(msg),
+		Signature: base64.URLEncoding.EncodeToString(signature),
+	}
+
+	httpReqBytes, err := r.marshalFunc(vReq)
+	if err != nil {
+		return fmt.Errorf("marshal verify request for Verify failed [%s, %w]", destination, err)
+	}
+
+	resp, err := r.postHTTPRequest(destination, httpReqBytes)
+	if err != nil {
+		return fmt.Errorf("posting Verify signature failed [%s, %w]", destination, err)
+	}
+
+	// handle response
+	defer closeResponseBody(resp.Body, logger, "Verify")
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("posting Verify signature returned http error: %s", resp.Status)
+	}
+
+	return nil
+}
+
+// ComputeMAC remotely computes message authentication code (MAC) for code data with key at keyURL.
+// using a matching MAC primitive in kh key handle.
+func (r *RemoteCrypto) ComputeMAC(data []byte, keyURL interface{}) ([]byte, error) {
+	destination := fmt.Sprintf("%s", keyURL) + computeMACURI
+
+	mReq := computeMACReq{
+		Data: base64.URLEncoding.EncodeToString(data),
+	}
+
+	httpReqBytes, err := r.marshalFunc(mReq)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request for ComputeMAC failed [%s, %w]", destination, err)
+	}
+
+	resp, err := r.postHTTPRequest(destination, httpReqBytes)
+	if err != nil {
+		return nil, fmt.Errorf("posting ComputeMAC request failed [%s, %w]", destination, err)
+	}
+
+	// handle response
+	defer closeResponseBody(resp.Body, logger, "ComputeMAC")
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response for ComputeMAC failed [%s, %w]", destination, err)
+	}
+
+	httpResp := &computeMACResp{}
+
+	err = r.unmarshalFunc(respBody, httpResp)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal ComputeMAC response failed [%s, %w]", destination, err)
+	}
+
+	macBytes, err := base64.URLEncoding.DecodeString(httpResp.MAC)
+	if err != nil {
+		return nil, err
+	}
+
+	return macBytes, nil
+}
+
+// VerifyMAC remotely determines if mac is a correct authentication code (MAC) for data using a key at KeyURL
+// using a matching MAC primitive in kh key handle and returns nil if so, otherwise it returns an error.
+func (r *RemoteCrypto) VerifyMAC(mac, data []byte, keyURL interface{}) error {
+	destination := fmt.Sprintf("%s", keyURL) + verifyMACURI
+
+	vReq := verifyMACReq{
+		MAC:  base64.URLEncoding.EncodeToString(mac),
+		Data: base64.URLEncoding.EncodeToString(data),
+	}
+
+	httpReqBytes, err := r.marshalFunc(vReq)
+	if err != nil {
+		return fmt.Errorf("marshal request for VerifyMAC failed [%s, %w]", destination, err)
+	}
+
+	resp, err := r.postHTTPRequest(destination, httpReqBytes)
+	if err != nil {
+		return fmt.Errorf("posting VerifyMAC request failed [%s, %w]", destination, err)
+	}
+
+	// handle response
+	defer closeResponseBody(resp.Body, logger, "VerifyMAC")
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("posting VerifyMAC request returned http error: %s", resp.Status)
+	}
+
+	return nil
+}
+
+// WrapKey will remotely execute key wrapping of cek using apu, apv and recipient public key 'recPubKey'.
+// 'opts' allows setting the option sender key handle using WithSender() option where the sender key handle consists
+// of a remote key located in the option as a keyURL. This option allows ECDH-1PU key wrapping (aka Authcrypt).
+// The absence of this option uses ECDH-ES key wrapping (aka Anoncrypt).
+// 		RecipientWrappedKey containing the wrapped cek value
+// 		error in case of errors
+func (r *RemoteCrypto) WrapKey(cek, apu, apv []byte, recPubKey *crypto.PublicKey,
+	opts ...crypto.WrapKeyOpts) (*crypto.RecipientWrappedKey, error) {
+	destination := r.keystoreURL + wrapURI
+
+	pOpts := crypto.NewOpt()
+
+	for _, opt := range opts {
+		opt(pOpts)
+	}
+
+	senderURL := pOpts.SenderKey()
+	recipientPubKey := pubKeyToSerializableReq(recPubKey)
+	wReq := &wrapKeyReq{
+		CEK:       base64.URLEncoding.EncodeToString(cek),
+		APU:       base64.URLEncoding.EncodeToString(apu),
+		APV:       base64.URLEncoding.EncodeToString(apv),
+		RecPubKey: recipientPubKey,
+	}
+
+	// if senderURL is set, extract keyID and add it to the request (for ECDH-1PU wrapping)
+	if senderURL != "" {
+		senderURLStr := fmt.Sprintf("%s", senderURL)
+		senderKID := senderURLStr[strings.LastIndex(senderURLStr, keysURI)+len(keysURI):]
+		// TODO key server must store the sender public key in the recipient's keystore (or by means of a
+		//  third party store). Need to confirm what needs to be done to make Authcrypt key wrapping work on the
+		//  key server side.
+		wReq.SenderKID = senderKID
+	}
+
+	httpReqBytes, err := r.marshalFunc(wReq)
+	if err != nil {
+		return nil, fmt.Errorf("marshal wrapKeyReq for WrapKey failed [%s, %w]", destination, err)
+	}
+
+	resp, err := r.postHTTPRequest(destination, httpReqBytes)
+	if err != nil {
+		return nil, fmt.Errorf("posting WrapKey failed [%s, %w]", destination, err)
+	}
+
+	// handle response
+	defer closeResponseBody(resp.Body, logger, "WrapKey")
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read wrap key response for WrapKey failed [%s, %w]", destination, err)
+	}
+
+	httpResp := &wrapKeyResp{}
+
+	err = r.unmarshalFunc(respBody, httpResp)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal wrapKeyResp for WrapKey failed [%s, %w]", destination, err)
+	}
+
+	wrappedKey, err := serializableToWrappedKey(&httpResp.WrappedKey)
+	if err != nil {
+		return nil, fmt.Errorf("convert http request of wrapKeyResp for WrapKey failed [%s, %w]", destination, err)
+	}
+
+	return wrappedKey, nil
+}
+
+// UnwrapKey remotely unwraps a key in recWK using recipient private key found at keyURL.
+// 'opts' allows setting the option sender key handle using WithSender() optionwhere the sender key handle consists
+// of a remote key located in the option as a keyURL. This options allows ECDH-1PU key unwrapping (aka Authcrypt).
+// The absence of this option uses ECDH-ES key unwrapping (aka Anoncrypt).
+// returns:
+// 		unwrapped key in raw bytes
+// 		error in case of errors
+func (r *RemoteCrypto) UnwrapKey(recWK *crypto.RecipientWrappedKey, keyURL interface{},
+	opts ...crypto.WrapKeyOpts) ([]byte, error) {
+	destination := fmt.Sprintf("%s", keyURL) + unwrapURI
+
+	pOpts := crypto.NewOpt()
+
+	for _, opt := range opts {
+		opt(pOpts)
+	}
+
+	senderURL := pOpts.SenderKey()
+	httpWK := wrappedKeyToSerializableReq(recWK)
+	uReq := unwrapKeyReq{
+		WrappedKey: httpWK,
+	}
+
+	// is senderURL is set, extract keyID and add it to the request (for ECDH-1PU unwrapping)
+	if senderURL != "" {
+		senderURLStr := fmt.Sprintf("%s", senderURL)
+		senderKID := senderURLStr[strings.LastIndex(senderURLStr, keysURI)+len(keysURI):]
+		uReq.SenderKID = base64.URLEncoding.EncodeToString([]byte(senderKID))
+	}
+
+	httpReqBytes, err := r.marshalFunc(uReq)
+	if err != nil {
+		return nil, fmt.Errorf("marshal unwrapKeyReq for UnwrapKey failed [%s, %w]", destination, err)
+	}
+
+	resp, err := r.postHTTPRequest(destination, httpReqBytes)
+	if err != nil {
+		return nil, fmt.Errorf("posting UnwrapKey failed [%s, %w]", destination, err)
+	}
+
+	// handle response
+	defer closeResponseBody(resp.Body, logger, "UnwrapKey")
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read unwrapped key response for UnwrapKey failed [%s, %w]", destination, err)
+	}
+
+	httpResp := &unwrapKeyResp{}
+
+	err = r.unmarshalFunc(respBody, httpResp)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal unwrapKeyResp for UnwrapKey failed [%s, %w]", destination, err)
+	}
+
+	keyBytes, err := base64.URLEncoding.DecodeString(httpResp.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	return keyBytes, nil
+}
+
+// closeResponseBody closes the response body.
+//nolint: interfacer // don't want to add test stretcher logger here
+func closeResponseBody(respBody io.Closer, logger log.Logger, action string) {
+	err := respBody.Close()
+	if err != nil {
+		logger.Errorf("Failed to close response body for '%s' REST call: %s", action, err.Error())
+	}
+}

--- a/pkg/crypto/webkms/remotecrypto_test.go
+++ b/pkg/crypto/webkms/remotecrypto_test.go
@@ -1,0 +1,1192 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package webkms
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/tink/go/aead"
+	aeadsubtle "github.com/google/tink/go/aead/subtle"
+	"github.com/google/tink/go/core/primitiveset"
+	"github.com/google/tink/go/keyset"
+	"github.com/google/tink/go/mac"
+	"github.com/google/tink/go/signature"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/chacha20poly1305"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdh"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+	webkmsimpl "github.com/hyperledger/aries-framework-go/pkg/kms/webkms"
+)
+
+const (
+	certPrefix        = "../../didcomm/transport/http/testdata/crypto/"
+	clientTimeout     = 5 * time.Second
+	defaultKeyStoreID = "12345"
+	defaultKID        = "99999"
+)
+
+func TestEncryptDecrypt(t *testing.T) {
+	kh, err := keyset.NewHandle(aead.XChaCha20Poly1305KeyTemplate())
+	require.NoError(t, err)
+
+	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err = processPOSTEncRequest(w, r, kh)
+		require.NoError(t, err)
+	})
+
+	server, url, client := CreateMockHTTPServerAndClient(t, hf)
+
+	defer func() {
+		e := server.Close()
+		require.NoError(t, e)
+	}()
+
+	defaultKeystoreURL := fmt.Sprintf("%s/%s", strings.ReplaceAll(webkmsimpl.KeystoreEndpoint,
+		"{serverEndpoint}", url), defaultKeyStoreID)
+	defaultKeyURL := defaultKeystoreURL + "/keys/" + defaultKID
+	rCrypto := New(defaultKeystoreURL, client)
+	plaintext := []byte("lorem ipsum")
+	aad := []byte("dolor sit")
+
+	// test successful Encrypt/Decrypt
+	ciphertext, nonce, err := rCrypto.Encrypt(plaintext, aad, defaultKeyURL)
+	require.NoError(t, err)
+
+	decrypted, err := rCrypto.Decrypt(ciphertext, aad, nonce, defaultKeyURL)
+	require.NoError(t, err)
+	require.EqualValues(t, plaintext, decrypted)
+
+	t.Run("Encrypt Post request failure", func(t *testing.T) {
+		blankClient := &http.Client{}
+		tmpCrypto := New(defaultKeystoreURL, blankClient)
+
+		_, _, err = tmpCrypto.Encrypt(plaintext, aad, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("posting Encrypt plaintext failed [%s, Post \"%s\": x509: "+
+			"certificate signed by unknown authority]", defaultKeyURL+encryptURI, defaultKeyURL+encryptURI).Error())
+
+		badURL := "``#$%"
+		_, _, err = tmpCrypto.Encrypt(plaintext, aad, badURL)
+		require.Contains(t, err.Error(), "posting Encrypt plaintext failed")
+		require.EqualError(t, err, fmt.Errorf("posting Encrypt plaintext failed [%s, build request error:"+
+			" parse \"%s\": invalid URL escape \"%s\"]", badURL+encryptURI, badURL+encryptURI, "%/e").Error())
+	})
+
+	t.Run("Decrypt Post request failure", func(t *testing.T) {
+		blankClient := &http.Client{}
+		tmpCrypto := New(defaultKeystoreURL, blankClient)
+
+		_, err = tmpCrypto.Decrypt(nil, aad, nil, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("posting Decrypt ciphertext failed [%s, Post \"%s\": x509: "+
+			"certificate signed by unknown authority]", defaultKeyURL+decryptURI, defaultKeyURL+decryptURI).Error())
+	})
+
+	t.Run("Encrypt json marshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.marshalFunc = failingMarshal
+		_, _, err = remoteCrypto2.Encrypt(plaintext, aad, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("marshal encryption request for Encrypt failed [%s, %w]",
+			defaultKeyURL+encryptURI, errFailingMarshal).Error())
+	})
+
+	t.Run("Encrypt json unmarshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.unmarshalFunc = failingUnmarshal
+		_, _, err = remoteCrypto2.Encrypt(plaintext, aad, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("unmarshal encryption for Encrypt failed [%s, %w]",
+			defaultKeyURL+encryptURI, errFailingUnmarshal).Error())
+	})
+
+	t.Run("Decrypt json marshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.marshalFunc = failingMarshal
+		_, err = remoteCrypto2.Decrypt(ciphertext, aad, nonce, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("marshal decryption request for Decrypt failed [%s, %w]",
+			defaultKeyURL+decryptURI, errFailingMarshal).Error())
+	})
+
+	t.Run("Decrypt json unmarshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.unmarshalFunc = failingUnmarshal
+		_, err = remoteCrypto2.Decrypt(ciphertext, aad, nonce, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("unmarshal decryption for Decrypt failed [%s, %w]",
+			defaultKeyURL+decryptURI, errFailingUnmarshal).Error())
+	})
+}
+
+func processPOSTEncRequest(w http.ResponseWriter, r *http.Request, encKH *keyset.Handle) error {
+	if valid := validateHTTPMethod(w, r); !valid {
+		return errors.New("http method invalid")
+	}
+
+	if valid := validatePostPayload(r, w); !valid {
+		return errors.New("http request body invalid")
+	}
+
+	reqBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+
+	if strings.LastIndex(r.URL.Path, encryptURI) == len(r.URL.Path)-len(encryptURI) {
+		err = encryptPOSTHandle(w, reqBody, encKH)
+		if err != nil {
+			return err
+		}
+	}
+
+	if strings.LastIndex(r.URL.Path, decryptURI) == len(r.URL.Path)-len(decryptURI) {
+		err = decryptPOSTHandle(w, reqBody, encKH)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// nolint: interfacer // unnecessary for tests to set w io.Writer, this is a helper for tests only
+func encryptPOSTHandle(w http.ResponseWriter, reqBody []byte, encKH *keyset.Handle) error {
+	encReq := &encryptReq{}
+
+	err := json.Unmarshal(reqBody, encReq)
+	if err != nil {
+		return err
+	}
+
+	ps, err := encKH.Primitives()
+	if err != nil {
+		return err
+	}
+
+	a, err := aead.New(encKH)
+	if err != nil {
+		return err
+	}
+
+	msg, err := base64.URLEncoding.DecodeString(encReq.Message)
+	if err != nil {
+		return err
+	}
+
+	aad, err := base64.URLEncoding.DecodeString(encReq.AdditionalData)
+	if err != nil {
+		return err
+	}
+
+	ct, err := a.Encrypt(msg, aad)
+	if err != nil {
+		return fmt.Errorf("encrypt msg: %w", err)
+	}
+
+	ivSize := nonceSize(ps)
+	prefixLength := len(ps.Primary.Prefix)
+	cipherText := ct[prefixLength+ivSize:]
+	nonce := ct[prefixLength : prefixLength+ivSize]
+
+	resp := &encryptResp{
+		CipherText: base64.URLEncoding.EncodeToString(cipherText),
+		Nonce:      base64.URLEncoding.EncodeToString(nonce),
+	}
+
+	mResp, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(mResp)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// nolint: interfacer // unnecessary for tests to set w io.Writer, this is a helper for tests only
+func decryptPOSTHandle(w http.ResponseWriter, reqBody []byte, encKH *keyset.Handle) error {
+	decReq := &decryptReq{}
+
+	err := json.Unmarshal(reqBody, decReq)
+	if err != nil {
+		return err
+	}
+
+	ps, err := encKH.Primitives()
+	if err != nil {
+		return err
+	}
+
+	a, err := aead.New(encKH)
+	if err != nil {
+		return err
+	}
+
+	cipher, err := base64.URLEncoding.DecodeString(decReq.CipherText)
+	if err != nil {
+		return err
+	}
+
+	aad, err := base64.URLEncoding.DecodeString(decReq.AdditionalData)
+	if err != nil {
+		return err
+	}
+
+	nonce, err := base64.URLEncoding.DecodeString(decReq.Nonce)
+	if err != nil {
+		return err
+	}
+
+	ct := make([]byte, 0, len(ps.Primary.Prefix)+len(nonce)+len(cipher))
+	ct = append(ct, ps.Primary.Prefix...)
+	ct = append(ct, nonce...)
+	ct = append(ct, cipher...)
+
+	plaintext, err := a.Decrypt(ct, aad)
+	if err != nil {
+		return fmt.Errorf("decrypt cipher: %w", err)
+	}
+
+	resp := &decryptResp{
+		PlainText: base64.URLEncoding.EncodeToString(plaintext),
+	}
+
+	mResp, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(mResp)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestSignVerify(t *testing.T) {
+	kh, err := keyset.NewHandle(signature.ECDSAP384KeyTemplate())
+	require.NoError(t, err)
+
+	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err = processPOSTSigRequest(w, r, kh)
+		require.NoError(t, err)
+	})
+
+	server, url, client := CreateMockHTTPServerAndClient(t, hf)
+
+	defer func() {
+		e := server.Close()
+		require.NoError(t, e)
+	}()
+
+	defaultKeystoreURL := fmt.Sprintf("%s/%s", strings.ReplaceAll(webkmsimpl.KeystoreEndpoint,
+		"{serverEndpoint}", url), defaultKeyStoreID)
+	defaultKeyURL := defaultKeystoreURL + "/keys/" + defaultKID
+	rCrypto := New(defaultKeystoreURL, client)
+	msg := []byte("lorem ipsum")
+
+	// test successful Sign/Verify
+	sig, err := rCrypto.Sign(msg, defaultKeyURL)
+	require.NoError(t, err)
+
+	err = rCrypto.Verify(sig, msg, defaultKeyURL)
+	require.NoError(t, err)
+
+	t.Run("Sign Post request failure", func(t *testing.T) {
+		blankClient := &http.Client{}
+		tmpCrypto := New(defaultKeystoreURL, blankClient)
+
+		_, err = tmpCrypto.Sign(nil, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("posting Sign message failed [%s, Post \"%s\": x509: "+
+			"certificate signed by unknown authority]", defaultKeyURL+signURI, defaultKeyURL+signURI).Error())
+	})
+
+	t.Run("Verify Post request failure", func(t *testing.T) {
+		blankClient := &http.Client{}
+		tmpCrypto := New(defaultKeystoreURL, blankClient)
+
+		err = tmpCrypto.Verify(nil, nil, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("posting Verify signature failed [%s, Post \"%s\": x509: "+
+			"certificate signed by unknown authority]", defaultKeyURL+verifyURI, defaultKeyURL+verifyURI).Error())
+	})
+
+	t.Run("Sign json marshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.marshalFunc = failingMarshal
+		_, err = remoteCrypto2.Sign(msg, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("marshal signature request for Sign failed [%s, %w]",
+			defaultKeyURL+signURI, errFailingMarshal).Error())
+	})
+
+	t.Run("Sign json unmarshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.unmarshalFunc = failingUnmarshal
+		_, err = remoteCrypto2.Sign(msg, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("unmarshal signature for Sign failed [%s, %w]",
+			defaultKeyURL+signURI, errFailingUnmarshal).Error())
+	})
+
+	t.Run("Verify json marshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.marshalFunc = failingMarshal
+		err = remoteCrypto2.Verify(sig, msg, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("marshal verify request for Verify failed [%s, %w]",
+			defaultKeyURL+verifyURI, errFailingMarshal).Error())
+	})
+}
+
+func processPOSTSigRequest(w http.ResponseWriter, r *http.Request, sigKH *keyset.Handle) error {
+	if valid := validateHTTPMethod(w, r); !valid {
+		return errors.New("http method invalid")
+	}
+
+	if valid := validatePostPayload(r, w); !valid {
+		return errors.New("http request body invalid")
+	}
+
+	reqBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+
+	if strings.LastIndex(r.URL.Path, signURI) == len(r.URL.Path)-len(signURI) {
+		err = signPOSTHandle(w, reqBody, sigKH)
+		if err != nil {
+			return err
+		}
+	}
+
+	if strings.LastIndex(r.URL.Path, verifyURI) == len(r.URL.Path)-len(verifyURI) {
+		err = verifyPOSTHandle(reqBody, sigKH)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// nolint: interfacer // unnecessary for tests to set w io.Writer, this is a helper for tests only
+func signPOSTHandle(w http.ResponseWriter, reqBody []byte, sigKH *keyset.Handle) error {
+	sigReq := &signReq{}
+
+	err := json.Unmarshal(reqBody, sigReq)
+	if err != nil {
+		return err
+	}
+
+	msg, err := base64.URLEncoding.DecodeString(sigReq.Message)
+	if err != nil {
+		return err
+	}
+
+	signer, err := signature.NewSigner(sigKH)
+	if err != nil {
+		return fmt.Errorf("create new signer: %w", err)
+	}
+
+	s, err := signer.Sign(msg)
+	if err != nil {
+		return fmt.Errorf("sign msg: %w", err)
+	}
+
+	resp := &signResp{
+		Signature: base64.URLEncoding.EncodeToString(s),
+	}
+
+	mResp, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(mResp)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func verifyPOSTHandle(reqBody []byte, sigKH *keyset.Handle) error {
+	verReq := &verifyReq{}
+
+	err := json.Unmarshal(reqBody, verReq)
+	if err != nil {
+		return err
+	}
+
+	sig, err := base64.URLEncoding.DecodeString(verReq.Signature)
+	if err != nil {
+		return err
+	}
+
+	msg, err := base64.URLEncoding.DecodeString(verReq.Message)
+	if err != nil {
+		return err
+	}
+
+	pubKH, err := sigKH.Public()
+	if err != nil {
+		return err
+	}
+
+	verifier, err := signature.NewVerifier(pubKH)
+	if err != nil {
+		return fmt.Errorf("create new verifier: %w", err)
+	}
+
+	err = verifier.Verify(sig, msg)
+	if err != nil {
+		return fmt.Errorf("verify msg: %w", err)
+	}
+
+	return nil
+}
+
+func TestComputeVerifyMAC(t *testing.T) {
+	kh, err := keyset.NewHandle(mac.HMACSHA256Tag256KeyTemplate())
+	require.NoError(t, err)
+
+	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err = processPOSTMACRequest(w, r, kh)
+		require.NoError(t, err)
+	})
+
+	server, url, client := CreateMockHTTPServerAndClient(t, hf)
+
+	defer func() {
+		e := server.Close()
+		require.NoError(t, e)
+	}()
+
+	defaultKeystoreURL := fmt.Sprintf("%s/%s", strings.ReplaceAll(webkmsimpl.KeystoreEndpoint,
+		"{serverEndpoint}", url), defaultKeyStoreID)
+	defaultKeyURL := defaultKeystoreURL + "/keys/" + defaultKID
+	rCrypto := New(defaultKeystoreURL, client)
+	data := []byte("lorem ipsum")
+
+	// test successful ComputeMAC/VerifyMAC
+	dataMAC, err := rCrypto.ComputeMAC(data, defaultKeyURL)
+	require.NoError(t, err)
+
+	err = rCrypto.VerifyMAC(dataMAC, data, defaultKeyURL)
+	require.NoError(t, err)
+
+	t.Run("ComputeMAC Post request failure", func(t *testing.T) {
+		blankClient := &http.Client{}
+		tmpCrypto := New(defaultKeystoreURL, blankClient)
+
+		_, err = tmpCrypto.ComputeMAC(nil, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("posting ComputeMAC request failed [%s, Post \"%s\": x509: certificate"+
+			" signed by unknown authority]", defaultKeyURL+computeMACURI, defaultKeyURL+computeMACURI).Error())
+	})
+
+	t.Run("VerifyMAC Post request failure", func(t *testing.T) {
+		blankClient := &http.Client{}
+		tmpCrypto := New(defaultKeystoreURL, blankClient)
+
+		err = tmpCrypto.VerifyMAC(nil, nil, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("posting VerifyMAC request failed [%s, Post \"%s\": x509: "+
+			"certificate signed by unknown authority]", defaultKeyURL+verifyMACURI, defaultKeyURL+verifyMACURI).Error())
+	})
+
+	t.Run("ComputeMAC json marshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.marshalFunc = failingMarshal
+		_, err = remoteCrypto2.ComputeMAC(data, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("marshal request for ComputeMAC failed [%s, %w]",
+			defaultKeyURL+computeMACURI, errFailingMarshal).Error())
+	})
+
+	t.Run("ComputeMAC json unmarshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.unmarshalFunc = failingUnmarshal
+		_, err = remoteCrypto2.ComputeMAC(data, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("unmarshal ComputeMAC response failed [%s, %w]",
+			defaultKeyURL+computeMACURI, errFailingUnmarshal).Error())
+	})
+
+	t.Run("VerifyMAC json marshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.marshalFunc = failingMarshal
+		err = remoteCrypto2.VerifyMAC(dataMAC, data, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("marshal request for VerifyMAC failed [%s, %w]",
+			defaultKeyURL+verifyMACURI, errFailingMarshal).Error())
+	})
+}
+
+func processPOSTMACRequest(w http.ResponseWriter, r *http.Request, macKH *keyset.Handle) error {
+	if valid := validateHTTPMethod(w, r); !valid {
+		return errors.New("http method invalid")
+	}
+
+	if valid := validatePostPayload(r, w); !valid {
+		return errors.New("http request body invalid")
+	}
+
+	reqBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+
+	if strings.LastIndex(r.URL.Path, computeMACURI) == len(r.URL.Path)-len(computeMACURI) {
+		err = computeMACPOSTHandle(w, reqBody, macKH)
+		if err != nil {
+			return err
+		}
+	}
+
+	if strings.LastIndex(r.URL.Path, verifyMACURI) == len(r.URL.Path)-len(verifyMACURI) {
+		err = verifyMACPOSTHandle(reqBody, macKH)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// nolint: interfacer // unnecessary for tests to set w io.Writer, this is a helper for tests only
+func computeMACPOSTHandle(w http.ResponseWriter, reqBody []byte, macKH *keyset.Handle) error {
+	macReq := &computeMACReq{}
+
+	err := json.Unmarshal(reqBody, macReq)
+	if err != nil {
+		return err
+	}
+
+	data, err := base64.URLEncoding.DecodeString(macReq.Data)
+	if err != nil {
+		return err
+	}
+
+	macPrimitive, err := mac.New(macKH)
+	if err != nil {
+		return err
+	}
+
+	dataMAC, err := macPrimitive.ComputeMAC(data)
+	if err != nil {
+		return err
+	}
+
+	resp := &computeMACResp{
+		MAC: base64.URLEncoding.EncodeToString(dataMAC),
+	}
+
+	mResp, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(mResp)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func verifyMACPOSTHandle(reqBody []byte, macKH *keyset.Handle) error {
+	verReq := &verifyMACReq{}
+
+	err := json.Unmarshal(reqBody, verReq)
+	if err != nil {
+		return err
+	}
+
+	dataMAC, err := base64.URLEncoding.DecodeString(verReq.MAC)
+	if err != nil {
+		return err
+	}
+
+	data, err := base64.URLEncoding.DecodeString(verReq.Data)
+	if err != nil {
+		return err
+	}
+
+	macPrimitive, err := mac.New(macKH)
+	if err != nil {
+		return err
+	}
+
+	err = macPrimitive.VerifyMAC(dataMAC, data)
+	if err != nil {
+		return fmt.Errorf("verify mac: %w", err)
+	}
+
+	return nil
+}
+
+func TestWrapUnWrapKey(t *testing.T) {
+	senderKID := "11111"
+
+	recipientKH, err := keyset.NewHandle(ecdh.ECDH256KWAES256GCMKeyTemplate())
+	require.NoError(t, err)
+
+	recipentPubKey, err := exportPubKey(recipientKH)
+	require.NoError(t, err)
+
+	senderKH, err := keyset.NewHandle(ecdh.ECDH256KWAES256GCMKeyTemplate())
+	require.NoError(t, err)
+
+	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err = processPOSTWrapRequest(w, r, senderKH, recipientKH)
+		require.NoError(t, err)
+	})
+
+	server, url, client := CreateMockHTTPServerAndClient(t, hf)
+
+	defer func() {
+		e := server.Close()
+		require.NoError(t, e)
+	}()
+
+	defaultKeystoreURL := fmt.Sprintf("%s/%s", strings.ReplaceAll(webkmsimpl.KeystoreEndpoint,
+		"{serverEndpoint}", url), defaultKeyStoreID)
+	defaultKeyURL := defaultKeystoreURL + "/keys/" + defaultKID
+	rCrypto := New(defaultKeystoreURL, client)
+	cek := random.GetRandomBytes(uint32(32))
+	apu := []byte("bob")
+	apv := []byte("alice")
+
+	// Test successful WrapKey/UnwrapKey
+	wKey, err := rCrypto.WrapKey(cek, apu, apv, recipentPubKey)
+	require.NoError(t, err)
+
+	decryptedCEK, err := rCrypto.UnwrapKey(wKey, defaultKeyURL)
+	require.NoError(t, err)
+	require.EqualValues(t, cek, decryptedCEK)
+
+	t.Run("WrapKey Post request failure", func(t *testing.T) {
+		blankClient := &http.Client{}
+		tmpCrypto := New(defaultKeystoreURL, blankClient)
+
+		_, err = tmpCrypto.WrapKey(cek, apu, apv, recipentPubKey)
+		require.EqualError(t, err, fmt.Errorf("posting WrapKey failed [%s, Post \"%s\": x509: certificate"+
+			" signed by unknown authority]", defaultKeystoreURL+wrapURI, defaultKeystoreURL+wrapURI).Error())
+	})
+
+	t.Run("UnwrapKey Post request failure", func(t *testing.T) {
+		blankClient := &http.Client{}
+		tmpCrypto := New(defaultKeystoreURL, blankClient)
+
+		_, err = tmpCrypto.UnwrapKey(wKey, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("posting UnwrapKey failed [%s, Post \"%s\": x509: "+
+			"certificate signed by unknown authority]", defaultKeyURL+unwrapURI, defaultKeyURL+unwrapURI).Error())
+	})
+
+	t.Run("WrapKey json marshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.marshalFunc = failingMarshal
+		_, err = remoteCrypto2.WrapKey(cek, apu, apv, recipentPubKey)
+		require.EqualError(t, err, fmt.Errorf("marshal wrapKeyReq for WrapKey failed [%s, %w]",
+			defaultKeystoreURL+wrapURI, errFailingMarshal).Error())
+	})
+
+	t.Run("WrapKey json unmarshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.unmarshalFunc = failingUnmarshal
+		_, err = remoteCrypto2.WrapKey(cek, apu, apv, recipentPubKey)
+		require.EqualError(t, err, fmt.Errorf("unmarshal wrapKeyResp for WrapKey failed [%s, %w]",
+			defaultKeystoreURL+wrapURI, errFailingUnmarshal).Error())
+	})
+
+	t.Run("UnwrapKey json unmarshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.unmarshalFunc = failingUnmarshal
+		_, err = remoteCrypto2.UnwrapKey(wKey, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("unmarshal unwrapKeyResp for UnwrapKey failed [%s, %w]",
+			defaultKeyURL+unwrapURI, errFailingUnmarshal).Error())
+	})
+
+	t.Run("Unwrap json marshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.marshalFunc = failingMarshal
+		_, err = remoteCrypto2.UnwrapKey(wKey, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("marshal unwrapKeyReq for UnwrapKey failed [%s, %w]",
+			defaultKeyURL+unwrapURI, errFailingMarshal).Error())
+	})
+
+	t.Run("Wrap/Unwrap successful with Sender key (authcrypt)", func(t *testing.T) {
+		wrappedKey, err := rCrypto.WrapKey(cek, apu, apv, recipentPubKey, crypto.WithSender(senderKID))
+		require.NoError(t, err)
+
+		dCEK, err := rCrypto.UnwrapKey(wrappedKey, defaultKeyURL, crypto.WithSender(senderKID))
+		require.NoError(t, err)
+		require.EqualValues(t, cek, dCEK)
+	})
+}
+
+func TestRemoteCryptoWithHeadersFunc(t *testing.T) {
+	recipientKH, err := keyset.NewHandle(ecdh.ECDH256KWAES256GCMKeyTemplate())
+	require.NoError(t, err)
+
+	recipentPubKey, err := exportPubKey(recipientKH)
+	require.NoError(t, err)
+
+	senderKH, err := keyset.NewHandle(ecdh.ECDH256KWAES256GCMKeyTemplate())
+	require.NoError(t, err)
+
+	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err = processPOSTWrapRequest(w, r, senderKH, recipientKH)
+		require.NoError(t, err)
+	})
+
+	server, url, client := CreateMockHTTPServerAndClient(t, hf)
+
+	defer func() {
+		e := server.Close()
+		require.NoError(t, e)
+	}()
+
+	defaultKeystoreURL := fmt.Sprintf("%s/%s", strings.ReplaceAll(webkmsimpl.KeystoreEndpoint,
+		"{serverEndpoint}", url), defaultKeyStoreID)
+	defaultKeyURL := defaultKeystoreURL + "/keys/" + defaultKID
+
+	t.Run("New remote crypto using WithHeaders with success function", func(t *testing.T) {
+		rCrypto := New(defaultKeystoreURL, client, webkmsimpl.WithHeaders(mockAddHeadersFuncSuccess))
+		cek := random.GetRandomBytes(uint32(32))
+		apu := []byte("bob")
+		apv := []byte("alice")
+
+		// Test successful WrapKey/UnwrapKey
+		wKey, e := rCrypto.WrapKey(cek, apu, apv, recipentPubKey)
+		require.NoError(t, e)
+
+		decryptedCEK, e := rCrypto.UnwrapKey(wKey, defaultKeyURL)
+		require.NoError(t, e)
+		require.EqualValues(t, cek, decryptedCEK)
+	})
+
+	t.Run("New remote crypto using WithHeaders with error function", func(t *testing.T) {
+		rCrypto := New(defaultKeystoreURL, client, webkmsimpl.WithHeaders(mockAddHeadersFuncError))
+		cek := random.GetRandomBytes(uint32(32))
+		apu := []byte("bob")
+		apv := []byte("alice")
+
+		// Test successful WrapKey/UnwrapKey
+		_, err = rCrypto.WrapKey(cek, apu, apv, recipentPubKey)
+		require.EqualError(t, err, fmt.Errorf("posting WrapKey failed [%s%s, add optional request "+
+			"headers error: %w]", defaultKeystoreURL, wrapURI, errAddHeadersFunc).Error())
+
+		wKey := &crypto.RecipientWrappedKey{
+			KID:          "1",
+			EncryptedCEK: []byte("111"),
+			EPK:          crypto.PublicKey{},
+			Alg:          "zlg",
+			APU:          []byte("bob"),
+			APV:          []byte("Alice"),
+		}
+
+		_, err = rCrypto.UnwrapKey(wKey, defaultKeyURL)
+		require.EqualError(t, err, fmt.Errorf("posting UnwrapKey failed [%s%s, add optional request "+
+			"headers error: %w]", defaultKeyURL, unwrapURI, errAddHeadersFunc).Error())
+	})
+}
+
+func exportPubKey(kh *keyset.Handle) (*crypto.PublicKey, error) {
+	pubKH, err := kh.Public()
+	if err != nil {
+		return nil, fmt.Errorf("exportPubKey: failed to get public keyset handle: %w", err)
+	}
+
+	buf := new(bytes.Buffer)
+	pubKeyWriter := localkms.NewWriter(buf)
+
+	err = pubKH.WriteWithNoSecrets(pubKeyWriter)
+	if err != nil {
+		return nil, fmt.Errorf("exportPubKey: failed to create keyset with no secrets (public "+
+			"key material): %w", err)
+	}
+
+	recPubKey := &crypto.PublicKey{}
+
+	err = json.Unmarshal(buf.Bytes(), recPubKey)
+	if err != nil {
+		return nil, fmt.Errorf("exportPubKey: failed to unmarshal public key: %w", err)
+	}
+
+	return recPubKey, nil
+}
+
+func processPOSTWrapRequest(w http.ResponseWriter, r *http.Request, senderKH, recKH *keyset.Handle) error {
+	if valid := validateHTTPMethod(w, r); !valid {
+		return errors.New("http method invalid")
+	}
+
+	if valid := validatePostPayload(r, w); !valid {
+		return errors.New("http request body invalid")
+	}
+
+	reqBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+
+	cr, err := tinkcrypto.New()
+	if err != nil {
+		return err
+	}
+
+	if strings.LastIndex(r.URL.Path, wrapURI) == len(r.URL.Path)-len(wrapURI) {
+		err = wrapKeyPostHandle(w, reqBody, senderKH, cr)
+		if err != nil {
+			return err
+		}
+	}
+
+	if strings.LastIndex(r.URL.Path, unwrapURI) == len(r.URL.Path)-len(unwrapURI) {
+		err = unwrapKeyPostHandle(w, reqBody, senderKH, recKH, cr)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// nolint: interfacer // unnecessary for tests to set w io.Writer, this is a helper for tests only
+func wrapKeyPostHandle(w http.ResponseWriter, reqBody []byte, senderKH *keyset.Handle, cr crypto.Crypto) error {
+	wrapReq := &wrapKeyReq{}
+
+	err := json.Unmarshal(reqBody, wrapReq)
+	if err != nil {
+		return err
+	}
+
+	cek, err := base64.URLEncoding.DecodeString(wrapReq.CEK)
+	if err != nil {
+		return err
+	}
+
+	apv, err := base64.URLEncoding.DecodeString(wrapReq.APV)
+	if err != nil {
+		return err
+	}
+
+	apu, err := base64.URLEncoding.DecodeString(wrapReq.APU)
+	if err != nil {
+		return err
+	}
+
+	wk, err := buildRecipientWK(cek, apu, apv, senderKH, wrapReq, cr)
+	if err != nil {
+		return err
+	}
+
+	httpWK := wrappedKeyToSerializableReq(wk)
+	resp := &wrapKeyResp{
+		WrappedKey: httpWK,
+	}
+
+	mResp, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(mResp)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func buildRecipientWK(cek, apu, apv []byte, senderKH *keyset.Handle, wrapReq *wrapKeyReq,
+	cr crypto.Crypto) (*crypto.RecipientWrappedKey, error) {
+	var (
+		wk  *crypto.RecipientWrappedKey
+		opt crypto.WrapKeyOpts
+	)
+
+	recPubKey, err := serializableReqToPubKey(&wrapReq.RecPubKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if wrapReq.SenderKID != "" {
+		opt = crypto.WithSender(senderKH)
+
+		wk, err = cr.WrapKey(cek, apu, apv, recPubKey, opt)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		wk, err = cr.WrapKey(cek, apu, apv, recPubKey)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return wk, nil
+}
+
+// nolint: interfacer // unnecessary for tests to set w io.Writer, this is a helper for tests only
+func unwrapKeyPostHandle(w http.ResponseWriter, reqBody []byte, senderKH, recKH *keyset.Handle,
+	cr crypto.Crypto) error {
+	unwrapReq := &unwrapKeyReq{}
+
+	err := json.Unmarshal(reqBody, unwrapReq)
+	if err != nil {
+		return err
+	}
+
+	var opt crypto.WrapKeyOpts
+
+	wk, err := serializableToWrappedKey(&unwrapReq.WrappedKey)
+	if err != nil {
+		return err
+	}
+
+	var cek []byte
+
+	if unwrapReq.SenderKID != "" {
+		opt = crypto.WithSender(senderKH)
+
+		cek, err = cr.UnwrapKey(wk, recKH, opt)
+		if err != nil {
+			return err
+		}
+	} else {
+		cek, err = cr.UnwrapKey(wk, recKH)
+		if err != nil {
+			return err
+		}
+	}
+
+	resp := &unwrapKeyResp{
+		Key: base64.URLEncoding.EncodeToString(cek),
+	}
+
+	mResp, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(mResp)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestCloseResponseBody(t *testing.T) {
+	closeResponseBody(&errFailingCloser{}, logger, "testing close fail should log: errFailingCloser always fails")
+}
+
+func nonceSize(ps *primitiveset.PrimitiveSet) int {
+	var ivSize int
+	// AESGCM and XChacha20Poly1305 nonce sizes supported only for now
+	switch ps.Primary.Primitive.(type) {
+	case *aeadsubtle.XChaCha20Poly1305:
+		ivSize = chacha20poly1305.NonceSizeX
+	case *aeadsubtle.AESGCM:
+		ivSize = aeadsubtle.AESGCMIVSize
+	default:
+		ivSize = aeadsubtle.AESGCMIVSize
+	}
+
+	return ivSize
+}
+
+// validateHTTPMethod validate HTTP method and content-type.
+func validateHTTPMethod(w http.ResponseWriter, r *http.Request) bool {
+	switch r.Method {
+	case http.MethodPost, http.MethodGet:
+	default:
+		http.Error(w, "HTTP Method not allowed", http.StatusMethodNotAllowed)
+		return false
+	}
+
+	ct := r.Header.Get("Content-type")
+	if ct != webkmsimpl.ContentType && r.Method == http.MethodPost {
+		http.Error(w, fmt.Sprintf("Unsupported Content-type \"%s\"", ct), http.StatusUnsupportedMediaType)
+		return false
+	}
+
+	return true
+}
+
+// validatePayload validate and get the payload from the request.
+func validatePostPayload(r *http.Request, w http.ResponseWriter) bool {
+	if r.ContentLength == 0 && r.Method == http.MethodPost { // empty payload should not be accepted for POST request
+		http.Error(w, "Empty payload", http.StatusBadRequest)
+		return false
+	}
+
+	return true
+}
+
+// CreateMockHTTPServerAndClient creates mock http server and client using tls and returns them.
+func CreateMockHTTPServerAndClient(t *testing.T, inHandler http.Handler) (net.Listener, string, *http.Client) {
+	server := startMockServer(inHandler)
+	port := getServerPort(server)
+	serverURL := fmt.Sprintf("https://localhost:%d", port)
+
+	// build a mock cert pool
+	cp := x509.NewCertPool()
+	err := addCertsToCertPool(cp)
+	require.NoError(t, err)
+
+	// build a tls.Config instance to be used by the outbound transport
+	tlsConfig := &tls.Config{ //nolint:gosec
+		RootCAs:      cp,
+		Certificates: nil,
+	}
+
+	// create an http client to communicate with the server that has our inbound handlers set above
+	client := &http.Client{
+		Timeout: clientTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+
+	return server, serverURL, client
+}
+
+func startMockServer(handler http.Handler) net.Listener {
+	// ":0" will make the listener auto assign a free port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		logger.Fatalf("HTTP listener failed to start: %s", err)
+	}
+
+	go func() {
+		err := http.ServeTLS(listener, handler, certPrefix+"ec-pubCert1.pem", certPrefix+"ec-key1.pem")
+		if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			logger.Fatalf("HTTP server failed to start: %s", err)
+		}
+	}()
+
+	return listener
+}
+
+func getServerPort(server net.Listener) int {
+	// read dynamic port assigned to the server to be used by the client
+	return server.Addr().(*net.TCPAddr).Port
+}
+
+func addCertsToCertPool(pool *x509.CertPool) error {
+	var rawCerts []string
+
+	// add contents of ec-pubCert(1, 2 and 3).pem to rawCerts
+	for i := 1; i <= 3; i++ {
+		certPath := fmt.Sprintf("%sec-pubCert%d.pem", certPrefix, i)
+		// Create a pool with server certificates
+		cert, e := ioutil.ReadFile(filepath.Clean(certPath))
+		if e != nil {
+			return fmt.Errorf("reading certificate failed: %w", e)
+		}
+
+		rawCerts = append(rawCerts, string(cert))
+	}
+
+	certs := decodeCerts(rawCerts)
+	for i := range certs {
+		pool.AddCert(certs[i])
+	}
+
+	return nil
+}
+
+// decodeCerts will decode a list of pemCertsList (string) into a list of x509 certificates.
+func decodeCerts(pemCertsList []string) []*x509.Certificate {
+	var certs []*x509.Certificate
+
+	for _, pemCertsString := range pemCertsList {
+		pemCerts := []byte(pemCertsString)
+		for len(pemCerts) > 0 {
+			var block *pem.Block
+
+			block, pemCerts = pem.Decode(pemCerts)
+			if block == nil {
+				break
+			}
+
+			if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+				continue
+			}
+
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				continue
+			}
+
+			certs = append(certs, cert)
+		}
+	}
+
+	return certs
+}
+
+var errFailingMarshal = errors.New("failingMarshal always fails")
+
+func failingMarshal(interface{}) ([]byte, error) {
+	return nil, errFailingMarshal
+}
+
+var errFailingUnmarshal = errors.New("failingUnmarshal always fails")
+
+func failingUnmarshal([]byte, interface{}) error {
+	return errFailingUnmarshal
+}
+
+type errFailingCloser struct{}
+
+func (c *errFailingCloser) Close() error {
+	return errors.New("errFailingCloser always fails")
+}
+
+func mockAddHeadersFuncSuccess(req *http.Request) (*http.Header, error) {
+	// mocking a call to an auth server to get necessary credentials.
+	// It only sets mock http.Header entries for testing purposes.
+	req.Header.Set("controller", "mockController")
+	req.Header.Set("authServerURL", "mockAuthServerURL")
+	req.Header.Set("secret", "mockSecret")
+
+	return &req.Header, nil
+}
+
+var errAddHeadersFunc = errors.New("mockAddHeadersFuncError always fails")
+
+func mockAddHeadersFuncError(_ *http.Request) (*http.Header, error) {
+	return nil, errAddHeadersFunc
+}

--- a/pkg/crypto/webkms/wrapkey_util.go
+++ b/pkg/crypto/webkms/wrapkey_util.go
@@ -1,0 +1,158 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package webkms
+
+import (
+	"encoding/base64"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto"
+)
+
+// wrapKeyReq serializable WrapKey request.
+type wrapKeyReq struct {
+	CEK       string       `json:"cek,omitempty"`
+	APU       string       `json:"apu,omitempty"`
+	APV       string       `json:"apv,omitempty"`
+	RecPubKey publicKeyReq `json:"recpubkey,omitempty"`
+	SenderKID string       `json:"senderkid,omitempty"`
+}
+
+// wrapKeyResp serializable WrapKey response.
+type wrapKeyResp struct {
+	WrappedKey recipientWrappedKeyReq `json:"wrappedKey,omitempty"`
+}
+
+// unwrapKeyReq serializable UnwrapKey request.
+type unwrapKeyReq struct {
+	WrappedKey recipientWrappedKeyReq `json:"wrappedKey,omitempty"`
+	SenderKID  string                 `json:"senderkid,omitempty"`
+}
+
+// unwrapKeyResp serializable UnwrapKey response.
+type unwrapKeyResp struct {
+	Key string `json:"key,omitempty"`
+}
+
+// recipientWrappedKeyReq contains recipient key material required to unwrap CEK for HTTP requests.
+type recipientWrappedKeyReq struct {
+	KID          string       `json:"kid,omitempty"`
+	EncryptedCEK string       `json:"encryptedcek,omitempty"`
+	EPK          publicKeyReq `json:"epk,omitempty"`
+	Alg          string       `json:"alg,omitempty"`
+	APU          string       `json:"apu,omitempty"`
+	APV          string       `json:"apv,omitempty"`
+}
+
+// publicKeyReq mainly to exchange EPK in RecipientWrappedKey for HTTP requests.
+type publicKeyReq struct {
+	KID   string `json:"kid,omitempty"`
+	X     string `json:"x,omitempty"`
+	Y     string `json:"y,omitempty"`
+	Curve string `json:"curve,omitempty"`
+	Type  string `json:"type,omitempty"`
+}
+
+// pubKeyToSerializableReq converts recPubKey into a serializable publicKeyReq.
+func pubKeyToSerializableReq(recPubKey *crypto.PublicKey) publicKeyReq {
+	return publicKeyReq{
+		KID:   base64.URLEncoding.EncodeToString([]byte(recPubKey.KID)),
+		X:     base64.URLEncoding.EncodeToString(recPubKey.X),
+		Y:     base64.URLEncoding.EncodeToString(recPubKey.Y),
+		Curve: base64.URLEncoding.EncodeToString([]byte(recPubKey.Curve)),
+		Type:  base64.URLEncoding.EncodeToString([]byte(recPubKey.Type)),
+	}
+}
+
+// wrappedKeyToSerializableReq converts wrappedKey into a serializable recipientWrappedKeyReq.
+func wrappedKeyToSerializableReq(wrappedKey *crypto.RecipientWrappedKey) recipientWrappedKeyReq {
+	return recipientWrappedKeyReq{
+		KID:          base64.URLEncoding.EncodeToString([]byte(wrappedKey.KID)),
+		EncryptedCEK: base64.URLEncoding.EncodeToString(wrappedKey.EncryptedCEK),
+		EPK:          pubKeyToSerializableReq(&wrappedKey.EPK),
+		Alg:          base64.URLEncoding.EncodeToString([]byte(wrappedKey.Alg)),
+		APU:          base64.URLEncoding.EncodeToString(wrappedKey.APU),
+		APV:          base64.URLEncoding.EncodeToString(wrappedKey.APV),
+	}
+}
+
+// serializableReqToPubKey converts a serializable mRecPubKeyReq into *crypto.PublicKey.
+func serializableReqToPubKey(mRecPubKeyReq *publicKeyReq) (*crypto.PublicKey, error) {
+	kid, err := base64.URLEncoding.DecodeString(mRecPubKeyReq.KID)
+	if err != nil {
+		return nil, err
+	}
+
+	x, err := base64.URLEncoding.DecodeString(mRecPubKeyReq.X)
+	if err != nil {
+		return nil, err
+	}
+
+	y, err := base64.URLEncoding.DecodeString(mRecPubKeyReq.Y)
+	if err != nil {
+		return nil, err
+	}
+
+	curve, err := base64.URLEncoding.DecodeString(mRecPubKeyReq.Curve)
+	if err != nil {
+		return nil, err
+	}
+
+	typ, err := base64.URLEncoding.DecodeString(mRecPubKeyReq.Type)
+	if err != nil {
+		return nil, err
+	}
+
+	return &crypto.PublicKey{
+		KID:   string(kid),
+		X:     x,
+		Y:     y,
+		Curve: string(curve),
+		Type:  string(typ),
+	}, nil
+}
+
+// serializableToWrappedKey converts a serializable mWKReq into *crypto.RecipientWrappedKey.
+func serializableToWrappedKey(mWKReq *recipientWrappedKeyReq) (*crypto.RecipientWrappedKey, error) {
+	kid, err := base64.URLEncoding.DecodeString(mWKReq.KID)
+	if err != nil {
+		return nil, err
+	}
+
+	alg, err := base64.URLEncoding.DecodeString(mWKReq.Alg)
+	if err != nil {
+		return nil, err
+	}
+
+	apu, err := base64.URLEncoding.DecodeString(mWKReq.APU)
+	if err != nil {
+		return nil, err
+	}
+
+	apv, err := base64.URLEncoding.DecodeString(mWKReq.APV)
+	if err != nil {
+		return nil, err
+	}
+
+	epk, err := serializableReqToPubKey(&mWKReq.EPK)
+	if err != nil {
+		return nil, err
+	}
+
+	enc, err := base64.URLEncoding.DecodeString(mWKReq.EncryptedCEK)
+	if err != nil {
+		return nil, err
+	}
+
+	return &crypto.RecipientWrappedKey{
+		KID:          string(kid),
+		EncryptedCEK: enc,
+		EPK:          *epk,
+		Alg:          string(alg),
+		APU:          apu,
+		APV:          apv,
+	}, nil
+}

--- a/pkg/crypto/webkms/wrapkey_util_test.go
+++ b/pkg/crypto/webkms/wrapkey_util_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package webkms
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_serializableReqToPubKey_failures(t *testing.T) {
+	flagTests := []struct {
+		tcName     string
+		sPubKeyReq *publicKeyReq
+	}{
+		{
+			tcName: "publicKeyReq with bad KID encoded value",
+			sPubKeyReq: &publicKeyReq{
+				KID: "&",
+			},
+		},
+		{
+			tcName: "publicKeyReq with bad X encoded value",
+			sPubKeyReq: &publicKeyReq{
+				X: "&",
+			},
+		},
+		{
+			tcName: "publicKeyReq with bad Y encoded value",
+			sPubKeyReq: &publicKeyReq{
+				Y: "&",
+			},
+		},
+		{
+			tcName: "publicKeyReq with bad Curve encoded value",
+			sPubKeyReq: &publicKeyReq{
+				Curve: "&",
+			},
+		},
+		{
+			tcName: "publicKeyReq with bad Type encoded value",
+			sPubKeyReq: &publicKeyReq{
+				Type: "&",
+			},
+		},
+	}
+
+	for _, tc := range flagTests {
+		tt := tc
+		t.Run(tt.tcName, func(t *testing.T) {
+			_, err := serializableReqToPubKey(tt.sPubKeyReq)
+			require.EqualError(t, err, "illegal base64 data at input byte 0")
+		})
+	}
+}
+
+func Test_serializableToWrappedKey_failures(t *testing.T) {
+	flagTests := []struct {
+		tcName    string
+		sRecWKReq *recipientWrappedKeyReq
+	}{
+		{
+			tcName: "sRecWKReq with bad KID encoded value",
+			sRecWKReq: &recipientWrappedKeyReq{
+				KID: "&",
+			},
+		},
+		{
+			tcName: "sRecWKReq with bad EncryptedCEK encoded value",
+			sRecWKReq: &recipientWrappedKeyReq{
+				EncryptedCEK: "&",
+			},
+		},
+		{
+			tcName: "sRecWKReq with bad EPK encoded value",
+			sRecWKReq: &recipientWrappedKeyReq{
+				EPK: publicKeyReq{
+					KID: "&",
+				},
+			},
+		},
+		{
+			tcName: "sRecWKReq with bad Alg encoded value",
+			sRecWKReq: &recipientWrappedKeyReq{
+				Alg: "&",
+			},
+		},
+		{
+			tcName: "sRecWKReq with bad APU encoded value",
+			sRecWKReq: &recipientWrappedKeyReq{
+				APU: "&",
+			},
+		},
+		{
+			tcName: "sRecWKReq with bad APV encoded value",
+			sRecWKReq: &recipientWrappedKeyReq{
+				APV: "&",
+			},
+		},
+	}
+
+	for _, tc := range flagTests {
+		tt := tc
+		t.Run(tt.tcName, func(t *testing.T) {
+			_, err := serializableToWrappedKey(tt.sRecWKReq)
+			require.EqualError(t, err, "illegal base64 data at input byte 0")
+		})
+	}
+}

--- a/pkg/crypto/wrapkey_opts.go
+++ b/pkg/crypto/wrapkey_opts.go
@@ -7,30 +7,35 @@ SPDX-License-Identifier: Apache-2.0
 package crypto
 
 type wrapKeyOpts struct {
-	senderKH interface{}
+	senderKey interface{}
 }
 
 // NewOpt creates a new empty wrap key option.
 // Not to be used directly. It's intended for implementations of Crypto interface
-// Use WithSenderKH() option function below instead.
+// Use WithSender() option function below instead.
 func NewOpt() *wrapKeyOpts { // nolint // unexported type doesn't need to be used outside of crypto package
 	return &wrapKeyOpts{}
 }
 
-// SenderKH gets the Sender key handle to be used for kew wrapping with a sender key (authcrypt).
-// Not to be used directly. It's intended for implementations of Crypto interface
-// Use WithSenderKH() option function below instead.
-func (pk *wrapKeyOpts) SenderKH() interface{} {
-	return pk.senderKH
+// SenderKey gets the Sender key to be used for key wrapping using a sender key (authcrypt).
+// Not to be used directly. It's intended for implementations of Crypto interface.
+// Use WithSender() option function below instead.
+func (pk *wrapKeyOpts) SenderKey() interface{} {
+	return pk.senderKey
 }
 
 // WrapKeyOpts are the crypto.Wrap key options.
 type WrapKeyOpts func(opts *wrapKeyOpts)
 
-// WithSenderKH option is for setting a sender key handle with crypto wrapping (eg: AuthCrypt). For Anoncrypt,
+// WithSender option is for setting a sender key with crypto wrapping (eg: AuthCrypt). For Anoncrypt,
 // this option must not be set.
-func WithSenderKH(senderKH interface{}) WrapKeyOpts {
+// Sender is a key used for ECDH-1PU key agreement for authenticating the sender.
+// senderkey can be of the following there types:
+//   - *keyset.Handle (requires private key handle for crypto.WrapKey())
+//   - *crypto.PublicKey (available for UnwrapKey() only)
+//   - *ecdsa.PublicKey (available for UnwrapKey() only)
+func WithSender(senderKey interface{}) WrapKeyOpts {
 	return func(opts *wrapKeyOpts) {
-		opts.senderKH = senderKH
+		opts.senderKey = senderKey
 	}
 }

--- a/pkg/doc/jose/decrypter.go
+++ b/pkg/doc/jose/decrypter.go
@@ -74,7 +74,7 @@ func (jd *JWEDecrypt) Decrypt(jwe *JSONWebEncryption) ([]byte, error) {
 			return nil, fmt.Errorf("jwedecrypt: failed to add sender public key for skid: %w", e)
 		}
 
-		senderOpt = cryptoapi.WithSenderKH(senderKH)
+		senderOpt = cryptoapi.WithSender(senderKH)
 	}
 
 	recWK, err := buildRecipientsWrappedKey(jwe)

--- a/pkg/doc/jose/encrypt_test.go
+++ b/pkg/doc/jose/encrypt_test.go
@@ -35,7 +35,7 @@ func TestFailConvertRecKeyToMarshalledJWK(t *testing.T) {
 	require.EqualError(t, err, "unsupported curve")
 }
 
-func TestBadSenderKH(t *testing.T) {
+func TestBadSenderKeyType(t *testing.T) {
 	c, err := tinkcrypto.New()
 	require.NoError(t, err)
 

--- a/pkg/doc/jose/encrypter.go
+++ b/pkg/doc/jose/encrypter.go
@@ -199,7 +199,7 @@ func (je *JWEEncrypt) wrapCEKForRecipients(cek, apu, apv, aad []byte,
 
 	if je.skid != "" && je.senderKH != nil {
 		kwAlg = tinkcrypto.ECDH1PUA256KWAlg
-		senderOpt = cryptoapi.WithSenderKH(je.senderKH)
+		senderOpt = cryptoapi.WithSender(je.senderKH)
 	}
 
 	for i, recPubKey := range je.recipientsKeys {

--- a/pkg/kms/webkms/headers_opts.go
+++ b/pkg/kms/webkms/headers_opts.go
@@ -11,24 +11,25 @@ import "net/http"
 // addHeaders function supports adding custom http headers.
 type addHeaders func(req *http.Request) (*http.Header, error)
 
-type headersOpts struct {
-	headersFunc addHeaders
+// HeadersOpts represents http header option.
+type HeadersOpts struct {
+	HeadersFunc addHeaders
 }
 
 // NewOpt creates a new empty additional http headers option.
 // Not to be used directly. It's intended for implementations of remoteKMS.
 // Use WithHeaders() option function below instead.
-func NewOpt() *headersOpts { // nolint // unexported type doesn't need to be used outside of remotekms package
-	return &headersOpts{}
+func NewOpt() *HeadersOpts {
+	return &HeadersOpts{}
 }
 
 // HeadersOpt are the remoteKMS headers option.
-type HeadersOpt func(opts *headersOpts)
+type HeadersOpt func(opts *HeadersOpts)
 
 // WithHeaders option is for setting additional http request headers (since it's a function, it can call a remote
 // authorization server to fetch the necessary info needed in these headers).
 func WithHeaders(addHeadersFunc addHeaders) HeadersOpt {
-	return func(opts *headersOpts) {
-		opts.headersFunc = addHeadersFunc
+	return func(opts *HeadersOpts) {
+		opts.HeadersFunc = addHeadersFunc
 	}
 }


### PR DESCRIPTION
feat: add remoteCrypto implementation

This change introduces remoteCrypto implementation of crypot.Crypto

It includes utility functions to transform key wrapping structs in
to serializable (marshalable) instances ready to be consumed by the
key server.

It also updates key wrapping optional function WithKH() to support
adding a sending key as *crypto.PublicKey on top of the already
supported *keyset.Handle and ecdsa.PublicKey

This change completes the implementaiton of WebKMS.

Closes #2307

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>