### PR TITLE
fix: fixes for outofband interop with acapy

### DIFF
--- a/pkg/client/outofband/client.go
+++ b/pkg/client/outofband/client.go
@@ -145,21 +145,21 @@ func (c *Client) CreateInvitation(services []interface{}, opts ...MessageOption)
 		Label:     msg.Label,
 		Goal:      msg.Goal,
 		GoalCode:  msg.GoalCode,
+		Services:  services,
 		Accept:    msg.Accept,
-		Service:   services,
 		Protocols: msg.HandshakeProtocols,
 		Requests:  msg.Attachments,
 	}
 
-	if len(inv.Service) == 0 {
+	if len(inv.Services) == 0 {
 		svc, err := c.didDocSvcFunc(msg.RouterConnection())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a new inlined did doc service block : %w", err)
 		}
 
-		inv.Service = []interface{}{svc}
+		inv.Services = []interface{}{svc}
 	} else {
-		err := validateServices(inv.Service...)
+		err := validateServices(inv.Services...)
 		if err != nil {
 			return nil, fmt.Errorf("invalid service: %w", err)
 		}

--- a/pkg/client/outofband/client_test.go
+++ b/pkg/client/outofband/client_test.go
@@ -87,8 +87,8 @@ func TestCreateInvitation(t *testing.T) {
 		}
 		inv, err := c.CreateInvitation(nil)
 		require.NoError(t, err)
-		require.Len(t, inv.Service, 1)
-		require.Equal(t, expected, inv.Service[0])
+		require.Len(t, inv.Services, 1)
+		require.Equal(t, expected, inv.Services[0])
 	})
 	t.Run("WithLabel", func(t *testing.T) {
 		c, err := New(withTestProvider())
@@ -112,7 +112,7 @@ func TestCreateInvitation(t *testing.T) {
 
 		inv, err := c.CreateInvitation(nil, WithRouterConnections(expectedConn))
 		require.NoError(t, err)
-		require.Equal(t, expectedConn, inv.Service[0].(*did.Service).ServiceEndpoint)
+		require.Equal(t, expectedConn, inv.Services[0].(*did.Service).ServiceEndpoint)
 	})
 	t.Run("WithGoal", func(t *testing.T) {
 		c, err := New(withTestProvider())
@@ -138,8 +138,8 @@ func TestCreateInvitation(t *testing.T) {
 		}
 		inv, err := c.CreateInvitation([]interface{}{expected})
 		require.NoError(t, err)
-		require.Len(t, inv.Service, 1)
-		require.Equal(t, expected, inv.Service[0])
+		require.Len(t, inv.Services, 1)
+		require.Equal(t, expected, inv.Services[0])
 	})
 	t.Run("WithServices dids", func(t *testing.T) {
 		c, err := New(withTestProvider())
@@ -147,8 +147,8 @@ func TestCreateInvitation(t *testing.T) {
 		expected := "did:example:234"
 		inv, err := c.CreateInvitation([]interface{}{expected})
 		require.NoError(t, err)
-		require.Len(t, inv.Service, 1)
-		require.Equal(t, expected, inv.Service[0])
+		require.Len(t, inv.Services, 1)
+		require.Equal(t, expected, inv.Services[0])
 	})
 	t.Run("WithServices dids and diddoc service blocks", func(t *testing.T) {
 		c, err := New(withTestProvider())
@@ -165,9 +165,20 @@ func TestCreateInvitation(t *testing.T) {
 		}
 		inv, err := c.CreateInvitation([]interface{}{svc, didRef})
 		require.NoError(t, err)
-		require.Len(t, inv.Service, 2)
-		require.Contains(t, inv.Service, didRef)
-		require.Contains(t, inv.Service, svc)
+		require.Len(t, inv.Services, 2)
+		require.Contains(t, inv.Services, didRef)
+		require.Contains(t, inv.Services, svc)
+	})
+	t.Run("WithAttachments", func(t *testing.T) {
+		c, err := New(withTestProvider())
+		require.NoError(t, err)
+		expected := dummyAttachment(t)
+		inv, err := c.CreateInvitation(
+			nil,
+			WithAttachments(expected),
+		)
+		require.NoError(t, err)
+		require.Contains(t, inv.Requests, expected)
 	})
 	t.Run("WithAttachments", func(t *testing.T) {
 		c, err := New(withTestProvider())

--- a/pkg/controller/command/outofband/command_test.go
+++ b/pkg/controller/command/outofband/command_test.go
@@ -157,7 +157,7 @@ func TestCommand_CreateInvitation(t *testing.T) {
 		require.Equal(t, expected.Label, res.Invitation.Label)
 		require.Equal(t, expected.Goal, res.Invitation.Goal)
 		require.Equal(t, expected.GoalCode, res.Invitation.GoalCode)
-		require.Equal(t, expected.Service, res.Invitation.Service)
+		require.Equal(t, expected.Service, res.Invitation.Services)
 		require.Equal(t, expected.Protocols, res.Invitation.Protocols)
 	})
 }

--- a/pkg/crypto/primitive/bbs12381g2pub/internal/kilic/bls12-381/swu_custom.go
+++ b/pkg/crypto/primitive/bbs12381g2pub/internal/kilic/bls12-381/swu_custom.go
@@ -17,4 +17,3 @@ func swuMapG1BE(u *fe) (*fe, *fe) {
 	}
 	return x, y
 }
-

--- a/pkg/didcomm/protocol/outofband/models.go
+++ b/pkg/didcomm/protocol/outofband/models.go
@@ -15,8 +15,8 @@ type Invitation struct {
 	Label     string                  `json:"label,omitempty"`
 	Goal      string                  `json:"goal,omitempty"`
 	GoalCode  string                  `json:"goal_code,omitempty"`
+	Services  []interface{}           `json:"services"` // Services is an array of either DIDs or 'services' block entries
 	Accept    []string                `json:"accept,omitempty"`
 	Protocols []string                `json:"handshake_protocols,omitempty"`
 	Requests  []*decorator.Attachment `json:"request~attach,omitempty"`
-	Service   []interface{}           `json:"service"` // Service is an array of either DIDs or 'service' block entries.
 }

--- a/pkg/didcomm/protocol/outofband/service_test.go
+++ b/pkg/didcomm/protocol/outofband/service_test.go
@@ -866,7 +866,7 @@ func TestSaveInvitation(t *testing.T) {
 				require.NotEmpty(t, i.ID)
 				require.Equal(t, expected.ID, i.ThreadID)
 				require.Equal(t, expected.Label, i.TheirLabel)
-				require.Equal(t, expected.Service[0], i.Target)
+				require.Equal(t, expected.Services[0], i.Target)
 				return nil
 			},
 		}
