### PR TITLE
fix: Incorrectly formatted new storage interface go module file

### DIFF
--- a/component/newstorage/go.mod
+++ b/component/newstorage/go.mod
@@ -2,4 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-module "github.com/hyperledger/aries-framework-go/component/newstorage"
+module github.com/hyperledger/aries-framework-go/component/newstorage
+
+go 1.15


### PR DESCRIPTION
While you could technically still import the module, the incorrect format was causing it to not be read correctly, so it would get listed as "indirect" when being imported.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>