### PR TITLE
feat: Cached provider

### DIFF
--- a/component/storageutil/cachedstore/cachedstore.go
+++ b/component/storageutil/cachedstore/cachedstore.go
@@ -1,0 +1,282 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cachedstore
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	spi "github.com/hyperledger/aries-framework-go/spi/storage"
+)
+
+type closer func(name string)
+
+// CachedProvider is a spi.Provider that allows for automatic caching of data.
+type CachedProvider struct {
+	mainProvider  spi.Provider
+	cacheProvider spi.Provider
+	openStores    map[string]*store
+	lock          sync.RWMutex
+}
+
+// NewProvider instantiates a new CachedProvider. It takes in two spi.Providers.
+// mainProvider is the primary data source. It should be the slower storage provider.
+// cacheProvider is the data source that will hold cached data. It should be the faster storage provider.
+func NewProvider(mainProvider, cacheProvider spi.Provider) *CachedProvider {
+	return &CachedProvider{
+		mainProvider:  mainProvider,
+		cacheProvider: cacheProvider,
+		openStores:    make(map[string]*store),
+	}
+}
+
+// OpenStore opens a store with the given name and returns a handle.
+// If the store has never been opened before, then it is created.
+// Store names are not case-sensitive.
+func (c *CachedProvider) OpenStore(name string) (spi.Store, error) {
+	if name == "" {
+		return nil, fmt.Errorf("store name cannot be empty")
+	}
+
+	storeName := strings.ToLower(name)
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	openStore, ok := c.openStores[storeName]
+	if !ok {
+		mainStore, err := c.mainProvider.OpenStore(storeName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open store in main provider: %w", err)
+		}
+
+		cacheStore, err := c.cacheProvider.OpenStore(storeName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open store in cache provider: %w", err)
+		}
+
+		newCachingStore := store{
+			name:       name,
+			mainStore:  mainStore,
+			cacheStore: cacheStore,
+			close:      c.removeStore,
+		}
+
+		c.openStores[storeName] = &newCachingStore
+
+		return &newCachingStore, nil
+	}
+
+	return openStore, nil
+}
+
+// SetStoreConfig sets the configuration on a store.
+func (c *CachedProvider) SetStoreConfig(name string, config spi.StoreConfiguration) error {
+	err := c.mainProvider.SetStoreConfig(name, config)
+	if err != nil {
+		return fmt.Errorf("failed to set store configuration in main provider: %w", err)
+	}
+
+	err = c.cacheProvider.SetStoreConfig(name, config)
+	if err != nil {
+		return fmt.Errorf("failed to set store configuration in cache provider: %w", err)
+	}
+
+	return nil
+}
+
+// GetStoreConfig gets the current store configuration.
+func (c *CachedProvider) GetStoreConfig(name string) (spi.StoreConfiguration, error) {
+	config, err := c.mainProvider.GetStoreConfig(name)
+	if err != nil {
+		return spi.StoreConfiguration{},
+			fmt.Errorf("failed to get store configuration from main provider: %w", err)
+	}
+
+	return config, nil
+}
+
+// GetOpenStores returns all currently open stores.
+func (c *CachedProvider) GetOpenStores() []spi.Store {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	openStores := make([]spi.Store, len(c.openStores))
+
+	var counter int
+
+	for _, openStore := range c.openStores {
+		openStores[counter] = openStore
+		counter++
+	}
+
+	return openStores
+}
+
+// Close closes all stores created under this store provider.
+// For persistent store implementations, this does not delete any data in the underlying databases.
+func (c *CachedProvider) Close() error {
+	err := c.mainProvider.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close main provider: %w", err)
+	}
+
+	err = c.cacheProvider.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close cache provider: %w", err)
+	}
+
+	return nil
+}
+
+func (c *CachedProvider) removeStore(name string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	delete(c.openStores, name)
+}
+
+type store struct {
+	name       string
+	mainStore  spi.Store
+	cacheStore spi.Store
+	close      closer
+}
+
+func (s *store) Put(key string, value []byte, tags ...spi.Tag) error {
+	err := s.mainStore.Put(key, value, tags...)
+	if err != nil {
+		return fmt.Errorf("failed to put key, values and tags in the main store: %w", err)
+	}
+
+	err = s.cacheStore.Put(key, value, tags...)
+	if err != nil {
+		return fmt.Errorf("failed to put key, values and tags in the cache store: %w", err)
+	}
+
+	return nil
+}
+
+func (s *store) Get(key string) ([]byte, error) {
+	value, err := s.cacheStore.Get(key)
+	if err == nil { // Cache hit.
+		return value, nil
+	} else if !errors.Is(err, spi.ErrDataNotFound) { // If err is spi.ErrDataNotFound, then it's a cache miss.
+		return nil, fmt.Errorf("unexpected failure while getting data from cache store: %w", err)
+	}
+
+	value, err = s.mainStore.Get(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get value from main store: %w", err)
+	}
+
+	err = s.cacheStore.Put(key, value)
+	if err != nil {
+		return nil,
+			fmt.Errorf("failed to put the newly retrieved data into the cache store for future use: %w", err)
+	}
+
+	return value, nil
+}
+
+func (s *store) GetTags(key string) ([]spi.Tag, error) {
+	tags, err := s.cacheStore.GetTags(key)
+	if err == nil { // Cache hit.
+		return tags, nil
+	} else if !errors.Is(err, spi.ErrDataNotFound) {
+		// If err is spi.ErrDataNotFound, then it's a cache miss. Anything else indicates some other problem.
+		return nil, fmt.Errorf("unexpected failure while getting tags from the cache store: %w", err)
+	}
+
+	tags, err = s.mainStore.GetTags(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tags from the main store: %w", err)
+	}
+
+	return tags, nil
+}
+
+// TODO (#2476): Add caching support to this method by having it trying to fetch as many values as possible from
+//  the cache provider, and only resort to the main provider for thos values that aren't found.
+func (s *store) GetBulk(keys ...string) ([][]byte, error) {
+	values, err := s.mainStore.GetBulk(keys...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get values from the main store: %w", err)
+	}
+
+	return values, nil
+}
+
+// Can't use the cache store here since it might be missing data that's in the main store.
+func (s *store) Query(expression string, options ...spi.QueryOption) (spi.Iterator, error) {
+	iterator, err := s.mainStore.Query(expression, options...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query the main store: %w", err)
+	}
+
+	return iterator, err
+}
+
+func (s *store) Delete(key string) error {
+	err := s.mainStore.Delete(key)
+	if err != nil {
+		return fmt.Errorf("failed to delete data in the main store: %w", err)
+	}
+
+	err = s.cacheStore.Delete(key)
+	if err != nil {
+		return fmt.Errorf("failed to delete data in the cache store: %w", err)
+	}
+
+	return nil
+}
+
+func (s *store) Batch(operations []spi.Operation) error {
+	err := s.mainStore.Batch(operations)
+	if err != nil {
+		return fmt.Errorf("failed to perform operations in the main store: %w", err)
+	}
+
+	err = s.cacheStore.Batch(operations)
+	if err != nil {
+		return fmt.Errorf("failed to perform operations in the cache store: %w", err)
+	}
+
+	return nil
+}
+
+func (s *store) Flush() error {
+	err := s.mainStore.Flush()
+	if err != nil {
+		return fmt.Errorf("failed to flush the main store: %w", err)
+	}
+
+	err = s.cacheStore.Flush()
+	if err != nil {
+		return fmt.Errorf("failed to flush the cache store: %w", err)
+	}
+
+	return nil
+}
+
+func (s *store) Close() error {
+	s.close(s.name)
+
+	err := s.mainStore.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close the main store: %w", err)
+	}
+
+	err = s.cacheStore.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close the cache store: %w", err)
+	}
+
+	return nil
+}

