### PR TITLE
feat: Formatted storage provider support for non-deterministic keys

### DIFF
--- a/component/storageutil/batchedstore/batchedstore_test.go
+++ b/component/storageutil/batchedstore/batchedstore_test.go
@@ -65,7 +65,8 @@ func TestCommon(t *testing.T) {
 		})
 		t.Run("With formatted storage as underlying provider", func(t *testing.T) {
 			provider := batchedstore.NewProvider(
-				formattedstore.NewProvider(mem.NewProvider(), &exampleformatters.Base64Formatter{}), 0)
+				formattedstore.NewProvider(mem.NewProvider(),
+					exampleformatters.NewBase64Formatter(true)), 0)
 			require.NotNil(t, provider)
 
 			storagetest.TestAll(t, provider)
@@ -80,7 +81,8 @@ func TestCommon(t *testing.T) {
 		})
 		t.Run("With formatted storage as underlying provider", func(t *testing.T) {
 			provider := batchedstore.NewProvider(
-				formattedstore.NewProvider(mem.NewProvider(), &exampleformatters.Base64Formatter{}), 1)
+				formattedstore.NewProvider(mem.NewProvider(),
+					exampleformatters.NewBase64Formatter(true)), 1)
 			require.NotNil(t, provider)
 
 			storagetest.TestAll(t, provider)
@@ -103,7 +105,8 @@ func TestCommon(t *testing.T) {
 			})
 			t.Run("With base64 formatter", func(t *testing.T) {
 				provider := batchedstore.NewProvider(
-					formattedstore.NewProvider(mem.NewProvider(), &exampleformatters.Base64Formatter{}), 2)
+					formattedstore.NewProvider(mem.NewProvider(),
+						exampleformatters.NewBase64Formatter(true)), 2)
 				require.NotNil(t, provider)
 
 				storagetest.TestAll(t, provider)
@@ -127,7 +130,8 @@ func TestCommon(t *testing.T) {
 			})
 			t.Run("With base64 formatter", func(t *testing.T) {
 				provider := batchedstore.NewProvider(
-					formattedstore.NewProvider(mem.NewProvider(), &exampleformatters.Base64Formatter{}), 10)
+					formattedstore.NewProvider(mem.NewProvider(),
+						exampleformatters.NewBase64Formatter(true)), 10)
 				require.NotNil(t, provider)
 
 				storagetest.TestAll(t, provider)
@@ -151,7 +155,8 @@ func TestCommon(t *testing.T) {
 			})
 			t.Run("With base64 formatter", func(t *testing.T) {
 				provider := batchedstore.NewProvider(
-					formattedstore.NewProvider(mem.NewProvider(), &exampleformatters.Base64Formatter{}), 100)
+					formattedstore.NewProvider(mem.NewProvider(),
+						exampleformatters.NewBase64Formatter(true)), 100)
 				require.NotNil(t, provider)
 
 				storagetest.TestAll(t, provider)

--- a/component/storageutil/formattedstore/exampleformatters/base64formatter.go
+++ b/component/storageutil/formattedstore/exampleformatters/base64formatter.go
@@ -9,11 +9,29 @@ package exampleformatters
 import (
 	"encoding/base64"
 
+	"github.com/google/uuid"
+
 	spi "github.com/hyperledger/aries-framework-go/spi/storage"
 )
 
-// Base64Formatter is a simple formatter that encodes and decodes base64 data.
+// Base64Formatter is a simple formatter that formats and deformats data between a plaintext format and base64 format.
+// It's intended for demonstrating formattedstore functionality. It's not intended for production usage.
 type Base64Formatter struct {
+	useDeterministicKeyFormatting bool
+	keyMap                        map[string]string // Only used if useDeterministicKeyFormatting is true.
+}
+
+// NewBase64Formatter creates a new Base64Formatter. If useDeterministicKeyFormatting is set to true, then the
+// formatted keys output by the Base64Formatter will simply be base64-encoded versions of the unformatted keys.
+// If useDeterministicKeyFormatting is set to false, then the formatted keys will instead be base64-formatted random
+// UUIDs, with no relation to the unformatted key. This can be used to simulate the method by which the
+// EDV Encrypted Formatter generates its formatted keys by default, which works in a similar way. An in-memory map
+// is used to map between the random formatted keys and unformatted keys.
+func NewBase64Formatter(useDeterministicKeyFormatting bool) *Base64Formatter {
+	return &Base64Formatter{
+		useDeterministicKeyFormatting: useDeterministicKeyFormatting,
+		keyMap:                        make(map[string]string),
+	}
 }
 
 // Format returns base64-encoded versions of key, value, and tags.
@@ -28,16 +46,33 @@ func (b *Base64Formatter) Format(key string, value []byte, tags ...spi.Tag) (str
 		}
 	}
 
-	return base64.StdEncoding.EncodeToString([]byte(key)), []byte(base64.StdEncoding.EncodeToString(value)),
+	var formattedKey string
+
+	if b.useDeterministicKeyFormatting {
+		formattedKey = base64.StdEncoding.EncodeToString([]byte(key))
+	} else {
+		formattedKey = base64.StdEncoding.EncodeToString([]byte(uuid.New().String()))
+		b.keyMap[formattedKey] = key
+	}
+
+	return formattedKey, []byte(base64.StdEncoding.EncodeToString(value)),
 		formattedTags, nil
 }
 
 // Deformat returns base64-decoded versions of formattedKey, formattedValue, and formattedTags.
 func (b *Base64Formatter) Deformat(formattedKey string, formattedValue []byte,
 	formattedTags ...spi.Tag) (string, []byte, []spi.Tag, error) {
-	key, err := base64.StdEncoding.DecodeString(formattedKey)
-	if err != nil {
-		return "", nil, nil, err
+	var key string
+
+	if b.useDeterministicKeyFormatting {
+		keyBytes, err := base64.StdEncoding.DecodeString(formattedKey)
+		if err != nil {
+			return "", nil, nil, err
+		}
+
+		key = string(keyBytes)
+	} else {
+		key = b.keyMap[formattedKey]
 	}
 
 	value, err := base64.StdEncoding.DecodeString(string(formattedValue))
@@ -64,5 +99,11 @@ func (b *Base64Formatter) Deformat(formattedKey string, formattedValue []byte,
 		}
 	}
 
-	return string(key), value, tags, nil
+	return key, value, tags, nil
+}
+
+// UsesDeterministicKeyFormatting indicates whether this Base64Formatter has been set up to use deterministic key
+// generation.
+func (b *Base64Formatter) UsesDeterministicKeyFormatting() bool {
+	return b.useDeterministicKeyFormatting
 }

