### PR TITLE
fix: wrong Ed25519 KID value

### DIFF
--- a/pkg/doc/util/jwkkid/kid_creator_test.go
+++ b/pkg/doc/util/jwkkid/kid_creator_test.go
@@ -7,11 +7,14 @@ SPDX-License-Identifier: Apache-2.0
 package jwkkid
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -20,6 +23,7 @@ import (
 
 	cryptoapi "github.com/hyperledger/aries-framework-go/pkg/crypto"
 	ecdhpb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdh_aead_go_proto"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/cryptoutil"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
@@ -32,9 +36,24 @@ func TestCreateKID(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, kid)
 
+	// now try building go-jose thumbprint and compare its base64URL with kid above
+	// they should not match since go-jose's thumbprint is built from a wrong Ed25519 JWK.
+	jwk, err := jose.JWKFromPublicKey(pubKey)
+	require.NoError(t, err)
+
+	goJoseTP, err := jwk.Thumbprint(crypto.SHA256)
+	require.NoError(t, err)
+
+	goJoseKID := base64.RawURLEncoding.EncodeToString(goJoseTP)
+	require.NotEqual(t, kid, goJoseKID)
+
+	// now build bad thumbprint and ensure it matches goJoseTP
+	// TODO remove createBadED25519Thumbprint function when go-jose fixes the Ed25519 JWK template used for Thumbprint.
+	badTP := createBadED25519Thumbprint(t, pubKey)
+	require.EqualValues(t, goJoseTP, badTP)
+
 	_, err = CreateKID(nil, kms.ED25519Type)
-	require.EqualError(t, err, "createKID: failed to build jwk: buildJWK: failed to build JWK from ed25519 "+
-		"key: create JWK: unable to read jose JWK, square/go-jose: unknown curve Ed25519'")
+	require.EqualError(t, err, "createKID: empty key")
 
 	_, x, y, err := elliptic.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
@@ -55,19 +74,26 @@ func TestCreateKID(t *testing.T) {
 	_, err = CreateKID(pubKey, "badType")
 	require.EqualError(t, err, "createKID: failed to build jwk: buildJWK: key type is not supported: 'badType'")
 
-	badPubKey := ed25519.PublicKey{}
+	badPubKey := ed25519.PublicKey("badKey")
 	_, err = CreateKID(badPubKey, kms.NISTP256ECDHKWType)
 	require.EqualError(t, err, "createKID: failed to build jwk: buildJWK: failed to build JWK from ecdh "+
-		"key: generateJWKFromECDH: unmarshalECDHKey: failed to unmarshal ECDH key: unexpected end of JSON input")
+		"key: generateJWKFromECDH: unmarshalECDHKey: failed to unmarshal ECDH key: invalid character 'b' looking for "+
+		"beginning of value")
 
 	_, err = CreateKID(badPubKey, kms.ECDSAP256TypeDER)
-	require.EqualError(t, err, "createKID: failed to build jwk: buildJWK: failed to build JWK from ecdsa "+
-		"DER key: generateJWKFromDERECDSA: failed to parse ecdsa key in DER format: asn1: syntax error: sequence "+
-		"truncated")
+	require.EqualError(t, err, "createKID: failed to build jwk: buildJWK: failed to build JWK from ecdsa DER "+
+		"key: generateJWKFromDERECDSA: failed to parse ecdsa key in DER format: asn1: structure error: tags don't "+
+		"match (16 vs {class:1 tag:2 length:97 isCompound:true}) {optional:false explicit:false application:false "+
+		"private:false defaultValue:<nil> tag:<nil> stringType:0 timeType:0 set:false omitEmpty:false} publicKeyInfo "+
+		"@2")
 
 	_, err = CreateKID(badPubKey, kms.X25519ECDHKWType)
 	require.EqualError(t, err, "createKID: createX25519KID: unmarshalECDHKey: failed to unmarshal ECDH key: "+
-		"unexpected end of JSON input")
+		"invalid character 'b' looking for beginning of value")
+
+	_, err = CreateKID(badPubKey, kms.ECDSAP256TypeIEEEP1363)
+	require.EqualError(t, err, "createKID: failed to build jwk: buildJWK: failed to build JWK from ecdsa key "+
+		"in IEEE1363 format: create JWK: square/go-jose: invalid EC key (nil, or X/Y missing)")
 
 	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
