### PR TITLE
feat: add integrity headers in JWE/DIDComm

### DIFF
--- a/pkg/didcomm/packer/authcrypt/pack_test.go
+++ b/pkg/didcomm/packer/authcrypt/pack_test.go
@@ -7,18 +7,26 @@ SPDX-License-Identifier: Apache-2.0
 package authcrypt
 
 import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/ed25519"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
+	"strings"
 	"testing"
 
+	hybrid "github.com/google/tink/go/hybrid/subtle"
 	"github.com/google/tink/go/keyset"
+	"github.com/square/go-jose/v3"
 	"github.com/stretchr/testify/require"
 
 	cryptoapi "github.com/hyperledger/aries-framework-go/pkg/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto"
+	ecdhpb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdh_aead_go_proto"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	afgjose "github.com/hyperledger/aries-framework-go/pkg/doc/jose"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
 	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
@@ -35,27 +43,27 @@ func TestAuthryptPackerSuccess(t *testing.T) {
 	tests := []struct {
 		name    string
 		keyType kms.KeyType
-		encAlg  jose.EncAlg
+		encAlg  afgjose.EncAlg
 	}{
 		{
 			"authpack using NISTP256ECDHKW and AES256-GCM",
 			kms.NISTP256ECDHKWType,
-			jose.A256GCM,
+			afgjose.A256GCM,
 		},
 		{
 			"authpack using X25519ECDHKW and XChacha20Poly1305",
 			kms.X25519ECDHKWType,
-			jose.XC20P,
+			afgjose.XC20P,
 		},
 		{
 			"authpack using NISTP256ECDHKW and XChacha20Poly1305",
 			kms.NISTP256ECDHKWType,
-			jose.XC20P,
+			afgjose.XC20P,
 		},
 		{
 			"authpack using X25519ECDHKW and AES256-GCM",
 			kms.X25519ECDHKWType,
-			jose.A256GCM,
+			afgjose.A256GCM,
 		},
 	}
 
@@ -64,9 +72,11 @@ func TestAuthryptPackerSuccess(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(fmt.Sprintf("running %s", tc.name), func(t *testing.T) {
-			_, recipientsKeys, keyHandles := createRecipientsByKeyType(t, k, 3, tc.keyType)
-
+			t.Logf("authcrypt packing - creating sender %s key...", tc.keyType)
 			skid, senderKey, _ := createAndMarshalKeyByKeyType(t, k, tc.keyType)
+
+			t.Logf("authcrypt packing - creating recipient %s keys...", tc.keyType)
+			_, recipientsKeys, keyHandles := createRecipientsByKeyType(t, k, 3, tc.keyType)
 
 			thirdPartyKeyStore := make(map[string][]byte)
 			mockStoreProvider := &mockstorage.MockStoreProvider{Store: &mockstorage.MockStore{
@@ -87,6 +97,10 @@ func TestAuthryptPackerSuccess(t *testing.T) {
 			ct, err := authPacker.Pack(origMsg, []byte(skid), recipientsKeys)
 			require.NoError(t, err)
 
+			jweStr, err := prettyPrint(ct)
+			require.NoError(t, err)
+			t.Logf("* authcrypt JWE: %s", jweStr)
+
 			msg, err := authPacker.Unpack(ct)
 			require.NoError(t, err)
 
@@ -98,6 +112,15 @@ func TestAuthryptPackerSuccess(t *testing.T) {
 			// try with only 1 recipient to force compact JWE serialization
 			ct, err = authPacker.Pack(origMsg, []byte(skid), [][]byte{recipientsKeys[0]})
 			require.NoError(t, err)
+
+			t.Logf("* authcrypt JWE Compact seriliazation (using first recipient only): %s", ct)
+
+			jweJSON, err := afgjose.Deserialize(string(ct))
+			require.NoError(t, err)
+
+			jweStr, err = jweJSON.FullSerialize(json.Marshal)
+			require.NoError(t, err)
+			t.Logf("* authcrypt Flattened JWE JSON seriliazation (using first recipient only): %s", jweStr)
 
 			msg, err = authPacker.Unpack(ct)
 			require.NoError(t, err)
@@ -137,7 +160,7 @@ func TestAuthryptPackerUsingKeysWithDifferentCurvesSuccess(t *testing.T) {
 	cryptoSvc, err := tinkcrypto.New()
 	require.NoError(t, err)
 
-	authPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), jose.A256GCM)
+	authPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), afgjose.A256GCM)
 	require.NoError(t, err)
 
 	// add sender key in thirdPartyKS (prep step before Authcrypt.Pack()/Unpack())
@@ -179,7 +202,7 @@ func TestAuthcryptPackerFail(t *testing.T) {
 	skid, senderKey, _ := createAndMarshalKey(t, k)
 
 	t.Run("new Pack fail with nil thirdPartyKS provider", func(t *testing.T) {
-		_, err = New(newMockProvider(nil, k, cryptoSvc), jose.A256GCM)
+		_, err = New(newMockProvider(nil, k, cryptoSvc), afgjose.A256GCM)
 		require.EqualError(t, err, "authcrypt: failed to create packer because StorageProvider is empty")
 	})
 
@@ -189,7 +212,7 @@ func TestAuthcryptPackerFail(t *testing.T) {
 			FailNamespace:      ThirdPartyKeysDB,
 		}
 
-		_, err = New(newMockProvider(badStoreProvider, k, cryptoSvc), jose.A256GCM)
+		_, err = New(newMockProvider(badStoreProvider, k, cryptoSvc), afgjose.A256GCM)
 		require.EqualError(t, err, "authcrypt: failed to open store for name space thirdpartykeysdb")
 	})
 
@@ -199,13 +222,13 @@ func TestAuthcryptPackerFail(t *testing.T) {
 	}}
 
 	t.Run("new Pack fail with nil kms", func(t *testing.T) {
-		_, err = New(newMockProvider(mockStoreProvider, nil, cryptoSvc), jose.A256GCM)
+		_, err = New(newMockProvider(mockStoreProvider, nil, cryptoSvc), afgjose.A256GCM)
 		require.EqualError(t, err, "authcrypt: failed to create packer because KMS is empty")
 	})
 
 	_, recipientsKeys, _ := createRecipients(t, k, 10)
 	origMsg := []byte("secret message")
-	authPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), jose.A256GCM)
+	authPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), afgjose.A256GCM)
 	require.NoError(t, err)
 
 	mockStoreMap[skid] = senderKey
