### PR TITLE
feat: VC wallet client - KMS client &  open/close

### DIFF
--- a/pkg/client/vcwallet/client.go
+++ b/pkg/client/vcwallet/client.go
@@ -9,25 +9,138 @@ package vcwallet
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
 // provider contains dependencies for the verifiable credential wallet client
 // and is typically created by using aries.Context().
 type provider interface {
-	// TODO to be added #2433
+	StorageProvider() storage.Provider
+}
+
+// kmsOpts contains options for creating verifiable credential wallet client.
+type kmsOpts struct {
+	// local kms options
+	secretLockSvc secretlock.Service
+	passphrase    string
+
+	// remote(web) kms options
+	keyServerURL string
+}
+
+// KeyManagerOptions is option for verifiable credential wallet client key manager.
+type KeyManagerOptions func(opts *kmsOpts)
+
+// WithSecretLockService option, when provided then wallet client will use local kms for key operations.
+func WithSecretLockService(svc secretlock.Service) KeyManagerOptions {
+	return func(opts *kmsOpts) {
+		opts.secretLockSvc = svc
+	}
+}
+
+// WithPassphrase option to provide passphrase for local kms for key operations.
+func WithPassphrase(passphrase string) KeyManagerOptions {
+	return func(opts *kmsOpts) {
+		opts.passphrase = passphrase
+	}
+}
+
+// WithKeyServerURL option, when provided then wallet client will use remote kms for key operations.
+// This option will be ignore if provided with 'WithSecretLockService' option.
+func WithKeyServerURL(url string) KeyManagerOptions {
+	return func(opts *kmsOpts) {
+		opts.keyServerURL = url
+	}
 }
 
 // Client enable access to verifiable credential wallet features.
 type Client struct {
 	// ID of wallet content owner
 	userID string
+
+	// wallet profile
+	profile *profile
+
+	// storage provider
+	storeProvider storage.Provider
 }
 
 // New returns new verifiable credential wallet client for given user.
-func New(userID string, ctx provider) *Client {
-	// TODO initialize providers for stores, VDR, KMS #2433
-	// TODO create user profile if not already created #2433
-	return &Client{userID: userID}
+// returns error if wallet profile is not found.
+// To create a new wallet profile, use `CreateProfile()`.
+// To update an existing profile, use `UpdateProfile()`.
+func New(userID string, ctx provider) (*Client, error) {
+	store, err := newProfileStore(ctx.StorageProvider())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get store to fetch VC wallet profile info: %w", err)
+	}
+
+	profile, err := store.get(userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get VC wallet profile: %w", err)
+	}
+
+	return &Client{userID: userID, profile: profile, storeProvider: ctx.StorageProvider()}, nil
+}
+
+// CreateProfile creates a new verifiable credential wallet profile for given user.
+// returns error if wallet profile is already created.
+// Use `UpdateProfile()` for replacing an already created verifiable credential wallet profile.
+func CreateProfile(userID string, ctx provider, options ...KeyManagerOptions) error {
+	return createOrUpdate(userID, ctx, false, options...)
+}
+
+// UpdateProfile updates existing verifiable credential wallet profile.
+// Will create new profile if no profile exists for given user.
+// Caution: you might lose your existing keys if you change kms options.
+func UpdateProfile(userID string, ctx provider, options ...KeyManagerOptions) error {
+	return createOrUpdate(userID, ctx, true, options...)
+}
+
+func createOrUpdate(userID string, ctx provider, update bool, options ...KeyManagerOptions) error {
+	opts := &kmsOpts{}
+
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	profile, err := createProfile(userID, opts.passphrase, opts.secretLockSvc, opts.keyServerURL)
+	if err != nil {
+		return fmt.Errorf("failed to create new VC wallet client: %w", err)
+	}
+
+	store, err := newProfileStore(ctx.StorageProvider())
+	if err != nil {
+		return fmt.Errorf("failed to get store to save VC wallet profile: %w", err)
+	}
+
+	err = store.save(profile, update)
+	if err != nil {
+		return fmt.Errorf("failed to save VC wallet profile: %w", err)
+	}
+
+	return nil
+}
+
+// Open unlocks wallet client's key manager instance and returns a token for subsequent use of wallet features.
+//
+//	Args:
+//		- auth : auth token in case of remotekms or passphrase in case of localkms.
+//		- secretLockSvc: secret lock service for localkms if you choose not to provide passphrase.
+//		- tokenExpiry : (optional, default: 10 * time.minute) time duration after which issued token will expiry.
+//
+//	Returns token with expiry that can be used for subsequent use of wallet features.
+func (c *Client) Open(auth string, secretLockSvc secretlock.Service, tokenExpiry time.Duration) (string, error) {
+	return keyManager().createKeyManager(c.profile, c.storeProvider, auth, secretLockSvc, tokenExpiry)
+}
+
+// Close expires token issued to this VC wallet client.
+// returns false if token is not found or already expired for this wallet user.
+func (c *Client) Close() bool {
+	return keyManager().removeKeyManager(c.userID)
 }
 
 // Export produces a serialized exported wallet representation.

--- a/pkg/client/vcwallet/client_test.go
+++ b/pkg/client/vcwallet/client_test.go
@@ -7,24 +7,313 @@ SPDX-License-Identifier: Apache-2.0
 package vcwallet
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/mock/secretlock"
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/local/masterlock/pbkdf2"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
 )
 
 const (
 	sampleUserID       = "sample-user01"
 	toBeImplementedErr = "to be implemented"
+	sampleClientErr    = "sample client err"
 )
 