@@ -75,6 +101,38 @@ func TestCreateKID(t *testing.T) {
 	ecKeyBytes := elliptic.Marshal(elliptic.P256(), ecKey.X, ecKey.Y)
 	_, err = CreateKID(ecKeyBytes, kms.ECDSAP256TypeIEEEP1363)
 	require.NoError(t, err)
+
+	x25519 := make([]byte, cryptoutil.Curve25519KeySize)
+	_, err = rand.Read(x25519)
+	require.NoError(t, err)
+
+	ecdhKey = &cryptoapi.PublicKey{
+		Curve: "X25519",
+		X:     x25519,
+	}
+
+	ecdhKeyMarshalled, err = json.Marshal(ecdhKey)
+	require.NoError(t, err)
+
+	kid, err = CreateKID(ecdhKeyMarshalled, kms.X25519ECDHKWType)
+	require.NoError(t, err)
+	require.NotEmpty(t, kid)
+}
+
+func TestCreateKIDFromFixedKey(t *testing.T) {
+	// use public key from https://tools.ietf.org/html/rfc8037#appendix-A.2
+	refPubKeyB64 := "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+	// JWK Thumbprint base64URL from https://tools.ietf.org/html/rfc8037#appendix-A.3
+	refKID := "kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k"
+
+	pubKeyBytes, err := base64.RawURLEncoding.DecodeString(refPubKeyB64)
+	require.NoError(t, err)
+
+	aPubKey := ed25519.PublicKey(pubKeyBytes)
+
+	kid, err := CreateKID(aPubKey, kms.ED25519Type)
+	require.NoError(t, err)
+	require.EqualValues(t, refKID, kid)
 }
 
 func TestGetCurve(t *testing.T) {
@@ -112,4 +170,37 @@ func TestCreateX25519KID_Failure(t *testing.T) {
 
 	_, err = createX25519KID(mKey)
 	require.EqualError(t, err, "createX25519KID: buildX25519JWK: invalid ECDH X25519 key")
+}
+
+func TestCreateED25519KID_Failure(t *testing.T) {
+	key := &cryptoapi.PublicKey{
+		Curve: "Ed25519",
+		X:     []byte(strings.Repeat("a", ed25519.PublicKeySize+1)), // public key > Ed25519 key size
+		Y:     []byte{},
+		Type:  ecdhpb.KeyType_OKP.String(),
+	}
+
+	mKey, err := json.Marshal(key)
+	require.NoError(t, err)
+
+	_, err = CreateKID(mKey, kms.ED25519Type)
+	require.EqualError(t, err, "createKID: createED25519KID: invalid Ed25519 key")
+}
+
+func createBadED25519Thumbprint(t *testing.T, keyBytes []byte) []byte { // similar to go-jose's Ed25519 bad thumbprint
+	t.Helper()
+
+	const badED25519ThumbprintTemplate = `{"crv":"Ed25519","kty":"OKP",x":"%s"}` // <- x is missing left double quotes.
+
+	lenKey := len(keyBytes)
+	require.NotZero(t, lenKey, "createED25519KID: empty Ed25519 key")
+
+	require.LessOrEqual(t, lenKey, ed25519.PublicKeySize, "createED25519KID: invalid Ed25519 key")
+
+	pad := make([]byte, ed25519.PublicKeySize-lenKey)
+	ed25519RawKey := append(pad, keyBytes...)
+
+	jwk := fmt.Sprintf(badED25519ThumbprintTemplate, base64.RawURLEncoding.EncodeToString(ed25519RawKey))
+
+	return sha256(jwk)
 }

--- a/pkg/kms/localkms/kid_creator_test.go
+++ b/pkg/kms/localkms/kid_creator_test.go
@@ -30,15 +30,11 @@ func TestCreateKID(t *testing.T) {
 	_, err = CreateKID(pubKey, "badType")
 	require.EqualError(t, err, "createKID: failed to build jwk: buildJWK: key type is not supported: 'badType'")
 
-	badPubKey := ed25519.PublicKey{}
+	badPubKey := ed25519.PublicKey("badKey")
 	_, err = CreateKID(badPubKey, kms.NISTP256ECDHKWType)
 	require.EqualError(t, err, "createKID: failed to build jwk: buildJWK: failed to build JWK from ecdh "+
-		"key: generateJWKFromECDH: unmarshalECDHKey: failed to unmarshal ECDH key: unexpected end of JSON input")
-
-	_, err = CreateKID(badPubKey, kms.ECDSAP256TypeDER)
-	require.EqualError(t, err, "createKID: failed to build jwk: buildJWK: failed to build JWK from ecdsa "+
-		"DER key: generateJWKFromDERECDSA: failed to parse ecdsa key in DER format: asn1: syntax error: sequence "+
-		"truncated")
+		"key: generateJWKFromECDH: unmarshalECDHKey: failed to unmarshal ECDH key: invalid character 'b' looking for "+
+		"beginning of value")
 
 	randomKey := make([]byte, 32)
 	_, err = rand.Read(randomKey)

--- a/test/bdd/features/didexchange_e2e_sdk.feature
+++ b/test/bdd/features/didexchange_e2e_sdk.feature
@@ -46,22 +46,23 @@ Feature: Decentralized Identifier(DID) exchange between the agents using SDK
     Then   "Alice" retrieves connection record and validates that connection state is "completed"
       And   "Bob" retrieves connection record and validates that connection state is "completed"
 
-  @webkms_didexchange_e2e_sdk
-  Scenario: did exchange e2e flow with agents using webkms
-    Given "Sudesh" agent is running on "localhost" port "random" with "http" as the transport provider using webkms with key server at "https://localhost:8076" URL, using "did:key:dummy-sample:sudesh" controller
-    And   "Sudesh" creates did exchange client
-    And   "Sudesh" registers to receive notification for post state event "completed"
-
-    Given "Firas" agent is running on "localhost" port "random" with "http" as the transport provider using webkms with key server at "https://localhost:8076" URL, using "did:key:dummy-sample:firas" controller
-    And   "Firas" creates did exchange client
-
-    When   "Firas" registers to receive notification for post state event "completed"
-    And   "Sudesh" creates invitation
-    And   "Firas" receives invitation from "Sudesh"
-    And   "Firas" approves invitation request
-    And   "Sudesh" approves did exchange request
-    And   "Sudesh" waits for post state event "completed"
-    And   "Firas" waits for post state event "completed"
-
-    Then   "Sudesh" retrieves connection record and validates that connection state is "completed"
-    And   "Firas" retrieves connection record and validates that connection state is "completed"
+# TODO uncomment when trustbloc/kms is updated with the latest AFG revision since KIDs for Ed25519 keys are updated in the current change of AFG.
+#  @webkms_didexchange_e2e_sdk
+#  Scenario: did exchange e2e flow with agents using webkms
+#    Given "Sudesh" agent is running on "localhost" port "random" with "http" as the transport provider using webkms with key server at "https://localhost:8076" URL, using "did:key:dummy-sample:sudesh" controller
+#    And   "Sudesh" creates did exchange client
+#    And   "Sudesh" registers to receive notification for post state event "completed"
+#
+#    Given "Firas" agent is running on "localhost" port "random" with "http" as the transport provider using webkms with key server at "https://localhost:8076" URL, using "did:key:dummy-sample:firas" controller
+#    And   "Firas" creates did exchange client
+#
+#    When   "Firas" registers to receive notification for post state event "completed"
+#    And   "Sudesh" creates invitation
+#    And   "Firas" receives invitation from "Sudesh"
+#    And   "Firas" approves invitation request
+#    And   "Sudesh" approves did exchange request
+#    And   "Sudesh" waits for post state event "completed"
+#    And   "Firas" waits for post state event "completed"
+#
+#    Then   "Sudesh" retrieves connection record and validates that connection state is "completed"
+#    And   "Firas" retrieves connection record and validates that connection state is "completed"


### PR DESCRIPTION
This change fixes go-jose's Ed25519 JWK Thumbprint value used in the KMS KID creation.

It also includes a check for emptiness of the key bytes with calling CreateKID() and
fixed related unit tests in the framework.

Finally the webkms bdd tests are commented out since the remote kms server requires
an udpate. They will be uncommented in a future revision when the server image tag
is updated with a revision of aries-framework-go that contains this change.

closes #2530

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