--- a/component/storageutil/formattedstore/exampleformatters/noopformatter.go
+++ b/component/storageutil/formattedstore/exampleformatters/noopformatter.go
@@ -27,3 +27,8 @@ func (n *NoOpFormatter) Deformat(formattedKey string, formattedValue []byte, for
 	[]byte, []spi.Tag, error) {
 	return formattedKey, formattedValue, formattedTags, nil
 }
+
+// UsesDeterministicKeyFormatting always returns true since NoOpFormatter always does deterministic key formatting.
+func (n *NoOpFormatter) UsesDeterministicKeyFormatting() bool {
+	return true
+}

--- a/component/storageutil/formattedstore/formattedstore.go
+++ b/component/storageutil/formattedstore/formattedstore.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package formattedstore
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,6 +20,8 @@ import (
 const (
 	expressionTagNameOnlyLength     = 1
 	expressionTagNameAndValueLength = 2
+
+	keyTagName = "Key"
 
 	invalidTagName                 = `"%s" is an invalid tag name since it contains one or more ':' characters`
 	invalidTagValue                = `"%s" is an invalid tag value since it contains one or more ':' characters`
@@ -41,6 +44,10 @@ type Formatter interface {
 		formattedTags []spi.Tag, err error)
 	Deformat(formattedKey string, formattedValue []byte, formattedTags ...spi.Tag) (key string, value []byte,
 		tags []spi.Tag, err error)
+	// UsesDeterministicKeyFormatting indicates whether the formatted keys produced by this formatter can be
+	// deterministically derived from the unformatted keys. If so, then FormattedProvider can take advantage of
+	// certain performance optimizations.
+	UsesDeterministicKeyFormatting() bool
 }
 
 // FormattedProvider is a spi.Provider that allows for data to be formatted in an underlying provider.
@@ -79,26 +86,12 @@ func (f *FormattedProvider) OpenStore(name string) (spi.Store, error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	openStore, ok := f.openStores[name]
-	if !ok {
-		store, err := f.provider.OpenStore(name)
-		if err != nil {
-			return nil, fmt.Errorf("failed to open store in underlying provider: %w", err)
-		}
-
-		newFormatStore := formatStore{
-			name:      name,
-			store:     store,
-			formatter: f.formatter,
-			close:     f.removeStore,
-		}
-
-		f.openStores[name] = &newFormatStore
-
-		return &newFormatStore, nil
+	store, err := f.openStore(name)
+	if err != nil {
+		return nil, err
 	}
 
-	return openStore, nil
+	return store, nil
 }
 
 // SetStoreConfig sets the configuration on a store.
@@ -112,20 +105,24 @@ func (f *FormattedProvider) SetStoreConfig(name string, config spi.StoreConfigur
 		}
 	}
 
-	storeName := strings.ToLower(name)
+	name = strings.ToLower(name)
 
-	tags := make([]spi.Tag, len(config.TagNames))
+	tagsToFormat := make([]spi.Tag, len(config.TagNames))
 
 	for i, tagName := range config.TagNames {
-		tags[i].Name = tagName
+		tagsToFormat[i].Name = tagName
 	}
 
-	_, _, formattedTags, err := f.formatter.Format("", nil, tags...)
+	if !f.formatter.UsesDeterministicKeyFormatting() {
+		tagsToFormat = append(tagsToFormat, spi.Tag{Name: keyTagName})
+	}
+
+	_, _, formattedTags, err := f.formatter.Format("", nil, tagsToFormat...)
 	if err != nil {
 		return fmt.Errorf("failed to format tag names: %w", err)
 	}
 
-	formattedTagNames := make([]string, len(config.TagNames))
+	formattedTagNames := make([]string, len(tagsToFormat))
 
 	for i, formattedTag := range formattedTags {
 		formattedTagNames[i] = formattedTag.Name
@@ -133,27 +130,26 @@ func (f *FormattedProvider) SetStoreConfig(name string, config spi.StoreConfigur
 
 	formattedConfig := spi.StoreConfiguration{TagNames: formattedTagNames}
 
-	err = f.provider.SetStoreConfig(storeName, formattedConfig)
+	err = f.provider.SetStoreConfig(name, formattedConfig)
 	if err != nil {
 		return fmt.Errorf("failed to set store configuration via underlying provider: %w", err)
 	}
 
-	// The EDV Encrypted Formatter implementation cannot deformat tags directly. It needs to wrap them in
-	// the store value. The code below does this, which will allow all formatters (including EDV) to function.
-
-	store, err := f.OpenStore(storeName + "_formattedstore_storeconfig")
-	if err != nil {
-		return fmt.Errorf("failed to open the store config store: %w", err)
-	}
+	// The EDV Encrypted Formatter implementation cannot deformat tag names directly. It needs to wrap them in
+	// a stored value. The code below does this, which will allow GetStoreConfig to function in a FormattedProvider
+	// regardless of what formatter is being used.
 
 	configBytes, err := json.Marshal(config)
 	if err != nil {
 		return fmt.Errorf("failed to marshal config into bytes: %w", err)
 	}
 
-	err = store.Put("formattedstore_storeconfig", configBytes)
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	err = f.storeStoreConfig(name, configBytes)
 	if err != nil {
-		return fmt.Errorf("failed to store config in store config store: %w", err)
+		return fmt.Errorf("failed to store store configuration: %w", err)
 	}
 
 	return nil
@@ -197,12 +193,12 @@ func (f *FormattedProvider) GetStoreConfig(name string) (spi.StoreConfiguration,
 
 // GetOpenStores returns all currently open stores.
 func (f *FormattedProvider) GetOpenStores() []spi.Store {
-	f.lock.RLock()
-	defer f.lock.RUnlock()
-
 	openStores := make([]spi.Store, len(f.openStores))
 
 	var counter int
+
+	f.lock.RLock()
+	defer f.lock.RUnlock()
 
 	for _, openStore := range f.openStores {
 		openStores[counter] = openStore
@@ -223,6 +219,43 @@ func (f *FormattedProvider) Close() error {
 	return nil
 }
 
+func (f *FormattedProvider) storeStoreConfig(storeName string, configBytes []byte) error {
+	store, err := f.openStore(storeName + "_formattedstore_storeconfig")
+	if err != nil {
+		return fmt.Errorf("failed to open the store config store: %w", err)
+	}
+
+	err = store.Put("formattedstore_storeconfig", configBytes)
+	if err != nil {
+		return fmt.Errorf("failed to store config bytes in the store config store: %w", err)
+	}
+
+	return nil
+}
+
+func (f *FormattedProvider) openStore(name string) (*formatStore, error) {
+	openStore, ok := f.openStores[name]
+	if !ok {
+		store, err := f.provider.OpenStore(name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open store in underlying provider: %w", err)
+		}
+
+		newFormatStore := formatStore{
+			name:            name,
+			underlyingStore: store,
+			formatter:       f.formatter,
+			close:           f.removeStore,
+		}
+
+		f.openStores[name] = &newFormatStore
+
+		return &newFormatStore, nil
+	}
+
+	return openStore, nil
+}
+
 func (f *FormattedProvider) removeStore(name string) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -231,39 +264,34 @@ func (f *FormattedProvider) removeStore(name string) {
 }
 
 type formatStore struct {
-	name      string
-	store     spi.Store
-	formatter Formatter
-	close     closer
+	name            string
+	underlyingStore spi.Store
+	formatter       Formatter
+	close           closer
+	lock            sync.RWMutex
 }
 
+// If using a formatter with non-deterministic key formatting, then the store configuration must be set prior to calling
+// this method, since it sets up a special "key" tag that's used to enable data retrieval.
+// TODO (#2666): automatically set store configuration.
 func (f *formatStore) Put(key string, value []byte, tags ...spi.Tag) error {
-	if key == "" {
-		return errEmptyKey
+	errInputValidation := validatePutInput(key, value, tags)
+	if errInputValidation != nil {
+		return errInputValidation
 	}
 
-	if value == nil {
-		return errors.New("value cannot be nil")
-	}
-
-	for _, tag := range tags {
-		if strings.Contains(tag.Name, ":") {
-			return fmt.Errorf(invalidTagName, tag.Name)
+	if f.formatter.UsesDeterministicKeyFormatting() {
+		err := f.formatAndPut(key, value, tags)
+		if err != nil {
+			return fmt.Errorf("failed to format and put data: %w", err)
 		}
 
-		if strings.Contains(tag.Value, ":") {
-			return fmt.Errorf(invalidTagValue, tag.Value)
-		}
+		return nil
 	}
 
-	formattedKey, formattedValue, formattedTags, err := f.formatter.Format(key, value, tags...)
+	err := f.storeUsingNonDeterministicKey(key, value, tags)
 	if err != nil {
-		return fmt.Errorf(failFormatData, err)
-	}
-
-	err = f.store.Put(formattedKey, formattedValue, formattedTags...)
-	if err != nil {
-		return fmt.Errorf("failed to put formatted data in underlying store: %w", err)
+		return fmt.Errorf("failed to store data using non-deterministic key formatting: %w", err)
 	}
 
 	return nil
@@ -274,12 +302,249 @@ func (f *formatStore) Get(key string) ([]byte, error) {
 		return nil, errEmptyKey
 	}
 
+	if f.formatter.UsesDeterministicKeyFormatting() {
+		value, err := f.getValueStoredUnderDeterministicKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get value stored under deterministically generated key: %w", err)
+		}
+
+		return value, nil
+	}
+
+	value, err := f.lockAndGetValueStoredUnderNonDeterministicKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get value stored under non-deterministically generated key: %w", err)
+	}
+
+	return value, nil
+}
+
+func (f *formatStore) GetTags(key string) ([]spi.Tag, error) {
+	if key == "" {
+		return nil, errEmptyKey
+	}
+
+	if f.formatter.UsesDeterministicKeyFormatting() {
+		tags, err := f.getTagsStoredUnderDeterministicKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get tags stored under deterministically generated key: %w", err)
+		}
+
+		return tags, nil
+	}
+
+	tags, err := f.getTagsStoredUnderNonDeterministicKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tags stored under non-deterministically generated key: %w", err)
+	}
+
+	return tags, nil
+}
+
+func (f *formatStore) GetBulk(keys ...string) ([][]byte, error) {
+	errInputValidation := ensureNoEmptyKeys(keys)
+	if errInputValidation != nil {
+		return nil, errInputValidation
+	}
+
+	if f.formatter.UsesDeterministicKeyFormatting() {
+		values, err := f.getValuesStoredUnderDeterministicKeys(keys)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get values stored under deterministically generated keys: %w", err)
+		}
+
+		return values, nil
+	}
+
+	values, err := f.getValuesStoredUnderNonDeterministicKeys(keys)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get values stored under non-deterministically generated keys: %w", err)
+	}
+
+	return values, nil
+}
+
+func (f *formatStore) Query(expression string, options ...spi.QueryOption) (spi.Iterator, error) {
+	if expression == "" {
+		return nil, errInvalidQueryExpressionFormat
+	}
+
+	expressionSplit := strings.Split(expression, ":")
+	switch len(expressionSplit) {
+	case expressionTagNameOnlyLength:
+		_, _, formattedTags, err := f.formatter.Format("", nil, spi.Tag{Name: expressionSplit[0]})
+		if err != nil {
+			return nil, fmt.Errorf(failFormat, "tag name", expressionSplit[0], err)
+		}
+
+		underlyingIterator, err := f.underlyingStore.Query(formattedTags[0].Name, options...)
+		if err != nil {
+			return nil, fmt.Errorf(failQueryUnderlyingStore, err)
+		}
+
+		return &formattedIterator{underlyingIterator: underlyingIterator, formatter: f.formatter}, nil
+	case expressionTagNameAndValueLength:
+		_, _, formattedTags, err := f.formatter.Format("", nil,
+			spi.Tag{Name: expressionSplit[0], Value: expressionSplit[1]})
+		if err != nil {
+			return nil, fmt.Errorf("failed to format tag: %w", err)
+		}
+
+		underlyingIterator, err := f.underlyingStore.Query(
+			fmt.Sprintf("%s:%s", formattedTags[0].Name, formattedTags[0].Value), options...)
+		if err != nil {
+			return nil, fmt.Errorf(failQueryUnderlyingStore, err)
+		}
+
+		return &formattedIterator{underlyingIterator: underlyingIterator, formatter: f.formatter}, nil
+	default:
+		return nil, errInvalidQueryExpressionFormat
+	}
+}
+
+func (f *formatStore) Delete(key string) error {
+	if key == "" {
+		return errEmptyKey
+	}
+
+	if f.formatter.UsesDeterministicKeyFormatting() {
+		err := f.deleteDataStoredUnderDeterministicKey(key)
+		if err != nil {
+			return fmt.Errorf("failed to delete data stored under deterministic key: %w", err)
+		}
+
+		return nil
+	}
+
+	err := f.deleteDataStoredUnderNonDeterministicKey(key)
+	if err != nil {
+		return fmt.Errorf("failed to delete data stored under non-deterministic key: %w", err)
+	}
+
+	return nil
+}
+
+func (f *formatStore) Batch(operations []spi.Operation) error {
+	for _, operation := range operations {
+		if operation.Key == "" {
+			return errEmptyKey
+		}
+	}
+
+	if f.formatter.UsesDeterministicKeyFormatting() {
+		err := f.batchUsingDeterministicKeys(operations)
+		if err != nil {
+			return fmt.Errorf("failed to perform batch operations using deterministic keys: %w", err)
+		}
+
+		return nil
+	}
+
+	err := f.batchUsingNonDeterministicKeys(operations)
+	if err != nil {
+		return fmt.Errorf("failed to perform batch operations using non-deterministic keys: %w", err)
+	}
+
+	return nil
+}
+
+func (f *formatStore) Flush() error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	err := f.underlyingStore.Flush()
+	if err != nil {
+		return fmt.Errorf("failed to flush underlying store: %w", err)
+	}
+
+	return nil
+}
+
+func (f *formatStore) Close() error {
+	f.close(f.name)
+
+	err := f.underlyingStore.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close underlying store: %w", err)
+	}
+
+	return nil
+}
+
+func (f *formatStore) storeUsingNonDeterministicKey(key string, value []byte, tags []spi.Tag) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	iterator, err := f.queryUsingKeyTag(key)
+	if err != nil {
+		return fmt.Errorf("failed to query using the key tag: %w", err)
+	}
+
+	atLeastOneReturnedValue, err := iterator.Next()
+	if err != nil {
+		return fmt.Errorf("failed to get next result from iterator: %w", err)
+	}
+
+	tags = append(tags, generateKeyTag(key))
+
+	if !atLeastOneReturnedValue {
+		// This is a new value, so there is no previous key to use. Must generate a new one.
+		errFormatAndPut := f.formatAndPut(key, value, tags)
+		if errFormatAndPut != nil {
+			return fmt.Errorf("failed to format and put data: %w", errFormatAndPut)
+		}
+
+		return nil
+	}
+
+	foundKey, err := iterator.Key()
+	if err != nil {
+		return fmt.Errorf("failed to get key from iterator: %w", err)
+	}
+
+	foundMoreMatchingKeys, err := iterator.Next()
+	if err != nil {
+		return fmt.Errorf("failed to get next result from iterator: %w", err)
+	}
+
+	if foundMoreMatchingKeys {
+		return fmt.Errorf("unexpectedly found multiple results matching query. Only one is expected")
+	}
+
+	_, formattedValue, formattedTags, err := f.formatter.Format(foundKey, value, tags...)
+	if err != nil {
+		return fmt.Errorf(failFormatData, err)
+	}
+
+	err = f.underlyingStore.Put(foundKey, formattedValue, formattedTags...)
+	if err != nil {
+		return fmt.Errorf("failed to put formatted data in underlying store: %w", err)
+	}
+
+	return nil
+}
+
+func (f *formatStore) formatAndPut(key string, value []byte, tags []spi.Tag) error {
+	formattedKey, formattedValue, formattedTags, err := f.formatter.Format(key, value, tags...)
+	if err != nil {
+		return fmt.Errorf(failFormatData, err)
+	}
+
+	err = f.underlyingStore.Put(formattedKey, formattedValue, formattedTags...)
+	if err != nil {
+		return fmt.Errorf("failed to put formatted data in underlying store: %w", err)
+	}
+
+	return nil
+}
+
+func (f *formatStore) getValueStoredUnderDeterministicKey(key string) ([]byte, error) {
 	formattedKey, _, _, err := f.formatter.Format(key, nil, nil...)
 	if err != nil {
 		return nil, fmt.Errorf(failFormat, "key", key, err)
 	}
 
-	formattedValue, err := f.store.Get(formattedKey)
+	formattedValue, err := f.underlyingStore.Get(formattedKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get formatted value from underlying store: %w", err)
 	}
@@ -292,13 +557,53 @@ func (f *formatStore) Get(key string) ([]byte, error) {
 	return value, nil
 }
 
-func (f *formatStore) GetTags(key string) ([]spi.Tag, error) {
+func (f *formatStore) lockAndGetValueStoredUnderNonDeterministicKey(key string) ([]byte, error) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	return f.getValueStoredUnderNonDeterministicKey(key)
+}
+
+func (f *formatStore) getValueStoredUnderNonDeterministicKey(key string) ([]byte, error) {
+	// Base64 encode in order to transform any ':' characters, since ':' is a special character in a query expression.
+	iterator, err := f.Query("Key:" + base64.StdEncoding.EncodeToString([]byte(key)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to query store: %w", err)
+	}
+
+	atLeastOneReturnedValue, err := iterator.Next()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get next result from iterator: %w", err)
+	}
+
+	if !atLeastOneReturnedValue {
+		return nil, spi.ErrDataNotFound
+	}
+
+	foundValue, err := iterator.Value()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get value from iterator: %w", err)
+	}
+
+	foundMoreMatchingValues, err := iterator.Next()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get next result from iterator: %w", err)
+	}
+
+	if foundMoreMatchingValues {
+		return nil, fmt.Errorf("unexpectedly found multiple results matching query. Only one is expected")
+	}
+
+	return foundValue, nil
+}
+
+func (f *formatStore) getTagsStoredUnderDeterministicKey(key string) ([]spi.Tag, error) {
 	formattedKey, _, _, err := f.formatter.Format(key, nil)
 	if err != nil {
 		return nil, fmt.Errorf(failFormat, "key", key, err)
 	}
 
-	formattedTags, err := f.store.GetTags(formattedKey)
+	formattedTags, err := f.underlyingStore.GetTags(formattedKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get formatted tags from underlying store: %w", err)
 	}
@@ -306,7 +611,7 @@ func (f *formatStore) GetTags(key string) ([]spi.Tag, error) {
 	// FormatProvider must support EDV formatting, and EDV tags are not reversible since they are hashed.
 	// Retrieving EDV tags requires embedding them in the stored value itself.
 	// In order to support this use case, formatStore also calls the underlying store's Get method.
-	formattedValue, err := f.store.Get(formattedKey)
+	formattedValue, err := f.underlyingStore.Get(formattedKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get formatted tags from underlying store: %w", err)
 	}
@@ -319,7 +624,43 @@ func (f *formatStore) GetTags(key string) ([]spi.Tag, error) {
 	return tags, nil
 }
 
-func (f *formatStore) GetBulk(keys ...string) ([][]byte, error) {
+func (f *formatStore) getTagsStoredUnderNonDeterministicKey(key string) ([]spi.Tag, error) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	// Base64 encode in order to transform any ':' characters, since ':' is a special character in a query expression.
+	iterator, err := f.Query(keyTagName + ":" + base64.StdEncoding.EncodeToString([]byte(key)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to query store: %w", err)
+	}
+
+	atLeastOneReturnedValue, err := iterator.Next()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get next result from iterator: %w", err)
+	}
+
+	if !atLeastOneReturnedValue {
+		return nil, spi.ErrDataNotFound
+	}
+
+	foundTags, err := iterator.Tags()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tags from iterator: %w", err)
+	}
+
+	foundMoreMatchingResults, err := iterator.Next()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get next result from iterator: %w", err)
+	}
+
+	if foundMoreMatchingResults {
+		return nil, fmt.Errorf("unexpectedly found multiple results matching query. Only one is expected")
+	}
+
+	return filterOutKeyTag(foundTags, base64.StdEncoding.EncodeToString([]byte(key))), nil
+}
+
+func (f *formatStore) getValuesStoredUnderDeterministicKeys(keys []string) ([][]byte, error) {
 	formattedKeys := make([]string, len(keys))
 
 	for i, key := range keys {
@@ -331,7 +672,7 @@ func (f *formatStore) GetBulk(keys ...string) ([][]byte, error) {
 		}
 	}
 
-	formattedValues, err := f.store.GetBulk(formattedKeys...)
+	formattedValues, err := f.underlyingStore.GetBulk(formattedKeys...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get formatted values from underlying store: %w", err)
 	}
@@ -352,51 +693,31 @@ func (f *formatStore) GetBulk(keys ...string) ([][]byte, error) {
 	return deformattedValues, nil
 }
 
-func (f *formatStore) Query(expression string, options ...spi.QueryOption) (spi.Iterator, error) {
-	if expression == "" {
-		return &formattedIterator{}, errInvalidQueryExpressionFormat
+func (f *formatStore) getValuesStoredUnderNonDeterministicKeys(keys []string) ([][]byte, error) {
+	retrievedValues := make([][]byte, len(keys))
+
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	for i, key := range keys {
+		value, err := f.getValueStoredUnderNonDeterministicKey(key)
+		if err != nil && !errors.Is(err, spi.ErrDataNotFound) {
+			return nil, fmt.Errorf("unexpected failure while attempting to retrieve value: %w", err)
+		}
+
+		retrievedValues[i] = value
 	}
 
-	expressionSplit := strings.Split(expression, ":")
-	switch len(expressionSplit) {
-	case expressionTagNameOnlyLength:
-		_, _, formattedTags, err := f.formatter.Format("", nil, spi.Tag{Name: expressionSplit[0]})
-		if err != nil {
-			return &formattedIterator{}, fmt.Errorf(failFormat, "tag name", expressionSplit[0], err)
-		}
-
-		underlyingIterator, err := f.store.Query(formattedTags[0].Name, options...)
-		if err != nil {
-			return &formattedIterator{}, fmt.Errorf(failQueryUnderlyingStore, err)
-		}
-
-		return &formattedIterator{underlyingIterator: underlyingIterator, formatter: f.formatter}, nil
-	case expressionTagNameAndValueLength:
-		_, _, formattedTags, err := f.formatter.Format("", nil,
-			spi.Tag{Name: expressionSplit[0], Value: expressionSplit[1]})
-		if err != nil {
-			return &formattedIterator{}, fmt.Errorf("failed to format tag: %w", err)
-		}
-
-		underlyingIterator, err := f.store.Query(
-			fmt.Sprintf("%s:%s", formattedTags[0].Name, formattedTags[0].Value), options...)
-		if err != nil {
-			return &formattedIterator{}, fmt.Errorf(failQueryUnderlyingStore, err)
-		}
-
-		return &formattedIterator{underlyingIterator: underlyingIterator, formatter: f.formatter}, nil
-	default:
-		return &formattedIterator{}, errInvalidQueryExpressionFormat
-	}
+	return retrievedValues, nil
 }
 
-func (f *formatStore) Delete(key string) error {
+func (f *formatStore) deleteDataStoredUnderDeterministicKey(key string) error {
 	formattedKey, _, _, err := f.formatter.Format(key, nil, nil...)
 	if err != nil {
 		return fmt.Errorf(failFormat, "key", key, err)
 	}
 
-	err = f.store.Delete(formattedKey)
+	err = f.underlyingStore.Delete(formattedKey)
 	if err != nil {
 		return fmt.Errorf("failed to delete data in underlying store: %w", err)
 	}
@@ -404,7 +725,47 @@ func (f *formatStore) Delete(key string) error {
 	return nil
 }
 
-func (f *formatStore) Batch(operations []spi.Operation) error {
+func (f *formatStore) deleteDataStoredUnderNonDeterministicKey(key string) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	iterator, err := f.queryUsingKeyTag(key)
+	if err != nil {
+		return fmt.Errorf("failed to query using the key tag: %w", err)
+	}
+
+	atLeastOneReturnedValue, err := iterator.Next()
+	if err != nil {
+		return fmt.Errorf("failed to get next result from iterator: %w", err)
+	}
+
+	if !atLeastOneReturnedValue {
+		return nil
+	}
+
+	foundKey, err := iterator.Key()
+	if err != nil {
+		return fmt.Errorf("failed to get key from iterator: %w", err)
+	}
+
+	foundMoreMatchingKeys, err := iterator.Next()
+	if err != nil {
+		return fmt.Errorf("failed to get next result from iterator: %w", err)
+	}
+
+	if foundMoreMatchingKeys {
+		return fmt.Errorf("unexpectedly found multiple results matching query. Only one is expected")
+	}
+
+	err = f.underlyingStore.Delete(foundKey)
+	if err != nil {
+		return fmt.Errorf("failed to delete data in underlying store: %w", err)
+	}
+
+	return nil
+}
+
+func (f *formatStore) batchUsingDeterministicKeys(operations []spi.Operation) error {
 	formattedOperations := make([]spi.Operation, len(operations))
 
 	for i, operation := range operations {
@@ -432,7 +793,7 @@ func (f *formatStore) Batch(operations []spi.Operation) error {
 		}
 	}
 
-	err := f.store.Batch(formattedOperations)
+	err := f.underlyingStore.Batch(formattedOperations)
 	if err != nil {
 		return fmt.Errorf("failed to perform formatted operations in underlying store: %w", err)
 	}
@@ -440,24 +801,212 @@ func (f *formatStore) Batch(operations []spi.Operation) error {
 	return nil
 }
 
-func (f *formatStore) Flush() error {
-	err := f.store.Flush()
+func (f *formatStore) batchUsingNonDeterministicKeys(operations []spi.Operation) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	formattedOperations, err := f.generateFormattedOperations(operations)
 	if err != nil {
-		return fmt.Errorf("failed to flush underlying store: %w", err)
+		return fmt.Errorf("failed to generate formatted operations: %w", err)
+	}
+
+	err = f.underlyingStore.Batch(formattedOperations)
+	if err != nil {
+		return fmt.Errorf("failed to perform formatted operations in underlying store: %w", err)
 	}
 
 	return nil
 }
 
-func (f *formatStore) Close() error {
-	f.close(f.name)
+func (f *formatStore) generateFormattedOperations(operations []spi.Operation) ([]spi.Operation, error) {
+	formattedOperations := make([]spi.Operation, len(operations))
 
-	err := f.store.Close()
+	resolvedKeys := make(map[string]string, len(operations))
+
+	for i, operation := range operations {
+		if operation.Value == nil {
+			err := f.prepareFormattedDeleteOperation(formattedOperations, resolvedKeys, operation, i)
+			if err != nil {
+				return nil, fmt.Errorf("failed to prepare formatted delete operation: %w", err)
+			}
+		} else {
+			err := f.prepareFormattedPutOperation(formattedOperations, resolvedKeys, operation, i)
+			if err != nil {
+				return nil, fmt.Errorf("failed to prepare formatted put operation: %w", err)
+			}
+		}
+	}
+
+	return formattedOperations, nil
+}
+
+func (f *formatStore) prepareFormattedDeleteOperation(formattedOperations []spi.Operation,
+	resolvedKeys map[string]string, operation spi.Operation, currentOperationIndex int) error {
+	// We must determine which formatted key to use. There are to cases to consider:
+	// 1. First, check the previous operations in this batch to this one to see if any of them
+	//    are puts for the same key. If so, then we must use that formatted key in order to ensure
+	//    consistency.
+	// 2. If the previous operations don't have the formatted key, then we have to query the store. If
+	//    a value is found, then we have the formatted key we must use. If no value is found, then that means
+	//    that this key was never stored, and since we know none of the prior operations store this key
+	//    either, then that means that there's nothing to do here, so this delete operation can be dropped.
+	formattedKey, err := f.determineFormattedKeyToUse(resolvedKeys, operation.Key)
 	if err != nil {
-		return fmt.Errorf("failed to close underlying store: %w", err)
+		return fmt.Errorf("unexpected failure while determining formatted key to use: %w", err)
+	}
+
+	resolvedKeys[operation.Key] = formattedKey
+
+	// If the formatted key still wasn't found, then there's nothing to delete, and this operation is not
+	// needed. We will drop this formatted operation later.
+
+	formattedOperations[currentOperationIndex] = spi.Operation{
+		Key: formattedKey,
 	}
 
 	return nil
+}
+
+func (f *formatStore) prepareFormattedPutOperation(formattedOperations []spi.Operation, resolvedKeys map[string]string,
+	operation spi.Operation, currentOperationIndex int) error {
+	// We must first determine which formatted key to use. There are two cases to consider:
+	// 2a. First, check the previous operations in this batch to this one to see if any of them
+	//     are puts for the same key. If so, then we must use that formatted key in order to ensure consistency.
+	// 2b. If the previous operations don't have the formatted key, then we have to query the store. If a value
+	//     is found, then that means that we must use that existing formatted key. If value is found, then that
+	//     means that this is a not an update and we must generate a new key.
+	formattedKey, err := f.determineFormattedKeyToUse(resolvedKeys, operation.Key)
+	if err != nil {
+		return fmt.Errorf("unexpected failure while determining formatted key to use: %w", err)
+	}
+
+	tagsToFormat := generateTagsToFormat(operation)
+
+	if formattedKey == "" {
+		err := f.prepareFormattedPutOperationUsingNewFormattedKey(formattedOperations,
+			resolvedKeys, operation, currentOperationIndex, tagsToFormat)
+		if err != nil {
+			return fmt.Errorf("failed to prepare formatted put operation using non-previously-resolved "+
+				"formatted key: %w", err)
+		}
+	} else {
+		err := f.prepareFormattedPutOperationUsingExistingFormattedKey(formattedOperations, resolvedKeys,
+			formattedKey, operation, tagsToFormat, currentOperationIndex)
+		if err != nil {
+			return fmt.Errorf("failed to prepare formatted put operation using previously-resolved "+
+				"formatted key: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (f *formatStore) determineFormattedKeyToUse(resolvedKeys map[string]string,
+	currentOperationKey string) (string, error) {
+	formattedKeyToUse := getFormattedKeyFromPreviouslyResolvedKeys(resolvedKeys, currentOperationKey)
+
+	// If we haven't determined the formatted key yet, then we must query the store.
+	if formattedKeyToUse == "" {
+		var err error
+
+		formattedKeyToUse, err = f.getFormattedKeyViaStoreQuery(currentOperationKey)
+		if err != nil {
+			return "", fmt.Errorf("unexpected failure while attempting to "+
+				"determine formatted key via store query: %w", err)
+		}
+	}
+
+	return formattedKeyToUse, nil
+}
+
+func (f *formatStore) prepareFormattedPutOperationUsingNewFormattedKey(
+	formattedOperations []spi.Operation, resolvedKeys map[string]string, operation spi.Operation,
+	currentOperationIndex int, tagsToFormat []spi.Tag) error {
+	// This is a new value, so there is no previous key to use. Must generate a new one.
+	formattedKey, formattedValue, formattedTags, err :=
+		f.formatter.Format(operation.Key, operation.Value, tagsToFormat...)
+	if err != nil {
+		return fmt.Errorf(failFormatData, err)
+	}
+
+	formattedOperations[currentOperationIndex] = spi.Operation{
+		Key:   formattedKey,
+		Value: formattedValue,
+		Tags:  formattedTags,
+	}
+
+	resolvedKeys[operation.Key] = formattedKey
+
+	return nil
+}
+
+func (f *formatStore) prepareFormattedPutOperationUsingExistingFormattedKey(formattedOperations []spi.Operation,
+	resolvedKeys map[string]string, formattedKey string, operation spi.Operation,
+	tagsToFormat []spi.Tag, currentOperationIndex int) error {
+	_, formattedValue, formattedTags, err :=
+		f.formatter.Format(formattedKey, operation.Value, tagsToFormat...)
+	if err != nil {
+		return fmt.Errorf(failFormatData, err)
+	}
+
+	formattedOperations[currentOperationIndex] = spi.Operation{
+		Key:   formattedKey,
+		Value: formattedValue,
+		Tags:  formattedTags,
+	}
+
+	resolvedKeys[operation.Key] = formattedKey
+
+	return nil
+}
+
+func (f *formatStore) getFormattedKeyViaStoreQuery(key string) (string, error) {
+	iterator, err := f.queryUsingKeyTag(key)
+	if err != nil {
+		return "", fmt.Errorf("failed to query using the key tag: %w", err)
+	}
+
+	atLeastOneReturnedValue, err := iterator.Next()
+	if err != nil {
+		return "", fmt.Errorf("failed to get next result from iterator: %w", err)
+	}
+
+	if atLeastOneReturnedValue {
+		formattedKeyToUse, err := iterator.Key()
+		if err != nil {
+			return "", fmt.Errorf("failed to get key from iterator: %w", err)
+		}
+
+		foundMoreMatchingKeys, err := iterator.Next()
+		if err != nil {
+			return "", fmt.Errorf("failed to get next result from iterator: %w", err)
+		}
+
+		if foundMoreMatchingKeys {
+			return "", fmt.Errorf("unexpectedly found multiple results matching query. Only one is expected")
+		}
+
+		return formattedKeyToUse, nil
+	}
+
+	return "", nil
+}
+
+func (f *formatStore) queryUsingKeyTag(key string) (spi.Iterator, error) {
+	// Base64 encode in order to transform any ':' characters, since ':' is a special character in a query expression.
+	_, _, formattedTags, err := f.formatter.Format("", nil,
+		generateKeyTag(key))
+	if err != nil {
+		return nil, fmt.Errorf("failed to format tag: %w", err)
+	}
+
+	iterator, err := f.underlyingStore.Query(
+		fmt.Sprintf("%s:%s", formattedTags[0].Name, formattedTags[0].Value))
+	if err != nil {
+		return nil, fmt.Errorf(failQueryUnderlyingStore, err)
+	}
+
+	return iterator, nil
 }
 
 type formattedIterator struct {
@@ -522,12 +1071,26 @@ func (f *formattedIterator) Tags() ([]spi.Tag, error) {
 		return nil, fmt.Errorf(failGetValueUnderlyingIterator, err)
 	}
 
-	_, _, tags, err := f.formatter.Deformat("", formattedValue, formattedTags...)
+	if f.formatter.UsesDeterministicKeyFormatting() {
+		_, _, tags, errDeformat := f.formatter.Deformat("", formattedValue, formattedTags...)
+		if errDeformat != nil {
+			return nil, fmt.Errorf(failDeformat, "value", string(formattedValue), err)
+		}
+
+		return tags, nil
+	}
+
+	formattedKey, err := f.underlyingIterator.Key()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get formatted key from the underlying iterator: %w", err)
+	}
+
+	key, _, tags, err := f.formatter.Deformat(formattedKey, formattedValue, formattedTags...)
 	if err != nil {
 		return nil, fmt.Errorf(failDeformat, "value", string(formattedValue), err)
 	}
 
-	return tags, nil
+	return filterOutKeyTag(tags, base64.StdEncoding.EncodeToString([]byte(key))), nil
 }
 
 func (f *formattedIterator) Close() error {
@@ -537,4 +1100,83 @@ func (f *formattedIterator) Close() error {
 	}
 
 	return nil
+}
+
+func validatePutInput(key string, value []byte, tags []spi.Tag) error {
+	if key == "" {
+		return errEmptyKey
+	}
+
+	if value == nil {
+		return errors.New("value cannot be nil")
+	}
+
+	for _, tag := range tags {
+		if strings.Contains(tag.Name, ":") {
+			return fmt.Errorf(invalidTagName, tag.Name)
+		}
+
+		if strings.Contains(tag.Value, ":") {
+			return fmt.Errorf(invalidTagValue, tag.Value)
+		}
+	}
+
+	return nil
+}
+
+func ensureNoEmptyKeys(keys []string) error {
+	if len(keys) == 0 {
+		return errors.New("keys slice must contain at least one key")
+	}
+
+	for _, key := range keys {
+		if key == "" {
+			return errEmptyKey
+		}
+	}
+
+	return nil
+}
+
+func generateKeyTag(key string) spi.Tag {
+	// Base64 encode the key in order to transform any ':' characters, since we need to do a query later for this key
+	// and ':' is a special character in a query expression.
+	return spi.Tag{Name: keyTagName, Value: base64.StdEncoding.EncodeToString([]byte(key))}
+}
+
+func filterOutKeyTag(tags []spi.Tag, tagValueToFilterOut string) []spi.Tag {
+	var filteredTags []spi.Tag
+
+	for _, tag := range tags {
+		if !(tag.Name == keyTagName && tag.Value == tagValueToFilterOut) {
+			filteredTags = append(filteredTags, tag)
+		}
+	}
+
+	return filteredTags
+}
+
+func getFormattedKeyFromPreviouslyResolvedKeys(resolvedKeys map[string]string, key string) string {
+	var formattedKeyToUse string
+
+	for unformattedKey, formattedKey := range resolvedKeys {
+		if unformattedKey == key {
+			formattedKeyToUse = formattedKey
+			break
+		}
+	}
+
+	return formattedKeyToUse
+}
+
+func generateTagsToFormat(operation spi.Operation) []spi.Tag {
+	tagsToFormat := make([]spi.Tag, len(operation.Tags)+1)
+
+	for j, tag := range operation.Tags {
+		tagsToFormat[j] = tag
+	}
+
+	tagsToFormat[len(tagsToFormat)-1] = generateKeyTag(operation.Key)
+
+	return tagsToFormat
 }

--- a/component/storageutil/go.mod
+++ b/component/storageutil/go.mod
@@ -8,8 +8,9 @@ go 1.15
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210320144851-40976de98ccf
-	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210320144851-40976de98ccf
+	github.com/google/uuid v1.1.2
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210322152545-e6ebe2c79a2a
+	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210322152545-e6ebe2c79a2a
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/component/storageutil/go.sum
+++ b/component/storageutil/go.sum
@@ -3,12 +3,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210310160016-d5eea2ecdd50 h1:HKfMN0vNY9bvJiZf1k85HctNuG14hIx8DCbHZhZwbjs=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210310160016-d5eea2ecdd50/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210320144851-40976de98ccf h1:5xKqwVy1gEBENyU7a+KCeDOOtF21wrYtHsEicuXWE/c=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210320144851-40976de98ccf/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210320144851-40976de98ccf h1:xUpXr9GhXgk1B0sIGEqcKfxRz4pFGyL1b9j/ZONtn0Q=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210320144851-40976de98ccf/go.mod h1:kgO90w18XJv9ZZWZKHcKPtNNWgjRhzLvSSAY4AXkKz4=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210322152545-e6ebe2c79a2a h1:HTmZ6X9IxPYmafSKSCfrKMIYjIrzrVzaJ+qxiCkNQW4=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210322152545-e6ebe2c79a2a/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210322152545-e6ebe2c79a2a h1:G2FAhxB6+oxw6VvwoIpn0EtusgEa8UwbMAha/guL39w=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210322152545-e6ebe2c79a2a/go.mod h1:eKGEEe+PJNDQo7kVif3sUKBWwnsQDkE3gD/QlpmukcQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=


### PR DESCRIPTION
This change allows the formatted storage provider to support a formatter that generates formatted keys in a non-deterministic manner. This is to support the EDV encrypted formatter which, in a commit in the near future, will support random encrypted document IDs.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>