### PR TITLE
feat: IndexedDB provider - create tag map on store open

### DIFF
--- a/component/storage/indexeddb/indexeddb_test.go
+++ b/component/storage/indexeddb/indexeddb_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/component/storage/indexeddb"
-	"github.com/hyperledger/aries-framework-go/spi/storage"
 	commontest "github.com/hyperledger/aries-framework-go/test/component/storage"
 )
 
@@ -63,58 +62,6 @@ func TestStoreFlush(t *testing.T) {
 
 	err = store.Flush()
 	require.NoError(t, err)
-}
-
-func TestMultiStore(t *testing.T) {
-	t.Run("Test multi store put and get", func(t *testing.T) {
-		prov, err := indexeddb.NewProvider(sampleDBName)
-		require.NoError(t, err)
-
-		const commonKey = "did:example:1"
-		data := []byte("value1")
-		// create store 1 & store 2
-		store1, err := prov.OpenStore("store1")
-		require.NoError(t, err)
-
-		store2, err := prov.OpenStore("store2")
-		require.NoError(t, err)
-
-		// put in store 1
-		err = store1.Put(commonKey, data)
-		require.NoError(t, err)
-
-		// get in store 1 - found
-		doc, err := store1.Get(commonKey)
-		require.NoError(t, err)
-		require.NotEmpty(t, doc)
-		require.Equal(t, data, doc)
-
-		// get in store 2 - not found
-		doc, err = store2.Get(commonKey)
-		require.Error(t, err)
-		require.Equal(t, err, storage.ErrDataNotFound)
-		require.Empty(t, doc)
-
-		// put in store 2
-		err = store2.Put(commonKey, data)
-		require.NoError(t, err)
-
-		// get in store 2 - found
-		doc, err = store2.Get(commonKey)
-		require.NoError(t, err)
-		require.NotEmpty(t, doc)
-		require.Equal(t, data, doc)
-
-		// create new store 3 with same name as store1
-		store3, err := prov.OpenStore("store1")
-		require.NoError(t, err)
-
-		// get in store 3 - found
-		doc, err = store3.Get(commonKey)
-		require.NoError(t, err)
-		require.NotEmpty(t, doc)
-		require.Equal(t, data, doc)
-	})
 }
 
 func randomStoreName() string {


### PR DESCRIPTION
- The IndexedDB provider now creates a tag map when opening a store, so it no longer requires a call to SetStoreConfig to use tags + querying (it never really needed to in the first place).
- Removed some redundant unit tests.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>