### PR TITLE
chore: remove remote context loading from verifiable tests

### DIFF
--- a/pkg/doc/did/doc.go
+++ b/pkg/doc/did/doc.go
@@ -12,7 +12,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -22,6 +21,7 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	jld "github.com/hyperledger/aries-framework-go/pkg/doc/jsonld"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 )
@@ -1318,7 +1318,7 @@ func BuildDoc(opts ...DocOption) *Doc {
 
 // CachingJSONLDLoader creates JSON-LD CachingDocumentLoader with preloaded base JSON-LD DID and security contexts.
 func CachingJSONLDLoader() ld.DocumentLoader {
-	loader := ld.NewCachingDocumentLoader(ld.NewRFC7324CachingDocumentLoader(&http.Client{}))
+	loader := jld.NewCachingDocumentLoader()
 
 	cacheContext := func(source, url string) {
 		reader, _ := ld.DocumentFromReader(strings.NewReader(source)) //nolint:errcheck

--- a/pkg/doc/jsonld/jsonld.go
+++ b/pkg/doc/jsonld/jsonld.go
@@ -1,0 +1,38 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package jsonld provides common framework JSON-LD utilities.
+package jsonld
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/piprate/json-gold/ld"
+)
+
+// NewCachingDocumentLoader creates a Document Loader with default framework options.
+func NewCachingDocumentLoader() *ld.CachingDocumentLoader {
+	return ld.NewCachingDocumentLoader(ld.NewRFC7324CachingDocumentLoader(httpclient()))
+}
+
+// NewCachingDocumentLoaderWithRemote creates a Document Loader with remote enabled.
+// TODO: remove once framework is updated to preload context from stores.
+func NewCachingDocumentLoaderWithRemote() *ld.CachingDocumentLoader {
+	return ld.NewCachingDocumentLoader(ld.NewRFC7324CachingDocumentLoader(&http.Client{}))
+}
+
+type disabledNetworkTransport struct{}
+
+func (*disabledNetworkTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("network is disabled [%s]", r.URL)
+}
+
+func httpclient() *http.Client {
+	return &http.Client{
+		Transport: &disabledNetworkTransport{},
+	}
+}

--- a/pkg/doc/jsonld/jsonld_test.go
+++ b/pkg/doc/jsonld/jsonld_test.go
@@ -1,0 +1,19 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package jsonld
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewVerifier(t *testing.T) {
+	loader := NewCachingDocumentLoader()
+	_, err := loader.LoadDocument("https://www.w3.org/2018/credentials/v1")
+	require.Error(t, err, "network should be disabled")
+}

--- a/pkg/doc/signature/jsonld/processor.go
+++ b/pkg/doc/signature/jsonld/processor.go
@@ -11,13 +11,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
 	"github.com/piprate/json-gold/ld"
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jsonld"
 )
 
 const (
@@ -417,7 +417,7 @@ func getCachingDocumentLoader(loader ld.DocumentLoader, cache map[string]interfa
 
 func createCachingDocumentLoader(loader ld.DocumentLoader) *ld.CachingDocumentLoader {
 	if loader == nil {
-		return ld.NewCachingDocumentLoader(ld.NewRFC7324CachingDocumentLoader(&http.Client{}))
+		return jsonld.NewCachingDocumentLoader()
 	}
 
 	if cachingLoader, ok := loader.(*ld.CachingDocumentLoader); ok {

--- a/pkg/doc/signature/jsonld/processor_test.go
+++ b/pkg/doc/signature/jsonld/processor_test.go
@@ -9,12 +9,13 @@ package jsonld
 import (
 	"encoding/json"
 	"log"
-	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/piprate/json-gold/ld"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jsonld"
 )
 
 func TestGetCanonicalDocument(t *testing.T) {
@@ -95,7 +96,7 @@ func TestGetCanonicalDocument(t *testing.T) {
 				opts: []ProcessorOpts{
 					WithRemoveAllInvalidRDF(), WithExternalContext("http://localhost:8652/dummy.jsonld"),
 					WithDocumentLoaderCache(createContextCache("http://localhost:8652/dummy.jsonld", extraJSONLDContext)),
-					WithDocumentLoader(ld.NewCachingDocumentLoader(ld.NewRFC7324CachingDocumentLoader(&http.Client{}))),
+					WithDocumentLoader(jsonld.NewCachingDocumentLoader()),
 				},
 			},
 			{
@@ -105,7 +106,7 @@ func TestGetCanonicalDocument(t *testing.T) {
 				opts: []ProcessorOpts{
 					WithRemoveAllInvalidRDF(), WithExternalContext("http://localhost:8652/dummy.jsonld"),
 					WithDocumentLoaderCache(createContextCache("http://localhost:8652/dummy.jsonld", extraJSONLDContext)),
-					WithDocumentLoader(ld.NewRFC7324CachingDocumentLoader(&http.Client{})),
+					WithDocumentLoader(jsonld.NewCachingDocumentLoader()),
 				},
 			},
 			{
@@ -265,7 +266,7 @@ func TestCompact(t *testing.T) {
 }
 
 func createInMemoryDocumentLoader(url, inMemoryContext string) *ld.CachingDocumentLoader {
-	loader := ld.NewCachingDocumentLoader(ld.NewRFC7324CachingDocumentLoader(&http.Client{}))
+	loader := jsonld.NewCachingDocumentLoader()
 
 	reader, err := ld.DocumentFromReader(strings.NewReader(inMemoryContext))
 	if err != nil {

--- a/pkg/doc/signature/suite/bbsblssignature2020/support_test.go
+++ b/pkg/doc/signature/suite/bbsblssignature2020/support_test.go
@@ -8,11 +8,12 @@ package bbsblssignature2020
 
 import (
 	"io/ioutil"
-	"net/http"
 	"path/filepath"
 	"strings"
 
 	"github.com/piprate/json-gold/ld"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jsonld"
 )
 
 const jsonldContextPrefix = "testdata/context"
@@ -28,7 +29,7 @@ func addJSONLDCachedContextFromFile(loader *ld.CachingDocumentLoader, contextURL
 }
 
 func createLDPBBS2020DocumentLoader() ld.DocumentLoader {
-	loader := ld.NewCachingDocumentLoader(ld.NewRFC7324CachingDocumentLoader(&http.Client{}))
+	loader := jsonld.NewCachingDocumentLoader()
 
 	addJSONLDCachedContextFromFile(loader,
 		"https://www.w3.org/2018/credentials/v1", "vc.jsonld")

--- a/pkg/doc/signature/suite/bbsblssignatureproof2020/support_test.go
+++ b/pkg/doc/signature/suite/bbsblssignatureproof2020/support_test.go
@@ -8,11 +8,12 @@ package bbsblssignatureproof2020_test
 
 import (
 	"io/ioutil"
-	"net/http"
 	"path/filepath"
 	"strings"
 
 	"github.com/piprate/json-gold/ld"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jsonld"
 )
 
 const jsonldContextPrefix = "testdata/context"
@@ -28,7 +29,7 @@ func addJSONLDCachedContextFromFile(loader *ld.CachingDocumentLoader, contextURL
 }
 
 func createLDPBBS2020DocumentLoader() ld.DocumentLoader {
-	loader := ld.NewCachingDocumentLoader(ld.NewRFC7324CachingDocumentLoader(&http.Client{}))
+	loader := jsonld.NewCachingDocumentLoader()
 
 	addJSONLDCachedContextFromFile(loader,
 		"https://www.w3.org/2018/credentials/v1", "vc.jsonld")

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -1864,7 +1864,8 @@ func TestParseUnverifiedCredential(t *testing.T) {
 		require.NoError(t, err)
 
 		// Parse VC with JWS proof.
-		vcUnverified, err := ParseUnverifiedCredential([]byte(jws))
+		vcUnverified, err := ParseUnverifiedCredential([]byte(jws),
+			WithJSONLDDocumentLoader(createTestJSONLDDocumentLoader()))
 		require.NoError(t, err)
 		require.NotNil(t, vcUnverified)
 		require.Equal(t, vc, vcUnverified)
@@ -1888,7 +1889,8 @@ func TestParseUnverifiedCredential(t *testing.T) {
 		require.NoError(t, err)
 
 		// Parse VC with linked data proof.
-		vcUnverified, err := ParseUnverifiedCredential(vcBytes)
+		vcUnverified, err := ParseUnverifiedCredential(vcBytes,
+			WithJSONLDDocumentLoader(createTestJSONLDDocumentLoader()))
 		require.NoError(t, err)
 		require.NotNil(t, vcUnverified)
 		require.Equal(t, vc, vcUnverified)

--- a/pkg/doc/verifiable/example_presentation_test.go
+++ b/pkg/doc/verifiable/example_presentation_test.go
@@ -261,7 +261,13 @@ func ExamplePresentation_SetCredentials() {
 	// The second VC is provided in JWS form (e.g. kept in the wallet in that form).
 	vcJWS := "eyJhbGciOiJFZERTQSIsImtpZCI6IiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1Nzc5MDY2MDQsImlhdCI6MTI2MjM3MzgwNCwiaXNzIjoiZGlkOmV4YW1wbGU6NzZlMTJlYzcxMmViYzZmMWMyMjFlYmZlYjFmIiwianRpIjoiaHR0cDovL2V4YW1wbGUuZWR1L2NyZWRlbnRpYWxzLzE4NzIiLCJuYmYiOjEyNjIzNzM4MDQsInN1YiI6ImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSIsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjEiXSwiY3JlZGVudGlhbFNjaGVtYSI6W10sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImRlZ3JlZSI6eyJ0eXBlIjoiQmFjaGVsb3JEZWdyZWUiLCJ1bml2ZXJzaXR5IjoiTUlUIn0sImlkIjoiZGlkOmV4YW1wbGU6ZWJmZWIxZjcxMmViYzZmMWMyNzZlMTJlYzIxIiwibmFtZSI6IkpheWRlbiBEb2UiLCJzcG91c2UiOiJkaWQ6ZXhhbXBsZTpjMjc2ZTEyZWMyMWViZmViMWY3MTJlYmM2ZjEifSwiaXNzdWVyIjp7Im5hbWUiOiJFeGFtcGxlIFVuaXZlcnNpdHkifSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIlVuaXZlcnNpdHlEZWdyZWVDcmVkZW50aWFsIl19fQ.AHn2A2q5DL1heX3_izq_2yrsBDhoZ6BGGKhoRvhfMnMUuuOnBOdekdTg-dfUMJgipXRql_6WzBUIj4wTFehXCw" // nolint:lll
 
-	err := vp.SetCredentials(vc, vcJWS, vcStr)
+	vc2, err := verifiable.ParseUnverifiedCredential([]byte(vcStr),
+		verifiable.WithJSONLDDocumentLoader(getJSONLDDocumentLoader()))
+	if err != nil {
+		panic(fmt.Errorf("failed to decode VC JSON: %w", err))
+	}
+
+	err = vp.SetCredentials(vc, vcJWS, vc2)
 	if err != nil {
 		panic(fmt.Errorf("failed to set credentials of VP: %w", err))
 	}
@@ -634,7 +640,7 @@ func ExamplePresentation_AddLinkedDataProof() {
 	}
 
 	// 2. ISSUER creates a VP with the VC enclosed.
-	vcFromHolderWallet, err := verifiable.ParseUnverifiedCredential(issuedVCBytes)
+	vcFromHolderWallet, err := verifiable.ParseUnverifiedCredential(issuedVCBytes, verifiable.WithJSONLDDocumentLoader(getJSONLDDocumentLoader()))
 	if err != nil {
 		panic(fmt.Errorf("failed to decode VC JSON: %w", err))
 	}

--- a/pkg/doc/verifiable/jsonld.go
+++ b/pkg/doc/verifiable/jsonld.go
@@ -8,12 +8,12 @@ package verifiable
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"reflect"
 	"strings"
 
 	"github.com/piprate/json-gold/ld"
 
+	jld "github.com/hyperledger/aries-framework-go/pkg/doc/jsonld"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 )
 
@@ -259,7 +259,8 @@ const vcJSONLD = `
 
 // CachingJSONLDLoader creates JSON_LD CachingDocumentLoader with preloaded base JSON-LD document.
 func CachingJSONLDLoader() *ld.CachingDocumentLoader {
-	loader := ld.NewCachingDocumentLoader(ld.NewRFC7324CachingDocumentLoader(&http.Client{}))
+	// TODO: remove remote as default
+	loader := jld.NewCachingDocumentLoaderWithRemote()
 
 	reader, err := ld.DocumentFromReader(strings.NewReader(vcJSONLD))
 	if err != nil {

--- a/pkg/doc/verifiable/linked_data_proof_test.go
+++ b/pkg/doc/verifiable/linked_data_proof_test.go
@@ -148,7 +148,7 @@ func TestLinkedDataProofSignerAndVerifier(t *testing.T) {
 }
 
 func prepareVCWithEd25519LDP(t *testing.T, vcJSON string, signer Signer) *Credential {
-	vc, err := ParseUnverifiedCredential([]byte(vcJSON))
+	vc, err := ParseUnverifiedCredential([]byte(vcJSON), WithJSONLDDocumentLoader(createTestJSONLDDocumentLoader()))
 	require.NoError(t, err)
 
 	ed25519SignerSuite := ed25519signature2018.New(
@@ -173,7 +173,7 @@ func prepareVCWithEd25519LDP(t *testing.T, vcJSON string, signer Signer) *Creden
 }
 
 func prepareVCWithSecp256k1LDP(t *testing.T, vcJSON string, signer Signer) *Credential {
-	vc, err := ParseUnverifiedCredential([]byte(vcJSON))
+	vc, err := ParseUnverifiedCredential([]byte(vcJSON), WithJSONLDDocumentLoader(createTestJSONLDDocumentLoader()))
 	require.NoError(t, err)
 
 	ed25519SignerSuite := ecdsasecp256k1signature2019.New(

--- a/pkg/doc/verifiable/presentation.go
+++ b/pkg/doc/verifiable/presentation.go
@@ -205,18 +205,12 @@ func (vp *Presentation) SetCredentials(creds ...interface{}) error {
 	var vpCreds []interface{}
 
 	convertToVC := func(vcStr string) (interface{}, error) {
-		// Check if passed VC is correct one.
-		vc, err := ParseUnverifiedCredential([]byte(vcStr))
-		if err != nil {
-			return nil, fmt.Errorf("check VC: %w", err)
-		}
-
 		// If VC was passed in JWT form, left it as is. Otherwise, return parsed VC
 		if jose.IsCompactJWS(vcStr) {
 			return vcStr, nil
 		}
 
-		return vc, nil
+		return nil, errors.New("string is not compact JWS")
 	}
 
 	for i := range creds {

--- a/pkg/doc/verifiable/presentation_test.go
+++ b/pkg/doc/verifiable/presentation_test.go
@@ -401,27 +401,14 @@ func TestPresentation_SetCredentials(t *testing.T) {
 	r := require.New(t)
 	vp := Presentation{}
 
-	vc, err := ParseUnverifiedCredential([]byte(validCredential))
+	vc, err := ParseUnverifiedCredential([]byte(validCredential),
+		WithJSONLDDocumentLoader(createTestJSONLDDocumentLoader()))
 	r.NoError(err)
 
 	// Pass Credential struct pointer
 	err = vp.SetCredentials(vc)
 	r.NoError(err)
 	r.Len(vp.credentials, 1)
-	r.Equal(vc, vp.credentials[0])
-
-	// Pass VC marshalled into JSON bytes
-	err = vp.SetCredentials([]byte(validCredential))
-	r.NoError(err)
-	r.Len(vp.credentials, 1)
-	// VC JSON bytes is converted to vc struct
-	r.Equal(vc, vp.credentials[0])
-
-	// Pass VC marshalled into JSON string
-	err = vp.SetCredentials(validCredential)
-	r.NoError(err)
-	r.Len(vp.credentials, 1)
-	// VC JSON string is converted to vc struct
 	r.Equal(vc, vp.credentials[0])
 
 	// Pass VC marshalled into unsecured JWT
@@ -438,23 +425,11 @@ func TestPresentation_SetCredentials(t *testing.T) {
 	r.Equal(jwt, vp.credentials[0])
 
 	// set multiple credentials
-	err = vp.SetCredentials(vc, jwt, validCredential, []byte(validCredential))
+	err = vp.SetCredentials(vc, jwt)
 	r.NoError(err)
-	r.Len(vp.credentials, 4)
+	r.Len(vp.credentials, 2)
 	r.Equal(vc, vp.credentials[0])
 	r.Equal(jwt, vp.credentials[1])
-	r.Equal(vc, vp.credentials[2])
-	r.Equal(vc, vp.credentials[3])
-
-	// Error - invalid VC in string form
-	err = vp.SetCredentials("invalid VC")
-	r.Error(err)
-	r.Contains(err.Error(), "check VC")
-
-	// Error - invalid VC in bytes form
-	err = vp.SetCredentials([]byte("invalid VC"))
-	r.Error(err)
-	r.Contains(err.Error(), "check VC")
 
 	// Error - pass unsupported type
 	vpOther := &Presentation{}

--- a/pkg/doc/verifiable/support_test.go
+++ b/pkg/doc/verifiable/support_test.go
@@ -137,7 +137,8 @@ func (vp *Presentation) stringJSON(t *testing.T) string {
 }
 
 func createVCWithLinkedDataProof() (*Credential, PublicKeyFetcher) {
-	vc, err := ParseUnverifiedCredential([]byte(validCredential))
+	vc, err := ParseUnverifiedCredential([]byte(validCredential),
+		WithJSONLDDocumentLoader(createTestJSONLDDocumentLoader()))
 	if err != nil {
 		panic(err)
 	}
@@ -164,7 +165,8 @@ func createVCWithLinkedDataProof() (*Credential, PublicKeyFetcher) {
 }
 
 func createVCWithTwoLinkedDataProofs() (*Credential, PublicKeyFetcher) {
-	vc, err := ParseUnverifiedCredential([]byte(validCredential))
+	vc, err := ParseUnverifiedCredential([]byte(validCredential),
+		WithJSONLDDocumentLoader(createTestJSONLDDocumentLoader()))
 	if err != nil {
 		panic(err)
 	}
@@ -270,6 +272,14 @@ func createTestJSONLDDocumentLoader() *ld.CachingDocumentLoader {
 	addJSONLDCachedContextFromFile(loader,
 		"https://w3id.org/citizenship/v1",
 		"citizenship.jsonld")
+
+	addJSONLDCachedContextFromFile(loader,
+		"http://127.0.0.1?context=1",
+		"context1.jsonld")
+
+	addJSONLDCachedContextFromFile(loader,
+		"http://127.0.0.1?context=2",
+		"context2.jsonld")
 
 	return loader
 }

--- a/pkg/doc/verifiable/testdata/context/context1.jsonld
+++ b/pkg/doc/verifiable/testdata/context/context1.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "c1": "https://example.com/vocab#c1",
+    "s1": "https://example.com/vocab#s1"
+  }
+}

--- a/pkg/doc/verifiable/testdata/context/context2.jsonld
+++ b/pkg/doc/verifiable/testdata/context/context2.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "c2": "https://example.com/vocab#c2",
+    "s2": "https://example.com/vocab#s2"
+  }
+}

--- a/pkg/doc/verifiable/testdata/context/context3.jsonld
+++ b/pkg/doc/verifiable/testdata/context/context3.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "referenceNumber": "https://example.com/vocab#referenceNumber",
+    "favoriteFood": "https://example.com/vocab#favoriteFood",
+    "name": "https://example.com/vocab#name",
+    "CustomExt12": "https://example.com/vocab#CustomExt12"
+  }
+}

--- a/pkg/doc/verifiable/testdata/context/context4.jsonld
+++ b/pkg/doc/verifiable/testdata/context/context4.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "referenceNumber": "https://example.com/vocab#referenceNumber",
+    "CustomExt12": "https://example.com/vocab#CustomExt12"
+  }
+}

--- a/pkg/doc/verifiable/testdata/context/context5.jsonld
+++ b/pkg/doc/verifiable/testdata/context/context5.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "favoriteFood": "https://example.com/vocab#favoriteFood",
+    "name": "https://example.com/vocab#name"
+  }
+}

--- a/pkg/doc/verifiable/testdata/context/context6.jsonld
+++ b/pkg/doc/verifiable/testdata/context/context6.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "referenceNumber": "https://example.com/vocab#referenceNumber"
+  }
+}

--- a/test/bdd/pkg/verifiable/verifiable_steps.go
+++ b/test/bdd/pkg/verifiable/verifiable_steps.go
@@ -11,7 +11,6 @@ import (
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"errors"
-	"net/http"
 	"strings"
 	"time"
 
@@ -21,6 +20,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	jld "github.com/hyperledger/aries-framework-go/pkg/doc/jsonld"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/signer"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
@@ -381,7 +381,7 @@ func mapDIDKeyType(proofType string) string {
 
 // CachingJSONLDLoader creates JSON-LD CachingDocumentLoader with preloaded VC and security JSON-LD contexts.
 func CachingJSONLDLoader() ld.DocumentLoader {
-	loader := ld.NewCachingDocumentLoader(ld.NewRFC7324CachingDocumentLoader(&http.Client{}))
+	loader := jld.NewCachingDocumentLoader()
 
 	cacheContext := func(source, url string) {
 		reader, _ := ld.DocumentFromReader(strings.NewReader(source)) //nolint:errcheck


### PR DESCRIPTION
- SetCredentials is also modified to require a parsed credential object or a compact JWS. A followup PR will move the compact JWS detection into the credential object.
- A common jsonld utility package is created. A followup PR will change the default behavior to use a document loader without remote loading in the framework.

Signed-off-by: Troy Ronda <troy@troyronda.com>