@@ -224,7 +247,7 @@ func TestAuthcryptPackerFail(t *testing.T) {
 
 	t.Run("pack fail with invalid encAlg", func(t *testing.T) {
 		invalidAlg := "invalidAlg"
-		invalidAuthPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), jose.EncAlg(invalidAlg))
+		invalidAuthPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), afgjose.EncAlg(invalidAlg))
 		require.NoError(t, err)
 
 		_, err = invalidAuthPacker.Pack(origMsg, skidB, recipientsKeys)
@@ -240,7 +263,7 @@ func TestAuthcryptPackerFail(t *testing.T) {
 		badKMS, err := localkms.New("local-lock://test/key/uri", p)
 		require.NoError(t, err)
 
-		badAuthPacker, err := New(newMockProvider(mockStoreProvider, badKMS, cryptoSvc), jose.A256GCM)
+		badAuthPacker, err := New(newMockProvider(mockStoreProvider, badKMS, cryptoSvc), afgjose.A256GCM)
 		require.NoError(t, err)
 
 		_, err = badAuthPacker.Pack(origMsg, skidB, recipientsKeys)
@@ -248,7 +271,7 @@ func TestAuthcryptPackerFail(t *testing.T) {
 	})
 
 	t.Run("pack success but unpack fails with invalid payload", func(t *testing.T) {
-		validAuthPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), jose.A256GCM)
+		validAuthPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), afgjose.A256GCM)
 		require.NoError(t, err)
 
 		_, err = validAuthPacker.Pack(origMsg, skidB, recipientsKeys)
