### PR TITLE
feat: presexch - parse VCs with proofs

### DIFF
--- a/pkg/doc/presexch/example_test.go
+++ b/pkg/doc/presexch/example_test.go
@@ -1056,7 +1056,7 @@ func ExamplePresentationDefinition_Match() {
 	// verifier matches the received VP against their definitions
 	matched, err := verifierDefinitions.Match(
 		receivedVP,
-		WithJSONLDDocumentLoader(loader),
+		WithCredentialOptions(verifiable.WithJSONLDDocumentLoader(loader)),
 	)
 	if err != nil {
 		panic(fmt.Errorf("presentation submission did not match definitions: %w", err))


### PR DESCRIPTION
Generalized credential parsing options, hence enabling a user to specify a public key fetcher. Used in downstream projects (eg. [rp adapter](https://github.com/trustbloc/edge-adapter/blob/6587a7111ada6bd16386bbcd9d97806d6cfb373a/pkg/restapi/rp/operation/credentials.go#L38)).

Signed-off-by: George Aristy <george.aristy@securekey.com>