### PR TITLE
feat: add BBS and NISTP did key creation

### DIFF
--- a/pkg/doc/util/jwkkid/kid_creator.go
+++ b/pkg/doc/util/jwkkid/kid_creator.go
@@ -62,7 +62,7 @@ func CreateKID(keyBytes []byte, kt kms.KeyType) (string, error) {
 		return bbsKID, nil
 	}
 
-	jwk, err := buildJWK(keyBytes, kt)
+	jwk, err := BuildJWK(keyBytes, kt)
 	if err != nil {
 		return "", fmt.Errorf("createKID: failed to build jwk: %w", err)
 	}
@@ -75,7 +75,8 @@ func CreateKID(keyBytes []byte, kt kms.KeyType) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(tp), nil
 }
 
-func buildJWK(keyBytes []byte, kt kms.KeyType) (*jose.JWK, error) {
+// BuildJWK builds a go jose JWK from keyBytes with key type kt.
+func BuildJWK(keyBytes []byte, kt kms.KeyType) (*jose.JWK, error) {
 	var (
 		jwk *jose.JWK
 		err error

--- a/pkg/vdr/fingerprint/fingerprint_test.go
+++ b/pkg/vdr/fingerprint/fingerprint_test.go
@@ -15,27 +15,98 @@ import (
 )
 
 func TestCreateDIDKey(t *testing.T) {
-	pubKeyBase58 := "B12NYF8RrR3h41TDCTJojY59usg3mbtbjnFs7Eud1Y6u"
-	expectedDIDKey := "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
-	expectedDIDKeyID := "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH" //nolint:lll
+	const (
+		edPubKeyBase58     = "B12NYF8RrR3h41TDCTJojY59usg3mbtbjnFs7Eud1Y6u"
+		edExpectedDIDKey   = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+		edExpectedDIDKeyID = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH" //nolint:lll
 
-	t.Run("test CreateDIDKey", func(t *testing.T) {
-		didKey, keyID := CreateDIDKey(base58.Decode(pubKeyBase58))
+		bbsPubKeyBase58     = "25EEkQtcLKsEzQ6JTo9cg4W7NHpaurn4Wg6LaNPFq6JQXnrP91SDviUz7KrJVMJd76CtAZFsRLYzvgX2JGxo2ccUHtuHk7ELCWwrkBDfrXCFVfqJKDootee9iVaF6NpdJtBE"                                                                                                                                                    //nolint:lll
+		bbsExpectedDIDKey   = "did:key:zUC7K4ndUaGZgV7Cp2yJy6JtMoUHY6u7tkcSYUvPrEidqBmLCTLmi6d5WvwnUqejscAkERJ3bfjEiSYtdPkRSE8kSa11hFBr4sTgnbZ95SJj19PN2jdvJjyzpSZgxkyyxNnBNnY"                                                                                                                                         //nolint:lll
+		bbsExpectedDIDKeyID = "did:key:zUC7K4ndUaGZgV7Cp2yJy6JtMoUHY6u7tkcSYUvPrEidqBmLCTLmi6d5WvwnUqejscAkERJ3bfjEiSYtdPkRSE8kSa11hFBr4sTgnbZ95SJj19PN2jdvJjyzpSZgxkyyxNnBNnY#zUC7K4ndUaGZgV7Cp2yJy6JtMoUHY6u7tkcSYUvPrEidqBmLCTLmi6d5WvwnUqejscAkERJ3bfjEiSYtdPkRSE8kSa11hFBr4sTgnbZ95SJj19PN2jdvJjyzpSZgxkyyxNnBNnY" //nolint:lll
 
-		require.Equal(t, didKey, expectedDIDKey)
-		require.Equal(t, keyID, expectedDIDKeyID)
-	})
+		ecP256PubKeyBase58     = "3YRwdf868zp2t8c4oT4XdYfCihMsfR1zrVYyXS5SS4FwQ7wftDfoY5nohvhdgSk9LxyfzjTLzffJPmHgFBqizX9v"
+		ecP256ExpectedDIDKey   = "did:key:zrurwcJZss4ruepVNu1H3xmSirvNbzgBk9qrCktB6kaewXnJAhYWwtP3bxACqBpzjZdN7TyHNzzGGSSH5qvZsSDir9z"                                                                                             //nolint:lll
+		ecP256ExpectedDIDKeyID = "did:key:zrurwcJZss4ruepVNu1H3xmSirvNbzgBk9qrCktB6kaewXnJAhYWwtP3bxACqBpzjZdN7TyHNzzGGSSH5qvZsSDir9z#zrurwcJZss4ruepVNu1H3xmSirvNbzgBk9qrCktB6kaewXnJAhYWwtP3bxACqBpzjZdN7TyHNzzGGSSH5qvZsSDir9z" //nolint:lll
 
-	t.Run("test PubKeyFromFingerprint success", func(t *testing.T) {
-		pubKey, code, err := PubKeyFromFingerprint(strings.Split(expectedDIDKeyID, "#")[1])
-		require.Equal(t, uint64(ed25519pub), code)
-		require.NoError(t, err)
+		ecP384PubKeyBase58     = "tAjHMcvoBXs3BSihDV85trHmstc3V3vTP7o2Si72eCWdVzeGgGvRd8h5neHEbqSL989h53yNj7M7wHckB2bKpGKQjnPDD7NphDa9nUUBggCB6aCWterfdXbH5DfWPZx5oXU"                                                                                                                                                     //nolint:lll
+		ecP384ExpectedDIDKey   = "did:key:zFwfeyrSyWdksRYykTGGtagWazFB5zS4CjQcxDMQSNmCTQB5QMqokx2VJz4vBB2hN1nUrYDTuYq3kd1BM5cUCfFD4awiNuzEBuoy6rZZTMCsZsdvWkDXY6832qcAnzE7YGw43KU"                                                                                                                                         //nolint:lll
+		ecP384ExpectedDIDKeyID = "did:key:zFwfeyrSyWdksRYykTGGtagWazFB5zS4CjQcxDMQSNmCTQB5QMqokx2VJz4vBB2hN1nUrYDTuYq3kd1BM5cUCfFD4awiNuzEBuoy6rZZTMCsZsdvWkDXY6832qcAnzE7YGw43KU#zFwfeyrSyWdksRYykTGGtagWazFB5zS4CjQcxDMQSNmCTQB5QMqokx2VJz4vBB2hN1nUrYDTuYq3kd1BM5cUCfFD4awiNuzEBuoy6rZZTMCsZsdvWkDXY6832qcAnzE7YGw43KU" //nolint:lll
 
-		require.Equal(t, base58.Encode(pubKey), pubKeyBase58)
-	})
+		ecP521PubKeyBase58     = "mTQ9pPr2wkKdiTHhVG7xmLwyJ5mrgq1FKcHFz2XJprs4zAPtjXWFiEz6vsscbseSEzGdjAVzcUhwdodT5cbrRjQqFdz8d1yYVqMHXsVCdCUrmWNNHcZLJeYCn1dCtQX9YRVdDFfnzczKFxDXe9HusLqBWTobbxVvdj9cTi7rSWVznP5Emfo"                                                                                                                                                                                                       //nolint:lll
+		ecP521ExpectedDIDKey   = "did:key:zWGhj2NTyCiehTPioanYSuSrfB7RJKwZj6bBUDNojfGEA21nr5NcBsHme7hcVSbptpWKarJpTcw814J3X8gVU9gZmeKM27JpGA5wNMzt8JZwjDyf8EzCJg5ve5GR2Xfm7d9Djp73V7s35KPeKe7VHMzmL8aPw4XBniNej5sXapPFoBs5R8m195HK"                                                                                                                                                                                          //nolint:lll
+		ecP521ExpectedDIDKeyID = "did:key:zWGhj2NTyCiehTPioanYSuSrfB7RJKwZj6bBUDNojfGEA21nr5NcBsHme7hcVSbptpWKarJpTcw814J3X8gVU9gZmeKM27JpGA5wNMzt8JZwjDyf8EzCJg5ve5GR2Xfm7d9Djp73V7s35KPeKe7VHMzmL8aPw4XBniNej5sXapPFoBs5R8m195HK#zWGhj2NTyCiehTPioanYSuSrfB7RJKwZj6bBUDNojfGEA21nr5NcBsHme7hcVSbptpWKarJpTcw814J3X8gVU9gZmeKM27JpGA5wNMzt8JZwjDyf8EzCJg5ve5GR2Xfm7d9Djp73V7s35KPeKe7VHMzmL8aPw4XBniNej5sXapPFoBs5R8m195HK" //nolint:lll
+	)
+
+	tests := []struct {
+		name     string
+		keyB58   string
+		DIDKey   string
+		DIDKeyID string
+		keyCode  uint64
+	}{
+		{
+			name:     "test ED25519",
+			keyB58:   edPubKeyBase58,
+			DIDKey:   edExpectedDIDKey,
+			DIDKeyID: edExpectedDIDKeyID,
+			keyCode:  ED25519PubKeyMultiCodec,
+		},
+		{
+			name:     "test BBS+",
+			keyB58:   bbsPubKeyBase58,
+			DIDKey:   bbsExpectedDIDKey,
+			DIDKeyID: bbsExpectedDIDKeyID,
+			keyCode:  BLS12381g2PubKeyMultiCodec,
+		},
+		{
+			name:     "test P-256",
+			keyB58:   ecP256PubKeyBase58,
+			DIDKey:   ecP256ExpectedDIDKey,
+			DIDKeyID: ecP256ExpectedDIDKeyID,
+			keyCode:  P256PubKeyMultiCodec,
+		},
+		{
+			name:     "test P-384",
+			keyB58:   ecP384PubKeyBase58,
+			DIDKey:   ecP384ExpectedDIDKey,
+			DIDKeyID: ecP384ExpectedDIDKeyID,
+			keyCode:  P384PubKeyMultiCodec,
+		},
+		{
+			name:     "test P-521",
+			keyB58:   ecP521PubKeyBase58,
+			DIDKey:   ecP521ExpectedDIDKey,
+			DIDKeyID: ecP521ExpectedDIDKeyID,
+			keyCode:  P521PubKeyMultiCodec,
+		},
+	}
+
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.name+" CreateDIDKey", func(t *testing.T) {
+			didKey, keyID := CreateDIDKeyByCode(tc.keyCode, base58.Decode(tc.keyB58))
+
+			require.Equal(t, didKey, tc.DIDKey)
+			require.Equal(t, keyID, tc.DIDKeyID)
+		})
+
+		t.Run(tc.name+" PubKeyFromFingerprint success", func(t *testing.T) {
+			pubKey, code, err := PubKeyFromFingerprint(strings.Split(tc.DIDKeyID, "#")[1])
+			require.Equal(t, tc.keyCode, code)
+			require.NoError(t, err)
+
+			require.Equal(t, base58.Encode(pubKey), tc.keyB58)
+		})
+
+		t.Run(tc.name+" PubKeyFromDIDKey", func(t *testing.T) {
+			pubKey, err := PubKeyFromDIDKey(tc.DIDKey)
+			require.Equal(t, tc.keyB58, base58.Encode(pubKey))
+			require.NoError(t, err)
+		})
+	}
 
 	t.Run("test PubKeyFromFingerprint fail", func(t *testing.T) {
-		badDIDKeyID := "AB" + strings.Split(expectedDIDKeyID, "#")[1][2:]
+		badDIDKeyID := "AB" + strings.Split(edExpectedDIDKeyID, "#")[1][2:]
 
 		_, _, err := PubKeyFromFingerprint(badDIDKeyID)
 		require.EqualError(t, err, "unknown key encoding")
@@ -54,7 +125,13 @@ func TestDIDKeyEd25519(t *testing.T) {
 	const (
 		k1       = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
 		k1Base58 = "B12NYF8RrR3h41TDCTJojY59usg3mbtbjnFs7Eud1Y6u"
+		k1KeyID  = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH" //nolint:lll
 	)
+
+	didKey, keyID := CreateDIDKey(base58.Decode(k1Base58))
+
+	require.Equal(t, didKey, k1)
+	require.Equal(t, keyID, k1KeyID)
 
 	pubKey, err := PubKeyFromDIDKey(k1)
 	require.Equal(t, k1Base58, base58.Encode(pubKey))

--- a/pkg/vdr/key/creator.go
+++ b/pkg/vdr/key/creator.go
@@ -7,6 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package key
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/x509"
+	"errors"
 	"fmt"
 	"time"
 
@@ -22,16 +26,12 @@ const (
 	ed25519VerificationKey2018 = "Ed25519VerificationKey2018"
 	x25519KeyAgreementKey2019  = "X25519KeyAgreementKey2019"
 	bls12381G2Key2020          = "Bls12381G2Key2020"
+	jsonWebKey2020             = "JsonWebKey2020"
 )
 
-const (
-	// source: https://github.com/multiformats/multicodec/blob/master/table.csv.
-	x25519pub     = 0xec // Curve25519 public key in multicodec table
-	ed25519pub    = 0xed // Ed25519 public key in multicodec table
-	bls12381g2pub = 0xeb // BLS12-381 G2 public key in multicodec table
-)
-
-// Create new DID document.
+// Create new DID document for didDoc.
+// Either didDoc must contain non-empty VerificationMethod[] or opts must contain KeyType value of kms.KeyType to create
+// a new key and a corresponding *VerificationMethod entry.
 func (v *VDR) Create(keyManager kms.KeyManager, didDoc *did.Doc,
 	opts ...vdrapi.DIDMethodOption) (*did.DocResolution, error) {
 	createDIDOpts := &vdrapi.DIDMethodOpts{Values: make(map[string]interface{})}
@@ -44,34 +44,37 @@ func (v *VDR) Create(keyManager kms.KeyManager, didDoc *did.Doc,
 		publicKey, keyAgr *did.VerificationMethod
 		err               error
 		didKey            string
+		keyID             string
+		keyCode           uint64
+		keyType           kms.KeyType
 	)
 
 	if len(didDoc.VerificationMethod) == 0 {
-		_, pubKeyBytes, errCreate := keyManager.CreateAndExportPubKeyBytes(kms.ED25519Type)
-		if errCreate != nil {
-			return nil, fmt.Errorf("failed to create and export public key: %w", errCreate)
+		keyType, err = extractKeyTypeFromOpts(createDIDOpts)
+		if err != nil {
+			return nil, err
 		}
 
-		didDoc.VerificationMethod = append(didDoc.VerificationMethod, did.VerificationMethod{
-			Type:  ed25519VerificationKey2018,
-			Value: pubKeyBytes,
-		})
+		err = createNewKeyAndVerificationMethod(didDoc, keyType, keyManager)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	switch didDoc.VerificationMethod[0].Type {
-	case ed25519VerificationKey2018:
-		var keyID string
+	keyCode, err = getKeyCode(keyType, &didDoc.VerificationMethod[0])
+	if err != nil {
+		return nil, err
+	}
 
-		didKey, keyID = fingerprint.CreateDIDKey(didDoc.VerificationMethod[0].Value)
-		publicKey = did.NewVerificationMethodFromBytes(keyID, ed25519VerificationKey2018, didKey,
-			didDoc.VerificationMethod[0].Value)
+	didKey, keyID = fingerprint.CreateDIDKeyByCode(keyCode, didDoc.VerificationMethod[0].Value)
+	publicKey = did.NewVerificationMethodFromBytes(keyID, didDoc.VerificationMethod[0].Type, didKey,
+		didDoc.VerificationMethod[0].Value)
 
+	if didDoc.VerificationMethod[0].Type == ed25519VerificationKey2018 {
 		keyAgr, err = keyAgreementFromEd25519(didKey, didDoc.VerificationMethod[0].Value)
 		if err != nil {
 			return nil, err
 		}
-	default:
-		return nil, fmt.Errorf("not supported public key type: %s", didDoc.VerificationMethod[0].Type)
 	}
 
 	// retrieve encryption key as keyAgreement from opts if available.
@@ -88,26 +91,151 @@ func (v *VDR) Create(keyManager kms.KeyManager, didDoc *did.Doc,
 	return &did.DocResolution{DIDDocument: createDoc(publicKey, keyAgr, didKey)}, nil
 }
 
+func createNewKeyAndVerificationMethod(didDoc *did.Doc, keyType kms.KeyType, keyManager kms.KeyManager) error {
+	vmType := getVerMethodType(keyType)
+
+	_, pubKeyBytes, err := keyManager.CreateAndExportPubKeyBytes(keyType)
+	if err != nil {
+		return err
+	}
+
+	pubKeyBytes, err = convertPubKeyBytes(pubKeyBytes, keyType)
+	if err != nil {
+		return err
+	}
+
+	didDoc.VerificationMethod = append(didDoc.VerificationMethod, did.VerificationMethod{
+		Type:  vmType,
+		Value: pubKeyBytes,
+	})
+
+	return nil
+}
+
+func extractKeyTypeFromOpts(createDIDOpts *vdrapi.DIDMethodOpts) (kms.KeyType, error) {
+	var keyType kms.KeyType
+
+	k := createDIDOpts.Values[KeyType]
+	if k != nil {
+		var ok bool
+		keyType, ok = k.(kms.KeyType)
+
+		if !ok {
+			return "", errors.New("keyType is not kms.KeyType")
+		}
+
+		return keyType, nil
+	}
+
+	return "", errors.New("keyType option is needed for empty didDoc.VerificationMethod")
+}
+
+// convertPubKeyBytes converts marshalled bytes into 'did:key' ready to use public key bytes. This is mainly useful for
+// ECDSA keys. The elliptic.Marshal() function returns 65 bytes (for P-256 curves) where the first byte is the
+// compression point, it must be truncated to build a proper public key for did:key construction. It must be set back
+// when building a public key from did:key (using default compression point value is 4 for non compressed marshalling,
+// see: https://github.com/golang/go/blob/master/src/crypto/elliptic/elliptic.go#L319).
+func convertPubKeyBytes(bytes []byte, keyType kms.KeyType) ([]byte, error) {
+	switch keyType {
+	case kms.ED25519Type, kms.BLS12381G2Type: // no conversion needed for non ECDSA keys.
+		return bytes, nil
+	case kms.ECDSAP256TypeIEEEP1363, kms.ECDSAP384TypeIEEEP1363, kms.ECDSAP521TypeIEEEP1363:
+		// truncate first byte to remove compression point.
+		return bytes[1:], nil
+	case kms.ECDSAP256TypeDER, kms.ECDSAP384TypeDER, kms.ECDSAP521TypeDER:
+		pubKey, err := x509.ParsePKIXPublicKey(bytes)
+		if err != nil {
+			return nil, err
+		}
+
+		ecKey, ok := pubKey.(*ecdsa.PublicKey)
+		if !ok {
+			return nil, errors.New("invalid EC key")
+		}
+
+		// truncate first byte to remove compression point.
+		return elliptic.Marshal(ecKey.Curve, ecKey.X, ecKey.Y)[1:], nil
+	default:
+		return nil, errors.New("invalid key type")
+	}
+}
+
+func getVerMethodType(kt kms.KeyType) string {
+	vmType := map[kms.KeyType]string{
+		kms.ED25519Type:            ed25519VerificationKey2018,
+		kms.BLS12381G2Type:         bls12381G2Key2020,
+		kms.ECDSAP256TypeDER:       jsonWebKey2020,
+		kms.ECDSAP256TypeIEEEP1363: jsonWebKey2020,
+		kms.ECDSAP384TypeDER:       jsonWebKey2020,
+		kms.ECDSAP384TypeIEEEP1363: jsonWebKey2020,
+		kms.ECDSAP521TypeDER:       jsonWebKey2020,
+		kms.ECDSAP521TypeIEEEP1363: jsonWebKey2020,
+	}
+
+	return vmType[kt]
+}
+
+func getKeyCode(keyType kms.KeyType, verificationMethod *did.VerificationMethod) (uint64, error) {
+	var keyCode uint64
+
+	switch verificationMethod.Type {
+	case ed25519VerificationKey2018:
+		keyCode = fingerprint.ED25519PubKeyMultiCodec
+	case bls12381G2Key2020:
+		keyCode = fingerprint.BLS12381g2PubKeyMultiCodec
+	case jsonWebKey2020:
+		if keyType == "" {
+			return fetchECKeyCodeFromVerMethod(verificationMethod)
+		}
+
+		switch keyType {
+		case kms.ECDSAP256TypeDER, kms.ECDSAP256TypeIEEEP1363:
+			keyCode = fingerprint.P256PubKeyMultiCodec
+		case kms.ECDSAP384TypeDER, kms.ECDSAP384TypeIEEEP1363:
+			keyCode = fingerprint.P384PubKeyMultiCodec
+		case kms.ECDSAP521TypeDER, kms.ECDSAP521TypeIEEEP1363:
+			keyCode = fingerprint.P521PubKeyMultiCodec
+		default:
+			return 0, errors.New("invalid jsonWebKey2020 key type")
+		}
+	default:
+		return 0, fmt.Errorf("not supported public key type: %s", verificationMethod.Type)
+	}
+
+	return keyCode, nil
+}
+
+func fetchECKeyCodeFromVerMethod(method *did.VerificationMethod) (uint64, error) {
+	ecdsaCodesByKeyLen := map[int]uint64{
+		64:  fingerprint.P256PubKeyMultiCodec,
+		96:  fingerprint.P384PubKeyMultiCodec,
+		132: fingerprint.P521PubKeyMultiCodec,
+	}
+
+	return ecdsaCodesByKeyLen[len(method.Value)], nil
+}
+
 func createDoc(pubKey, keyAgreement *did.VerificationMethod, didKey string) *did.Doc {
 	// Created/Updated time
 	t := time.Now()
 
+	kaVerification := make([]did.Verification, 0)
+
+	if keyAgreement != nil {
+		kaVerification = []did.Verification{*did.NewEmbeddedVerification(keyAgreement, did.KeyAgreement)}
+	}
+
 	return &did.Doc{
-		Context:            []string{schemaV1},
-		ID:                 didKey,
-		VerificationMethod: []did.VerificationMethod{*pubKey},
-		Authentication: []did.Verification{*did.NewReferencedVerification(pubKey,
-			did.Authentication)},
-		AssertionMethod: []did.Verification{*did.NewReferencedVerification(pubKey,
-			did.AssertionMethod)},
-		CapabilityDelegation: []did.Verification{*did.NewReferencedVerification(pubKey,
-			did.CapabilityDelegation)},
-		CapabilityInvocation: []did.Verification{*did.NewReferencedVerification(pubKey,
-			did.CapabilityInvocation)},
-		KeyAgreement: []did.Verification{*did.NewEmbeddedVerification(keyAgreement,
-			did.KeyAgreement)},
-		Created: &t,
-		Updated: &t,
+		Context:              []string{schemaV1},
+		ID:                   didKey,
+		VerificationMethod:   []did.VerificationMethod{*pubKey},
+		Authentication:       []did.Verification{*did.NewReferencedVerification(pubKey, did.Authentication)},
+		AssertionMethod:      []did.Verification{*did.NewReferencedVerification(pubKey, did.AssertionMethod)},
+		CapabilityDelegation: []did.Verification{*did.NewReferencedVerification(pubKey, did.CapabilityDelegation)},
+		CapabilityInvocation: []did.Verification{*did.NewReferencedVerification(pubKey, did.CapabilityInvocation)},
+		KeyAgreement:         kaVerification,
+		Created:              &t,
+		Updated:              &t,
 	}
 }
 
@@ -117,7 +245,7 @@ func keyAgreementFromEd25519(didKey string, ed25519PubKey []byte) (*did.Verifica
 		return nil, err
 	}
 
-	fp := fingerprint.KeyFingerprint(x25519pub, curve25519PubKey)
+	fp := fingerprint.KeyFingerprint(fingerprint.X25519PubKeyMultiCodec, curve25519PubKey)
 	keyID := fmt.Sprintf("%s#%s", didKey, fp)
 	pubKey := did.NewVerificationMethodFromBytes(keyID, x25519KeyAgreementKey2019, didKey, curve25519PubKey)
 

--- a/pkg/vdr/key/resolver.go
+++ b/pkg/vdr/key/resolver.go
@@ -41,10 +41,12 @@ func (v *VDR) Read(didKey string, opts ...vdrapi.ResolveOption) (*did.DocResolut
 
 func createDIDDocFromPubKey(kid string, code uint64, pubKeyBytes []byte) (*did.Doc, error) {
 	switch code {
-	case ed25519pub:
+	case fingerprint.ED25519PubKeyMultiCodec:
 		return createEd25519DIDDoc(kid, pubKeyBytes)
-	case bls12381g2pub:
+	case fingerprint.BLS12381g2PubKeyMultiCodec:
 		return createBase58DIDDoc(kid, bls12381G2Key2020, pubKeyBytes)
+	case fingerprint.P256PubKeyMultiCodec, fingerprint.P384PubKeyMultiCodec, fingerprint.P521PubKeyMultiCodec:
+		return createBase58DIDDoc(kid, jsonWebKey2020, pubKeyBytes)
 	}
 
 	return nil, fmt.Errorf("unsupported key multicodec code [0x%x]", code)

--- a/pkg/vdr/key/resolver_test.go
+++ b/pkg/vdr/key/resolver_test.go
@@ -86,3 +86,90 @@ func TestReadBBS(t *testing.T) {
 		assertBase58Doc(t, docResolution.DIDDocument, k2, k2KID, bls12381G2Key2020, k2Base58)
 	})
 }
+
+func TestReadP256(t *testing.T) {
+	v := New()
+
+	const (
+		k1       = "did:key:zrurwcJZss4ruepVNu1H3xmSirvNbzgBk9qrCktB6kaewXnJAhYWwtP3bxACqBpzjZdN7TyHNzzGGSSH5qvZsSDir9z"
+		k1KID    = "did:key:zrurwcJZss4ruepVNu1H3xmSirvNbzgBk9qrCktB6kaewXnJAhYWwtP3bxACqBpzjZdN7TyHNzzGGSSH5qvZsSDir9z#zrurwcJZss4ruepVNu1H3xmSirvNbzgBk9qrCktB6kaewXnJAhYWwtP3bxACqBpzjZdN7TyHNzzGGSSH5qvZsSDir9z" //nolint:lll
+		k1Base58 = "3YRwdf868zp2t8c4oT4XdYfCihMsfR1zrVYyXS5SS4FwQ7wftDfoY5nohvhdgSk9LxyfzjTLzffJPmHgFBqizX9v"
+		k2       = "did:key:zrusAFgBbf84b8mBz8Cmy8UoFWKV52EaeRnK86vnLo4Z5QoRypE6hXVPN2urevZMAMtcTaCDFLWBaE1Q3jmdb1FHgve"
+		k2KID    = "did:key:zrusAFgBbf84b8mBz8Cmy8UoFWKV52EaeRnK86vnLo4Z5QoRypE6hXVPN2urevZMAMtcTaCDFLWBaE1Q3jmdb1FHgve#zrusAFgBbf84b8mBz8Cmy8UoFWKV52EaeRnK86vnLo4Z5QoRypE6hXVPN2urevZMAMtcTaCDFLWBaE1Q3jmdb1FHgve" //nolint:lll
+		k2Base58 = "3m5KFNv9LgHyajqGJNEEz5JbqAPS4KHwKQu28g7vLC8xXw4MTyJusqsZMkSN2sYQbK5tvbnruySsWjBXJuQkZMva"
+	)
+
+	t.Run("key 1", func(t *testing.T) {
+		docResolution, err := v.Read(k1)
+		require.NoError(t, err)
+		require.NotNil(t, docResolution.DIDDocument)
+
+		assertBase58Doc(t, docResolution.DIDDocument, k1, k1KID, jsonWebKey2020, k1Base58)
+	})
+
+	t.Run("key 2", func(t *testing.T) {
+		docResolution, err := v.Read(k2)
+		require.NoError(t, err)
+		require.NotNil(t, docResolution.DIDDocument)
+
+		assertBase58Doc(t, docResolution.DIDDocument, k2, k2KID, jsonWebKey2020, k2Base58)
+	})
+}
+
+func TestReadP384(t *testing.T) {
+	v := New()
+
+	const (
+		k1       = "did:key:zFwfeyrSyWdksRYykTGGtagWazFB5zS4CjQcxDMQSNmCTQB5QMqokx2VJz4vBB2hN1nUrYDTuYq3kd1BM5cUCfFD4awiNuzEBuoy6rZZTMCsZsdvWkDXY6832qcAnzE7YGw43KU"                                                                                                                                         //nolint:lll
+		k1KID    = "did:key:zFwfeyrSyWdksRYykTGGtagWazFB5zS4CjQcxDMQSNmCTQB5QMqokx2VJz4vBB2hN1nUrYDTuYq3kd1BM5cUCfFD4awiNuzEBuoy6rZZTMCsZsdvWkDXY6832qcAnzE7YGw43KU#zFwfeyrSyWdksRYykTGGtagWazFB5zS4CjQcxDMQSNmCTQB5QMqokx2VJz4vBB2hN1nUrYDTuYq3kd1BM5cUCfFD4awiNuzEBuoy6rZZTMCsZsdvWkDXY6832qcAnzE7YGw43KU" //nolint:lll
+		k1Base58 = "tAjHMcvoBXs3BSihDV85trHmstc3V3vTP7o2Si72eCWdVzeGgGvRd8h5neHEbqSL989h53yNj7M7wHckB2bKpGKQjnPDD7NphDa9nUUBggCB6aCWterfdXbH5DfWPZx5oXU"                                                                                                                                                     //nolint:lll
+		k2       = "did:key:zFwepbBSaPFjt5T1zWptHaXugLNxHYABfJrDoAZRYxKjNkpdfrniF3pvYQAXwxVB7afhmsgzYtSCzTVZQ3F5SPHzP5PuHgtBGNYucZTSrnA7yTTDr7WGQZaTTkJWfiH47jW5ahU"                                                                                                                                         //nolint:lll
+		k2KID    = "did:key:zFwepbBSaPFjt5T1zWptHaXugLNxHYABfJrDoAZRYxKjNkpdfrniF3pvYQAXwxVB7afhmsgzYtSCzTVZQ3F5SPHzP5PuHgtBGNYucZTSrnA7yTTDr7WGQZaTTkJWfiH47jW5ahU#zFwepbBSaPFjt5T1zWptHaXugLNxHYABfJrDoAZRYxKjNkpdfrniF3pvYQAXwxVB7afhmsgzYtSCzTVZQ3F5SPHzP5PuHgtBGNYucZTSrnA7yTTDr7WGQZaTTkJWfiH47jW5ahU" //nolint:lll
+		k2Base58 = "3n4GxVYnCBm5RWHJcUyUzCRZ5SLAwdN4E513ZHfZZZABmVbBANirrYnhZRjiMQKZ4TdDiPaXxwqVzFFMQke78kmbeZHAHa7mCvU3BuRS6G1URwVFm8K64SHcwwiSy2X7LuU"                                                                                                                                                     //nolint:lll
+	)
+
+	t.Run("key 1", func(t *testing.T) {
+		docResolution, err := v.Read(k1)
+		require.NoError(t, err)
+		require.NotNil(t, docResolution.DIDDocument)
+
+		assertBase58Doc(t, docResolution.DIDDocument, k1, k1KID, jsonWebKey2020, k1Base58)
+	})
+
+	t.Run("key 2", func(t *testing.T) {
+		docResolution, err := v.Read(k2)
+		require.NoError(t, err)
+		require.NotNil(t, docResolution.DIDDocument)
+
+		assertBase58Doc(t, docResolution.DIDDocument, k2, k2KID, jsonWebKey2020, k2Base58)
+	})
+}
+
+func TestRead521(t *testing.T) {
+	v := New()
+
+	const (
+		k1       = "did:key:zWGhj2NTyCiehTPioanYSuSrfB7RJKwZj6bBUDNojfGEA21nr5NcBsHme7hcVSbptpWKarJpTcw814J3X8gVU9gZmeKM27JpGA5wNMzt8JZwjDyf8EzCJg5ve5GR2Xfm7d9Djp73V7s35KPeKe7VHMzmL8aPw4XBniNej5sXapPFoBs5R8m195HK"                                                                                                                                                                                          //nolint:lll
+		k1KID    = "did:key:zWGhj2NTyCiehTPioanYSuSrfB7RJKwZj6bBUDNojfGEA21nr5NcBsHme7hcVSbptpWKarJpTcw814J3X8gVU9gZmeKM27JpGA5wNMzt8JZwjDyf8EzCJg5ve5GR2Xfm7d9Djp73V7s35KPeKe7VHMzmL8aPw4XBniNej5sXapPFoBs5R8m195HK#zWGhj2NTyCiehTPioanYSuSrfB7RJKwZj6bBUDNojfGEA21nr5NcBsHme7hcVSbptpWKarJpTcw814J3X8gVU9gZmeKM27JpGA5wNMzt8JZwjDyf8EzCJg5ve5GR2Xfm7d9Djp73V7s35KPeKe7VHMzmL8aPw4XBniNej5sXapPFoBs5R8m195HK" //nolint:lll
+		k1Base58 = "mTQ9pPr2wkKdiTHhVG7xmLwyJ5mrgq1FKcHFz2XJprs4zAPtjXWFiEz6vsscbseSEzGdjAVzcUhwdodT5cbrRjQqFdz8d1yYVqMHXsVCdCUrmWNNHcZLJeYCn1dCtQX9YRVdDFfnzczKFxDXe9HusLqBWTobbxVvdj9cTi7rSWVznP5Emfo"                                                                                                                                                                                                       //nolint:lll
+		k2       = "did:key:zWGhiwzmESrRykvUMCSNCadMyhzgAMVXST3KLSxY5unckUdYaGBZs59WMkMggeenMFAr938YxbEesbQ7myxmqDYo3m7xgFu8ppYDx2waz2Lw6eD9aADLn6Cw6Q6gTrH6sry211Z16nvVW25dsY6bZKhGKt4DeB1gGfvBk8bxwKuxTUtZrgwrMm1S"                                                                                                                                                                                          //nolint:lll
+		k2KID    = "did:key:zWGhiwzmESrRykvUMCSNCadMyhzgAMVXST3KLSxY5unckUdYaGBZs59WMkMggeenMFAr938YxbEesbQ7myxmqDYo3m7xgFu8ppYDx2waz2Lw6eD9aADLn6Cw6Q6gTrH6sry211Z16nvVW25dsY6bZKhGKt4DeB1gGfvBk8bxwKuxTUtZrgwrMm1S#zWGhiwzmESrRykvUMCSNCadMyhzgAMVXST3KLSxY5unckUdYaGBZs59WMkMggeenMFAr938YxbEesbQ7myxmqDYo3m7xgFu8ppYDx2waz2Lw6eD9aADLn6Cw6Q6gTrH6sry211Z16nvVW25dsY6bZKhGKt4DeB1gGfvBk8bxwKuxTUtZrgwrMm1S" //nolint:lll
+		k2Base58 = "h5hR4XdKFH5BL77TASdHJECqKdja3H97ZC1cEYuuHUcoAyMZwPEyLu4J8vq52YAzRp18hU2s9anCV5up9Uq8YY2VQEJhHUG8An49FeUa3RyJgjWqhjZndUoe6cxy8EKQjsTEtK8DhJys9wKobqnucpetcxJ5ZW2wgTaxyEpWjXzSLZvTTPv"                                                                                                                                                                                                       //nolint:lll
+	)
+
+	t.Run("key 1", func(t *testing.T) {
+		docResolution, err := v.Read(k1)
+		require.NoError(t, err)
+		require.NotNil(t, docResolution.DIDDocument)
+
+		assertBase58Doc(t, docResolution.DIDDocument, k1, k1KID, jsonWebKey2020, k1Base58)
+	})
+
+	t.Run("key 2", func(t *testing.T) {
+		docResolution, err := v.Read(k2)
+		require.NoError(t, err)
+		require.NotNil(t, docResolution.DIDDocument)
+
+		assertBase58Doc(t, docResolution.DIDDocument, k2, k2KID, jsonWebKey2020, k2Base58)
+	})
+}

--- a/pkg/vdr/key/vdr.go
+++ b/pkg/vdr/key/vdr.go
@@ -19,6 +19,8 @@ const (
 	DIDMethod = "key"
 	// EncryptionKey encryption key.
 	EncryptionKey = "encryptionKey"
+	// KeyType option to create a new kms key for DIDDocs with empty VerificationMethod.
+	KeyType = "keyType"
 )
 
 // VDR implements did:key method support.


### PR DESCRIPTION
This change introduces NIST P ECDSA and BBS did:key creation
And did:key resolution for ECDSA keys.

closes #2319

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
