### PR TITLE
fix: IndexedDB query issues

### DIFF
--- a/component/storage/edv/go.mod
+++ b/component/storage/edv/go.mod
@@ -1,3 +1,7 @@
+// Copyright SecureKey Technologies Inc. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module github.com/hyperledger/aries-framework-go/component/storage/edv
 
 go 1.15
@@ -10,7 +14,6 @@ require (
 	github.com/hyperledger/aries-framework-go v0.1.6-0.20210205204348-bdf6f43f8864
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210205204348-bdf6f43f8864
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210205204348-bdf6f43f8864
-	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210205204348-bdf6f43f8864
+	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210219073333-c46e84ce678f
 	github.com/stretchr/testify v1.7.0
-
 )

--- a/component/storage/edv/go.sum
+++ b/component/storage/edv/go.sum
@@ -170,8 +170,8 @@ github.com/hyperledger/aries-framework-go/spi v0.0.0-20210205164538-22156a96813c
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210205204348-bdf6f43f8864 h1:NLHS9n3A/HYquZNMP3Yy/Gnix6SO49HepAJqTYVstYQ=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210205204348-bdf6f43f8864/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210205164538-22156a96813c/go.mod h1:/ljIFCu5iDIziwuvObF0vEc3fJ5dgDpT8RYAhQdNeHI=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210205204348-bdf6f43f8864 h1:JHXvaQbqXb9GxUyfSWmcoB2hhA7o3CmG2j+TmeqX01s=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210205204348-bdf6f43f8864/go.mod h1:/ljIFCu5iDIziwuvObF0vEc3fJ5dgDpT8RYAhQdNeHI=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210219073333-c46e84ce678f h1:TLj32iLLK6/bhvfJruWqjlgbw/OsC5+dMjwxpLf1D9s=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210219073333-c46e84ce678f/go.mod h1:/ljIFCu5iDIziwuvObF0vEc3fJ5dgDpT8RYAhQdNeHI=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a/go.mod h1:yL958EeXv8Ylng6IfnvG4oflryUi3vgA3xPs9hmII1s=

--- a/component/storage/indexeddb/go.mod
+++ b/component/storage/indexeddb/go.mod
@@ -10,6 +10,6 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/hyperledger/aries-framework-go v0.1.5-0.20201017112511-5734c20820a9
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210209165120-79220075f539
-	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210212132055-b94cce120dda
+	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210219073333-c46e84ce678f
 	github.com/stretchr/testify v1.6.1
 )

--- a/component/storage/indexeddb/go.sum
+++ b/component/storage/indexeddb/go.sum
@@ -109,8 +109,8 @@ github.com/hyperledger/aries-framework-go v0.1.5-0.20201017112511-5734c20820a9/g
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210205153949-f852f978a0d6/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210209165120-79220075f539 h1:cf6j6+j9C5XmpOC31fnhEeEsg8bFdRoPjKXw/SZ/mbs=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210209165120-79220075f539/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210212132055-b94cce120dda h1:9D2UmkqEPGYxDyVeJNX57geI6ivgjlnlZcIKOBShLuc=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210212132055-b94cce120dda/go.mod h1:/ljIFCu5iDIziwuvObF0vEc3fJ5dgDpT8RYAhQdNeHI=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210219073333-c46e84ce678f h1:TLj32iLLK6/bhvfJruWqjlgbw/OsC5+dMjwxpLf1D9s=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210219073333-c46e84ce678f/go.mod h1:/ljIFCu5iDIziwuvObF0vEc3fJ5dgDpT8RYAhQdNeHI=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a h1:zPPuIq2jAWWPTrGt70eK/BSch+gFAGrNzecsoENgu2o=

--- a/component/storageutil/go.mod
+++ b/component/storageutil/go.mod
@@ -9,7 +9,7 @@ go 1.15
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210210184327-0b9d0fd4c34e
-	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210210184327-0b9d0fd4c34e
+	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210219073333-c46e84ce678f
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/component/storageutil/go.sum
+++ b/component/storageutil/go.sum
@@ -6,8 +6,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210205153949-f852f978a0d6/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210210184327-0b9d0fd4c34e h1:lUWDo7zJxespMMNny3RhkFclGkfnexdcXrvc9eApYjc=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210210184327-0b9d0fd4c34e/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210210184327-0b9d0fd4c34e h1:Rwo1t3inESFu8EgqXwpJY3WbcGasexT25SiVb88eIeI=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210210184327-0b9d0fd4c34e/go.mod h1:/ljIFCu5iDIziwuvObF0vEc3fJ5dgDpT8RYAhQdNeHI=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210219073333-c46e84ce678f h1:TLj32iLLK6/bhvfJruWqjlgbw/OsC5+dMjwxpLf1D9s=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210219073333-c46e84ce678f/go.mod h1:/ljIFCu5iDIziwuvObF0vEc3fJ5dgDpT8RYAhQdNeHI=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=


### PR DESCRIPTION
- Fixed an issue where doing a query on a store with no values in it would result in an error instead of returning an iterator with no results (which is the expected behaviour).
- Fixed an issue where querying a store after deleting a key could still return those deleted keys since the tag map was not being updated on key deletion.
- Added comment above the IndexedDB SetStoreConfig method to make it clear that a store configuration must be set in order to make use of the Query method.
- Improved error message in cases where someone tries to store tags or do a query without a store configuration set.
- Updated common storage tests version, which includes new tests to check for the cases above.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>