### PR TITLE
fix: single recipient JWE with AAD decrypt error

### DIFF
--- a/pkg/doc/util/jwkkid/kid_creator.go
+++ b/pkg/doc/util/jwkkid/kid_creator.go
@@ -171,7 +171,7 @@ func createX25519KID(marshalledKey []byte) (string, error) {
 }
 
 func buildX25519JWK(keyBytes []byte) (string, error) {
-	const x25519ThumbprintTemplate = `{"crv":"X25519","kty":"OKP",x":"%s"}`
+	const x25519ThumbprintTemplate = `{"crv":"X25519","kty":"OKP","x":"%s"}`
 
 	if len(keyBytes) > cryptoutil.Curve25519KeySize {
 		return "", errors.New("buildX25519JWK: invalid ECDH X25519 key")


### PR DESCRIPTION
This fixes a problem when using Flattened serialization of a JWE (using a single recipient).
Decryption fails when AAD is not empty because the authentication data is not properly 
rebuilt when calling Decrypt().

This change also increases unit-test cases to cover Full (with AAD), Flattened (with AAD) and Compact(no AAD) serializations.

Closes #2496

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
