### PR TITLE
fix: Formatted storage provider batch method fails in some cases

### DIFF
--- a/component/storageutil/formattedstore/formattedstore_test.go
+++ b/component/storageutil/formattedstore/formattedstore_test.go
@@ -54,7 +54,7 @@ func TestCommon(t *testing.T) {
 
 			storagetest.TestAll(t, provider)
 		})
-		t.Run("With base64 formatter", func(t *testing.T) {
+		t.Run("With deterministic key formatting", func(t *testing.T) {
 			provider := formattedstore.NewProvider(mem.NewProvider(),
 				exampleformatters.NewBase64Formatter(true))
 			require.NotNil(t, provider)
@@ -599,8 +599,8 @@ func TestFormatStore_Batch(t *testing.T) {
 					Value: []byte("Value1"),
 				},
 			})
-			require.EqualError(t, err, "failed to perform batch operations using non-deterministic keys: "+
-				"failed to generate formatted operations: failed to prepare formatted put operation: "+
+			require.EqualError(t, err, "failed to generate formatted operations using non-deterministic "+
+				"keys: failed to prepare formatted put operation: "+
 				"unexpected failure while determining formatted key to use: "+
 				"unexpected failure while attempting to determine formatted key via store query: "+
 				"failed to query using the key tag: failed to format tag: key formatting failure")
@@ -623,7 +623,7 @@ func TestFormatStore_Batch(t *testing.T) {
 					Value: []byte("Value1"),
 				},
 			})
-			require.EqualError(t, err, "failed to perform batch operations using deterministic keys: "+
+			require.EqualError(t, err, "failed to generate formatted operations using deterministic keys: "+
 				"failed to format data: key formatting failure")
 		})
 	})
@@ -643,8 +643,7 @@ func TestFormatStore_Batch(t *testing.T) {
 				Value: []byte("Value1"),
 			},
 		})
-		require.EqualError(t, err, "failed to perform batch operations using deterministic keys: "+
-			"failed to perform formatted operations in underlying store: batch failure")
+		require.EqualError(t, err, "failed to perform formatted operations in underlying store: batch failure")
 	})
 }
 

--- a/component/storageutil/go.mod
+++ b/component/storageutil/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.1.2
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210322152545-e6ebe2c79a2a
-	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210322152545-e6ebe2c79a2a
+	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210324232048-34ff560ed041
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/component/storageutil/go.sum
+++ b/component/storageutil/go.sum
@@ -7,8 +7,8 @@ github.com/hyperledger/aries-framework-go/spi v0.0.0-20210320144851-40976de98ccf
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210320144851-40976de98ccf/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210322152545-e6ebe2c79a2a h1:HTmZ6X9IxPYmafSKSCfrKMIYjIrzrVzaJ+qxiCkNQW4=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210322152545-e6ebe2c79a2a/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210322152545-e6ebe2c79a2a h1:G2FAhxB6+oxw6VvwoIpn0EtusgEa8UwbMAha/guL39w=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210322152545-e6ebe2c79a2a/go.mod h1:eKGEEe+PJNDQo7kVif3sUKBWwnsQDkE3gD/QlpmukcQ=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210324232048-34ff560ed041 h1:9Bg5XyKZM+JNikMmn88qj4BOJfJPHfecweQi0HOZzfE=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210324232048-34ff560ed041/go.mod h1:eKGEEe+PJNDQo7kVif3sUKBWwnsQDkE3gD/QlpmukcQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=


### PR DESCRIPTION
- Updated common storage test module commit tags. The updated common storage tests include tests to ensure this bug is fixed.
- Also did some minor refactoring to reduce code duplication.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>