### PR TITLE
fix: Inconsistent iterator close log message

### DIFF
--- a/spi/storage/storage.go
+++ b/spi/storage/storage.go
@@ -168,7 +168,7 @@ func Close(iterator Iterator, logger spi.Logger) { //nolint: interfacer // The l
 		if logger == nil {
 			standardlog.Println(fmt.Sprintf("failed to close iterator: %s", errClose.Error()))
 		} else {
-			logger.Errorf("failed to close records iterator: %s", errClose.Error())
+			logger.Errorf("failed to close iterator: %s", errClose.Error())
 		}
 	}
 }


### PR DESCRIPTION
Fixes a minor issue with the Close helper method where it had inconsistent log messages depending on whether you passed in a custom logger or not.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>