@@ -260,16 +283,16 @@ func TestAuthcryptPackerFail(t *testing.T) {
 	})
 
 	t.Run("pack success but unpack fails with missing keyID in protectedHeader", func(t *testing.T) {
-		validAuthPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), jose.A256GCM)
+		validAuthPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), afgjose.A256GCM)
 		require.NoError(t, err)
 
 		ct, err := validAuthPacker.Pack(origMsg, skidB, [][]byte{recipientsKeys[0]})
 		require.NoError(t, err)
 
-		jwe, err := jose.Deserialize(string(ct))
+		jwe, err := afgjose.Deserialize(string(ct))
 		require.NoError(t, err)
 
-		delete(jwe.ProtectedHeaders, jose.HeaderKeyID)
+		delete(jwe.ProtectedHeaders, afgjose.HeaderKeyID)
 
 		newCT, err := jwe.CompactSerialize(json.Marshal)
 		require.NoError(t, err)
@@ -280,7 +303,7 @@ func TestAuthcryptPackerFail(t *testing.T) {
 
 	t.Run("pack success but unpack fails with missing kid in kms", func(t *testing.T) {
 		kids, newRecKeys, _ := createRecipients(t, k, 2)
-		validAuthPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), jose.A256GCM)
+		validAuthPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), afgjose.A256GCM)
 		require.NoError(t, err)
 
 		ct, err := validAuthPacker.Pack(origMsg, skidB, newRecKeys)
