### PR TITLE
feat: add bbs to did:key resolver

### DIFF
--- a/pkg/vdr/key/creator.go
+++ b/pkg/vdr/key/creator.go
@@ -21,12 +21,14 @@ const (
 	schemaV1                   = "https://w3id.org/did/v1"
 	ed25519VerificationKey2018 = "Ed25519VerificationKey2018"
 	x25519KeyAgreementKey2019  = "X25519KeyAgreementKey2019"
+	bls12381G2Key2020          = "Bls12381G2Key2020"
 )
 
 const (
 	// source: https://github.com/multiformats/multicodec/blob/master/table.csv.
-	x25519pub  = 0xec // Curve25519 public key in multicodec table
-	ed25519pub = 0xed // Ed25519 public key in multicodec table
+	x25519pub     = 0xec // Curve25519 public key in multicodec table
+	ed25519pub    = 0xed // Ed25519 public key in multicodec table
+	bls12381g2pub = 0xeb // BLS12-381 G2 public key in multicodec table
 )
 
 // Create new DID document.
@@ -64,7 +66,7 @@ func (v *VDR) Create(keyManager kms.KeyManager, didDoc *did.Doc,
 		publicKey = did.NewVerificationMethodFromBytes(keyID, ed25519VerificationKey2018, didKey,
 			didDoc.VerificationMethod[0].Value)
 
-		keyAgr, err = keyAgreement(didKey, didDoc.VerificationMethod[0].Value)
+		keyAgr, err = keyAgreementFromEd25519(didKey, didDoc.VerificationMethod[0].Value)
 		if err != nil {
 			return nil, err
 		}
@@ -109,7 +111,7 @@ func createDoc(pubKey, keyAgreement *did.VerificationMethod, didKey string) *did
 	}
 }
 
-func keyAgreement(didKey string, ed25519PubKey []byte) (*did.VerificationMethod, error) {
+func keyAgreementFromEd25519(didKey string, ed25519PubKey []byte) (*did.VerificationMethod, error) {
 	curve25519PubKey, err := cryptoutil.PublicEd25519toCurve25519(ed25519PubKey)
 	if err != nil {
 		return nil, err

--- a/pkg/vdr/key/resolver_test.go
+++ b/pkg/vdr/key/resolver_test.go
@@ -12,16 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRead(t *testing.T) {
-	t.Run("validate did:key", func(t *testing.T) {
-		v := New()
-
-		doc, err := v.Read("invalid")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid did: invalid")
-		require.Nil(t, doc)
-	})
-
+func TestReadInvalid(t *testing.T) {
 	t.Run("validate did:key method specific ID", func(t *testing.T) {
 		v := New()
 
@@ -40,14 +31,58 @@ func TestRead(t *testing.T) {
 		require.Nil(t, doc)
 	})
 
+	t.Run("validate did:key", func(t *testing.T) {
+		v := New()
+
+		doc, err := v.Read("invalid")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid did: invalid")
+		require.Nil(t, doc)
+	})
+}
+
+func TestReadEd25519(t *testing.T) {
+	const (
+		didEd25519 = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+	)
+
 	t.Run("resolve assuming default key type", func(t *testing.T) {
 		v := New()
 
-		docResolution, err := v.Read(didKey)
+		docResolution, err := v.Read(didEd25519)
 		require.NoError(t, err)
 		require.NotNil(t, docResolution.DIDDocument)
 		require.True(t, docResolution.DIDDocument.KeyAgreement[0].Embedded)
 
-		assertDoc(t, docResolution.DIDDocument)
+		assertEd25519Doc(t, docResolution.DIDDocument)
+	})
+}
+
+func TestReadBBS(t *testing.T) {
+	v := New()
+
+	const (
+		k1       = "did:key:zUC7K4ndUaGZgV7Cp2yJy6JtMoUHY6u7tkcSYUvPrEidqBmLCTLmi6d5WvwnUqejscAkERJ3bfjEiSYtdPkRSE8kSa11hFBr4sTgnbZ95SJj19PN2jdvJjyzpSZgxkyyxNnBNnY"                                                                                                                                         //nolint:lll
+		k1KID    = "did:key:zUC7K4ndUaGZgV7Cp2yJy6JtMoUHY6u7tkcSYUvPrEidqBmLCTLmi6d5WvwnUqejscAkERJ3bfjEiSYtdPkRSE8kSa11hFBr4sTgnbZ95SJj19PN2jdvJjyzpSZgxkyyxNnBNnY#zUC7K4ndUaGZgV7Cp2yJy6JtMoUHY6u7tkcSYUvPrEidqBmLCTLmi6d5WvwnUqejscAkERJ3bfjEiSYtdPkRSE8kSa11hFBr4sTgnbZ95SJj19PN2jdvJjyzpSZgxkyyxNnBNnY" //nolint:lll
+		k1Base58 = "25EEkQtcLKsEzQ6JTo9cg4W7NHpaurn4Wg6LaNPFq6JQXnrP91SDviUz7KrJVMJd76CtAZFsRLYzvgX2JGxo2ccUHtuHk7ELCWwrkBDfrXCFVfqJKDootee9iVaF6NpdJtBE"                                                                                                                                                    //nolint:lll
+		k2       = "did:key:zUC7KKoJk5ttwuuc8pmQDiUmtckEPTwcaFVZe4DSFV7fURuoRnD17D3xkBK3A9tZqdADkTTMKSwNkhjo9Hs6HfgNUXo48TNRaxU6XPLSPdRgMc15jCD5DfN34ixjoVemY62JxnW"                                                                                                                                         //nolint:lll
+		k2KID    = "did:key:zUC7KKoJk5ttwuuc8pmQDiUmtckEPTwcaFVZe4DSFV7fURuoRnD17D3xkBK3A9tZqdADkTTMKSwNkhjo9Hs6HfgNUXo48TNRaxU6XPLSPdRgMc15jCD5DfN34ixjoVemY62JxnW#zUC7KKoJk5ttwuuc8pmQDiUmtckEPTwcaFVZe4DSFV7fURuoRnD17D3xkBK3A9tZqdADkTTMKSwNkhjo9Hs6HfgNUXo48TNRaxU6XPLSPdRgMc15jCD5DfN34ixjoVemY62JxnW" //nolint:lll
+		k2Base58 = "25VFRgQEfbJ3Pit6Z3mnZbKPK9BdQYGwdmfdcmderjYZ12BFNQYeowjMN1AYKKKcacF3UH35ZNpBqCR8y8QLeeaGLL7UKdKLcFje3VQnosesDNHsU8jBvtvYmLJusxXsSUBC"                                                                                                                                                    //nolint:lll
+	)
+
+	t.Run("key 1", func(t *testing.T) {
+		docResolution, err := v.Read(k1)
+		require.NoError(t, err)
+		require.NotNil(t, docResolution.DIDDocument)
+
+		assertBase58Doc(t, docResolution.DIDDocument, k1, k1KID, bls12381G2Key2020, k1Base58)
+	})
+
+	t.Run("key 2", func(t *testing.T) {
+		docResolution, err := v.Read(k2)
+		require.NoError(t, err)
+		require.NotNil(t, docResolution.DIDDocument)
+
+		assertBase58Doc(t, docResolution.DIDDocument, k2, k2KID, bls12381G2Key2020, k2Base58)
 	})
 }


### PR DESCRIPTION
This adds bbs to the resolver. Followups are needed for other
key types and to create a did:key for bbs.

Signed-off-by: Troy Ronda <troy@troyronda.com>
