### PR TITLE
chore: Fixes permission denied (linux)

### DIFF
--- a/test/aries-js-worker/fixtures/docker-compose.yml
+++ b/test/aries-js-worker/fixtures/docker-compose.yml
@@ -87,5 +87,3 @@ services:
       - SIDETREE_MOCK_DID_NAMESPACE=did:sidetree:test
     ports:
       - 48326:48326
-    volumes:
-      - ../keys/tls:/etc/sidetree/tls


### PR DESCRIPTION
The error  `rm: cannot remove 'test/aries-js-worker/keys/tls': Permission denied` was related to the docker.
Due to folder (`tls`) absence when we mount a volume the `tls` folder was created automatically by docker. It was the root cause of `Permission denied` error. 

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>