### PR TITLE
perf: boost ECDH key creation for Primitive execution

### DIFF
--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh_key_template_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh_key_template_test.go
@@ -9,6 +9,7 @@ package ecdh
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/tink/go/keyset"
 	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
@@ -63,6 +64,8 @@ func TestECDHESKeyTemplateSuccess(t *testing.T) {
 			require.Error(t, err)
 			require.Empty(t, ct)
 
+			elapsed := time.Now()
+
 			// now try to create a new KH for primitive execution and try to encrypt
 			if strings.Contains(tc.tcName, "XChacha") {
 				kt = X25519ECDHXChachaKeyTemplateWithCEK(cek)
@@ -70,8 +73,12 @@ func TestECDHESKeyTemplateSuccess(t *testing.T) {
 				kt = NISTPECDHAES256GCMKeyTemplateWithCEK(cek)
 			}
 
+			t.Logf("time spent in ECDH keyTemplateWithCEK: %s", time.Since(elapsed))
+
 			kh, err = keyset.NewHandle(kt)
 			require.NoError(t, err)
+
+			t.Logf("time spent in ECDH keyTemplateWithCEK + NewHandle(): %s", time.Since(elapsed))
 
 			pubKH, err = kh.Public()
 			require.NoError(t, err)


### PR DESCRIPTION
before this change, creating new keyset.Handle for Primitive execution key took (on MacOS):
=== RUN   TestECDHESKeyTemplateSuccess/Test_create_ECDH_NIST_P-256_KW_with_AES256-GCM_key_templates_test
    ecdh_key_template_test.go:76: time spent in ECDH keyTemplateWithCEK: 5.425µs
    ecdh_key_template_test.go:81: time spent in ECDH keyTemplateWithCEK + NewHandle(): 7.15322ms
=== RUN   TestECDHESKeyTemplateSuccess/Test_create_ECDH_NIST_P-384_KW_AES256-GCM_key_templates_test
    ecdh_key_template_test.go:76: time spent in ECDH keyTemplateWithCEK: 4.686µs
    ecdh_key_template_test.go:81: time spent in ECDH keyTemplateWithCEK + NewHandle(): 5.828677ms
=== RUN   TestECDHESKeyTemplateSuccess/Test_create_ECDH_NIST_P-521_KW_AES256-GCM_key_templates_test
    ecdh_key_template_test.go:76: time spent in ECDH keyTemplateWithCEK: 4.353µs
    ecdh_key_template_test.go:81: time spent in ECDH keyTemplateWithCEK + NewHandle(): 4.85629ms
=== RUN   TestECDHESKeyTemplateSuccess/Test_creat_ECDH_X25519_KW_with_XChacha20Poly1305_key_templates_test
    ecdh_key_template_test.go:76: time spent in ECDH keyTemplateWithCEK: 8.085µs
    ecdh_key_template_test.go:81: time spent in ECDH keyTemplateWithCEK + NewHandle(): 112.4µs

with this change, it now takes:
=== RUN   TestECDHESKeyTemplateSuccess/Test_create_ECDH_NIST_P-256_KW_with_AES256-GCM_key_templates_test
    ecdh_key_template_test.go:76: time spent in ECDH keyTemplateWithCEK: 4.036µs
    ecdh_key_template_test.go:81: time spent in ECDH keyTemplateWithCEK + NewHandle(): 37.461µs
=== RUN   TestECDHESKeyTemplateSuccess/Test_create_ECDH_NIST_P-384_KW_AES256-GCM_key_templates_test
    ecdh_key_template_test.go:76: time spent in ECDH keyTemplateWithCEK: 5.113µs
    ecdh_key_template_test.go:81: time spent in ECDH keyTemplateWithCEK + NewHandle(): 33.606µs
=== RUN   TestECDHESKeyTemplateSuccess/Test_create_ECDH_NIST_P-521_KW_AES256-GCM_key_templates_test
    ecdh_key_template_test.go:76: time spent in ECDH keyTemplateWithCEK: 4.255µs
    ecdh_key_template_test.go:81: time spent in ECDH keyTemplateWithCEK + NewHandle(): 32.067µs
=== RUN   TestECDHESKeyTemplateSuccess/Test_creat_ECDH_X25519_KW_with_XChacha20Poly1305_key_templates_test
    ecdh_key_template_test.go:76: time spent in ECDH keyTemplateWithCEK: 2.266µs
    ecdh_key_template_test.go:81: time spent in ECDH keyTemplateWithCEK + NewHandle(): 18.061µs

closes #2589

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
