### PR TITLE
refactor: make fingerprint function generic to return multicodec code

### DIFF
--- a/pkg/vdr/fingerprint/fingerprint_test.go
+++ b/pkg/vdr/fingerprint/fingerprint_test.go
@@ -27,7 +27,8 @@ func TestCreateDIDKey(t *testing.T) {
 	})
 
 	t.Run("test PubKeyFromFingerprint success", func(t *testing.T) {
-		pubKey, err := PubKeyFromFingerprint(strings.Split(expectedDIDKeyID, "#")[1])
+		pubKey, code, err := PubKeyFromFingerprint(strings.Split(expectedDIDKeyID, "#")[1])
+		require.Equal(t, uint64(ed25519pub), code)
 		require.NoError(t, err)
 
 		require.Equal(t, base58.Encode(pubKey), pubKeyBase58)
@@ -36,7 +37,26 @@ func TestCreateDIDKey(t *testing.T) {
 	t.Run("test PubKeyFromFingerprint fail", func(t *testing.T) {
 		badDIDKeyID := "AB" + strings.Split(expectedDIDKeyID, "#")[1][2:]
 
-		_, err := PubKeyFromFingerprint(badDIDKeyID)
-		require.EqualError(t, err, "pubKeyFromFingerprint: not supported public key (multicodec code: 0x1)")
+		_, _, err := PubKeyFromFingerprint(badDIDKeyID)
+		require.EqualError(t, err, "unknown key encoding")
 	})
+
+	t.Run("invalid fingerprint", func(t *testing.T) {
+		_, _, err := PubKeyFromFingerprint("")
+		require.Error(t, err)
+
+		_, _, err = PubKeyFromFingerprint("a6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH")
+		require.Error(t, err)
+	})
+}
+
+func TestDIDKeyEd25519(t *testing.T) {
+	const (
+		k1       = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+		k1Base58 = "B12NYF8RrR3h41TDCTJojY59usg3mbtbjnFs7Eud1Y6u"
+	)
+
+	pubKey, err := PubKeyFromDIDKey(k1)
+	require.Equal(t, k1Base58, base58.Encode(pubKey))
+	require.NoError(t, err)
 }

--- a/pkg/vdr/key/creator.go
+++ b/pkg/vdr/key/creator.go
@@ -25,7 +25,8 @@ const (
 
 const (
 	// source: https://github.com/multiformats/multicodec/blob/master/table.csv.
-	x25519pub = 0xec // Curve25519 public key in multicodec table
+	x25519pub  = 0xec // Curve25519 public key in multicodec table
+	ed25519pub = 0xed // Ed25519 public key in multicodec table
 )
 
 // Create new DID document.

--- a/pkg/vdr/key/resolver.go
+++ b/pkg/vdr/key/resolver.go
@@ -26,9 +26,17 @@ func (v *VDR) Read(didKey string, opts ...vdrapi.ResolveOption) (*did.DocResolut
 		return nil, fmt.Errorf("vdr Read: invalid did:key method ID: %s", parsed.MethodSpecificID)
 	}
 
-	pubKeyBytes, err := fingerprint.PubKeyFromFingerprint(parsed.MethodSpecificID)
+	pubKeyBytes, code, err := fingerprint.PubKeyFromFingerprint(parsed.MethodSpecificID)
 	if err != nil {
 		return nil, fmt.Errorf("pub:key vdr Read: failed to get key fingerPrint: %w", err)
+	}
+
+	// TODO: support additional codes for did:key
+	switch code {
+	case ed25519pub:
+		break
+	default:
+		return nil, fmt.Errorf("unsupported key multicodec code [0x%x]", code)
 	}
 
 	// did:key can't add non converted encryption key as keyAgreement (unless it's added as an option just like creator,

--- a/pkg/vdr/key/resolver_test.go
+++ b/pkg/vdr/key/resolver_test.go
@@ -36,7 +36,7 @@ func TestRead(t *testing.T) {
 
 		doc, err := v.Read("did:key:z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "not supported public key (multicodec code: 0xec)") // Curve25519 public key
+		require.Contains(t, err.Error(), "unsupported key multicodec code [0xec]") // Curve25519 public key
 		require.Nil(t, doc)
 	})
 


### PR DESCRIPTION
Signed-off-by: Troy Ronda <troy@troyronda.com>