+func TestCreate(t *testing.T) {
+	t.Run("test create new wallet client using local kms passphrase", func(t *testing.T) {
+		mockctx := newMockProvider()
+		err := CreateProfile(sampleUserID, mockctx, WithPassphrase(samplePassPhrase))
+		require.NoError(t, err)
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, wallet)
+	})
+
+	t.Run("test create new wallet client using local kms secret lock service", func(t *testing.T) {
+		mockctx := newMockProvider()
+		err := CreateProfile(sampleUserID, mockctx, WithSecretLockService(&secretlock.MockSecretLock{}))
+		require.NoError(t, err)
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, wallet)
+	})
+
+	t.Run("test create new wallet client using remote kms key server URL", func(t *testing.T) {
+		mockctx := newMockProvider()
+		err := CreateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+		require.NoError(t, err)
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, wallet)
+	})
+
+	t.Run("test create new wallet failure", func(t *testing.T) {
+		mockctx := newMockProvider()
+		err := CreateProfile(sampleUserID, mockctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid create profile options")
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.Error(t, err)
+		require.Empty(t, wallet)
+	})
+
+	t.Run("test create new wallet failure - create store error", func(t *testing.T) {
+		mockctx := newMockProvider()
+		mockctx.storeProvider = &mockstorage.MockStoreProvider{
+			ErrOpenStoreHandle: fmt.Errorf(sampleClientErr),
+		}
+
+		err := CreateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), sampleClientErr)
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.Error(t, err)
+		require.Empty(t, wallet)
+	})
+
+	t.Run("test create new wallet failure - save profile error", func(t *testing.T) {
+		mockctx := newMockProvider()
+		mockctx.storeProvider = &mockstorage.MockStoreProvider{
+			Store: &mockstorage.MockStore{
+				ErrPut: fmt.Errorf(sampleClientErr),
+			},
+		}
+
+		err := CreateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), sampleClientErr)
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.Error(t, err)
+		require.Empty(t, wallet)
+	})
+}
+
+func TestUpdate(t *testing.T) {
+	t.Run("test update wallet client using local kms passphrase", func(t *testing.T) {
+		mockctx := newMockProvider()
+		err := UpdateProfile(sampleUserID, mockctx, WithPassphrase(samplePassPhrase))
+		require.NoError(t, err)
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, wallet)
+	})
+
+	t.Run("test update wallet client using local kms secret lock service", func(t *testing.T) {
+		mockctx := newMockProvider()
+		err := UpdateProfile(sampleUserID, mockctx, WithSecretLockService(&secretlock.MockSecretLock{}))
+		require.NoError(t, err)
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, wallet)
+	})
+
+	t.Run("test update wallet client using remote kms key server URL", func(t *testing.T) {
+		mockctx := newMockProvider()
+		err := UpdateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+		require.NoError(t, err)
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, wallet)
+	})
+
+	t.Run("test update wallet failure", func(t *testing.T) {
+		mockctx := newMockProvider()
+		err := UpdateProfile(sampleUserID, mockctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid create profile options")
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.Error(t, err)
+		require.Empty(t, wallet)
+	})
+
+	t.Run("test update wallet failure - create store error", func(t *testing.T) {
+		mockctx := newMockProvider()
+		mockctx.storeProvider = &mockstorage.MockStoreProvider{
+			ErrOpenStoreHandle: fmt.Errorf(sampleClientErr),
+		}
+
+		err := UpdateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), sampleClientErr)
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.Error(t, err)
+		require.Empty(t, wallet)
+	})
+
+	t.Run("test update wallet failure - save profile error", func(t *testing.T) {
+		mockctx := newMockProvider()
+		mockctx.storeProvider = &mockstorage.MockStoreProvider{
+			Store: &mockstorage.MockStore{
+				ErrPut: fmt.Errorf(sampleClientErr),
+			},
+		}
+
+		err := UpdateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), sampleClientErr)
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.Error(t, err)
+		require.Empty(t, wallet)
+	})
+}
+
 func TestNew(t *testing.T) {
-	vcWalletClient := New(sampleUserID, nil)
-	require.NotEmpty(t, vcWalletClient)
+	t.Run("test get client by user", func(t *testing.T) {
+		mockctx := newMockProvider()
+		// create a wallet
+		err := CreateProfile(sampleUserID, mockctx, WithPassphrase(samplePassPhrase))
+		require.NoError(t, err)
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, wallet)
+	})
+
+	t.Run("test get client by invalid userID", func(t *testing.T) {
+		mockctx := newMockProvider()
+		err := CreateProfile(sampleUserID, mockctx, WithPassphrase(samplePassPhrase))
+		require.NoError(t, err)
+
+		wallet, err := New(sampleUserID+"invalid", mockctx)
+		require.Empty(t, wallet)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "profile does not exist")
+	})
+
+	t.Run("test update wallet failure - save profile error", func(t *testing.T) {
+		mockctx := newMockProvider()
+		mockctx.storeProvider = &mockstorage.MockStoreProvider{
+			ErrOpenStoreHandle: fmt.Errorf(sampleClientErr),
+		}
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.Error(t, err)
+		require.Empty(t, wallet)
+		require.Contains(t, err.Error(), sampleClientErr)
+	})
+}
+
+func TestClient_OpenClose(t *testing.T) {
+	t.Run("test open & close wallet using local kms passphrase", func(t *testing.T) {
+		mockctx := newMockProvider()
+		err := CreateProfile(sampleUserID, mockctx, WithPassphrase(samplePassPhrase))
+		require.NoError(t, err)
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, wallet)
+
+		// get token
+		token, err := wallet.Open(samplePassPhrase, nil, 0)
+		require.NoError(t, err)
+		require.NotEmpty(t, token)
+
+		// try again
+		token, err = wallet.Open(samplePassPhrase, nil, 0)
+		require.Empty(t, token)
+		require.Error(t, err)
+		require.Equal(t, err, ErrAlreadyUnlocked)
+
+		// close wallet
+		require.True(t, wallet.Close())
+		require.False(t, wallet.Close())
+
+		// try to open with wrong passphrase
+		token, err = wallet.Open(samplePassPhrase+"wrong", nil, 0)
+		require.Empty(t, token)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "message authentication failed")
+	})
+
+	t.Run("test open & close wallet using secret lock service", func(t *testing.T) {
+		mockctx := newMockProvider()
+		masterLock, err := pbkdf2.NewMasterLock(samplePassPhrase, sha256.New, 0, nil)
+		require.NoError(t, err)
+
+		err = CreateProfile(sampleUserID, mockctx, WithSecretLockService(masterLock))
+		require.NoError(t, err)
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, wallet)
+
+		// get token
+		token, err := wallet.Open("", masterLock, 0)
+		require.NoError(t, err)
+		require.NotEmpty(t, token)
+
+		// try again
+		token, err = wallet.Open("", masterLock, 0)
+		require.Empty(t, token)
+		require.Error(t, err)
+		require.Equal(t, err, ErrAlreadyUnlocked)
+
+		// close wallet
+		require.True(t, wallet.Close())
+		require.False(t, wallet.Close())
+
+		// try to open with wrong secret lock service
+		badLock, err := pbkdf2.NewMasterLock(samplePassPhrase+"wrong", sha256.New, 0, nil)
+		require.NoError(t, err)
+
+		token, err = wallet.Open("", badLock, 0)
+		require.Empty(t, token)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "message authentication failed")
+	})
+
+	t.Run("test open & close wallet using remote kms URL", func(t *testing.T) {
+		mockctx := newMockProvider()
+		err := CreateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+		require.NoError(t, err)
+
+		wallet, err := New(sampleUserID, mockctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, wallet)
+
+		// get token
+		token, err := wallet.Open(sampleRemoteKMSAuth, nil, 0)
+		require.NoError(t, err)
+		require.NotEmpty(t, token)
+
+		// try again
+		token, err = wallet.Open(sampleRemoteKMSAuth, nil, 0)
+		require.Empty(t, token)
+		require.Error(t, err)
+		require.Equal(t, err, ErrAlreadyUnlocked)
+
+		// close wallet
+		require.True(t, wallet.Close())
+		require.False(t, wallet.Close())
+	})
 }
 
 func TestClient_Export(t *testing.T) {
-	vcWalletClient := New(sampleUserID, nil)
+	mockctx := newMockProvider()
+	err := CreateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+	require.NoError(t, err)
+
+	vcWalletClient, err := New(sampleUserID, mockctx)
 	require.NotEmpty(t, vcWalletClient)
+	require.NoError(t, err)
 
 	result, err := vcWalletClient.Export("")
 	require.Empty(t, result)
@@ -33,35 +322,55 @@ func TestClient_Export(t *testing.T) {
 }
 
 func TestClient_Import(t *testing.T) {
-	vcWalletClient := New(sampleUserID, nil)
-	require.NotEmpty(t, vcWalletClient)
+	mockctx := newMockProvider()
+	err := CreateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+	require.NoError(t, err)
 
-	err := vcWalletClient.Import("", nil)
+	vcWalletClient, err := New(sampleUserID, mockctx)
+	require.NotEmpty(t, vcWalletClient)
+	require.NoError(t, err)
+
+	err = vcWalletClient.Import("", nil)
 	require.Error(t, err)
 	require.EqualError(t, err, toBeImplementedErr)
 }
 
 func TestClient_Add(t *testing.T) {
-	vcWalletClient := New(sampleUserID, nil)
-	require.NotEmpty(t, vcWalletClient)
+	mockctx := newMockProvider()
+	err := CreateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+	require.NoError(t, err)
 
-	err := vcWalletClient.Add(nil)
+	vcWalletClient, err := New(sampleUserID, mockctx)
+	require.NotEmpty(t, vcWalletClient)
+	require.NoError(t, err)
+
+	err = vcWalletClient.Add(nil)
 	require.Error(t, err)
 	require.EqualError(t, err, toBeImplementedErr)
 }
 
 func TestClient_Remove(t *testing.T) {
-	vcWalletClient := New(sampleUserID, nil)
-	require.NotEmpty(t, vcWalletClient)
+	mockctx := newMockProvider()
+	err := CreateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+	require.NoError(t, err)
 
-	err := vcWalletClient.Remove("")
+	vcWalletClient, err := New(sampleUserID, mockctx)
+	require.NotEmpty(t, vcWalletClient)
+	require.NoError(t, err)
+
+	err = vcWalletClient.Remove("")
 	require.Error(t, err)
 	require.EqualError(t, err, toBeImplementedErr)
 }
 
 func TestClient_Get(t *testing.T) {
-	vcWalletClient := New(sampleUserID, nil)
+	mockctx := newMockProvider()
+	err := CreateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+	require.NoError(t, err)
+
+	vcWalletClient, err := New(sampleUserID, mockctx)
 	require.NotEmpty(t, vcWalletClient)
+	require.NoError(t, err)
 
 	result, err := vcWalletClient.Get("")
 	require.Empty(t, result)
@@ -70,8 +379,13 @@ func TestClient_Get(t *testing.T) {
 }
 
 func TestClient_Query(t *testing.T) {
-	vcWalletClient := New(sampleUserID, nil)
+	mockctx := newMockProvider()
+	err := CreateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+	require.NoError(t, err)
+
+	vcWalletClient, err := New(sampleUserID, mockctx)
 	require.NotEmpty(t, vcWalletClient)
+	require.NoError(t, err)
 
 	results, err := vcWalletClient.Query(&QueryParams{})
 	require.Empty(t, results)
@@ -80,8 +394,13 @@ func TestClient_Query(t *testing.T) {
 }
 
 func TestClient_Issue(t *testing.T) {
-	vcWalletClient := New(sampleUserID, nil)
+	mockctx := newMockProvider()
+	err := CreateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+	require.NoError(t, err)
+
+	vcWalletClient, err := New(sampleUserID, mockctx)
 	require.NotEmpty(t, vcWalletClient)
+	require.NoError(t, err)
 
 	result, err := vcWalletClient.Issue(nil, &ProofOptions{})
 	require.Empty(t, result)
@@ -90,8 +409,13 @@ func TestClient_Issue(t *testing.T) {
 }
 
 func TestClient_Prove(t *testing.T) {
-	vcWalletClient := New(sampleUserID, nil)
+	mockctx := newMockProvider()
+	err := CreateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+	require.NoError(t, err)
+
+	vcWalletClient, err := New(sampleUserID, mockctx)
 	require.NotEmpty(t, vcWalletClient)
+	require.NoError(t, err)
 
 	result, err := vcWalletClient.Prove(nil, &ProofOptions{})
 	require.Empty(t, result)
@@ -100,11 +424,29 @@ func TestClient_Prove(t *testing.T) {
 }
 
 func TestClient_Verify(t *testing.T) {
-	vcWalletClient := New(sampleUserID, nil)
+	mockctx := newMockProvider()
+	err := CreateProfile(sampleUserID, mockctx, WithKeyServerURL(sampleKeyServerURL))
+	require.NoError(t, err)
+
+	vcWalletClient, err := New(sampleUserID, mockctx)
 	require.NotEmpty(t, vcWalletClient)
+	require.NoError(t, err)
 
 	result, err := vcWalletClient.Verify(nil)
 	require.Empty(t, result)
 	require.Error(t, err)
 	require.EqualError(t, err, toBeImplementedErr)
+}
+
+type mockProvider struct {
+	storeProvider storage.Provider
+}
+
+// StorageProvider returns the mock storage provider.
+func (p *mockProvider) StorageProvider() storage.Provider {
+	return p.storeProvider
+}
+
+func newMockProvider() *mockProvider {
+	return &mockProvider{storeProvider: mockstorage.NewMockStoreProvider()}
 }

--- a/pkg/client/vcwallet/kmsclient.go
+++ b/pkg/client/vcwallet/kmsclient.go
@@ -1,0 +1,207 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vcwallet
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/bluele/gcache"
+	"github.com/google/tink/go/subtle/random"
+	"github.com/google/uuid"
+
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/webkms"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/local"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/local/masterlock/hkdf"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+const (
+	// LocalKeyURIPrefix for locally stored keys.
+	localKeyURIPrefix = "local-lock://"
+
+	defaultCacheExpiry = 10 * time.Minute
+)
+
+// ErrAlreadyUnlocked error when key manager is already created for a given user.
+var ErrAlreadyUnlocked = errors.New("profile already unlocked")
+
+// walletKMSInstance is key manager store singleton - access only via keyManager()
+//nolint:gochecknoglobals
+var (
+	walletKMSInstance *walletKeyManager
+	kmsStoreOnce      sync.Once
+)
+
+func keyManager() *walletKeyManager {
+	kmsStoreOnce.Do(func() {
+		walletKMSInstance = &walletKeyManager{
+			gstore: gcache.New(0).Build(),
+		}
+	})
+
+	return walletKMSInstance
+}
+
+// walletKeyManager manages key manager instances in cache.
+// underlying gcache is threasafe, no need of locks.
+type walletKeyManager struct {
+	gstore gcache.Cache
+}
+
+func (k *walletKeyManager) createKeyManager(profileInfo *profile, storeProvider storage.Provider, auth string,
+	secretLockSvc secretlock.Service, expiration time.Duration) (string, error) {
+	if profileInfo.MasterLockCipher == "" && profileInfo.KeyServerURL == "" {
+		return "", fmt.Errorf("invalid wallet profile")
+	}
+
+	// get user from cache if token already exists
+	token, _ := k.getKeyMangerToken(profileInfo.User) //nolint: errcheck
+	if token != "" {
+		return "", ErrAlreadyUnlocked
+	}
+
+	var err error
+
+	var keyManager kms.KeyManager
+
+	// create key manager
+	if profileInfo.MasterLockCipher != "" {
+		// local kms
+		keyManager, err = createLocalKeyManager(profileInfo.User, auth,
+			profileInfo.MasterLockCipher, secretLockSvc, storeProvider)
+		if err != nil {
+			return "", fmt.Errorf("failed to create local key manager: %w", err)
+		}
+	} else {
+		// remote kms
+		keyManager = createRemoteKeyManager(auth, profileInfo.KeyServerURL)
+	}
+
+	// generate token
+	token = uuid.New().String()
+
+	// save key manager
+	err = k.saveKeyManger(profileInfo.User, token, keyManager, expiration)
+	if err != nil {
+		return "", fmt.Errorf("failed to persist local key manager: %w", err)
+	}
+
+	return token, nil
+}
+
+// TODO refresh expiry on each access.
+func (k *walletKeyManager) saveKeyManger(user, key string, manager kms.KeyManager, expiration time.Duration) error {
+	if expiration == 0 {
+		expiration = defaultCacheExpiry
+	}
+
+	err := k.gstore.SetWithExpire(user, key, expiration)
+	if err != nil {
+		return err
+	}
+
+	return k.gstore.SetWithExpire(key, manager, expiration)
+}
+
+func (k *walletKeyManager) getKeyManger(key string) (kms.KeyManager, error) {
+	val, err := k.gstore.Get(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return val.(kms.KeyManager), nil
+}
+
+func (k *walletKeyManager) getKeyMangerToken(user string) (string, error) {
+	val, err := k.gstore.Get(user)
+	if err != nil {
+		return "", err
+	}
+
+	return val.(string), nil
+}
+
+func (k *walletKeyManager) removeKeyManager(user string) bool {
+	token, _ := k.getKeyMangerToken(user) //nolint: errcheck
+	if token != "" {
+		return k.gstore.Remove(token) && k.gstore.Remove(user)
+	}
+
+	return false
+}
+
+// createMasterLock creates master lock from secret lock service provided.
+func createMasterLock(secretLockSvc secretlock.Service) (string, error) {
+	masterKeyContent := random.GetRandomBytes(uint32(32)) //nolint: gomnd
+
+	masterLockEnc, err := secretLockSvc.Encrypt(localKeyURIPrefix, &secretlock.EncryptRequest{
+		Plaintext: string(masterKeyContent),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create master lock from secret lock service provided: %w", err)
+	}
+
+	return masterLockEnc.Ciphertext, nil
+}
+
+type kmsProvider struct {
+	storageProvider storage.Provider
+	secretLock      secretlock.Service
+}
+
+func (k kmsProvider) StorageProvider() storage.Provider {
+	return k.storageProvider
+}
+
+func (k kmsProvider) SecretLock() secretlock.Service {
+	return k.secretLock
+}
+
+// createLocalKeyManager creates and returns local KMS instance.
+func createLocalKeyManager(user, passphrase, masterLockCipher string,
+	masterLocker secretlock.Service, storeProvider storage.Provider) (*localkms.LocalKMS, error) {
+	var err error
+	if passphrase != "" {
+		masterLocker, err = getDefaultSecretLock(passphrase)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	secretLockSvc, err := local.NewService(bytes.NewBufferString(masterLockCipher), masterLocker)
+	if err != nil {
+		return nil, err
+	}
+
+	return localkms.New(localKeyURIPrefix+user, &kmsProvider{
+		storageProvider: storeProvider,
+		secretLock:      secretLockSvc,
+	})
+}
+
+// getDefaultSecretLock returns hkdf secret lock service from passphrase.
+func getDefaultSecretLock(passphrase string) (secretlock.Service, error) {
+	return hkdf.NewMasterLock(passphrase, sha256.New, nil)
+}
+
+// createLocalKeyManager creates and returns remote KMS instance.
+func createRemoteKeyManager(auth, keyServerURL string) *webkms.RemoteKMS {
+	return webkms.New(keyServerURL, http.DefaultClient, webkms.WithHeaders(func(req *http.Request) (*http.Header, error) {
+		req.Header.Set("authorization", fmt.Sprintf("Bearer %s", auth))
+
+		return &req.Header, nil
+	}))
+}

--- a/pkg/client/vcwallet/kmsclient_test.go
+++ b/pkg/client/vcwallet/kmsclient_test.go
@@ -1,0 +1,249 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vcwallet
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	kmsapi "github.com/hyperledger/aries-framework-go/pkg/kms"
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/local/masterlock/pbkdf2"
+)
+
+const (
+	samplePassPhrase    = "fakepassphrase"
+	sampleRemoteKMSAuth = "sample-auth-token"
+	keyNotFoundErr      = "Key not found."
+)
+
+func TestKeyManagerStore(t *testing.T) {
+	t.Run("test key manager instance", func(t *testing.T) {
+		require.NotEmpty(t, keyManager())
+		require.Equal(t, keyManager(), keyManager())
+	})
+}
+
+func TestKeyManager(t *testing.T) {
+	t.Run("create key manager for localkms - with passphrase", func(t *testing.T) {
+		sampleUser := uuid.New().String()
+		masterLock, err := getDefaultSecretLock(samplePassPhrase)
+		require.NoError(t, err)
+
+		masterLockCipherText, err := createMasterLock(masterLock)
+		require.NoError(t, err)
+		require.NotEmpty(t, masterLockCipherText)
+
+		profileInfo := &profile{
+			User:             sampleUser,
+			MasterLockCipher: masterLockCipherText,
+		}
+
+		tkn, err := keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
+			samplePassPhrase, nil, 0)
+		require.NoError(t, err)
+		require.NotEmpty(t, tkn)
+
+		// get key manager
+		kms, err := keyManager().getKeyManger(tkn)
+		require.NoError(t, err)
+		require.NotEmpty(t, kms)
+
+		// try to create again before expiry
+		tkn, err = keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
+			samplePassPhrase, nil, 0)
+		require.Error(t, err)
+		require.Equal(t, err, ErrAlreadyUnlocked)
+		require.Empty(t, tkn)
+	})
+
+	t.Run("create key manager for localkms - with secret lock service", func(t *testing.T) {
+		sampleUser := uuid.New().String()
+		masterLock, err := pbkdf2.NewMasterLock(samplePassPhrase, sha256.New, 0, nil)
+		require.NoError(t, err)
+
+		masterLockCipherText, err := createMasterLock(masterLock)
+		require.NoError(t, err)
+		require.NotEmpty(t, masterLockCipherText)
+
+		profileInfo := &profile{
+			User:             sampleUser,
+			MasterLockCipher: masterLockCipherText,
+		}
+
+		tkn, err := keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
+			"", masterLock, 0)
+		require.NoError(t, err)
+		require.NotEmpty(t, tkn)
+
+		// get key manager
+		kms, err := keyManager().getKeyManger(tkn)
+		require.NoError(t, err)
+		require.NotEmpty(t, kms)
+
+		// try to create again before expiry
+		tkn, err = keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
+			"", masterLock, 0)
+		require.Error(t, err)
+		require.Equal(t, err, ErrAlreadyUnlocked)
+		require.Empty(t, tkn)
+	})
+
+	t.Run("create key manager for localkms - passphrase missmatch", func(t *testing.T) {
+		sampleUser := uuid.New().String()
+		masterLock, err := getDefaultSecretLock(samplePassPhrase)
+		require.NoError(t, err)
+
+		masterLockCipherText, err := createMasterLock(masterLock)
+		require.NoError(t, err)
+		require.NotEmpty(t, masterLockCipherText)
+
+		profileInfo := &profile{
+			User:             sampleUser,
+			MasterLockCipher: masterLockCipherText,
+		}
+
+		// use wrong passphrase
+		tkn, err := keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
+			samplePassPhrase+"wrong", nil, 0)
+		require.Empty(t, tkn)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "message authentication failed")
+
+		// get key manager
+		kms, err := keyManager().getKeyManger(tkn)
+		require.Empty(t, kms)
+		require.Error(t, err)
+		require.EqualError(t, err, keyNotFoundErr)
+	})
+
+	t.Run("create key manager for localkms - secret lock service missmatch", func(t *testing.T) {
+		sampleUser := uuid.New().String()
+		masterLock, err := pbkdf2.NewMasterLock(samplePassPhrase, sha256.New, 0, nil)
+		require.NoError(t, err)
+
+		masterLockCipherText, err := createMasterLock(masterLock)
+		require.NoError(t, err)
+		require.NotEmpty(t, masterLockCipherText)
+
+		profileInfo := &profile{
+			User:             sampleUser,
+			MasterLockCipher: masterLockCipherText,
+		}
+
+		// use wrong secret lock service
+		masterLockBad, err := pbkdf2.NewMasterLock(samplePassPhrase+"wrong", sha256.New, 0, nil)
+		require.NoError(t, err)
+
+		tkn, err := keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
+			"", masterLockBad, 0)
+		require.Empty(t, tkn)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "message authentication failed")
+
+		// get key manager
+		kms, err := keyManager().getKeyManger(tkn)
+		require.Empty(t, kms)
+		require.Error(t, err)
+		require.EqualError(t, err, keyNotFoundErr)
+	})
+
+	t.Run("create key manager for remotekms", func(t *testing.T) {
+		sampleUser := uuid.New().String()
+		profileInfo := &profile{
+			User:         sampleUser,
+			KeyServerURL: sampleKeyServerURL,
+		}
+
+		tkn, err := keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
+			sampleRemoteKMSAuth, nil, 0)
+		require.NoError(t, err)
+		require.NotEmpty(t, tkn)
+
+		// get key manager
+		kmgr, err := keyManager().getKeyManger(tkn)
+		require.NoError(t, err)
+		require.NotEmpty(t, kmgr)
+
+		_, _, err = kmgr.Create(kmsapi.ED25519Type)
+		require.Error(t, err)
+
+		// try to create again before expiry
+		tkn, err = keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
+			sampleRemoteKMSAuth, nil, 0)
+		require.Error(t, err)
+		require.Equal(t, err, ErrAlreadyUnlocked)
+		require.Empty(t, tkn)
+	})
+
+	t.Run("create key manager for failure - invalid profile", func(t *testing.T) {
+		profileInfo := &profile{
+			User: uuid.New().String(),
+		}
+
+		tkn, err := keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
+			sampleRemoteKMSAuth, nil, 0)
+		require.Empty(t, tkn)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid wallet profile")
+
+		// get key manager
+		kms, err := keyManager().getKeyManger(tkn)
+		require.Empty(t, kms)
+		require.Error(t, err)
+		require.EqualError(t, err, keyNotFoundErr)
+	})
+
+	t.Run("test remove key manager", func(t *testing.T) {
+		sampleUser := uuid.New().String()
+		profileInfo := &profile{
+			User:         sampleUser,
+			KeyServerURL: sampleKeyServerURL,
+		}
+
+		tkn, err := keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
+			sampleRemoteKMSAuth, nil, 0)
+		require.NoError(t, err)
+		require.NotEmpty(t, tkn)
+
+		// get key manager
+		kmgr, err := keyManager().getKeyManger(tkn)
+		require.NoError(t, err)
+		require.NotEmpty(t, kmgr)
+
+		// try to create again before expiry
+		tkn, err = keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
+			sampleRemoteKMSAuth, nil, 0)
+		require.Error(t, err)
+		require.Equal(t, err, ErrAlreadyUnlocked)
+		require.Empty(t, tkn)
+
+		// remove key manager
+		require.True(t, keyManager().removeKeyManager(profileInfo.User))
+		require.False(t, keyManager().removeKeyManager(profileInfo.User))
+
+		// try to get key manager
+		kmgr, err = keyManager().getKeyManger(tkn)
+		require.Empty(t, kmgr)
+		require.Error(t, err)
+		require.EqualError(t, err, keyNotFoundErr)
+
+		// try again to create
+		tkn, err = keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
+			sampleRemoteKMSAuth, nil, 0)
+		require.NoError(t, err)
+		require.NotEmpty(t, tkn)
+
+		// get key manager
+		kmgr, err = keyManager().getKeyManger(tkn)
+		require.NoError(t, err)
+		require.NotEmpty(t, kmgr)
+	})
+}

