### PR TITLE
feat: Add option to EDV REST provider to get full document on query

### DIFF
--- a/pkg/storage/edv/models/models.go
+++ b/pkg/storage/edv/models/models.go
@@ -54,7 +54,9 @@ type IDTypePair struct {
 // Query represents a name+value pair that can be used to query the encrypted indices for specific data.
 // TODO: #2262 This is a simplified version of the actual EDV query format, which is still not finalized
 // in the spec as of writing. See: https://github.com/decentralized-identity/secure-data-store/issues/34.
+// ReturnFullDocuments is currently non-standard and should only be used with an EDV server that supports it.
 type Query struct {
-	Name  string `json:"index"`
-	Value string `json:"equals"`
+	ReturnFullDocuments bool   `json:"returnFullDocuments"`
+	Name                string `json:"index"`
+	Value               string `json:"equals"`
 }


### PR DESCRIPTION
- Added an option to enable a performance optimization that can be enabled if being used with an EDV server that supports it.
- Removed a comment with a ToDo regarding dealing with a potential edge-case issue since I've now realized that the design of the EDV provider already prevents it from happening in the first place.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>