### PR TITLE
fix: Leave BBS+ Selective Disclosure proofs only

### DIFF
--- a/cmd/aries-agent-mobile/go.sum
+++ b/cmd/aries-agent-mobile/go.sum
@@ -34,6 +34,7 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/gval v1.1.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=

--- a/cmd/aries-agent-rest/go.sum
+++ b/cmd/aries-agent-rest/go.sum
@@ -35,6 +35,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/gval v1.1.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=

--- a/cmd/aries-js-worker/go.sum
+++ b/cmd/aries-js-worker/go.sum
@@ -34,6 +34,7 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/gval v1.1.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=

--- a/component/storage/jsindexeddb/go.sum
+++ b/component/storage/jsindexeddb/go.sum
@@ -9,7 +9,6 @@ github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+q
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=

--- a/component/storage/leveldb/go.sum
+++ b/component/storage/leveldb/go.sum
@@ -9,7 +9,6 @@ github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+q
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@
 module github.com/hyperledger/aries-framework-go
 
 require (
-	github.com/PaesslerAG/gval v1.0.0
+	github.com/PaesslerAG/gval v1.1.0
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/VictoriaMetrics/fastcache v1.5.7
 	github.com/bluele/gcache v0.0.0-20190518031135-bc40bd653833

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,9 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/PaesslerAG/gval v1.0.0 h1:GEKnRwkWDdf9dOmKcNrar9EA1bz1z9DqPIO1+iLzhd8=
 github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/gval v1.1.0 h1:k3RuxeZDO3eejD4cMPSt+74tUSvTnbGvLx0df4mdwFc=
+github.com/PaesslerAG/gval v1.1.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=

--- a/pkg/doc/signature/suite/bbsblssignature2020/suite.go
+++ b/pkg/doc/signature/suite/bbsblssignature2020/suite.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
 )
 
