### PR TITLE
feat: Present proof - signs the presentation

### DIFF
--- a/pkg/client/presentproof/client_test.go
+++ b/pkg/client/presentproof/client_test.go
@@ -132,7 +132,7 @@ func TestClient_AcceptRequestPresentation(t *testing.T) {
 	client, err := New(provider)
 	require.NoError(t, err)
 
-	require.NoError(t, client.AcceptRequestPresentation("PIID", &Presentation{}))
+	require.NoError(t, client.AcceptRequestPresentation("PIID", &Presentation{}, nil))
 }
 
 func TestClient_DeclineRequestPresentation(t *testing.T) {

--- a/pkg/client/presentproof/example_test.go
+++ b/pkg/client/presentproof/example_test.go
@@ -145,7 +145,7 @@ func ExampleClient_SendRequestPresentation() {
 			case e := <-actionsAlice:
 				acceptErr = clientAlice.AcceptPresentation(e.Properties.All()["piid"].(string))
 			case e := <-actionsBob:
-				acceptErr = clientBob.AcceptRequestPresentation(e.Properties.All()["piid"].(string), &Presentation{})
+				acceptErr = clientBob.AcceptRequestPresentation(e.Properties.All()["piid"].(string), &Presentation{}, nil)
 			}
 
 			if acceptErr != nil {
@@ -214,7 +214,7 @@ func ExampleClient_SendRequestPresentation_second() {
 			case e := <-actionsAlice:
 				acceptErr = clientAlice.AcceptPresentation(e.Properties.All()["piid"].(string))
 			case e := <-actionsBob:
-				acceptErr = clientBob.AcceptRequestPresentation(e.Properties.All()["piid"].(string), &Presentation{})
+				acceptErr = clientBob.AcceptRequestPresentation(e.Properties.All()["piid"].(string), &Presentation{}, nil)
 			}
 
 			if acceptErr != nil {
@@ -302,7 +302,7 @@ func ExampleClient_SendProposePresentation() {
 			}
 
 			if e.Message.Type() == presentproof.RequestPresentationMsgType {
-				acceptErr = clientAlice.AcceptRequestPresentation(piid, &Presentation{})
+				acceptErr = clientAlice.AcceptRequestPresentation(piid, &Presentation{}, nil)
 			}
 
 			if acceptErr != nil {

--- a/pkg/controller/command/presentproof/command.go
+++ b/pkg/controller/command/presentproof/command.go
@@ -253,7 +253,7 @@ func (c *Command) AcceptRequestPresentation(rw io.Writer, req io.Reader) command
 		return command.NewValidationError(InvalidRequestErrorCode, errors.New(errEmptyPresentation))
 	}
 
-	if err := c.client.AcceptRequestPresentation(args.PIID, args.Presentation); err != nil {
+	if err := c.client.AcceptRequestPresentation(args.PIID, args.Presentation, nil); err != nil {
 		logutil.LogError(logger, CommandName, AcceptRequestPresentation, err.Error())
 		return command.NewExecuteError(AcceptRequestPresentationErrorCode, err)
 	}

--- a/pkg/didcomm/protocol/presentproof/middleware.go
+++ b/pkg/didcomm/protocol/presentproof/middleware.go
@@ -6,7 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package presentproof
 
-import "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+)
 
 // Handler describes middleware interface.
 type Handler interface {
@@ -40,4 +43,6 @@ type Metadata interface {
 	StateName() string
 	// Properties provides the possibility to set properties
 	Properties() map[string]interface{}
+	// GetAddProofFn provides function to sign the Presentation.
+	GetAddProofFn() func(presentation *verifiable.Presentation) error
 }

--- a/pkg/didcomm/protocol/presentproof/service_test.go
+++ b/pkg/didcomm/protocol/presentproof/service_test.go
@@ -105,6 +105,7 @@ func TestService_Use(t *testing.T) {
 				require.Equal(t, meta.request, metadata.RequestPresentation())
 				require.Equal(t, meta.presentationNames, metadata.PresentationNames())
 				require.Equal(t, meta.state.Name(), metadata.StateName())
+				require.Nil(t, metadata.GetAddProofFn())
 
 				executed = true
 				return next.Handle(metadata)
@@ -457,7 +458,7 @@ func TestService_HandleInbound(t *testing.T) {
 		require.Equal(t, properties.MyDID(), Alice)
 		require.Equal(t, properties.TheirDID(), Bob)
 
-		action.Continue(WithPresentation(&Presentation{}))
+		action.Continue(WithMultiOptions(WithPresentation(&Presentation{}), WithAddProofFn(nil)))
 
 		select {
 		case <-done:

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -122,7 +122,9 @@ func newPresentProofSvc() api.ProtocolSvcCreator {
 		// sets default middleware to the service
 		service.Use(
 			mdpresentproof.SavePresentation(prv),
-			mdpresentproof.PresentationDefinition(prv),
+			mdpresentproof.PresentationDefinition(prv,
+				mdpresentproof.WithAddProofFn(mdpresentproof.AddBBSProofFn(prv)),
+			),
 		)
 
 		return service, nil

--- a/pkg/internal/gomocks/didcomm/protocol/middleware/presentproof/mocks.go
+++ b/pkg/internal/gomocks/didcomm/protocol/middleware/presentproof/mocks.go
@@ -6,10 +6,13 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	crypto "github.com/hyperledger/aries-framework-go/pkg/crypto"
 	service "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	presentproof "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/presentproof"
+	verifiable "github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	vdr "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
-	verifiable "github.com/hyperledger/aries-framework-go/pkg/store/verifiable"
+	kms "github.com/hyperledger/aries-framework-go/pkg/kms"
+	verifiable0 "github.com/hyperledger/aries-framework-go/pkg/store/verifiable"
 	reflect "reflect"
 )
 
@@ -36,6 +39,34 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 	return m.recorder
 }
 
+// Crypto mocks base method
+func (m *MockProvider) Crypto() crypto.Crypto {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Crypto")
+	ret0, _ := ret[0].(crypto.Crypto)
+	return ret0
+}
+
+// Crypto indicates an expected call of Crypto
+func (mr *MockProviderMockRecorder) Crypto() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Crypto", reflect.TypeOf((*MockProvider)(nil).Crypto))
+}
+
+// KMS mocks base method
+func (m *MockProvider) KMS() kms.KeyManager {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "KMS")
+	ret0, _ := ret[0].(kms.KeyManager)
+	return ret0
+}
+
+// KMS indicates an expected call of KMS
+func (mr *MockProviderMockRecorder) KMS() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KMS", reflect.TypeOf((*MockProvider)(nil).KMS))
+}
+
 // VDRegistry mocks base method
 func (m *MockProvider) VDRegistry() vdr.Registry {
 	m.ctrl.T.Helper()
@@ -51,10 +82,10 @@ func (mr *MockProviderMockRecorder) VDRegistry() *gomock.Call {
 }
 
 // VerifiableStore mocks base method
-func (m *MockProvider) VerifiableStore() verifiable.Store {
+func (m *MockProvider) VerifiableStore() verifiable0.Store {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifiableStore")
-	ret0, _ := ret[0].(verifiable.Store)
+	ret0, _ := ret[0].(verifiable0.Store)
 	return ret0
 }
 
@@ -85,6 +116,20 @@ func NewMockMetadata(ctrl *gomock.Controller) *MockMetadata {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockMetadata) EXPECT() *MockMetadataMockRecorder {
 	return m.recorder
+}
+
+// GetAddProofFn mocks base method
+func (m *MockMetadata) GetAddProofFn() func(*verifiable.Presentation) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAddProofFn")
+	ret0, _ := ret[0].(func(*verifiable.Presentation) error)
+	return ret0
+}
+
+// GetAddProofFn indicates an expected call of GetAddProofFn
+func (mr *MockMetadataMockRecorder) GetAddProofFn() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAddProofFn", reflect.TypeOf((*MockMetadata)(nil).GetAddProofFn))
 }
 
 // Message mocks base method

--- a/test/bdd/features/presentproof.feature
+++ b/test/bdd/features/presentproof.feature
@@ -19,10 +19,18 @@ Feature: Present Proof protocol
   Scenario: The Verifier begins with a request presentation (BBS+)
     Given "Julia" exchange DIDs with "Max"
     Then "Julia" sends a request presentation with presentation definition to the "Max"
-    And "Max" accepts a request and sends credentials with BBS to the "Julia"
+    And "Max" accepts a request and sends credentials with BBS to the "Julia" and proof "BbsBlsSignature2020"
     And "Julia" accepts a presentation with name "bbs-license"
-    And "Julia" checks that presentation is being stored under "bbs-license" name
+    And "Julia" checks that presentation is being stored under "bbs-license" name and has "BbsBlsSignature2020" proof
     Then "Max" checks the history of events "request-received,request-received,presentation-sent,presentation-sent,done,done"
+  @begin_with_request_presentation_default_sign_bbs
+  Scenario: The Verifier begins with a request presentation (default sign with BBS+)
+    Given "Jennifer" exchange DIDs with "John"
+    Then "Jennifer" sends a request presentation with presentation definition to the "John"
+    And "John" accepts a request and sends credentials with BBS to the "Jennifer" and proof "default"
+    And "Jennifer" accepts a presentation with name "bbs-license"
+    And "Jennifer" checks that presentation is being stored under "bbs-license" name and has "BbsBlsSignature2020" proof
+    Then "John" checks the history of events "request-received,request-received,presentation-sent,presentation-sent,done,done"
   @decline_presentation
   Scenario: The Verifier declines presentation
     Given "Thomas" exchange DIDs with "Paul"


### PR DESCRIPTION
By default, we will sign the presentation with `BbsBlsSignature2020` (if a signature is needed). Also, it can be changed by providing an option e.g `WithAddProofFn`. 


Signed-off-by: Andrii Soluk <isoluchok@gmail.com>