### PR TITLE
feat: RFC0360 use-did-key

### DIFF
--- a/cmd/aries-js-worker/go.sum
+++ b/cmd/aries-js-worker/go.sum
@@ -180,6 +180,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325 h1:CmZ1Z8SxVbNxZPKih/eOY52CsYTuE1qweIMrGS/Zy6E=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a h1:zPPuIq2jAWWPTrGt70eK/BSch+gFAGrNzecsoENgu2o=

--- a/pkg/client/messaging/client.go
+++ b/pkg/client/messaging/client.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/btcsuite/btcutil/base58"
 	"github.com/google/uuid"
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
@@ -21,6 +20,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
 )
 
 const (
@@ -264,8 +264,10 @@ func (c *Client) sendToDestination(msg service.DIDCommMsgMap, dest *service.Dest
 		return nil, err
 	}
 
+	didKey, _ := fingerprint.CreateDIDKey(sigPubKey)
+
 	return func() error {
-		return c.ctx.Messenger().SendToDestination(msg, base58.Encode(sigPubKey), dest)
+		return c.ctx.Messenger().SendToDestination(msg, didKey, dest)
 	}, nil
 }
 

--- a/pkg/client/messaging/client_test.go
+++ b/pkg/client/messaging/client_test.go
@@ -400,7 +400,7 @@ func TestCommand_Send(t *testing.T) { // nolint: gocognit, gocyclo
 				option: SendByTheirDID("theirDID-001"),
 				vdr: &mockvdr.MockVDRegistry{
 					ResolveFunc: func(didID string, opts ...vdrapi.ResolveOption) (doc *did.DocResolution, e error) {
-						return &did.DocResolution{DIDDocument: mockdiddoc.GetMockDIDDoc()}, nil
+						return &did.DocResolution{DIDDocument: mockdiddoc.GetMockDIDDoc(t)}, nil
 					},
 				},
 				errorMsg: "invalid payload data format",

--- a/pkg/controller/command/messaging/command_test.go
+++ b/pkg/controller/command/messaging/command_test.go
@@ -537,7 +537,7 @@ func TestCommand_Send(t *testing.T) {
 				requestJSON: `{"message_body": "sample-input", "their_did": "theirDID-001"}`,
 				vdr: &mockvdr.MockVDRegistry{
 					ResolveFunc: func(didID string, opts ...vdrapi.ResolveOption) (doc *did.DocResolution, e error) {
-						return &did.DocResolution{DIDDocument: mockdiddoc.GetMockDIDDoc()}, nil
+						return &did.DocResolution{DIDDocument: mockdiddoc.GetMockDIDDoc(t)}, nil
 					},
 				},
 				errorCode: SendMsgError,

--- a/pkg/controller/rest/messaging/operation_test.go
+++ b/pkg/controller/rest/messaging/operation_test.go
@@ -567,7 +567,7 @@ func TestOperation_Send(t *testing.T) {
 				requestJSON: `{"message_body": "sample-input", "their_did": "theirDID-001"}`,
 				vdr: &mockvdr.MockVDRegistry{
 					ResolveFunc: func(didID string, opts ...vdrapi.ResolveOption) (*did.DocResolution, error) {
-						return &did.DocResolution{DIDDocument: mockdiddoc.GetMockDIDDoc()}, nil
+						return &did.DocResolution{DIDDocument: mockdiddoc.GetMockDIDDoc(t)}, nil
 					},
 				},
 				httpErrCode: http.StatusInternalServerError,

--- a/pkg/didcomm/common/service/destination_test.go
+++ b/pkg/didcomm/common/service/destination_test.go
@@ -81,19 +81,17 @@ func TestGetDestinationFromDID(t *testing.T) {
 }
 
 func TestPrepareDestination(t *testing.T) {
-	ed25519KeyType := "Ed25519VerificationKey2018"
-	didCommServiceType := "did-communication"
-
 	t.Run("successfully prepared destination", func(t *testing.T) {
-		dest, err := CreateDestination(mockdiddoc.GetMockDIDDoc())
+		doc := mockdiddoc.GetMockDIDDoc(t)
+		dest, err := CreateDestination(doc)
 		require.NoError(t, err)
 		require.NotNil(t, dest)
 		require.Equal(t, dest.ServiceEndpoint, "https://localhost:8090")
-		require.Equal(t, []string{"76HmFbj8sds7jjdnZ4hMVcQgtUYZpEN1HEmPnCrH2Bby"}, dest.RoutingKeys)
+		require.Equal(t, doc.Service[0].RoutingKeys, dest.RoutingKeys)
 	})
 
 	t.Run("error while getting service", func(t *testing.T) {
-		didDoc := mockdiddoc.GetMockDIDDoc()
+		didDoc := mockdiddoc.GetMockDIDDoc(t)
 		didDoc.Service = nil
 
 		dest, err := CreateDestination(didDoc)
@@ -103,10 +101,10 @@ func TestPrepareDestination(t *testing.T) {
 	})
 
 	t.Run("error while getting recipient keys from did doc", func(t *testing.T) {
-		didDoc := mockdiddoc.GetMockDIDDoc()
+		didDoc := mockdiddoc.GetMockDIDDoc(t)
 		didDoc.Service[0].RecipientKeys = []string{}
 
-		recipientKeys, ok := did.LookupRecipientKeys(didDoc, didCommServiceType, ed25519KeyType)
+		recipientKeys, ok := did.LookupDIDCommRecipientKeys(didDoc)
 		require.False(t, ok)
 		require.Nil(t, recipientKeys)
 	})

--- a/pkg/didcomm/dispatcher/outbound_test.go
+++ b/pkg/didcomm/dispatcher/outbound_test.go
@@ -35,7 +35,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			packagerValue:           &mockpackager.Packager{},
 			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: true}},
 		})
-		require.NoError(t, o.Send("data", "", &service.Destination{ServiceEndpoint: "url"}))
+		require.NoError(t, o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"}))
 	})
 
 	t.Run("test no outbound transport found", func(t *testing.T) {
@@ -43,9 +43,9 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			packagerValue:           &mockpackager.Packager{},
 			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: false}},
 		})
