### PR TITLE
Fixed the swagger API comment.

### DIFF
--- a/pkg/controller/rest/vdr/operation.go
+++ b/pkg/controller/rest/vdr/operation.go
@@ -75,7 +75,7 @@ func (o *Operation) registerHandler() {
 	}
 }
 
-// CreateDID swagger:route POST /vdr/create vdr createDIDReq
+// CreateDID swagger:route POST /vdr/did/create vdr createDIDReq
 //
 // Create a did document.
 //


### PR DESCRIPTION
**Title:**
Fixed the part where the swagger api and the rest controller api did not match.

**Description:**
The rest controller REST API is '/vdr/did/create', whereas the swagger API is '/vdr/create', so the swagger API is changed to '/vdr/did/create'.

**Summary:**

Change the swagger API in vdr rest controller. ('/vdr/create' -> '/vdr/did/create')