@@ -350,7 +373,72 @@ func createAndMarshalKeyByKeyType(t *testing.T, k *localkms.LocalKMS, kt kms.Key
 	mKey, err := json.Marshal(key)
 	require.NoError(t, err)
 
+	printKey(t, mKey, kid)
+
 	return kid, mKey, kh
+}
+
+func printKey(t *testing.T, mPubKey []byte, kid string) {
+	t.Helper()
+
+	pubKey := new(cryptoapi.PublicKey)
+	err := json.Unmarshal(mPubKey, pubKey)
+	require.NoError(t, err)
+
+	switch pubKey.Type {
+	case ecdhpb.KeyType_EC.String():
+		t.Logf("** EC key: %s, kid: %s", getPrintedECPubKey(t, pubKey), kid)
+	case ecdhpb.KeyType_OKP.String():
+		t.Logf("** X25519 key: %s, kid: %s", getPrintedX25519PubKey(t, pubKey), kid)
+	default:
+		t.Errorf("not supported key type: %s", pubKey.Type)
+	}
+}
+
+func prettyPrint(msg []byte) (string, error) {
+	var prettyJSON bytes.Buffer
+
+	err := json.Indent(&prettyJSON, msg, "", "\t")
+	if err != nil {
+		return "", err
+	}
+
+	return prettyJSON.String(), nil
+}
+
+func getPrintedECPubKey(t *testing.T, pubKey *cryptoapi.PublicKey) string {
+	crv, err := hybrid.GetCurve(pubKey.Curve)
+	require.NoError(t, err)
+
+	jwk := jose.JSONWebKey{
+		Key: &ecdsa.PublicKey{
+			Curve: crv,
+			X:     new(big.Int).SetBytes(pubKey.X),
+			Y:     new(big.Int).SetBytes(pubKey.Y),
+		},
+	}
+
+	jwkByte, err := jwk.MarshalJSON()
+	require.NoError(t, err)
+
+	jwkStr, err := prettyPrint(jwkByte)
+	require.NoError(t, err)
+
+	return jwkStr
+}
+
+func getPrintedX25519PubKey(t *testing.T, pubKeyType *cryptoapi.PublicKey) string {
+	jwk := jose.JSONWebKey{
+		Key: ed25519.PublicKey(pubKeyType.X),
+	}
+
+	jwkByte, err := jwk.MarshalJSON()
+	require.NoError(t, err)
+
+	jwkStr, err := prettyPrint(jwkByte)
+	require.NoError(t, err)
+
+	return strings.Replace(jwkStr, "Ed25519", "X25519", 1)
 }
 
 func createKMS(t *testing.T) *localkms.LocalKMS {

--- a/pkg/doc/jose/encrypt_test.go
+++ b/pkg/doc/jose/encrypt_test.go
@@ -115,7 +115,7 @@ func TestMergeSingleRecipientsHeadersFailureWithUnsetCurve(t *testing.T) {
 	require.EqualError(t, err, errFailingMarshal.Error())
 
 	fm = &failingMarshaller{
-		numTimesMarshalCalledBeforeReturnErr: 2,
+		numTimesMarshalCalledBeforeReturnErr: 1,
 	}
 
 	// fail EPK marshalling

--- a/pkg/doc/jose/jwe.go
+++ b/pkg/doc/jose/jwe.go
@@ -34,6 +34,9 @@ var errNotOnlyOneRecipient = errors.New(errCompactSerializationCommonText +
 var errUnprotectedHeaderUnsupported = errors.New(errCompactSerializationCommonText +
 	"JWE compact serialization does not support a shared unprotected header")
 
+var errAADHeaderUnsupported = errors.New(errCompactSerializationCommonText +
+	"JWE compact serialization does not support AAD")
+
 var errPerRecipientHeaderUnsupported = errors.New(errCompactSerializationCommonText +
 	"JWE compact serialization does not support a per-recipient unprotected header")
 
@@ -208,6 +211,10 @@ func (e *JSONWebEncryption) CompactSerialize(marshal marshalFunc) (string, error
 
 	if e.UnprotectedHeaders != nil {
 		return "", errUnprotectedHeaderUnsupported
+	}
+
+	if e.AAD != "" {
+		return "", errAADHeaderUnsupported
 	}
 
 	if e.Recipients[0].Header != nil {

--- a/pkg/doc/jose/jwe_test.go
+++ b/pkg/doc/jose/jwe_test.go
@@ -524,7 +524,6 @@ func TestJSONWebEncryption_CompactSerialize(t *testing.T) {
 		jwe := JSONWebEncryption{
 			ProtectedHeaders: protectedHeaders,
 			Recipients:       recipients,
-			AAD:              "TestAAD",
 			IV:               "TestIV",
 			Ciphertext:       "TestCipherText",
 			Tag:              "TestTag",
@@ -624,7 +623,6 @@ func TestJSONWebEncryption_CompactSerialize(t *testing.T) {
 		jwe := JSONWebEncryption{
 			ProtectedHeaders: protectedHeaders,
 			Recipients:       recipients,
-			AAD:              "TestAAD",
 			IV:               "TestIV",
 			Ciphertext:       "TestCipherText",
 			Tag:              "TestTag",
@@ -636,6 +634,30 @@ func TestJSONWebEncryption_CompactSerialize(t *testing.T) {
 
 		compactJWE, err := jwe.CompactSerialize(fm.failingMarshal)
 		require.Equal(t, errFailingMarshal, err)
+		require.Empty(t, compactJWE)
+	})
+	t.Run("Fail to marshal with non empty AAD", func(t *testing.T) {
+		protectedHeaders := Headers{
+			"protectedheader1": "protectedtestvalue1",
+			"protectedheader2": "protectedtestvalue2",
+		}
+		recipients := make([]*Recipient, 1)
+
+		recipients[0] = &Recipient{
+			EncryptedKey: "TestKey",
+		}
+
+		jwe := JSONWebEncryption{
+			ProtectedHeaders: protectedHeaders,
+			Recipients:       recipients,
+			AAD:              "AAD", // compact serialize should fail with AAD field
+			IV:               "TestIV",
+			Ciphertext:       "TestCipherText",
+			Tag:              "TestTag",
+		}
+
+		compactJWE, err := jwe.CompactSerialize(json.Marshal)
+		require.EqualError(t, err, errAADHeaderUnsupported.Error())
 		require.Empty(t, compactJWE)
 	})
 }


### PR DESCRIPTION
This changes adds JWE integrity checks to help verify the recipients and/or the sender.
It also fixes the encrypter's AEAD's AAD content for single recipient envelopes where it used to contain
only the two main JWE Protected headers (enc and typ). It now includes the single recipient's
merged headers into the protected header (ie: epk, apu, apv, typ, enc, kid and alg).

closes #2513

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