@@ -891,7 +891,7 @@ func TestSaveInvitation(t *testing.T) {
 	})
 	t.Run("fails when invitation does not have services", func(t *testing.T) {
 		inv := newInvitation()
-		inv.Service = []interface{}{}
+		inv.Services = []interface{}{}
 		s := newAutoService(t, testProvider())
 		err := s.SaveInvitation(inv)
 		require.Error(t, err)
@@ -974,7 +974,7 @@ func newInvitation() *Invitation {
 		Label:     "test",
 		Goal:      "test",
 		GoalCode:  "test",
-		Service:   []interface{}{"did:example:1235"},
+		Services:  []interface{}{"did:example:1235"},
 		Protocols: []string{didexchange.PIURI},
 		Requests: []*decorator.Attachment{
 			{

--- a/pkg/doc/signature/suite/bbsblssignatureproof2020/signer_test.go
+++ b/pkg/doc/signature/suite/bbsblssignatureproof2020/signer_test.go
@@ -407,7 +407,7 @@ func TestSuite_SelectiveDisclosure(t *testing.T) {
 
 		case18DerivationBytes, err := json.Marshal(docWithSelectiveDisclosure)
 
-		pubKeyFetcher := verifiable.SingleKey(pubKeyBytes,"Bls12381G2Key2020")
+		pubKeyFetcher := verifiable.SingleKey(pubKeyBytes, "Bls12381G2Key2020")
 		docLoader := createLDPBBS2020DocumentLoader()
 
 		_, err = verifiable.ParseCredential(case18DerivationBytes, verifiable.WithPublicKeyFetcher(pubKeyFetcher),


### PR DESCRIPTION
Push 1:
- accept old and new outofband message format
- did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/out-of-band/1.0/invitation is accepted as an old invitation message type

Push 2:
- Currently `afgo` used to only look for a `service` field in the invitation message, but `acapy` sends `services` instead of `service`. Added that to the OOB Invitation struct to support parsing `services` and choose a target accordingly.
- Solves #2675 

Signed-off-by: Haardik Haardik haardik.haardik@securekey.com