--- a/component/storageutil/cachedstore/cachedstore_test.go
+++ b/component/storageutil/cachedstore/cachedstore_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cachedstore_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/component/storageutil/cachedstore"
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mock"
+	spi "github.com/hyperledger/aries-framework-go/spi/storage"
+	commonstoragetest "github.com/hyperledger/aries-framework-go/test/component/storage"
+)
+
+func Test_Common(t *testing.T) {
+	commonstoragetest.TestAll(t, cachedstore.NewProvider(mem.NewProvider(), mem.NewProvider()))
+}
+
+func TestCachedProvider_OpenStore(t *testing.T) {
+	t.Run("Fail to open store in the main provider", func(t *testing.T) {
+		cachedProvider := cachedstore.NewProvider(&mock.Provider{
+			ErrOpenStore: errors.New("open store failure"),
+		}, mem.NewProvider())
+
+		store, err := cachedProvider.OpenStore("StoreName")
+		require.EqualError(t, err, "failed to open store in main provider: open store failure")
+		require.Nil(t, store)
+	})
+	t.Run("Fail to open store in the cache provider", func(t *testing.T) {
+		cachedProvider := cachedstore.NewProvider(mem.NewProvider(),
+			&mock.Provider{
+				ErrOpenStore: errors.New("open store failure"),
+			})
+
+		store, err := cachedProvider.OpenStore("StoreName")
+		require.EqualError(t, err, "failed to open store in cache provider: open store failure")
+		require.Nil(t, store)
+	})
+}
+
+func TestCachedProvider_SetStoreConfig(t *testing.T) {
+	t.Run("Fail to set the store config in the cache provider", func(t *testing.T) {
+		mainProvider := mem.NewProvider()
+
+		_, err := mainProvider.OpenStore("StoreName")
+		require.NoError(t, err)
+
+		cachedProvider := cachedstore.NewProvider(mainProvider,
+			&mock.Provider{
+				ErrSetStoreConfig: errors.New("set config failure"),
+			})
+
+		err = cachedProvider.SetStoreConfig("StoreName", spi.StoreConfiguration{})
+		require.EqualError(t, err, "failed to set store configuration in cache provider: set config failure")
+	})
+}
+
+func TestCachedProvider_Close(t *testing.T) {
+	t.Run("Fail to close the main provider", func(t *testing.T) {
+		provider := cachedstore.NewProvider(&mock.Provider{}, mem.NewProvider())
+
+		err := provider.Close()
+		require.EqualError(t, err, "failed to close main provider: close failure")
+	})
+	t.Run("Fail to close the cache provider", func(t *testing.T) {
+		provider := cachedstore.NewProvider(mem.NewProvider(), &mock.Provider{})
+
+		err := provider.Close()
+		require.EqualError(t, err, "failed to close cache provider: close failure")
+	})
+}
+
+func TestStore_Put(t *testing.T) {
+	t.Run("Fail to put data in the cache store", func(t *testing.T) {
+		provider := cachedstore.NewProvider(mem.NewProvider(),
+			&mock.Provider{OpenStoreReturn: &mock.Store{ErrPut: errors.New("put failure")}})
+
+		store, err := provider.OpenStore("TestStore")
+		require.NoError(t, err)
+
+		err = store.Put("key", []byte("value"))
+		require.EqualError(t, err, "failed to put key, values and tags in the cache store: put failure")
+	})
+}
+
+func TestStore_Get(t *testing.T) {
+	t.Run("Fail to put newly retrieved data into the cache store", func(t *testing.T) {
+		mainProvider := mem.NewProvider()
+
+		mainStore, err := mainProvider.OpenStore("TestStore")
+		require.NoError(t, err)
+
+		err = mainStore.Put("key", []byte("value"))
+		require.NoError(t, err)
+
+		provider := cachedstore.NewProvider(mainProvider,
+			&mock.Provider{OpenStoreReturn: &mock.Store{
+				ErrGet: spi.ErrDataNotFound, ErrPut: errors.New("put failure"),
+			}})
+
+		store, err := provider.OpenStore("TestStore")
+		require.NoError(t, err)
+
+		_, err = store.Get("key")
+		require.EqualError(t, err,
+			"failed to put the newly retrieved data into the cache store for future use: put failure")
+	})
+}
+
+func TestStore_Close(t *testing.T) {
+	t.Run("Fail to close the main store", func(t *testing.T) {
+		provider := cachedstore.NewProvider(&mock.Provider{OpenStoreReturn: &mock.Store{}}, mem.NewProvider())
+
+		store, err := provider.OpenStore("TestStore")
+		require.NoError(t, err)
+
+		err = store.Close()
+		require.EqualError(t, err, "failed to close the main store: close failure")
+	})
+	t.Run("Fail to close the cache store", func(t *testing.T) {
+		provider := cachedstore.NewProvider(mem.NewProvider(), &mock.Provider{OpenStoreReturn: &mock.Store{}})
+
+		store, err := provider.OpenStore("TestStore")
+		require.NoError(t, err)
+
+		err = store.Close()
+		require.EqualError(t, err, "failed to close the cache store: close failure")
+	})
+}