-// Suite implements EcdsaSecp256k1Signature2019 signature suite.
+// Suite implements BbsBlsSignature2020 signature suite.
 type Suite struct {
 	suite.SignatureSuite
 	jsonldProcessor *jsonld.Processor
@@ -40,7 +40,7 @@ func New(opts ...suite.Opt) *Suite {
 }
 
 // GetCanonicalDocument will return normalized/canonical version of the document.
-// EcdsaSecp256k1Signature2019 signature suite uses RDF Dataset Normalization as canonicalization algorithm.
+// BbsBlsSignature2020 signature suite uses RDF Dataset Normalization as canonicalization algorithm.
 func (s *Suite) GetCanonicalDocument(doc map[string]interface{}, opts ...jsonld.ProcessorOpts) ([]byte, error) {
 	return s.jsonldProcessor.GetCanonicalDocument(doc, opts...)
 }
@@ -50,7 +50,7 @@ func (s *Suite) GetDigest(doc []byte) []byte {
 	return doc
 }
 
-// Accept will accept only EcdsaSecp256k1Signature2019 signature type.
+// Accept will accept only BbsBlsSignature2020 signature type.
 func (s *Suite) Accept(t string) bool {
 	return t == signatureType
 }

--- a/pkg/doc/signature/suite/bbsblssignatureproof2020/suite.go
+++ b/pkg/doc/signature/suite/bbsblssignatureproof2020/suite.go
@@ -15,19 +15,22 @@ package bbsblssignatureproof2020
 // It uses BLS12-381 pairing-friendly curve (https://tools.ietf.org/html/draft-irtf-cfrg-pairing-friendly-curves-03).
 
 import (
+	"strings"
+
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
 )
 
-// Suite implements EcdsaSecp256k1Signature2019 signature suite.
+// Suite implements BbsBlsSignatureProof2020 signature suite.
 type Suite struct {
 	suite.SignatureSuite
 	jsonldProcessor *jsonld.Processor
 }
 
 const (
-	signatureType = "BbsBlsSignatureProof2020"
-	rdfDataSetAlg = "URDNA2015"
+	signatureType      = "BbsBlsSignature2020"
+	signatureProofType = "BbsBlsSignatureProof2020"
+	rdfDataSetAlg      = "URDNA2015"
 )
 
 // New an instance of Linked Data Signatures for the suite.
@@ -40,11 +43,14 @@ func New(opts ...suite.Opt) *Suite {
 }
 
 // GetCanonicalDocument will return normalized/canonical version of the document.
-// EcdsaSecp256k1Signature2019 signature suite uses RDF Dataset Normalization as canonicalization algorithm.
+// BbsBlsSignatureProof2020 signature suite uses RDF Dataset Normalization as canonicalization algorithm.
 func (s *Suite) GetCanonicalDocument(doc map[string]interface{}, opts ...jsonld.ProcessorOpts) ([]byte, error) {
 	if v, ok := doc["type"]; ok {
-		if v == "https://w3c-ccg.github.io/ldp-bbs2020/context/v1#BbsBlsSignatureProof2020" {
-			doc["type"] = "https://w3c-ccg.github.io/ldp-bbs2020/context/v1#BbsBlsSignature2020"
+		docType, ok := v.(string)
+
+		if ok && strings.HasSuffix(docType, signatureProofType) {
+			docType = strings.Replace(docType, signatureProofType, signatureType, 1)
+			doc["type"] = docType
 		}
 	}
 
@@ -56,7 +62,7 @@ func (s *Suite) GetDigest(doc []byte) []byte {
 	return doc
 }
 
-// Accept will accept only EcdsaSecp256k1Signature2019 signature type.
+// Accept will accept only BbsBlsSignatureProof2020 signature type.
 func (s *Suite) Accept(t string) bool {
-	return t == signatureType
+	return t == signatureProofType
 }

--- a/pkg/doc/signature/suite/bbsblssignatureproof2020/suite_test.go
+++ b/pkg/doc/signature/suite/bbsblssignatureproof2020/suite_test.go
@@ -132,9 +132,18 @@ func (v *testVerifier) Verify(_ *sigverifier.PublicKey, doc, _ []byte) error {
 
 type testKeyResolver struct {
 	publicKey *sigverifier.PublicKey
+	variants  map[string]*sigverifier.PublicKey
 	err       error
 }
 
-func (r *testKeyResolver) Resolve(string) (*sigverifier.PublicKey, error) {
+func (r *testKeyResolver) Resolve(id string) (*sigverifier.PublicKey, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	if len(r.variants) > 0 {
+		return r.variants[id], nil
+	}
+
 	return r.publicKey, r.err
 }

--- a/pkg/doc/verifiable/example_credential_test.go
+++ b/pkg/doc/verifiable/example_credential_test.go
@@ -609,7 +609,8 @@ func ExampleCredential_GenerateBBSSelectiveDisclosure() {
 		panic(err)
 	}
 
-	hideProofValue(vcWithSelectiveDisclosure.Proofs[1], "dummy signature proof value")
+	// Only BBS+ related proof left.
+	hideProofValue(vcWithSelectiveDisclosure.Proofs[0], "dummy signature proof value")
 
 	vcJSONWithProof, err = json.MarshalIndent(vcWithSelectiveDisclosure, "", "\t")
 	if err != nil {
@@ -690,23 +691,14 @@ func ExampleCredential_GenerateBBSSelectiveDisclosure() {
 	//	"identifier": "83627465",
 	//	"issuanceDate": "2019-12-03T12:19:52Z",
 	//	"issuer": "did:example:489398593",
-	//	"proof": [
-	//		{
-	//			"created": "2010-01-01T19:23:24Z",
-	//			"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..eOf78dZntdhgtMMipTPYuylQYZLsgCDb9OIqIpbxUbMapAQ29ai0-f1VZHLe8m9DvDY3Mah8ndPI0bJ5a0j0Bg",
-	//			"proofPurpose": "assertionMethod",
-	//			"type": "Ed25519Signature2018",
-	//			"verificationMethod": "did:example:123456#key1"
-	//		},
-	//		{
-	//			"created": "2010-01-01T19:23:24Z",
-	//			"nonce": "c29tZSBub25jZQ==",
-	//			"proofPurpose": "assertionMethod",
-	//			"proofValue": "ZHVtbXkgc2lnbmF0dXJlIHByb29mIHZhbHVl",
-	//			"type": "BbsBlsSignatureProof2020",
-	//			"verificationMethod": "did:example:123456#key1"
-	//		}
-	//	],
+	//	"proof": {
+	//		"created": "2010-01-01T19:23:24Z",
+	//		"nonce": "c29tZSBub25jZQ==",
+	//		"proofPurpose": "assertionMethod",
+	//		"proofValue": "ZHVtbXkgc2lnbmF0dXJlIHByb29mIHZhbHVl",
+	//		"type": "BbsBlsSignatureProof2020",
+	//		"verificationMethod": "did:example:123456#key1"
+	//	},
 	//	"type": [
 	//		"PermanentResidentCard",
 	//		"VerifiableCredential"

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -49,6 +49,7 @@ github.com/Microsoft/hcsshim v0.8.11 h1:qs8+XI1mFA1H/zhXT9qVG/lcJO18p1yCsICIrCjV
 github.com/Microsoft/hcsshim v0.8.11/go.mod h1:NtVKoYxQuTLx6gEq0L96c9Ju4JbRJ4nY2ow3VK6a9Lg=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/gval v1.1.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=


### PR DESCRIPTION
When creating BBS+ selective disclosure, only BBS+ Signatures converted to BBS+ Signature proofs are left in the result document (e.g. VC). Other signatures are removed as otherwise, their check would fail because of test data mismatch on the verification stage.
Also, we now produce selective disclosure for all present BBS+ Signatures (before we did this for the very first one found in the `proof` list).

closes #2440

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>