### PR TITLE
fix: correct check of "type" field of VC and VP

### DIFF
--- a/pkg/doc/verifiable/credential.go
+++ b/pkg/doc/verifiable/credential.go
@@ -71,22 +71,17 @@ const defaultSchema = `{
       "oneOf": [
         {
           "type": "array",
-          "items": [
-            {
-              "type": "string",
-              "pattern": "^VerifiableCredential$"
-            }
-          ]
+          "minItems": 1,
+          "contains": {
+            "type": "string",
+            "pattern": "^VerifiableCredential$"
+          }
         },
         {
           "type": "string",
           "pattern": "^VerifiableCredential$"
         }
-      ],
-      "additionalItems": {
-        "type": "string"
-      },
-      "minItems": 2
+      ]
     },
     "credentialSubject": {
       "anyOf": [
@@ -135,7 +130,7 @@ const defaultSchema = `{
           "items": {
             "$ref": "#/definitions/proof"
           }
-        },        
+        },
         {
           "type": "null"
         }

--- a/pkg/doc/verifiable/credential_bbs.go
+++ b/pkg/doc/verifiable/credential_bbs.go
@@ -38,37 +38,10 @@ func (vc *Credential) GenerateBBSSelectiveDisclosure(revealDoc map[string]interf
 		return nil, fmt.Errorf("create VC selective disclosure: %w", err)
 	}
 
-	fixTypesOrder(vcWithSelectiveDisclosureDoc)
-
 	vcWithSelectiveDisclosureBytes, err := json.Marshal(vcWithSelectiveDisclosureDoc)
 	if err != nil {
 		return nil, err
 	}
 
 	return ParseUnverifiedCredential(vcWithSelectiveDisclosureBytes)
-}
-
-func fixTypesOrder(vcDoc map[string]interface{}) {
-	theType := vcDoc["type"]
-
-	t, ok := theType.([]interface{})
-	if !ok {
-		return
-	}
-
-	if t[0] == vcType {
-		return
-	}
-
-	vcTypes := make([]string, 1, len(t))
-
-	vcTypes[0] = vcType
-
-	for _, nextType := range t {
-		if nextType != vcType {
-			vcTypes = append(vcTypes, nextType.(string))
-		}
-	}
-
-	vcDoc["type"] = vcTypes
 }

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -226,7 +226,7 @@ func TestValidateVerCredType(t *testing.T) {
 		require.NoError(t, err)
 		err = validateCredentialUsingJSONSchema(bytes, nil, &credentialOpts{})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "Array must have at least 2 items")
+		require.Contains(t, err.Error(), "Array must have at least 1 items")
 	})
 
 	t.Run("test verifiable credential with not first VerifiableCredential type", func(t *testing.T) {
@@ -241,18 +241,6 @@ func TestValidateVerCredType(t *testing.T) {
 		require.Contains(t, err.Error(), "Does not match pattern '^VerifiableCredential$")
 	})
 
-	t.Run("test verifiable credential with VerifiableCredential type only", func(t *testing.T) {
-		var raw rawCredential
-
-		require.NoError(t, json.Unmarshal([]byte(validCredential), &raw))
-		raw.Type = []string{"VerifiableCredential"}
-		bytes, err := json.Marshal(raw)
-		require.NoError(t, err)
-		err = validateCredentialUsingJSONSchema(bytes, nil, &credentialOpts{})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "Array must have at least 2 items")
-	})
-
 	t.Run("test verifiable credential with VerifiableCredential type only as string", func(t *testing.T) {
 		var raw rawCredential
 
@@ -263,6 +251,18 @@ func TestValidateVerCredType(t *testing.T) {
 		err = validateCredentialUsingJSONSchema(bytes, nil, &credentialOpts{})
 		require.NoError(t, err)
 	})
+
+	t.Run("test verifiable credential with several types where VerifiableCredential is not a first type",
+		func(t *testing.T) {
+			var raw rawCredential
+
+			require.NoError(t, json.Unmarshal([]byte(validCredential), &raw))
+			raw.Type = []string{"UniversityDegreeCredentail", "VerifiableCredential"}
+			bytes, err := json.Marshal(raw)
+			require.NoError(t, err)
+			err = validateCredentialUsingJSONSchema(bytes, nil, &credentialOpts{})
+			require.NoError(t, err)
+		})
 }
 
 func TestValidateVerCredCredentialSubject(t *testing.T) {

--- a/pkg/doc/verifiable/presentation.go
+++ b/pkg/doc/verifiable/presentation.go
@@ -61,22 +61,17 @@ const basePresentationSchema = `
       "oneOf": [
         {
           "type": "array",
-          "items": [
-            {
-              "type": "string",
-              "pattern": "^VerifiablePresentation$"
-            }
-          ],
-          "minItems": 1
+          "minItems": 1,
+          "contains": {
+            "type": "string",
+            "pattern": "^VerifiablePresentation$"
+          }
         },
         {
           "type": "string",
           "pattern": "^VerifiablePresentation$"
         }
-      ],
-      "additionalItems": {
-        "type": "string"
-      }
+      ]
     },
     "verifiableCredential": {
       "anyOf": [

--- a/pkg/doc/verifiable/presentation_test.go
+++ b/pkg/doc/verifiable/presentation_test.go
@@ -328,6 +328,17 @@ func TestValidateVP_Type(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+	t.Run("accepts verifiable presentation with multiple types where VerifiablePresentation is not a first type",
+		func(t *testing.T) {
+			raw := &rawPresentation{}
+			require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
+			raw.Type = []string{"CredentialManagerPresentation", "VerifiablePresentation"}
+			bytes, err := json.Marshal(raw)
+			require.NoError(t, err)
+			_, err = newTestPresentation(bytes)
+			require.NoError(t, err)
+		})
+
 	t.Run("rejects verifiable presentation with no type defined", func(t *testing.T) {
 		raw := &rawPresentation{}
 		require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
@@ -351,19 +362,6 @@ func TestValidateVP_Type(t *testing.T) {
 		require.Contains(t, err.Error(), "Does not match pattern '^VerifiablePresentation$'")
 		require.Nil(t, vp)
 	})
-
-	t.Run("rejects verifiable presentation where several types are defined and first one is not VerifiablePresentation", // nolint:lll
-		func(t *testing.T) {
-			raw := &rawPresentation{}
-			require.NoError(t, json.Unmarshal([]byte(validPresentation), &raw))
-			raw.Type = []string{"CredentialManagerPresentation", "VerifiablePresentation"}
-			bytes, err := json.Marshal(raw)
-			require.NoError(t, err)
-			vp, err := newTestPresentation(bytes)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "Does not match pattern '^VerifiablePresentation$'")
-			require.Nil(t, vp)
-		})
 }
 
 func TestValidateVP_Holder(t *testing.T) {


### PR DESCRIPTION
I faced this problem during BBS+ interop testing with Mattr. They generate VCs which have the following type definition:
```
  "type": [
    "PermanentResidentCard",
    "VerifiableCredential"
  ]
```
Current JSON schema check of VC rejects this (as it expects `VerifiableCredential` be the first element of the list) what is not mandatory according to https://www.w3.org/TR/vc-data-model/#types.

closes #2387

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>
