### PR TITLE
test: fix for common storage query test

### DIFF
--- a/test/component/storage/storage.go
+++ b/test/component/storage/storage.go
@@ -931,6 +931,9 @@ func TestStoreQuery(t *testing.T, provider spi.Provider) { // nolint: funlen // 
 		require.NoError(t, err)
 		require.NotNil(t, store)
 
+		err = provider.SetStoreConfig(storeName, spi.StoreConfiguration{})
+		require.NoError(t, err)
+
 		t.Run("Empty expression", func(t *testing.T) {
 			iterator, err := store.Query("")
 			require.Error(t, err)


### PR DESCRIPTION
Fixes an issue where one of the common storage tests would result in the wrong path being tested for storage implementations that require setting a store config before doing a query.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>