### PR TITLE
test: BBS+ selective disclosure extended examples

### DIFF
--- a/pkg/doc/presexch/definition.go
+++ b/pkg/doc/presexch/definition.go
@@ -530,11 +530,13 @@ func filterConstraints(constraints *Constraints, creds []*verifiable.Credential)
 
 			if constraints.LimitDisclosure {
 				template, err = json.Marshal(map[string]interface{}{
-					"id":               credential.ID,
-					"credentialSchema": credential.Schemas,
-					"type":             credential.Types,
-					"@context":         credential.Context,
-					"issuer":           "",
+					"id":                credential.ID,
+					"credentialSchema":  credential.Schemas,
+					"type":              credential.Types,
+					"@context":          credential.Context,
+					"issuer":            credential.Issuer,
+					"credentialSubject": credential.Subject,
+					"issuanceDate":      credential.Issued,
 				})
 				if err != nil {
 					return nil, err

--- a/pkg/doc/verifiable/credential_bbs.go
+++ b/pkg/doc/verifiable/credential_bbs.go
@@ -47,5 +47,5 @@ func (vc *Credential) GenerateBBSSelectiveDisclosure(revealDoc map[string]interf
 		return nil, err
 	}
 
-	return ParseUnverifiedCredential(vcWithSelectiveDisclosureBytes)
+	return ParseUnverifiedCredential(vcWithSelectiveDisclosureBytes, opts...)
 }

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -1327,6 +1327,12 @@ func TestParseIssuer(t *testing.T) {
 		require.Contains(t, err.Error(), "unmarshal Issuer")
 		require.Empty(t, issuer.ID)
 	})
+
+	t.Run("Parse undefined Issuer", func(t *testing.T) {
+		issuer, err := parseIssuer(nil)
+		require.NoError(t, err)
+		require.Equal(t, Issuer{}, issuer)
+	})
 }
 
 func TestParseSubject(t *testing.T) {
@@ -1922,6 +1928,18 @@ func TestParseUnverifiedCredential(t *testing.T) {
 		vc, err = ParseUnverifiedCredential(rawVCMapBytes)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "build new credential")
+		require.Nil(t, vc)
+
+		require.NoError(t, json.Unmarshal([]byte(validCredential), &rawVCMap))
+		delete(rawVCMap, "issuer")
+
+		rawVCMapBytes, err = json.Marshal(rawVCMap)
+		require.NoError(t, err)
+
+		vc, err = ParseUnverifiedCredential(rawVCMapBytes)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "verifiable credential is not valid")
+		require.Contains(t, err.Error(), "issuer is required")
 		require.Nil(t, vc)
 	})
 }

--- a/pkg/doc/verifiable/example_credential_test.go
+++ b/pkg/doc/verifiable/example_credential_test.go
@@ -565,6 +565,9 @@ func ExampleCredential_GenerateBBSSelectiveDisclosure() {
 
 	// Create BBS+ selective disclosure. We explicitly state the fields we want to reveal in the output document.
 	// For example, "credentialSubject.birthDate" is not mentioned and thus will be hidden.
+	// To hide top-level VC fields, "@explicit": true is used on top level of reveal doc.
+	// For example, we can reveal "identifier" top-level VC field only. "issuer" and "issuanceDate" are mandatory
+	// and thus must be defined in reveal doc in case of hiding top-level VC fields.
 	revealDoc := `
 {
   "@context": [
@@ -573,6 +576,10 @@ func ExampleCredential_GenerateBBSSelectiveDisclosure() {
     "https://w3c-ccg.github.io/ldp-bbs2020/context/v1"
   ],
   "type": ["VerifiableCredential", "PermanentResidentCard"],
+  "@explicit": true,
+  "identifier": {},
+  "issuer": {},
+  "issuanceDate": {},
   "credentialSubject": {
     "@explicit": true,
     "type": ["PermanentResident", "Person"],
@@ -679,13 +686,10 @@ func ExampleCredential_GenerateBBSSelectiveDisclosure() {
 	//			"PermanentResident"
 	//		]
 	//	},
-	//	"description": "Government of Example Permanent Resident Card.",
-	//	"expirationDate": "2029-12-03T12:19:52Z",
 	//	"id": "https://issuer.oidp.uscis.gov/credentials/83627465",
 	//	"identifier": "83627465",
 	//	"issuanceDate": "2019-12-03T12:19:52Z",
 	//	"issuer": "did:example:489398593",
-	//	"name": "Permanent Resident Card",
 	//	"proof": [
 	//		{
 	//			"created": "2010-01-01T19:23:24Z",

--- a/test/bdd/features/issue_credential.feature
+++ b/test/bdd/features/issue_credential.feature
@@ -43,6 +43,8 @@ Feature: Issue credential protocol
     And "Stanford University" accepts request and sends credential to the Holder
     And "Graduate" accepts credential with name "bachelors degree"
     Then "Graduate" checks that credential is being stored under "bachelors degree" name
+    And "Graduate" waits for state "done"
+    And "Stanford University" waits for state "done"
   @decline_request
   Scenario: The Holder begins with a request and the Issuer declines it
     Given   "Alice" exchange DIDs with "Bank"


### PR DESCRIPTION
BBS+ selective disclosure extended examples with a more constrained set of claims in the derived credential.

Another changes/fixes:
- verify VC structure at `verifiable.ParseUnverifiableCredential`. Use case: find that BBS+ reveal doc missing mandatory fields like `issuer`.

closes #2410

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>