--- a/component/storageutil/go.mod
+++ b/component/storageutil/go.mod
@@ -8,8 +8,8 @@ go 1.15
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210205164538-22156a96813c
-	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210205164538-22156a96813c
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210210184327-0b9d0fd4c34e
+	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210210184327-0b9d0fd4c34e
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/component/storageutil/go.sum
+++ b/component/storageutil/go.sum
@@ -4,10 +4,10 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210205153949-f852f978a0d6/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210205164538-22156a96813c h1:uQosU/HzJMWnncwZD7e1hljb2QtwSgOEodVhCM1MksM=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210205164538-22156a96813c/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210205164538-22156a96813c h1:y6gCivYcK7/b/w0scQzNuDtkI/4ebpu7KV8TJZcbtYc=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210205164538-22156a96813c/go.mod h1:/ljIFCu5iDIziwuvObF0vEc3fJ5dgDpT8RYAhQdNeHI=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210210184327-0b9d0fd4c34e h1:lUWDo7zJxespMMNny3RhkFclGkfnexdcXrvc9eApYjc=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210210184327-0b9d0fd4c34e/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210210184327-0b9d0fd4c34e h1:Rwo1t3inESFu8EgqXwpJY3WbcGasexT25SiVb88eIeI=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210210184327-0b9d0fd4c34e/go.mod h1:/ljIFCu5iDIziwuvObF0vEc3fJ5dgDpT8RYAhQdNeHI=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=


### PR DESCRIPTION
- Added a new "wrapper" store provider that allows for automatic caching of data.
- Removed caching option from FormatedProvider since the functionality is now redundant, since a CachedProvider can wrap a FormatProvider.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>

closes #2479