### PR TITLE
Fix - change vds endpoint order to support records endpoint correctly

### DIFF
--- a/pkg/controller/rest/vdr/operation.go
+++ b/pkg/controller/rest/vdr/operation.go
@@ -67,9 +67,9 @@ func (o *Operation) registerHandler() {
 	// Add more protocol endpoints here to expose them as controller API endpoints
 	o.handlers = []rest.Handler{
 		cmdutil.NewHTTPHandler(SaveDIDPath, http.MethodPost, o.SaveDID),
-		cmdutil.NewHTTPHandler(GetDIDPath, http.MethodGet, o.GetDID),
 		cmdutil.NewHTTPHandler(ResolveDIDPath, http.MethodGet, o.ResolveDID),
 		cmdutil.NewHTTPHandler(GetDIDRecordsPath, http.MethodGet, o.GetDIDRecords),
+		cmdutil.NewHTTPHandler(GetDIDPath, http.MethodGet, o.GetDID),
 	}
 }
 


### PR DESCRIPTION
**Title:**
Change VDS endpoint order to support records endpoint correctly (/vdr/did/records)

**Description:**
Previous order of VDS endpoints treated `/vdr/did/records` endpoint as `/vdr/did/{id}`, so the result of `GET /vdr/did/records` was `{"code":4000,"message":"invalid id"}`. 
The solution is simply moving `/vdr/did/{id}` endpoint under `/vdr/did/records`, to change priority of request handling.

**Summary:**
I just changed the order of endpoints

