### PR TITLE
refactor: CreateAndExportPubKeyBytes in remotekms

### DIFF
--- a/test/bdd/fixtures/agent-rest/.env
+++ b/test/bdd/fixtures/agent-rest/.env
@@ -107,6 +107,6 @@ COUCHDB_PASSWORD=password
 COUCHDB_PORT=5984
 
 # KMS
-KMS_REST_IMAGE=ghcr.io/trustbloc/kms
-KMS_REST_TAG=0.1.5
+KMS_REST_IMAGE=ghcr.io/trustbloc-cicd/kms
+KMS_REST_TAG=0.1.6-snapshot-a5fd731
 


### PR DESCRIPTION
This PR updates `CreateAndExportPubKeyBytes` in remotekms to use a single call to the remote KMS service. It was done mainly because of performance considerations.