### PR TITLE
feat: VC wallet - wallet content based VDR

### DIFF
--- a/pkg/client/vcwallet/client_test.go
+++ b/pkg/client/vcwallet/client_test.go
@@ -769,6 +769,7 @@ func TestClient_Prove(t *testing.T) {
 
 		defer vcWalletClient.Close()
 
+		require.NoError(t, vcWalletClient.Remove(wallet.Credential, "http://example.edu/credentials/1872"))
 		require.NoError(t, vcWalletClient.Add(wallet.Credential, []byte(sampleUDCVC)))
 
 		result, err := vcWalletClient.Prove(&wallet.ProofOptions{Controller: sampleDIDKey},
@@ -836,6 +837,7 @@ func TestClient_Verify(t *testing.T) {
 
 		// store tampered credential in wallet
 		tamperedVC := strings.ReplaceAll(sampleUDCVCWithProof, `"name": "Example University"`, `"name": "Fake University"`)
+		require.NoError(t, vcWalletClient.Remove(wallet.Credential, "http://example.edu/credentials/1872"))
 		require.NoError(t, vcWalletClient.Add(wallet.Credential, []byte(tamperedVC)))
 
 		ok, err := vcWalletClient.Verify(wallet.WithStoredCredentialToVerify("http://example.edu/credentials/1872"))


### PR DESCRIPTION
- wallet user specific VDR which goes through user saved DIDs first
before going through VDR provider.
- duplicate content error (to avoid accidental replace of wallet contents)
- use uuid if JSON LD data model id is missing.
- validate DID resolution data models while saving instead of during
signing.
- Closes #2698

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
