### PR TITLE
fix: BBS+ Selective Disclosure output fields mix

### DIFF
--- a/pkg/doc/signature/suite/bbsblssignatureproof2020/signer.go
+++ b/pkg/doc/signature/suite/bbsblssignatureproof2020/signer.go
@@ -192,19 +192,7 @@ func buildDocVerificationData(docCompacted, revealDoc map[string]interface{},
 		return nil, fmt.Errorf("create verify document data: %w", err)
 	}
 
-	transformedInputDocumentStatements := make([]string, len(documentStatements))
-
-	for i, element := range documentStatements {
-		nodeIdentifier := strings.Split(element, " ")[0]
-		if strings.HasPrefix(nodeIdentifier, "_:c14n") {
-			transformedInputDocumentStatements[i] = "urn:bnid:" + nodeIdentifier
-			continue
-		}
-
-		transformedInputDocumentStatements[i] = element
-	}
-
-	revealDocumentResult, err := jsonld.Default().Frame(documentStatements, revealDoc, opts...)
+	revealDocumentResult, err := jsonld.Default().Frame(docCompacted, revealDoc, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("frame doc with reveal doc: %w", err)
 	}
@@ -216,14 +204,14 @@ func buildDocVerificationData(docCompacted, revealDoc map[string]interface{},
 
 	revealIndexes := make([]int, len(revealDocumentStatements))
 
-	transformedInputDocumentStatementsMap := make(map[string]int)
-	for i, statement := range transformedInputDocumentStatements {
-		transformedInputDocumentStatementsMap[statement] = i
+	documentStatementsMap := make(map[string]int)
+	for i, statement := range documentStatements {
+		documentStatementsMap[statement] = i
 	}
 
 	for i := range revealDocumentStatements {
 		statement := revealDocumentStatements[i]
-		statementInd := transformedInputDocumentStatementsMap[statement]
+		statementInd := documentStatementsMap[statement]
 		revealIndexes[i] = statementInd
 	}
 

--- a/pkg/doc/verifiable/example_credential_test.go
+++ b/pkg/doc/verifiable/example_credential_test.go
@@ -484,7 +484,7 @@ func ExampleCredential_GenerateBBSSelectiveDisclosure() {
 	   "VerifiableCredential",
 	   "PermanentResidentCard"
 	 ],
-	 "issuer": "did:example:489398593",
+	 "issuer": "did:example:b34ca6cd37bbf23",
 	 "identifier": "83627465",
 	 "name": "Permanent Resident Card",
 	 "description": "Government of Example Permanent Resident Card.",
@@ -647,12 +647,12 @@ func ExampleCredential_GenerateBBSSelectiveDisclosure() {
 	//	"id": "https://issuer.oidp.uscis.gov/credentials/83627465",
 	//	"identifier": "83627465",
 	//	"issuanceDate": "2019-12-03T12:19:52Z",
-	//	"issuer": "did:example:489398593",
+	//	"issuer": "did:example:b34ca6cd37bbf23",
 	//	"name": "Permanent Resident Card",
 	//	"proof": [
 	//		{
 	//			"created": "2010-01-01T19:23:24Z",
-	//			"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..eOf78dZntdhgtMMipTPYuylQYZLsgCDb9OIqIpbxUbMapAQ29ai0-f1VZHLe8m9DvDY3Mah8ndPI0bJ5a0j0Bg",
+	//			"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..HsBapUAZDdaZZy6hrn951768kJaRmNAwTWvVnTDM-Bp5k08eEnnxrii5n47AeWVLDJJo7P0dEPafyC_gMjFPAA",
 	//			"proofPurpose": "assertionMethod",
 	//			"type": "Ed25519Signature2018",
 	//			"verificationMethod": "did:example:123456#key1"
@@ -683,14 +683,14 @@ func ExampleCredential_GenerateBBSSelectiveDisclosure() {
 	//		"givenName": "JOHN",
 	//		"id": "did:example:b34ca6cd37bbf23",
 	//		"type": [
-	//			"Person",
-	//			"PermanentResident"
+	//			"PermanentResident",
+	//			"Person"
 	//		]
 	//	},
 	//	"id": "https://issuer.oidp.uscis.gov/credentials/83627465",
 	//	"identifier": "83627465",
 	//	"issuanceDate": "2019-12-03T12:19:52Z",
-	//	"issuer": "did:example:489398593",
+	//	"issuer": "did:example:b34ca6cd37bbf23",
 	//	"proof": {
 	//		"created": "2010-01-01T19:23:24Z",
 	//		"nonce": "c29tZSBub25jZQ==",
@@ -700,8 +700,8 @@ func ExampleCredential_GenerateBBSSelectiveDisclosure() {
 	//		"verificationMethod": "did:example:123456#key1"
 	//	},
 	//	"type": [
-	//		"PermanentResidentCard",
-	//		"VerifiableCredential"
+	//		"VerifiableCredential",
+	//		"PermanentResidentCard"
 	//	]
 	//}
 }


### PR DESCRIPTION
When the input VC document has the same `id` of two fields, output BBS+ Signature Proof of VC (selective disclosure) may contain invalid substituted fields.

The issue is filed in json-gold library ([link](https://github.com/piprate/json-gold/issues/44)). It works properly at JSON-LD playground ([link](https://tinyurl.com/y3ypdrcj)). So current PR provides a workaround solution - to replace duplicated IDs with generated unique IDs before JSON-LD framing and then replacing IDs back.

closes #2460

Signed-off-by: Dmitriy Kinoshenko <dkinoshenko@gmail.com>