-		err := o.Send("data", "", &service.Destination{ServiceEndpoint: "url"})
+		err := o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "outboundDispatcher.Send: no transport found for serviceEndpoint: url")
+		require.Contains(t, err.Error(), "outboundDispatcher.Send: no transport found for destination")
 	})
 
 	t.Run("test pack msg failure", func(t *testing.T) {
@@ -53,7 +53,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			packagerValue:           &mockpackager.Packager{PackErr: fmt.Errorf("pack error")},
 			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: true}},
 		})
-		err := o.Send("data", "", &service.Destination{ServiceEndpoint: "url"})
+		err := o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "pack error")
 	})
@@ -65,7 +65,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 				&mockdidcomm.MockOutboundTransport{AcceptValue: true, SendErr: fmt.Errorf("send error")},
 			},
 		})
-		err := o.Send("data", "", &service.Destination{ServiceEndpoint: "url"})
+		err := o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "send error")
 	})
@@ -76,7 +76,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: true}},
 		})
 
-		require.NoError(t, o.Send("data", "", &service.Destination{
+		require.NoError(t, o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{
 			ServiceEndpoint: "url",
 			RecipientKeys:   []string{"abc"},
 			RoutingKeys:     []string{"xyz"},
@@ -92,7 +92,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			},
 		})
 
-		err := o.Send("data", "", &service.Destination{
+		err := o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{
 			ServiceEndpoint: "url",
 			RecipientKeys:   []string{"abc"},
 			RoutingKeys:     []string{"xyz"},
@@ -133,7 +133,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 }
 
 func TestOutboundDispatcher_SendToDID(t *testing.T) {
-	mockDoc := mockdiddoc.GetMockDIDDoc()
+	mockDoc := mockdiddoc.GetMockDIDDoc(t)
 
 	t.Run("success", func(t *testing.T) {
 		o := NewOutbound(&mockProvider{
@@ -194,7 +194,7 @@ func TestOutboundDispatcherTransportReturnRoute(t *testing.T) {
 			transportReturnRoute: transportReturnRoute,
 		})
 
-		require.NoError(t, o.Send(req, "", &service.Destination{ServiceEndpoint: "url"}))
+		require.NoError(t, o.Send(req, mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"}))
 	})
 
 	t.Run("transport route option - value set thread", func(t *testing.T) {
@@ -224,7 +224,7 @@ func TestOutboundDispatcherTransportReturnRoute(t *testing.T) {
 			transportReturnRoute: transportReturnRoute,
 		})
 
-		require.NoError(t, o.Send(req, "", &service.Destination{ServiceEndpoint: "url"}))
+		require.NoError(t, o.Send(req, mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"}))
 	})
 
 	t.Run("transport route option - no value set", func(t *testing.T) {
@@ -246,7 +246,7 @@ func TestOutboundDispatcherTransportReturnRoute(t *testing.T) {
 			transportReturnRoute: "",
 		})
 
-		require.NoError(t, o.Send(req, "", &service.Destination{ServiceEndpoint: "url"}))
+		require.NoError(t, o.Send(req, mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"}))
 	})
 
 	t.Run("transport route option - forward message", func(t *testing.T) {

--- a/pkg/didcomm/packager/package_test.go
+++ b/pkg/didcomm/packager/package_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/btcsuite/btcutil/base58"
 	"github.com/stretchr/testify/require"
 
 	cryptoapi "github.com/hyperledger/aries-framework-go/pkg/crypto"
@@ -31,6 +30,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/storage/wrapper/prefix"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
 )
 
 func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
@@ -152,11 +152,13 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 		toKID, toKey, err := customKMS.CreateAndExportPubKeyBytes(kms.NISTP256ECDHKW)
 		require.NoError(t, err)
 
+		didKey, _ := fingerprint.CreateDIDKey(toKey)
+
 		// PackMessage should pass with both value from and to keys
 		packMsg, err := packager.PackMessage(&transport.Envelope{
 			Message: []byte("msg1"),
 			FromKey: []byte(fromKID), // authcrypt uses sender's KID as Fromkey value
-			ToKeys:  []string{base58.Encode(toKey)},
+			ToKeys:  []string{didKey},
 		})
 		require.NoError(t, err)
 
@@ -213,6 +215,8 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 		_, toKey, err := customKMS.CreateAndExportPubKeyBytes(kms.NISTP384ECDHKWType)
 		require.NoError(t, err)
 
+		didKey, _ := fingerprint.CreateDIDKey(toKey)
+
 		// try pack with nil envelope - should fail
 		packMsg, err := packager.PackMessage(nil)
 		require.EqualError(t, err, "packMessage: envelope argument is nil")
@@ -222,7 +226,7 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 		packMsg, err = packager.PackMessage(&transport.Envelope{
 			Message: []byte("msg1"),
 			FromKey: []byte(fromKID),
-			ToKeys:  []string{base58.Encode(toKey)},
+			ToKeys:  []string{didKey},
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, packMsg)
@@ -244,7 +248,7 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 		packMsg, err = packager.PackMessage(&transport.Envelope{
 			Message: []byte("msg1"),
 			FromKey: []byte(fromKID),
-			ToKeys:  []string{base58.Encode(toKey)},
+			ToKeys:  []string{didKey},
 		})
 		require.Error(t, err)
 		require.Empty(t, packMsg)
@@ -288,11 +292,13 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 		_, toKey, err := customKMS.CreateAndExportPubKeyBytes(kms.NISTP256ECDHKWType)
 		require.NoError(t, err)
 
+		didKey, _ := fingerprint.CreateDIDKey(toKey)
+
 		// pack an non empty envelope - should pass
 		packMsg, err := packager.PackMessage(&transport.Envelope{
 			Message: []byte("msg1"),
 			FromKey: []byte(fromKID),
-			ToKeys:  []string{base58.Encode(toKey)},
+			ToKeys:  []string{didKey},
 		})
 		require.NoError(t, err)
 
@@ -320,10 +326,12 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 		_, toKey, err = customKMS.CreateAndExportPubKeyBytes(kms.ED25519)
 		require.NoError(t, err)
 
+		legacyDIDKey, _ := fingerprint.CreateDIDKey(toKey)
+
 		packMsg, err = packager2.PackMessage(&transport.Envelope{
 			Message: []byte("msg2"),
 			FromKey: fromKey,
-			ToKeys:  []string{base58.Encode(toKey)},
+			ToKeys:  []string{legacyDIDKey},
 		})
 		require.NoError(t, err)
 
@@ -364,11 +372,13 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 		_, toKey, err := customKMS.CreateAndExportPubKeyBytes(kms.ED25519Type)
 		require.NoError(t, err)
 
+		didKey, _ := fingerprint.CreateDIDKey(toKey)
+
 		// pack an non empty envelope - should pass
 		packMsg, err := packager.PackMessage(&transport.Envelope{
 			Message: []byte("msg1"),
 			FromKey: fromKey,
-			ToKeys:  []string{base58.Encode(toKey)},
+			ToKeys:  []string{didKey},
 		})
 		require.NoError(t, err)
 
@@ -411,11 +421,13 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 		_, toKey, err := customKMS.CreateAndExportPubKeyBytes(kms.ED25519Type)
 		require.NoError(t, err)
 
+		didKey, _ := fingerprint.CreateDIDKey(toKey)
+
 		// pack an non empty envelope - should pass
 		packMsg, err := packager.PackMessage(&transport.Envelope{
 			Message: []byte("msg1"),
 			FromKey: fromKey,
-			ToKeys:  []string{base58.Encode(toKey)},
+			ToKeys:  []string{didKey},
 		})
 		require.NoError(t, err)
 

--- a/pkg/didcomm/protocol/mediator/service.go
+++ b/pkg/didcomm/protocol/mediator/service.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/btcsuite/btcutil/base58"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
 )
 
 var logger = log.New("aries-framework/route/service")
@@ -350,13 +350,15 @@ func (s *Service) handleInboundRequest(c *callback) error {
 		c.options,
 		s.endpoint,
 		func() (string, error) {
-			_, key, er := s.kms.CreateAndExportPubKeyBytes(kms.ED25519Type)
+			_, pubKeyBytes, er := s.kms.CreateAndExportPubKeyBytes(kms.ED25519Type)
 			if er != nil {
 				return "", fmt.Errorf("outboundGrant from handleInboundRequest: kms failed to create and "+
 					"export ED25519 key: %w", er)
 			}
 
-			return base58.Encode(key), er
+			didKey, _ := fingerprint.CreateDIDKey(pubKeyBytes)
+
+			return didKey, er
 		},
 	)
 	if err != nil {

--- a/pkg/didcomm/protocol/mediator/service_test.go
+++ b/pkg/didcomm/protocol/mediator/service_test.go
@@ -805,7 +805,7 @@ func TestServiceForwardMsg(t *testing.T) {
 					if didID == invalidDID {
 						return nil, errors.New("invalid")
 					}
-					return &did.DocResolution{DIDDocument: mockdiddoc.GetMockDIDDoc()}, nil
+					return &did.DocResolution{DIDDocument: mockdiddoc.GetMockDIDDoc(t)}, nil
 				},
 			},
 		})
@@ -858,7 +858,7 @@ func TestMessagePickup(t *testing.T) {
 				},
 				VDRegistryValue: &mockvdr.MockVDRegistry{
 					ResolveFunc: func(didID string, opts ...vdrapi.ResolveOption) (*did.DocResolution, error) {
-						return &did.DocResolution{DIDDocument: mockdiddoc.GetMockDIDDoc()}, nil
+						return &did.DocResolution{DIDDocument: mockdiddoc.GetMockDIDDoc(t)}, nil
 					},
 				},
 			})
@@ -901,7 +901,7 @@ func TestMessagePickup(t *testing.T) {
 			},
 			VDRegistryValue: &mockvdr.MockVDRegistry{
 				ResolveFunc: func(didID string, opts ...vdrapi.ResolveOption) (doc *did.DocResolution, e error) {
-					return &did.DocResolution{DIDDocument: mockdiddoc.GetMockDIDDoc()}, nil
+					return &did.DocResolution{DIDDocument: mockdiddoc.GetMockDIDDoc(t)}, nil
 				},
 			},
 		})

--- a/pkg/didcomm/transport/ws/pool.go
+++ b/pkg/didcomm/transport/ws/pool.go
@@ -11,12 +11,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/btcsuite/btcutil/base58"
 	"nhooyr.io/websocket"
 
 	commtransport "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
 )
 
 const (
@@ -100,8 +100,10 @@ func (d *connPool) listener(conn *websocket.Conn, outbound bool) {
 			logger.Errorf("unmarshal transport decorator : %v", err)
 		}
 
+		didKey, _ := fingerprint.CreateDIDKey(unpackMsg.FromKey)
+
 		if trans != nil && trans.ReturnRoute != nil && trans.ReturnRoute.Value == decorator.TransportReturnRouteAll {
-			d.add(base58.Encode(unpackMsg.FromKey), conn)
+			d.add(didKey, conn)
 		}
 
 		messageHandler := d.msgHandler

--- a/pkg/didcomm/transport/ws/pool_test.go
+++ b/pkg/didcomm/transport/ws/pool_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/btcsuite/btcutil/base58"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"nhooyr.io/websocket"
@@ -20,6 +19,8 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/test/transportutil"
 	mockpackager "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/packager"
+	mockdiddoc "github.com/hyperledger/aries-framework-go/pkg/mock/diddoc"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
 )
 
 func TestConnectionStore(t *testing.T) {
@@ -39,9 +40,13 @@ func TestConnectionStore(t *testing.T) {
 		require.NotNil(t, outbound)
 
 		// create a transport provider (framework context)
-		verKey := "ABCD"
+		verKey := mockdiddoc.MockDIDKey(t)
+
+		verKeyBytes, err := fingerprint.PubKeyFromDIDKey(verKey)
+		require.NoError(t, err)
+
 		mockPackager := &mockpackager.Packager{
-			UnpackValue: &commontransport.Envelope{Message: request, FromKey: base58.Decode(verKey)},
+			UnpackValue: &commontransport.Envelope{Message: request, FromKey: verKeyBytes},
 		}
 
 		response := "Hello"

--- a/pkg/doc/did/doc.go
+++ b/pkg/doc/did/doc.go
@@ -91,7 +91,7 @@ func Parse(did string) (*DID, error) {
 
 	if !r.MatchString(did) {
 		return nil, fmt.Errorf(
-			"invalid did: %s. Make sure it conforms to the generic DID syntax: https://w3c.github.io/did-core/#generic-did-syntax", //nolint:lll
+			"invalid did: %s. Make sure it conforms to the DID syntax: https://w3c.github.io/did-core/#did-syntax", //nolint:lll
 			did)
 	}
 

--- a/pkg/doc/did/helpers.go
+++ b/pkg/doc/did/helpers.go
@@ -5,10 +5,6 @@ SPDX-License-Identifier: Apache-2.0
 
 package did
 
-import (
-	"github.com/btcsuite/btcutil/base58"
-)
-
 // LookupService returns the service from the given DIDDoc matching the given service type.
 func LookupService(didDoc *Doc, serviceType string) (*Service, bool) {
 	const notFound = -1
@@ -29,9 +25,13 @@ func LookupService(didDoc *Doc, serviceType string) (*Service, bool) {
 	return &didDoc.Service[index], true
 }
 
-// LookupRecipientKeys gets the recipient keys from the did doc which match the given parameters.
-func LookupRecipientKeys(didDoc *Doc, serviceType, keyType string) ([]string, bool) {
-	didCommService, ok := LookupService(didDoc, serviceType)
+// LookupDIDCommRecipientKeys gets the DIDComm recipient keys from the did doc which match the given parameters.
+// DIDComm recipient keys are encoded as did:key identifiers.
+// See:
+// - https://github.com/hyperledger/aries-rfcs/blob/master/features/0067-didcomm-diddoc-conventions/README.md
+// - https://github.com/hyperledger/aries-rfcs/blob/master/features/0360-use-did-key/README.md
+func LookupDIDCommRecipientKeys(didDoc *Doc) ([]string, bool) {
+	didCommService, ok := LookupService(didDoc, "did-communication")
 	if !ok {
 		return nil, false
 	}
@@ -40,25 +40,7 @@ func LookupRecipientKeys(didDoc *Doc, serviceType, keyType string) ([]string, bo
 		return nil, false
 	}
 
-	var recipientKeys []string
-
-	for _, keyID := range didCommService.RecipientKeys {
-		key, ok := LookupPublicKey(keyID, didDoc)
-		if !ok {
-			return nil, false
-		}
-
-		if key.Type == keyType {
-			// TODO fix hardcode base58 https://github.com/hyperledger/aries-framework-go/issues/1207
-			recipientKeys = append(recipientKeys, base58.Encode(key.Value))
-		}
-	}
-
-	if len(recipientKeys) == 0 {
-		return nil, false
-	}
-
-	return recipientKeys, true
+	return didCommService.RecipientKeys, true
 }
 
 // LookupPublicKey returns the public key with the given id from the given DID Doc.

--- a/pkg/doc/did/helpers_test.go
+++ b/pkg/doc/did/helpers_test.go
@@ -15,49 +15,28 @@ import (
 )
 
 func TestGetRecipientKeys(t *testing.T) {
-	ed25519KeyType := "Ed25519VerificationKey2018"
-	didCommServiceType := "did-communication"
-
 	t.Run("successfully getting recipient keys", func(t *testing.T) {
-		didDoc := mockdiddoc.GetMockDIDDoc()
+		didDoc := mockdiddoc.GetMockDIDDoc(t)
 
-		recipientKeys, ok := LookupRecipientKeys(didDoc, didCommServiceType, ed25519KeyType)
+		recipientKeys, ok := LookupDIDCommRecipientKeys(didDoc)
 		require.True(t, ok)
 		require.Equal(t, 1, len(recipientKeys))
 	})
 
 	t.Run("error due to missing did-communication service", func(t *testing.T) {
-		didDoc := mockdiddoc.GetMockDIDDoc()
+		didDoc := mockdiddoc.GetMockDIDDoc(t)
 		didDoc.Service = nil
 
-		recipientKeys, ok := LookupRecipientKeys(didDoc, didCommServiceType, ed25519KeyType)
+		recipientKeys, ok := LookupDIDCommRecipientKeys(didDoc)
 		require.False(t, ok)
 		require.Nil(t, recipientKeys)
 	})
 
 	t.Run("error due to missing recipient keys in did-communication service", func(t *testing.T) {
-		didDoc := mockdiddoc.GetMockDIDDoc()
+		didDoc := mockdiddoc.GetMockDIDDoc(t)
 		didDoc.Service[0].RecipientKeys = []string{}
 
-		recipientKeys, ok := LookupRecipientKeys(didDoc, didCommServiceType, ed25519KeyType)
-		require.False(t, ok)
-		require.Nil(t, recipientKeys)
-	})
-
-	t.Run("error due to missing public key in did doc", func(t *testing.T) {
-		didDoc := mockdiddoc.GetMockDIDDoc()
-		didDoc.Service[0].RecipientKeys = []string{"invalid"}
-
-		recipientKeys, ok := LookupRecipientKeys(didDoc, didCommServiceType, ed25519KeyType)
-		require.False(t, ok)
-		require.Nil(t, recipientKeys)
-	})
-
-	t.Run("error due to unsupported key types", func(t *testing.T) {
-		didDoc := mockdiddoc.GetMockDIDDoc()
-		didDoc.Service[0].RecipientKeys = []string{didDoc.VerificationMethod[0].ID}
-
-		recipientKeys, ok := LookupRecipientKeys(didDoc, didCommServiceType, ed25519KeyType)
+		recipientKeys, ok := LookupDIDCommRecipientKeys(didDoc)
 		require.False(t, ok)
 		require.Nil(t, recipientKeys)
 	})
@@ -67,7 +46,7 @@ func TestGetDidCommService(t *testing.T) {
 	didCommServiceType := "did-communication"
 
 	t.Run("successfully getting did-communication service", func(t *testing.T) {
-		didDoc := mockdiddoc.GetMockDIDDoc()
+		didDoc := mockdiddoc.GetMockDIDDoc(t)
 
 		s, ok := LookupService(didDoc, didCommServiceType)
 		require.True(t, ok)
@@ -76,7 +55,7 @@ func TestGetDidCommService(t *testing.T) {
 	})
 
 	t.Run("error due to missing service", func(t *testing.T) {
-		didDoc := mockdiddoc.GetMockDIDDoc()
+		didDoc := mockdiddoc.GetMockDIDDoc(t)
 		didDoc.Service = nil
 
 		s, ok := LookupService(didDoc, didCommServiceType)
@@ -85,9 +64,8 @@ func TestGetDidCommService(t *testing.T) {
 	})
 
 	t.Run("error due to missing did-communication service", func(t *testing.T) {
-		didDoc := mockdiddoc.GetMockDIDDoc()
+		didDoc := mockdiddoc.GetMockDIDDoc(t)
 		didDoc.Service[0].Type = "some-type"
-		didDoc.Service[1].Type = "other-type"
 
 		s, ok := LookupService(didDoc, didCommServiceType)
 		require.False(t, ok)

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/msghandler"
 	mockdidexchange "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/generic"
+	mockdiddoc "github.com/hyperledger/aries-framework-go/pkg/mock/diddoc"
 	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 	mockvdr "github.com/hyperledger/aries-framework-go/pkg/mock/vdr"
@@ -119,7 +120,11 @@ func TestFramework(t *testing.T) {
 		ctx, err := aries.Context()
 		require.NoError(t, err)
 
-		e := ctx.OutboundDispatcher().Send([]byte("Hello World"), "", &service.Destination{ServiceEndpoint: serverURL})
+		e := ctx.OutboundDispatcher().Send(
+			[]byte("Hello World"),
+			mockdiddoc.MockDIDKey(t),
+			&service.Destination{ServiceEndpoint: serverURL},
+		)
 		require.NoError(t, e)
 	})
 

--- a/pkg/mock/diddoc/mock_diddoc.go
+++ b/pkg/mock/diddoc/mock_diddoc.go
@@ -6,29 +6,31 @@ SPDX-License-Identifier: Apache-2.0
 package mockdiddoc
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+
 	"github.com/btcsuite/btcutil/base58"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
 )
 
 // GetMockDIDDoc creates a mock DID Doc for testing.
-func GetMockDIDDoc() *did.Doc {
+func GetMockDIDDoc(t *testing.T) *did.Doc {
+	t.Helper()
+
 	return &did.Doc{
 		Context: []string{"https://w3id.org/did/v1"},
-		ID:      "did:peer:123456789abcdefghi#inbox",
+		ID:      "did:peer:123456789abcdefghi",
 		Service: []did.Service{
 			{
 				ServiceEndpoint: "https://localhost:8090",
 				Type:            "did-communication",
 				Priority:        0,
-				RecipientKeys:   []string{"did:example:123456789abcdefghi#keys-2"},
-				RoutingKeys:     []string{"76HmFbj8sds7jjdnZ4hMVcQgtUYZpEN1HEmPnCrH2Bby"},
-			},
-			{
-				ServiceEndpoint: "https://localhost:8090",
-				Type:            "did-communication",
-				Priority:        1,
-				RecipientKeys:   []string{"did:example:123456789abcdefghi#keys-1"},
+				RecipientKeys:   []string{MockDIDKey(t)},
+				RoutingKeys:     []string{MockDIDKey(t)},
 			},
 		},
 		VerificationMethod: []did.VerificationMethod{
@@ -52,4 +54,16 @@ func GetMockDIDDoc() *did.Doc {
 			},
 		},
 	}
+}
+
+// MockDIDKey returns a new did:key DID for testing purposes.
+func MockDIDKey(t *testing.T) string {
+	t.Helper()
+
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	d, _ := fingerprint.CreateDIDKey(pub)
+
+	return d
 }

--- a/pkg/store/did/didconnection_test.go
+++ b/pkg/store/did/didconnection_test.go
@@ -36,8 +36,8 @@ func TestBaseConnectionStore(t *testing.T) {
 	prov := ctx{
 		store: mockstorage.NewMockStoreProvider(),
 		vdr: &mockvdr.MockVDRegistry{
-			CreateValue:  mockdiddoc.GetMockDIDDoc(),
-			ResolveValue: mockdiddoc.GetMockDIDDoc(),
+			CreateValue:  mockdiddoc.GetMockDIDDoc(t),
+			ResolveValue: mockdiddoc.GetMockDIDDoc(t),
 		},
 	}
 
@@ -63,8 +63,8 @@ func TestBaseConnectionStore(t *testing.T) {
 				},
 			},
 			vdr: &mockvdr.MockVDRegistry{
-				CreateValue:  mockdiddoc.GetMockDIDDoc(),
-				ResolveValue: mockdiddoc.GetMockDIDDoc(),
+				CreateValue:  mockdiddoc.GetMockDIDDoc(t),
+				ResolveValue: mockdiddoc.GetMockDIDDoc(t),
 			},
 		})
 		require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestBaseConnectionStore(t *testing.T) {
 		connStore, err := NewConnectionStore(&prov)
 		require.NoError(t, err)
 
-		err = connStore.SaveDIDFromDoc(mockdiddoc.GetMockDIDDoc())
+		err = connStore.SaveDIDFromDoc(mockdiddoc.GetMockDIDDoc(t))
 		require.NoError(t, err)
 	})
 
@@ -109,7 +109,7 @@ func TestBaseConnectionStore(t *testing.T) {
 		cs, err := NewConnectionStore(&prov)
 		require.NoError(t, err)
 
-		err = cs.SaveDIDByResolving(mockdiddoc.GetMockDIDDoc().ID)
+		err = cs.SaveDIDByResolving(mockdiddoc.GetMockDIDDoc(t).ID)
 		require.NoError(t, err)
 	})
 

--- a/pkg/vdr/peer/creator.go
+++ b/pkg/vdr/peer/creator.go
@@ -10,12 +10,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/btcsuite/btcutil/base58"
 	"github.com/google/uuid"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	vdrapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
 )
 
 const ed25519VerificationKey2018 = "Ed25519VerificationKey2018"
@@ -114,8 +114,8 @@ func build(keyManager kms.KeyManager, didDoc *did.Doc,
 		}
 
 		if didDoc.Service[i].Type == vdrapi.DIDCommServiceType {
-			didDoc.Service[i].RecipientKeys = []string{base58.Encode(
-				didDoc.VerificationMethod[0].Value)}
+			didKey, _ := fingerprint.CreateDIDKey(didDoc.VerificationMethod[0].Value)
+			didDoc.Service[i].RecipientKeys = []string{didKey}
 			didDoc.Service[i].Priority = 0
 		}
 

--- a/pkg/vdr/peer/creator_test.go
+++ b/pkg/vdr/peer/creator_test.go
@@ -11,11 +11,11 @@ import (
 	"crypto/rand"
 	"testing"
 
-	"github.com/btcsuite/btcutil/base58"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
 )
 
 const (
@@ -84,10 +84,12 @@ func TestBuild(t *testing.T) {
 				Type: "did-communication",
 			}}})
 
+		expectedDIDKey, _ := fingerprint.CreateDIDKey(expected.Value)
+
 		require.NoError(t, err)
 		require.NotEmpty(t, result.DIDDocument.Service)
 		require.NotEmpty(t, result.DIDDocument.Service[0].RecipientKeys)
-		require.Equal(t, base58.Encode(expected.Value),
+		require.Equal(t, expectedDIDKey,
 			result.DIDDocument.Service[0].RecipientKeys[0])
 	})
 }

--- a/test/bdd/pkg/messaging/messaging_steps.go
+++ b/test/bdd/pkg/messaging/messaging_steps.go
@@ -12,12 +12,11 @@ package messaging
 import (
 	"fmt"
 
-	"github.com/btcsuite/btcutil/base58"
-
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/context"
 )
 
@@ -128,8 +127,10 @@ func (d *messagingSDKSteps) sendMessageToPublicDID(fromAgentID, toAgentID string
 		return fmt.Errorf("unable to create sender verkey : %w", err)
 	}
 
+	didKey, _ := fingerprint.CreateDIDKey(sigPubKey)
+
 	// send message
-	err = messenger.SendToDestination(msg, base58.Encode(sigPubKey), dest)
+	err = messenger.SendToDestination(msg, didKey, dest)
 	if err != nil {
 		return fmt.Errorf("failed to send message to agent[%s] : %w", toAgentID, err)
 	}

--- a/test/bdd/pkg/sidetree/sidetree.go
+++ b/test/bdd/pkg/sidetree/sidetree.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/btcsuite/btcutil/base58"
 	"github.com/trustbloc/sidetree-core-go/pkg/commitment"
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
@@ -19,6 +18,7 @@ import (
 
 	diddoc "github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/util"
 )
 
@@ -103,12 +103,14 @@ func getOpaqueDocument(params *CreateDIDParams) ([]byte, error) {
 		return nil, err
 	}
 
+	didKey, _ := fingerprint.CreateDIDKey(keyBytes)
+
 	keyType := params.KeyType
 	if keyType == "" {
 		keyType = defaultKeyType
 	}
 
-	data := fmt.Sprintf(docTemplate, params.KeyID, keyType, opsPubKey, params.ServiceEndpoint, base58.Encode(keyBytes))
+	data := fmt.Sprintf(docTemplate, params.KeyID, keyType, opsPubKey, params.ServiceEndpoint, didKey)
 
 	doc, err := document.FromBytes([]byte(data))
 	if err != nil {


### PR DESCRIPTION
Add support for [RFC0360](https://github.com/hyperledger/aries-rfcs/blob/master/features/0360-use-did-key/README.md) for interop.

Fixed:

* out-of-band invitations
* did-exchange invitations and signature computation
* mediator-coordination
* DIDComm service types when creating did:peer
* dispatchers and transports (converting b/w did:key and raw pub key bytes)

Signed-off-by: George Aristy <george.aristy@securekey.com>