--- a/pkg/client/vcwallet/profile.go
+++ b/pkg/client/vcwallet/profile.go
@@ -1,0 +1,132 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vcwallet
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
+	"github.com/hyperledger/aries-framework-go/pkg/storage"
+)
+
+const (
+	profileStoreName          = "vcwallet_profiles"
+	profileStoreUserKeyPrefix = "vcwallet_usr_%s"
+)
+
+// ErrProfileNotFound error for wallet profile not found scenario.
+var ErrProfileNotFound = errors.New("profile does not exist")
+
+// profile of VC wallet contains wallet specific settings of wallet user to be remembered.
+type profile struct {
+	// User ID of the wallet profile user.
+	User string
+
+	// Encrypted MasterLock is for localkms.
+	MasterLockCipher string
+
+	// KeyServerURL for remotekms.
+	KeyServerURL string
+}
+
+// createProfile creates new verifiable credential wallet profile for given user and saves it in store.
+// This profile is required for creating verifiable credential wallet client.
+func createProfile(user, passphrase string, secretLockSvc secretlock.Service, keyServerURL string) (*profile, error) {
+	profile := &profile{User: user}
+
+	var err error
+
+	switch {
+	case passphrase != "":
+		// localkms with passphrase
+		secretLockSvc, err = getDefaultSecretLock(passphrase)
+		if err != nil {
+			return nil, err
+		}
+
+		profile.MasterLockCipher, err = createMasterLock(secretLockSvc)
+		if err != nil {
+			return nil, err
+		}
+		// local
+	case secretLockSvc != nil:
+		// localkms with secret lock service
+		profile.MasterLockCipher, err = createMasterLock(secretLockSvc)
+		if err != nil {
+			return nil, err
+		}
+	case keyServerURL != "":
+		// remotekms
+		profile.KeyServerURL = keyServerURL
+	default:
+		return nil, fmt.Errorf("invalid create profile options")
+	}
+
+	return profile, nil
+}
+
+// getUserKeyPrefix is key prefix for vc wallet profile store user key.
+func getUserKeyPrefix(user string) string {
+	return fmt.Sprintf(profileStoreUserKeyPrefix, user)
+}
+
+// newProfileStore creates new profile store.
+func newProfileStore(provider storage.Provider) (*profileStore, error) {
+	store, err := provider.OpenStore(profileStoreName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &profileStore{store: store}, nil
+}
+
+// profileStore is store for vc wallet profiles contains unique collection of user profile info.
+// key --> userID, val --> profile.
+type profileStore struct {
+	store storage.Store
+}
+
+// getProfile gets profile from store.
+func (p *profileStore) get(user string) (*profile, error) {
+	profileBytes, err := p.store.Get(getUserKeyPrefix(user))
+	if err != nil {
+		if errors.Is(err, storage.ErrDataNotFound) {
+			return nil, ErrProfileNotFound
+		}
+
+		return nil, err
+	}
+
+	var result profile
+
+	err = json.Unmarshal(profileBytes, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// save saves profile into store,
+// if argument 'override=true' then replaces existing profile for given user else returns error.
+func (p *profileStore) save(val *profile, override bool) error {
+	if !override {
+		profileBytes, _ := p.get(val.User) //nolint: errcheck
+		if profileBytes != nil {
+			return fmt.Errorf("profile already exists for given user")
+		}
+	}
+
+	profileBytes, err := json.Marshal(val)
+	if err != nil {
+		return err
+	}
+
+	return p.store.Put(getUserKeyPrefix(val.User), profileBytes)
+}

--- a/pkg/client/vcwallet/profile_test.go
+++ b/pkg/client/vcwallet/profile_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vcwallet
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/mock/secretlock"
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+)
+
+const (
+	sampleProfileUser      = "sampleProfileUser#01"
+	sampleKeyServerURL     = "sample/keyserver/test"
+	sampleMasterCipherText = "sample-master-cipher"
+	sampleCustomProfileErr = "sample profile custom error"
+)
+
+func TestCreateNewProfile(t *testing.T) {
+	t.Run("test create new profile with key server URL", func(t *testing.T) {
+		profile, err := createProfile(sampleProfileUser, "", nil, sampleKeyServerURL)
+
+		require.NoError(t, err)
+		require.NotEmpty(t, profile)
+		require.Equal(t, profile.KeyServerURL, sampleKeyServerURL)
+		require.Empty(t, profile.MasterLockCipher)
+	})
+
+	t.Run("test create new profile with passphrase", func(t *testing.T) {
+		profile, err := createProfile(sampleProfileUser, samplePassPhrase, nil, "")
+
+		require.NoError(t, err)
+		require.NotEmpty(t, profile)
+		require.Empty(t, profile.KeyServerURL, "")
+		require.NotEmpty(t, profile.MasterLockCipher)
+	})
+
+	t.Run("test create new profile with secret lock service", func(t *testing.T) {
+		profile, err := createProfile(sampleProfileUser, "", &secretlock.MockSecretLock{
+			ValEncrypt: sampleMasterCipherText,
+		}, sampleKeyServerURL)
+
+		require.NoError(t, err)
+		require.NotEmpty(t, profile)
+		require.Empty(t, profile.KeyServerURL, "")
+		require.Equal(t, profile.MasterLockCipher, sampleMasterCipherText)
+	})
+
+	t.Run("test create new profile failure", func(t *testing.T) {
+		// invalid profile option
+		profile, err := createProfile(sampleProfileUser, "", nil, "")
+
+		require.Empty(t, profile)
+		require.Error(t, err)
+		require.EqualError(t, err, "invalid create profile options")
+
+		// secret lock service error
+		profile, err = createProfile(sampleProfileUser, "", &secretlock.MockSecretLock{
+			ErrEncrypt: fmt.Errorf(sampleCustomProfileErr),
+		}, "")
+
+		require.Empty(t, profile)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to create master lock from secret lock service provided")
+		require.Contains(t, err.Error(), sampleCustomProfileErr)
+	})
+}
+
+func TestProfileStore(t *testing.T) {
+	t.Run("test create new profile store instance", func(t *testing.T) {
+		// success
+		profileStore, err := newProfileStore(mockstorage.NewMockStoreProvider())
+		require.NoError(t, err)
+		require.NotEmpty(t, profileStore)
+
+		// error
+		profileStore, err = newProfileStore(&mockstorage.MockStoreProvider{
+			ErrOpenStoreHandle: fmt.Errorf(sampleCustomProfileErr),
+		})
+		require.Error(t, err)
+		require.EqualError(t, err, sampleCustomProfileErr)
+		require.Empty(t, profileStore)
+	})
+
+	t.Run("test save profiles in store", func(t *testing.T) {
+		profileStore, err := newProfileStore(mockstorage.NewMockStoreProvider())
+		require.NoError(t, err)
+		require.NotEmpty(t, profileStore)
+
+		// success save
+		err = profileStore.save(&profile{User: sampleProfileUser}, false)
+		require.NoError(t, err)
+		result, err := profileStore.get(sampleProfileUser)
+		require.NoError(t, err)
+		require.Equal(t, result.User, sampleProfileUser)
+
+		// save existing profile
+		err = profileStore.save(&profile{User: sampleProfileUser}, false)
+		require.Error(t, err)
+		require.EqualError(t, err, "profile already exists for given user")
+
+		// save override existing profile
+		err = profileStore.save(&profile{User: sampleProfileUser}, true)
+		require.NoError(t, err)
+		result, err = profileStore.get(sampleProfileUser)
+		require.NoError(t, err)
+		require.Equal(t, result.User, sampleProfileUser)
+	})
+
+	t.Run("test get profiles from store", func(t *testing.T) {
+		profileStore, err := newProfileStore(mockstorage.NewMockStoreProvider())
+		require.NoError(t, err)
+		require.NotEmpty(t, profileStore)
+
+		// setup data
+		err = profileStore.save(&profile{User: sampleProfileUser}, false)
+		require.NoError(t, err)
+
+		// get profile from store
+		result, err := profileStore.get(sampleProfileUser)
+		require.NoError(t, err)
+		require.Equal(t, result.User, sampleProfileUser)
+
+		// get non-existing profile from store
+		result, err = profileStore.get("non-existing-user")
+		require.Empty(t, result)
+		require.Error(t, err)
+		require.Equal(t, err, ErrProfileNotFound)
+	})
+
+	t.Run("test errors while getting profiles from store", func(t *testing.T) {
+		const sampleProfileUser2 = "sampleProfileUser#02"
+		profileStore, err := newProfileStore(&mockstorage.MockStoreProvider{
+			Store: &mockstorage.MockStore{
+				ErrGet: fmt.Errorf(sampleCustomProfileErr),
+			},
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, profileStore)
+
+		// get profile from store
+		result, err := profileStore.get(sampleProfileUser)
+		require.Empty(t, result)
+		require.Error(t, err)
+		require.EqualError(t, err, sampleCustomProfileErr)
+
+		// unmarshal error test
+		profileStore, err = newProfileStore(&mockstorage.MockStoreProvider{
+			Store: &mockstorage.MockStore{
+				Store: map[string][]byte{
+					getUserKeyPrefix(sampleProfileUser2): []byte("----"),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// put invalid data in store to get unmarshal error
+		result, err = profileStore.get(sampleProfileUser2)
+		require.Empty(t, result)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid character")
+	})
+}


### PR DESCRIPTION
VC wallet client can be initialized with following key manager options.

`passphrase` : if client chooses to use passphrase for localkms.
`secret lock service`: if client chooses to use its own secret lock service.
`keyServerURL`: if client chooses to user remotekms (webkms).

**wallet.Open() :** accepts one of the below params to instantiate key
manager client and unlock wallet for use.

`auth token`: auth token to be part of header for remote kms calls
to key server.
`passphrase` : if client chooses to use passphrase for localkms.
secret lock service: if client chooses to use its own secret lock
service.
`expiration`: time duration for which token has to be active

**wallet.Close()**: expires token and removes key manager client instance.

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
