### PR TITLE
feat: X25519 ECDH export pub key

### DIFF
--- a/pkg/crypto/tinkcrypto/crypto.go
+++ b/pkg/crypto/tinkcrypto/crypto.go
@@ -270,7 +270,7 @@ func (t *Crypto) UnwrapKey(recWK *cryptoapi.RecipientWrappedKey, kh interface{},
 		return nil, fmt.Errorf("unwrapKey: %w", err)
 	}
 
-	// TODO: add support for 25519 key wrapping https://github.com/hyperledger/aries-framework-go/issues/1637
+	// TODO: add support for 25519 key wrapping https://github.com/hyperledger/aries-framework-go/issues/2445
 	recPrivKey := hybridECPrivToECDSAKey(recipientPrivateKey)
 
 	epkCurve, err := t.kw.getCurve(recWK.EPK.Curve)

--- a/pkg/crypto/tinkcrypto/key_wrapper.go
+++ b/pkg/crypto/tinkcrypto/key_wrapper.go
@@ -84,7 +84,7 @@ func (t *Crypto) deriveKEKAndWrap(cek, apu, apv []byte, senderKH interface{}, ep
 	recPubKey *ecdsa.PublicKey, recKID string) (*cryptoapi.RecipientWrappedKey, error) {
 	var kek []byte
 
-	// TODO: add support for 25519 key wrapping https://github.com/hyperledger/aries-framework-go/issues/1637
+	// TODO: add support for 25519 key wrapping https://github.com/hyperledger/aries-framework-go/issues/2445
 	keyType := ecdhpb.KeyType_EC.String()
 	wrappingAlg := ECDHESA256KWAlg
 

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdh/subtle/ecdh_aes_aead_composite_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdh/subtle/ecdh_aes_aead_composite_test.go
@@ -67,11 +67,16 @@ func TestEncryptDecryptNegativeTCs(t *testing.T) {
 
 	cEnc := NewECDHAEADCompositeEncrypt(mEncHelper, cek)
 
-	// Encrypt should fail with large AEAD key size value
+	// Encrypt should fail with AEAD error value
 	_, err := cEnc.Encrypt(pt, aad)
 	require.EqualError(t, err, "error from GetAEAD")
 
 	mEncHelper.AEADErrValue = nil
+
+	// Encrypt should fail with nil cek
+	cEncNilCEK := NewECDHAEADCompositeEncrypt(mEncHelper, nil)
+	_, err = cEncNilCEK.Encrypt(pt, aad)
+	require.EqualError(t, err, "ecdhAEADCompositeEncrypt: missing cek")
 
 	// create a valid ciphertext to test Decrypt for all recipients
 	cEnc = NewECDHAEADCompositeEncrypt(mEncHelper, cek)
@@ -101,6 +106,11 @@ func TestEncryptDecryptNegativeTCs(t *testing.T) {
 	require.EqualError(t, err, "error from GetAEAD")
 
 	mEncHelper.AEADErrValue = nil
+
+	// Decrypt should fail with nil cek
+	dEncNilCEK := NewECDHAEADCompositeDecrypt(mEncHelper, nil)
+	_, err = dEncNilCEK.Decrypt(ct, aad)
+	require.EqualError(t, err, "ecdh decrypt: missing cek")
 
 	// create a valid Decrypt message and test against ct
 	dEnc = NewECDHAEADCompositeDecrypt(mEncHelper, cek)


### PR DESCRIPTION
This change includes eporting the public key from ECDH Tink key templates
based on the key type and curve

closes #1806
closes #1637

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
