### PR TITLE
feat:KMS support for BBS+ keys: support Public key export, Private Key Import

### DIFF
--- a/pkg/kms/api.go
+++ b/pkg/kms/api.go
@@ -118,6 +118,8 @@ const (
 	NISTP521ECDHKW = "NISTP521ECDHKW"
 	// X25519ECDHKW key type value.
 	X25519ECDHKW = "X25519ECDHKW"
+	// BLS12381G2 BBS+ key type value.
+	BLS12381G2 = "BLS12381G2"
 )
 
 // KeyType represents a key type supported by the KMS.
@@ -164,6 +166,8 @@ const (
 	NISTP521ECDHKWType = KeyType(NISTP521ECDHKW)
 	// X25519ECDHKWType key type value.
 	X25519ECDHKWType = KeyType(X25519ECDHKW)
+	// BLS12381G2Type BBS+ key type value.
+	BLS12381G2Type = KeyType(BLS12381G2)
 )
 
 // CryptoBox is a libsodium crypto service used by legacy authcrypt packer.

--- a/pkg/kms/localkms/localkms.go
+++ b/pkg/kms/localkms/localkms.go
@@ -24,7 +24,9 @@ import (
 	"github.com/google/tink/go/signature"
 
 	cryptoapi "github.com/hyperledger/aries-framework-go/pkg/crypto"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/bbs"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdh"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/bbs/bbs12381g2pub"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms/internal/keywrapper"
 	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
@@ -212,6 +214,8 @@ func getKeyTemplate(keyType kms.KeyType) (*tinkpb.KeyTemplate, error) {
 		return ecdh.NISTP521ECDHKWKeyTemplate(), nil
 	case kms.X25519ECDHKWType:
 		return ecdh.X25519ECDHKWKeyTemplate(), nil
+	case kms.BLS12381G2Type:
+		return bbs.BLS12381G2KeyTemplate(), nil
 	default:
 		return nil, fmt.Errorf("getKeyTemplate: key type '%s' unrecognized", keyType)
 	}
@@ -391,6 +395,8 @@ func (l *LocalKMS) ImportPrivateKey(privKey interface{}, kt kms.KeyType,
 		return l.importECDSAKey(pk, kt, opts...)
 	case ed25519.PrivateKey:
 		return l.importEd25519Key(pk, kt, opts...)
+	case *bbs12381g2pub.PrivateKey:
+		return l.importBBSKey(pk, kt, opts...)
 	default:
 		return "", nil, fmt.Errorf("import private key does not support this key type or key is public")
 	}

--- a/pkg/kms/localkms/pubkey_reader.go
+++ b/pkg/kms/localkms/pubkey_reader.go
@@ -21,6 +21,7 @@ import (
 	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
 	"github.com/google/tink/go/subtle"
 
+	bbspb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/bbs_go_proto"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
@@ -145,6 +146,18 @@ func getMarshalledProtoKeyAndKeyURL(pubKey []byte, kt kms.KeyType) ([]byte, stri
 		tURL = ed25519VerifierTypeURL
 		pubKeyProto := new(ed25519pb.Ed25519PublicKey)
 		pubKeyProto.Version = 0
+		pubKeyProto.KeyValue = make([]byte, len(pubKey))
+		copy(pubKeyProto.KeyValue, pubKey)
+
+		keyValue, err = proto.Marshal(pubKeyProto)
+		if err != nil {
+			return nil, "", err
+		}
+	case kms.BLS12381G2Type:
+		tURL = bbsVerifierKeyTypeURL
+		pubKeyProto := new(bbspb.BBSPublicKey)
+		pubKeyProto.Version = 0
+		pubKeyProto.Params = buidBBSParams(kt)
 		pubKeyProto.KeyValue = make([]byte, len(pubKey))
 		copy(pubKeyProto.KeyValue, pubKey)
 


### PR DESCRIPTION
This change also adds new kms type for BBS+ keys.

closes #2549

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
