### PR TITLE
fix: typo in derive credential controller

### DIFF
--- a/pkg/controller/command/verifiable/command.go
+++ b/pkg/controller/command/verifiable/command.go
@@ -482,7 +482,7 @@ func (o *Command) DeriveCredential(rw io.Writer, req io.Reader) command.Error {
 			fmt.Errorf("failed to marshal derived credential  : %w", err))
 	}
 
-	command.WriteNillableResponse(rw, &SignCredentialResponse{
+	command.WriteNillableResponse(rw, &DeriveCredentialResponse{
 		VerifiableCredential: vcBytes,
 	}, logger)
 


### PR DESCRIPTION
- part of #2592

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
