### PR TITLE
feat: #2701 save inbound didexchange.Request envelope media type into connection record

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -237,7 +237,7 @@ func (c *Client) HandleInvitation(invitation *Invitation) (string, error) {
 		return "", fmt.Errorf("handleInvitation: failed to create DIDCommMsg: %w", err)
 	}
 
-	connectionID, err := c.didexchangeSvc.HandleInbound(msg, "", "")
+	connectionID, err := c.didexchangeSvc.HandleInbound(msg, service.EmptyDIDCommContext())
 	if err != nil {
 		return "", fmt.Errorf("handleInvitation: failed from didexchange service handle: %w", err)
 	}

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -1190,7 +1190,7 @@ func TestServiceEvents(t *testing.T) {
 
 	msg, err := service.ParseDIDCommMsgMap(request)
 	require.NoError(t, err)
-	_, err = didExSvc.HandleInbound(msg, "", "")
+	_, err = didExSvc.HandleInbound(msg, service.EmptyDIDCommContext())
 	require.NoError(t, err)
 
 	select {
@@ -1302,7 +1302,7 @@ func TestAcceptExchangeRequest(t *testing.T) {
 
 	msg, err := service.ParseDIDCommMsgMap(request)
 	require.NoError(t, err)
-	_, err = didExSvc.HandleInbound(msg, "", "")
+	_, err = didExSvc.HandleInbound(msg, service.EmptyDIDCommContext())
 	require.NoError(t, err)
 
 	select {
@@ -1406,7 +1406,7 @@ func TestAcceptInvitation(t *testing.T) {
 
 		msg, svcErr := service.ParseDIDCommMsgMap(invitation)
 		require.NoError(t, svcErr)
-		_, err = didExSvc.HandleInbound(msg, "", "")
+		_, err = didExSvc.HandleInbound(msg, service.EmptyDIDCommContext())
 		require.NoError(t, err)
 
 		select {

--- a/pkg/client/introduce/example_test.go
+++ b/pkg/client/introduce/example_test.go
@@ -125,11 +125,11 @@ func mockContext(agent string, tr map[string]chan payload, done chan struct{}) P
 					continue
 				}
 
-				if err = msgSvc.HandleInbound(didMap, msg.myDID, msg.theirDID); err != nil {
+				if err = msgSvc.HandleInbound(didMap, service.NewDIDCommContext(msg.myDID, msg.theirDID, nil)); err != nil {
 					fmt.Println(err)
 				}
 
-				_, err = svc.HandleInbound(didMap, msg.myDID, msg.theirDID)
+				_, err = svc.HandleInbound(didMap, service.NewDIDCommContext(msg.myDID, msg.theirDID, nil))
 				if err != nil {
 					fmt.Println(err)
 				}

--- a/pkg/client/issuecredential/example_test.go
+++ b/pkg/client/issuecredential/example_test.go
@@ -82,11 +82,11 @@ func mockContext(agent string, tr map[string]chan payload) Provider {
 
 				fmt.Println(agent, "received", didMap.Type(), "from", msg.theirDID)
 
-				if err = msgSvc.HandleInbound(didMap, msg.myDID, msg.theirDID); err != nil {
+				if err = msgSvc.HandleInbound(didMap, service.NewDIDCommContext(msg.myDID, msg.theirDID, nil)); err != nil {
 					fmt.Println(err)
 				}
 
-				_, err = svc.HandleInbound(didMap, msg.myDID, msg.theirDID)
+				_, err = svc.HandleInbound(didMap, service.NewDIDCommContext(msg.myDID, msg.theirDID, nil))
 				if err != nil {
 					fmt.Println(err)
 				}

--- a/pkg/client/messaging/client_test.go
+++ b/pkg/client/messaging/client_test.go
@@ -297,7 +297,7 @@ func TestCommand_Send(t *testing.T) { // nolint: gocognit, gocyclo
 					for {
 						services := registrar.Services()
 						if len(services) > 0 {
-							_, e := services[0].HandleInbound(replyMsg, "sampleDID", "sampleTheirDID")
+							_, e := services[0].HandleInbound(replyMsg, service.NewDIDCommContext("sampleDID", "sampleTheirDID", nil))
 							require.NoError(t, e)
 
 							break
@@ -578,7 +578,7 @@ func TestCommand_Reply(t *testing.T) {
 				services := registrar.Services()
 
 				if len(services) > 0 {
-					_, e := services[0].HandleInbound(replyMsg, "sampleDID", "sampleTheirDID")
+					_, e := services[0].HandleInbound(replyMsg, service.NewDIDCommContext("sampleDID", "sampleTheirDID", nil))
 					require.NoError(t, e)
 				}
 			}
@@ -607,7 +607,8 @@ func TestCommand_Reply(t *testing.T) {
 		go func() {
 			for {
 				if len(registrar.Services()) > 0 {
-					_, e := registrar.Services()[0].HandleInbound(replyMsg, "sampleDID", "sampleTheirDID")
+					_, e := registrar.Services()[0].HandleInbound(
+						replyMsg, service.NewDIDCommContext("sampleDID", "sampleTheirDID", nil))
 					require.NoError(t, e)
 				}
 			}

--- a/pkg/client/messaging/msgservice_test.go
+++ b/pkg/client/messaging/msgservice_test.go
@@ -188,7 +188,8 @@ func TestMsgService_HandleInbound(t *testing.T) {
 		require.NotNil(t, msgsvc)
 
 		go func() {
-			s, err := msgsvc.HandleInbound(service.DIDCommMsgMap{"payload": sampleName}, myDID, theirDID)
+			s, err := msgsvc.HandleInbound(
+				service.DIDCommMsgMap{"payload": sampleName}, service.NewDIDCommContext(myDID, theirDID, nil))
 			require.NoError(t, err)
 			require.Empty(t, s)
 		}()
@@ -213,7 +214,8 @@ func TestMsgService_HandleInbound(t *testing.T) {
 
 	t.Run("message service handle inbound failure", func(t *testing.T) {
 		msgsvc := newMessageService("", "", nil, &mockNotifier{})
-		s, err := msgsvc.HandleInbound(service.DIDCommMsgMap{"payload": []byte(sampleName)}, myDID, theirDID)
+		s, err := msgsvc.HandleInbound(
+			service.DIDCommMsgMap{"payload": []byte(sampleName)}, service.NewDIDCommContext(myDID, theirDID, nil))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errTopicNotFound)
 		require.Empty(t, s)
@@ -221,12 +223,13 @@ func TestMsgService_HandleInbound(t *testing.T) {
 
 	t.Run("message service handle inbound topic handle failure", func(t *testing.T) {
 		const sampleErr = "sample topic error"
-		topicHandle := func(msg service.DIDCommMsg, myDID, theirDID string) ([]byte, error) {
+		topicHandle := func(service.DIDCommMsg, service.DIDCommContext) ([]byte, error) {
 			return nil, fmt.Errorf(sampleErr)
 		}
 
 		msgsvc := newCustomMessageService(sampleName, "test", nil, &mockNotifier{}, topicHandle)
-		s, err := msgsvc.HandleInbound(service.DIDCommMsgMap{"payload": []byte(sampleName)}, myDID, theirDID)
+		s, err := msgsvc.HandleInbound(
+			service.DIDCommMsgMap{"payload": []byte(sampleName)}, service.NewDIDCommContext(myDID, theirDID, nil))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), sampleErr)
 		require.Empty(t, s)

--- a/pkg/client/presentproof/client.go
+++ b/pkg/client/presentproof/client.go
@@ -94,7 +94,7 @@ func (c *Client) SendRequestPresentation(msg *RequestPresentation, myDID, theirD
 
 	msg.Type = presentproof.RequestPresentationMsgType
 
-	return c.service.HandleInbound(service.NewDIDCommMsgMap(msg), myDID, theirDID)
+	return c.service.HandleInbound(service.NewDIDCommMsgMap(msg), service.NewDIDCommContext(myDID, theirDID, nil))
 }
 
 type addProof func(presentation *verifiable.Presentation) error
@@ -123,7 +123,7 @@ func (c *Client) SendProposePresentation(msg *ProposePresentation, myDID, theirD
 
 	msg.Type = presentproof.ProposePresentationMsgType
 
-	return c.service.HandleInbound(service.NewDIDCommMsgMap(msg), myDID, theirDID)
+	return c.service.HandleInbound(service.NewDIDCommMsgMap(msg), service.NewDIDCommContext(myDID, theirDID, nil))
 }
 
 // AcceptProposePresentation is used when the Verifier is willing to accept the propose presentation.

--- a/pkg/client/presentproof/client_test.go
+++ b/pkg/client/presentproof/client_test.go
@@ -54,8 +54,8 @@ func TestClient_SendRequestPresentation(t *testing.T) {
 		thid := uuid.New().String()
 
 		svc := mocks.NewMockProtocolService(ctrl)
-		svc.EXPECT().HandleInbound(gomock.Any(), Alice, Bob).
-			DoAndReturn(func(msg service.DIDCommMsg, _, _ string) (string, error) {
+		svc.EXPECT().HandleInbound(gomock.Any(), service.NewDIDCommContext(Alice, Bob, nil)).
+			DoAndReturn(func(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) {
 				require.Equal(t, msg.Type(), presentproof.RequestPresentationMsgType)
 
 				return thid, nil
@@ -91,8 +91,8 @@ func TestClient_SendProposePresentation(t *testing.T) {
 		thid := uuid.New().String()
 
 		svc := mocks.NewMockProtocolService(ctrl)
-		svc.EXPECT().HandleInbound(gomock.Any(), Alice, Bob).
-			DoAndReturn(func(msg service.DIDCommMsg, _, _ string) (string, error) {
+		svc.EXPECT().HandleInbound(gomock.Any(), service.NewDIDCommContext(Alice, Bob, nil)).
+			DoAndReturn(func(msg service.DIDCommMsg, _ service.DIDCommContext) (string, error) {
 				require.Equal(t, msg.Type(), presentproof.ProposePresentationMsgType)
 
 				return thid, nil

--- a/pkg/client/presentproof/example_test.go
+++ b/pkg/client/presentproof/example_test.go
@@ -83,11 +83,11 @@ func mockContext(agent string, tr map[string]chan payload) Provider {
 
 				fmt.Println(agent, "received", didMap.Type(), "from", msg.theirDID)
 
-				if err = msgSvc.HandleInbound(didMap, msg.myDID, msg.theirDID); err != nil {
+				if err = msgSvc.HandleInbound(didMap, service.NewDIDCommContext(msg.myDID, msg.theirDID, nil)); err != nil {
 					fmt.Println(err)
 				}
 
-				_, err = svc.HandleInbound(didMap, msg.myDID, msg.theirDID)
+				_, err = svc.HandleInbound(didMap, service.NewDIDCommContext(msg.myDID, msg.theirDID, nil))
 				if err != nil {
 					fmt.Println(err)
 				}

--- a/pkg/controller/command/didexchange/command_test.go
+++ b/pkg/controller/command/didexchange/command_test.go
@@ -583,7 +583,7 @@ func TestCommand_AcceptInvitation(t *testing.T) {
 		msg, err := service.ParseDIDCommMsgMap(invitation)
 		require.NoError(t, err)
 
-		_, err = didExSvc.HandleInbound(msg, "", "")
+		_, err = didExSvc.HandleInbound(msg, service.EmptyDIDCommContext())
 		require.NoError(t, err)
 
 		var cid string
@@ -837,7 +837,7 @@ func TestCommand_AcceptExchangeRequest(t *testing.T) {
 		msg, err := service.ParseDIDCommMsgMap(request)
 		require.NoError(t, err)
 
-		_, err = didExSvc.HandleInbound(msg, "", "")
+		_, err = didExSvc.HandleInbound(msg, service.EmptyDIDCommContext())
 		require.NoError(t, err)
 
 		cid := <-connID

--- a/pkg/controller/command/presentproof/command_test.go
+++ b/pkg/controller/command/presentproof/command_test.go
@@ -151,7 +151,6 @@ func TestCommand_SendRequestPresentation(t *testing.T) {
 		service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
 		service.EXPECT().HandleInbound(
 			gomock.Any(), gomock.Any(),
-			gomock.Any(),
 		).Return("", errors.New("some error message"))
 
 		provider := mocks.NewMockProvider(ctrl)
@@ -175,7 +174,7 @@ func TestCommand_SendRequestPresentation(t *testing.T) {
 		service := mocks.NewMockProtocolService(ctrl)
 		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
 		service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
-		service.EXPECT().HandleInbound(gomock.Any(), gomock.Any(), gomock.Any())
+		service.EXPECT().HandleInbound(gomock.Any(), gomock.Any())
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
@@ -262,7 +261,6 @@ func TestCommand_SendProposePresentation(t *testing.T) {
 		service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
 		service.EXPECT().HandleInbound(
 			gomock.Any(), gomock.Any(),
-			gomock.Any(),
 		).Return("", errors.New("some error message"))
 
 		provider := mocks.NewMockProvider(ctrl)
@@ -286,7 +284,7 @@ func TestCommand_SendProposePresentation(t *testing.T) {
 		service := mocks.NewMockProtocolService(ctrl)
 		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
 		service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
-		service.EXPECT().HandleInbound(gomock.Any(), gomock.Any(), gomock.Any())
+		service.EXPECT().HandleInbound(gomock.Any(), gomock.Any())
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)

--- a/pkg/didcomm/common/service/messenger.go
+++ b/pkg/didcomm/common/service/messenger.go
@@ -6,6 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 
 package service
 
+// DIDCommContextEnvelopeMediaTypeKey is DIDCommContext property key holding the DIDComm envelope's media type.
+const DIDCommContextEnvelopeMediaTypeKey = "DIDCommContextEnvelopeMediaType"
+
 // DIDCommMsg describes message interface.
 type DIDCommMsg interface {
 	ID() string
@@ -16,6 +19,45 @@ type DIDCommMsg interface {
 	Clone() DIDCommMsgMap
 	Metadata() map[string]interface{}
 	Decode(v interface{}) error
+}
+
+// DIDCommContext holds information on the context in which a DIDCommMsg is being processed.
+type DIDCommContext interface {
+	MyDID() string
+	TheirDID() string
+	EventProperties
+}
+
+// NewDIDCommContext returns a new DIDCommContext with the given DIDs and properties.
+func NewDIDCommContext(myDID, theirDID string, props map[string]interface{}) DIDCommContext {
+	return &context{
+		myDID:    myDID,
+		theirDID: theirDID,
+		props:    props,
+	}
+}
+
+// EmptyDIDCommContext returns a DIDCommContext with no DIDs nor properties.
+func EmptyDIDCommContext() DIDCommContext {
+	return &context{props: make(map[string]interface{})}
+}
+
+type context struct {
+	myDID    string
+	theirDID string
+	props    map[string]interface{}
+}
+
+func (c *context) MyDID() string {
+	return c.myDID
+}
+
+func (c *context) TheirDID() string {
+	return c.theirDID
+}
+
+func (c *context) All() map[string]interface{} {
+	return c.props
 }
 
 // The messenger package is responsible for the handling of communication between agents.
@@ -55,7 +97,7 @@ type Messenger interface {
 type MessengerHandler interface {
 	Messenger
 	// HandleInbound handles all inbound messages
-	HandleInbound(msg DIDCommMsgMap, myDID, theirDID string) error
+	HandleInbound(msg DIDCommMsgMap, ctx DIDCommContext) error
 }
 
 // NestedReplyOpts options for performing `ReplyToNested` operation.

--- a/pkg/didcomm/common/service/messenger_test.go
+++ b/pkg/didcomm/common/service/messenger_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package service_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+)
+
+func TestNewDIDCommContext(t *testing.T) {
+	t.Run("returns DIDs and properties", func(t *testing.T) {
+		myDID := uuid.New().String()
+		theirDID := uuid.New().String()
+		propKey := uuid.New().String()
+		propValue := uuid.New().String()
+
+		c := service.NewDIDCommContext(myDID, theirDID, map[string]interface{}{
+			propKey: propValue,
+		})
+		require.NotNil(t, c)
+
+		require.Equal(t, myDID, c.MyDID())
+		require.Equal(t, theirDID, c.TheirDID())
+		p, ok := c.All()[propKey].(string)
+		require.True(t, ok)
+		require.Equal(t, propValue, p)
+	})
+}
+
+func TestEmptyDIDCommContext(t *testing.T) {
+	t.Run("returns an empty context", func(t *testing.T) {
+		c := service.EmptyDIDCommContext()
+		require.NotNil(t, c)
+		require.Empty(t, c.MyDID())
+		require.Empty(t, c.TheirDID())
+		require.Empty(t, c.All())
+	})
+}

--- a/pkg/didcomm/common/service/service.go
+++ b/pkg/didcomm/common/service/service.go
@@ -9,7 +9,7 @@ package service
 // InboundHandler is handler for inbound messages.
 type InboundHandler interface {
 	// HandleInbound handles inbound messages.
-	HandleInbound(msg DIDCommMsg, myDID, theirDID string) (string, error)
+	HandleInbound(msg DIDCommMsg, ctx DIDCommContext) (string, error)
 }
 
 // OutboundHandler is handler for outbound messages.

--- a/pkg/didcomm/messaging/service/basic/basicmsgsvc.go
+++ b/pkg/didcomm/messaging/service/basic/basicmsgsvc.go
@@ -51,7 +51,7 @@ var logger = log.New("aries-framework/basicmsg")
 // Returns
 //
 // error : handle can return error back to service to notify message dispatcher about failures.
-type MessageHandle func(message Message, myDID, theirDID string) error
+type MessageHandle func(message Message, ctx service.DIDCommContext) error
 
 // NewMessageService creates basic message service which serves
 // incoming basic messages [RFC-0095]
@@ -96,7 +96,7 @@ func (m *MessageService) Accept(msgType string, purpose []string) bool {
 }
 
 // HandleInbound for basic message service.
-func (m *MessageService) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (m *MessageService) HandleInbound(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) {
 	basicMsg := Message{}
 
 	err := msg.Decode(&basicMsg)
@@ -108,5 +108,5 @@ func (m *MessageService) HandleInbound(msg service.DIDCommMsg, myDID, theirDID s
 		logutil.CreateKeyValueString("msgType", msg.Type()),
 		logutil.CreateKeyValueString("msgID", msg.ID()))
 
-	return "", m.handle(basicMsg, myDID, theirDID)
+	return "", m.handle(basicMsg, ctx)
 }

--- a/pkg/didcomm/messaging/service/basic/basicmsgsvc_test.go
+++ b/pkg/didcomm/messaging/service/basic/basicmsgsvc_test.go
@@ -80,13 +80,13 @@ func TestMessageService_HandleInbound(t *testing.T) {
 			myDID    string
 			theirDID string
 		})
-		handleFn := func(message Message, myDID, theirDID string) error {
+		handleFn := func(message Message, ctx service.DIDCommContext) error {
 			testCh <- struct {
 				message  Message
 				myDID    string
 				theirDID string
 			}{
-				message: message, myDID: myDID, theirDID: theirDID,
+				message: message, myDID: ctx.MyDID(), theirDID: ctx.TheirDID(),
 			}
 			return nil
 		}
@@ -99,7 +99,7 @@ func TestMessageService_HandleInbound(t *testing.T) {
 			msg, err := service.ParseDIDCommMsgMap([]byte(jsonStr))
 			require.NoError(t, err)
 
-			_, err = svc.HandleInbound(msg, myDID, theirDID)
+			_, err = svc.HandleInbound(msg, service.NewDIDCommContext(myDID, theirDID, nil))
 			require.NoError(t, err)
 		}()
 
@@ -122,14 +122,14 @@ func TestMessageService_HandleInbound(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, svc)
 
-		_, err = svc.HandleInbound(&mockMsg{err: fmt.Errorf(sampleErr)}, myDID, theirDID)
+		_, err = svc.HandleInbound(&mockMsg{err: fmt.Errorf(sampleErr)}, service.NewDIDCommContext(myDID, theirDID, nil))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unable to decode incoming DID comm message")
 	})
 }
 
 func getMockMessageHandle() MessageHandle {
-	return func(message Message, myDID, theirDID string) error {
+	return func(Message, service.DIDCommContext) error {
 		return nil
 	}
 }

--- a/pkg/didcomm/messaging/service/http/httpmsgsvc.go
+++ b/pkg/didcomm/messaging/service/http/httpmsgsvc.go
@@ -135,7 +135,7 @@ func (m *OverDIDComm) Accept(msgType string, purpose []string) bool {
 }
 
 // HandleInbound for HTTP over DIDComm message service.
-func (m *OverDIDComm) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (m *OverDIDComm) HandleInbound(msg service.DIDCommMsg, _ service.DIDCommContext) (string, error) {
 	svcMsg := httpOverDIDCommMsg{}
 
 	err := msg.Decode(&svcMsg)

--- a/pkg/didcomm/messaging/service/http/httpmsgsvc_test.go
+++ b/pkg/didcomm/messaging/service/http/httpmsgsvc_test.go
@@ -315,14 +315,14 @@ func TestOverDIDComm_HandleInbound(t *testing.T) {
 			require.NoError(t, err)
 
 			if tc.expected.failure != "" {
-				_, err = svc.HandleInbound(didCommMsg, "", "")
+				_, err = svc.HandleInbound(didCommMsg, service.EmptyDIDCommContext())
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.expected.failure)
 				return
 			}
 
 			go func() {
-				_, err = svc.HandleInbound(didCommMsg, "", "")
+				_, err = svc.HandleInbound(didCommMsg, service.EmptyDIDCommContext())
 				require.NoError(t, err)
 			}()
 
@@ -360,7 +360,7 @@ func TestOverDIDComm_HandleInbound_InvalidMsg(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 
-	_, err = svc.HandleInbound(&mockMsg{err: fmt.Errorf("sample-error")}, "", "")
+	_, err = svc.HandleInbound(&mockMsg{err: fmt.Errorf("sample-error")}, service.EmptyDIDCommContext())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unable to decode DID comm message")
 }

--- a/pkg/didcomm/messenger/messenger.go
+++ b/pkg/didcomm/messenger/messenger.go
@@ -65,7 +65,7 @@ func NewMessenger(ctx Provider) (*Messenger, error) {
 }
 
 // HandleInbound handles all inbound messages.
-func (m *Messenger) HandleInbound(msg service.DIDCommMsgMap, myDID, theirDID string) error {
+func (m *Messenger) HandleInbound(msg service.DIDCommMsgMap, ctx service.DIDCommContext) error {
 	// an incoming message cannot be without id
 	if msg.ID() == "" {
 		return errors.New("message-id is absent and can't be processed")
@@ -82,8 +82,8 @@ func (m *Messenger) HandleInbound(msg service.DIDCommMsgMap, myDID, theirDID str
 	// saves message payload
 	return m.saveRecord(msg.ID(), record{
 		ParentThreadID: msg.ParentThreadID(),
-		MyDID:          myDID,
-		TheirDID:       theirDID,
+		MyDID:          ctx.MyDID(),
+		TheirDID:       ctx.TheirDID(),
 		ThreadID:       thID,
 	})
 }

--- a/pkg/didcomm/messenger/messenger_test.go
+++ b/pkg/didcomm/messenger/messenger_test.go
@@ -81,7 +81,8 @@ func TestMessenger_HandleInbound(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, msgr)
 
-		require.NoError(t, msgr.HandleInbound(service.DIDCommMsgMap{jsonID: ID}, myDID, theirDID))
+		require.NoError(t,
+			msgr.HandleInbound(service.DIDCommMsgMap{jsonID: ID}, service.NewDIDCommContext(myDID, theirDID, nil)))
 	})
 
 	t.Run("absent ID", func(t *testing.T) {
@@ -96,7 +97,7 @@ func TestMessenger_HandleInbound(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, msgr)
 
-		err = msgr.HandleInbound(service.DIDCommMsgMap{}, myDID, theirDID)
+		err = msgr.HandleInbound(service.DIDCommMsgMap{}, service.NewDIDCommContext(myDID, theirDID, nil))
 		require.Contains(t, fmt.Sprintf("%v", err), "message-id is absent")
 	})
 }

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -180,7 +180,7 @@ func TestService_Handle_Inviter(t *testing.T) {
 	require.NoError(t, err)
 	msg, err := service.ParseDIDCommMsgMap(payloadBytes)
 	require.NoError(t, err)
-	_, err = s.HandleInbound(msg, doc.DIDDocument.ID, "")
+	_, err = s.HandleInbound(msg, service.NewDIDCommContext(doc.DIDDocument.ID, "", nil))
 	require.NoError(t, err)
 
 	select {
@@ -202,7 +202,7 @@ func TestService_Handle_Inviter(t *testing.T) {
 	didMsg, err := service.ParseDIDCommMsgMap(payloadBytes)
 	require.NoError(t, err)
 
-	_, err = s.HandleInbound(didMsg, doc.DIDDocument.ID, "theirDID")
+	_, err = s.HandleInbound(didMsg, service.NewDIDCommContext(doc.DIDDocument.ID, "", nil))
 	require.NoError(t, err)
 
 	select {
@@ -341,7 +341,7 @@ func TestService_Handle_Invitee(t *testing.T) {
 	didMsg, err := service.ParseDIDCommMsgMap(payloadBytes)
 	require.NoError(t, err)
 
-	_, err = s.HandleInbound(didMsg, "", "")
+	_, err = s.HandleInbound(didMsg, service.EmptyDIDCommContext())
 	require.NoError(t, err)
 
 	var connID string
@@ -383,7 +383,7 @@ func TestService_Handle_Invitee(t *testing.T) {
 	didMsg, err = service.ParseDIDCommMsgMap(payloadBytes)
 	require.NoError(t, err)
 
-	_, err = s.HandleInbound(didMsg, "", "")
+	_, err = s.HandleInbound(didMsg, service.EmptyDIDCommContext())
 	require.NoError(t, err)
 
 	// Alice automatically sends an ACK to Bob
@@ -439,7 +439,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 		didMsg, err := service.ParseDIDCommMsgMap(response)
 		require.NoError(t, err)
 
-		_, err = s.HandleInbound(didMsg, "", "")
+		_, err = s.HandleInbound(didMsg, service.EmptyDIDCommContext())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "handle inbound - next state : invalid state transition: "+
 			"null -> responded")
@@ -467,7 +467,8 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = svc.HandleInbound(
-			generateRequestMsgPayload(t, &protocol.MockProvider{}, randomString(), randomString()), "", "")
+			generateRequestMsgPayload(t, &protocol.MockProvider{}, randomString(), randomString()),
+			service.EmptyDIDCommContext())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "save connection record")
 	})
@@ -518,7 +519,7 @@ func TestService_Handle_EdgeCases(t *testing.T) {
 		didMsg, err := service.ParseDIDCommMsgMap(requestBytes)
 		require.NoError(t, err)
 
-		_, err = svc.HandleInbound(didMsg, "", "")
+		_, err = svc.HandleInbound(didMsg, service.EmptyDIDCommContext())
 		require.NoError(t, err)
 	})
 }
@@ -870,7 +871,7 @@ func TestEventsSuccess(t *testing.T) {
 	didMsg, err := service.ParseDIDCommMsgMap(invite)
 	require.NoError(t, err)
 
-	_, err = svc.HandleInbound(didMsg, "", "")
+	_, err = svc.HandleInbound(didMsg, service.EmptyDIDCommContext())
 	require.NoError(t, err)
 
 	select {
@@ -913,7 +914,7 @@ func TestContinueWithPublicDID(t *testing.T) {
 	didMsg, err := service.ParseDIDCommMsgMap(invite)
 	require.NoError(t, err)
 
-	_, err = svc.HandleInbound(didMsg, "", "")
+	_, err = svc.HandleInbound(didMsg, service.EmptyDIDCommContext())
 	require.NoError(t, err)
 }
 
@@ -981,7 +982,9 @@ func TestEventsUserError(t *testing.T) {
 	err = svc.connectionRecorder.SaveConnectionRecordWithMappings(connRec)
 	require.NoError(t, err)
 
-	_, err = svc.HandleInbound(generateRequestMsgPayload(t, &protocol.MockProvider{}, id, randomString()), "", "")
+	_, err = svc.HandleInbound(
+		generateRequestMsgPayload(t, &protocol.MockProvider{}, id, randomString()),
+		service.EmptyDIDCommContext())
 	require.NoError(t, err)
 
 	select {
@@ -1013,7 +1016,8 @@ func TestEventStoreError(t *testing.T) {
 	}()
 
 	_, err = svc.HandleInbound(
-		generateRequestMsgPayload(t, &protocol.MockProvider{}, randomString(), randomString()), "", "")
+		generateRequestMsgPayload(t, &protocol.MockProvider{}, randomString(), randomString()),
+		service.EmptyDIDCommContext())
 	require.NoError(t, err)
 }
 
@@ -1088,7 +1092,7 @@ func TestServiceErrors(t *testing.T) {
 	require.NoError(t, err)
 
 	payload := generateRequestMsgPayload(t, prov, randomString(), "")
-	_, err = svc.HandleInbound(payload, "", "")
+	_, err = svc.HandleInbound(payload, service.EmptyDIDCommContext())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot fetch state from store")
 
@@ -1104,7 +1108,7 @@ func TestServiceErrors(t *testing.T) {
 	svc.connectionRecorder, err = connection.NewRecorder(&protocol.MockProvider{})
 	require.NoError(t, err)
 
-	_, err = svc.HandleInbound(msg, "", "")
+	_, err = svc.HandleInbound(msg, service.EmptyDIDCommContext())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unrecognized msgType: invalid")
 
@@ -1145,7 +1149,7 @@ func TestConnectionRecord(t *testing.T) {
 	require.NoError(t, err)
 
 	conn, err := svc.connectionRecord(generateRequestMsgPayload(t, &protocol.MockProvider{},
-		randomString(), randomString()))
+		randomString(), randomString()), service.EmptyDIDCommContext())
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 
@@ -1157,7 +1161,7 @@ func TestConnectionRecord(t *testing.T) {
 	msg, err := service.ParseDIDCommMsgMap(requestBytes)
 	require.NoError(t, err)
 
-	_, err = svc.connectionRecord(msg)
+	_, err = svc.connectionRecord(msg, service.EmptyDIDCommContext())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid message type")
 }
@@ -1315,7 +1319,7 @@ func TestRequestRecord(t *testing.T) {
 
 		didcommMsg := generateRequestMsgPayload(t, &protocol.MockProvider{}, randomString(), uuid.New().String())
 		require.NotEmpty(t, didcommMsg.ParentThreadID())
-		conn, err := svc.requestMsgRecord(didcommMsg)
+		conn, err := svc.requestMsgRecord(didcommMsg, service.EmptyDIDCommContext())
 		require.NoError(t, err)
 		require.NotNil(t, conn)
 		require.Equal(t, didcommMsg.ParentThreadID(), conn.InvitationID)
@@ -1334,7 +1338,7 @@ func TestRequestRecord(t *testing.T) {
 		delete(didcommMsg, "connection")
 		didcommMsg["did"] = "did:test:abc"
 
-		conn, err := svc.requestMsgRecord(didcommMsg)
+		conn, err := svc.requestMsgRecord(didcommMsg, service.EmptyDIDCommContext())
 		require.NoError(t, err)
 		require.NotNil(t, conn)
 		require.Equal(t, didcommMsg.ParentThreadID(), conn.InvitationID)
@@ -1354,7 +1358,7 @@ func TestRequestRecord(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = svc.requestMsgRecord(generateRequestMsgPayload(t, &protocol.MockProvider{},
-			randomString(), uuid.New().String()))
+			randomString(), uuid.New().String()), service.EmptyDIDCommContext())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "save connection record")
 	})
@@ -1370,7 +1374,7 @@ func TestRequestRecord(t *testing.T) {
 		parentThreadID := ""
 		didcommMsg := generateRequestMsgPayload(t, &protocol.MockProvider{}, randomString(), parentThreadID)
 		require.Empty(t, didcommMsg.ParentThreadID())
-		_, err = svc.requestMsgRecord(didcommMsg)
+		_, err = svc.requestMsgRecord(didcommMsg, service.EmptyDIDCommContext())
 		require.Error(t, err)
 	})
 }
@@ -1426,7 +1430,7 @@ func TestAcceptExchangeRequest(t *testing.T) {
 
 	_, err = svc.HandleInbound(generateRequestMsgPayload(t, &protocol.MockProvider{
 		StoreProvider: mockstorage.NewMockStoreProvider(),
-	}, randomString(), invitation.ID), "", "")
+	}, randomString(), invitation.ID), service.EmptyDIDCommContext())
 	require.NoError(t, err)
 
 	select {
@@ -1494,7 +1498,7 @@ func TestAcceptExchangeRequestWithPublicDID(t *testing.T) {
 
 	_, err = svc.HandleInbound(generateRequestMsgPayload(t, &protocol.MockProvider{
 		StoreProvider: mockstorage.NewMockStoreProvider(),
-	}, randomString(), invitation.ID), "", "")
+	}, randomString(), invitation.ID), service.EmptyDIDCommContext())
 	require.NoError(t, err)
 
 	select {
@@ -1562,7 +1566,7 @@ func TestAcceptInvitation(t *testing.T) {
 		didMsg, err := service.ParseDIDCommMsgMap(invitationBytes)
 		require.NoError(t, err)
 
-		_, err = svc.HandleInbound(didMsg, "", "")
+		_, err = svc.HandleInbound(didMsg, service.EmptyDIDCommContext())
 		require.NoError(t, err)
 
 		select {
@@ -1696,7 +1700,7 @@ func TestAcceptInvitationWithPublicDID(t *testing.T) {
 		didMsg, err := service.ParseDIDCommMsgMap(invitationBytes)
 		require.NoError(t, err)
 
-		_, err = svc.HandleInbound(didMsg, "", "")
+		_, err = svc.HandleInbound(didMsg, service.EmptyDIDCommContext())
 		require.NoError(t, err)
 
 		select {

--- a/pkg/didcomm/protocol/introduce/service.go
+++ b/pkg/didcomm/protocol/introduce/service.go
@@ -268,13 +268,13 @@ func (s *Service) OOBMessageReceived(msg service.StateMsg) error {
 		Type:   AckMsgType,
 		ID:     uuid.New().String(),
 		Thread: &decorator.Thread{ID: msg.Msg.ParentThreadID()},
-	}), "internal", "internal")
+	}), service.EmptyDIDCommContext())
 
 	return err
 }
 
 // HandleInbound handles inbound message (introduce protocol).
-func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (s *Service) HandleInbound(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) {
 	aEvent := s.ActionEvent()
 
 	// throw error if there is no action event registered for inbound messages
@@ -293,8 +293,8 @@ func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) 
 
 	// sets inbound payload
 	md.inbound = true
-	md.MyDID = myDID
-	md.TheirDID = theirDID
+	md.MyDID = ctx.MyDID()
+	md.TheirDID = ctx.TheirDID()
 
 	// trigger action event based on message type for inbound messages
 	if canTriggerActionEvents(msg) {

--- a/pkg/didcomm/protocol/introduce/service_test.go
+++ b/pkg/didcomm/protocol/introduce/service_test.go
@@ -110,8 +110,8 @@ func agentSetup(agent string, t *testing.T, ctrl *gomock.Controller, tr map[stri
 					continue
 				}
 
-				require.NoError(t, msgSvc.HandleInbound(didMap, msg.myDID, msg.theirDID))
-				_, err = svc.HandleInbound(didMap, msg.myDID, msg.theirDID)
+				require.NoError(t, msgSvc.HandleInbound(didMap, service.NewDIDCommContext(msg.myDID, msg.theirDID, nil)))
+				_, err = svc.HandleInbound(didMap, service.NewDIDCommContext(msg.myDID, msg.theirDID, nil))
 				require.NoError(t, err)
 			case <-time.After(time.Second):
 				return
@@ -1592,7 +1592,7 @@ func TestService_HandleInbound(t *testing.T) {
 		svc, err := introduce.New(provider)
 		require.NoError(t, err)
 
-		_, err = svc.HandleInbound(service.DIDCommMsgMap{}, "", "")
+		_, err = svc.HandleInbound(service.DIDCommMsgMap{}, service.EmptyDIDCommContext())
 		require.EqualError(t, err, "no clients are registered to handle the message")
 	})
 
@@ -1626,7 +1626,7 @@ func TestService_HandleInbound(t *testing.T) {
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
 
-		_, err = svc.HandleInbound(msg, "", "")
+		_, err = svc.HandleInbound(msg, service.EmptyDIDCommContext())
 		require.EqualError(t, err, "doHandle: currentStateName: test err")
 	})
 
@@ -1659,7 +1659,7 @@ func TestService_HandleInbound(t *testing.T) {
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
 
-		_, err = svc.HandleInbound(msg, "", "")
+		_, err = svc.HandleInbound(msg, service.EmptyDIDCommContext())
 		require.EqualError(t, err, "populate metadata: get record: test err")
 	})
 
@@ -1691,7 +1691,7 @@ func TestService_HandleInbound(t *testing.T) {
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
 
-		_, err = svc.HandleInbound(msg, "", "")
+		_, err = svc.HandleInbound(msg, service.EmptyDIDCommContext())
 		require.EqualError(t, err, "doHandle: invalid state transition: noop -> deciding")
 	})
 
@@ -1723,7 +1723,7 @@ func TestService_HandleInbound(t *testing.T) {
 		ch := make(chan service.DIDCommAction)
 		require.NoError(t, svc.RegisterActionEvent(ch))
 
-		_, err = svc.HandleInbound(msg, "", "")
+		_, err = svc.HandleInbound(msg, service.EmptyDIDCommContext())
 		require.EqualError(t, err, "doHandle: nextState: unrecognized msgType: unknown")
 	})
 }

--- a/pkg/didcomm/protocol/issuecredential/service.go
+++ b/pkg/didcomm/protocol/issuecredential/service.go
@@ -218,7 +218,7 @@ func (s *Service) Use(items ...Middleware) {
 }
 
 // HandleInbound handles inbound message (issuecredential protocol).
-func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (s *Service) HandleInbound(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) {
 	aEvent := s.ActionEvent()
 
 	// throw error if there is no action event registered for inbound messages
@@ -233,8 +233,8 @@ func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) 
 
 	// sets inbound payload
 	md.inbound = true
-	md.MyDID = myDID
-	md.TheirDID = theirDID
+	md.MyDID = ctx.MyDID()
+	md.TheirDID = ctx.TheirDID()
 
 	// trigger action event based on message type for inbound messages
 	if canTriggerActionEvents(msg) {

--- a/pkg/didcomm/protocol/issuecredential/service_test.go
+++ b/pkg/didcomm/protocol/issuecredential/service_test.go
@@ -189,7 +189,7 @@ func TestService_HandleInbound(t *testing.T) {
 		svc, err := New(provider)
 		require.NoError(t, err)
 
-		_, err = svc.HandleInbound(nil, "", "")
+		_, err = svc.HandleInbound(nil, service.EmptyDIDCommContext())
 		require.Contains(t, fmt.Sprintf("%v", err), "no clients")
 	})
 
@@ -203,7 +203,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		msg := service.NewDIDCommMsgMap(struct{}{})
 		require.NoError(t, msg.SetID(uuid.New().String()))
-		_, err = svc.HandleInbound(msg, "", "")
+		_, err = svc.HandleInbound(msg, service.EmptyDIDCommContext())
 		require.Contains(t, fmt.Sprintf("%v", err), "doHandle: getCurrentStateNameAndPIID: currentStateName: "+errMsg)
 	})
 
@@ -220,7 +220,7 @@ func TestService_HandleInbound(t *testing.T) {
 			Type: ProposeCredentialMsgType,
 		})
 		require.NoError(t, msg.SetID(uuid.New().String()))
-		_, err = svc.HandleInbound(msg, "", "")
+		_, err = svc.HandleInbound(msg, service.EmptyDIDCommContext())
 		require.Contains(t, fmt.Sprintf("%v", err), "save transitional payload: "+errMsg)
 	})
 
@@ -230,7 +230,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, svc.RegisterActionEvent(make(chan<- service.DIDCommAction)))
 
-		_, err = svc.HandleInbound(service.NewDIDCommMsgMap(struct{}{}), "", "")
+		_, err = svc.HandleInbound(service.NewDIDCommMsgMap(struct{}{}), service.EmptyDIDCommContext())
 		require.Contains(t, fmt.Sprintf("%v", err), "doHandle: nextState: unrecognized msgType: ")
 	})
 
@@ -271,7 +271,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -329,7 +329,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -380,7 +380,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		actions, err := svc.Actions()
@@ -431,7 +431,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		actions, err := svc.Actions()
@@ -487,7 +487,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -543,7 +543,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -599,7 +599,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -658,7 +658,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -716,7 +716,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -772,7 +772,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -819,7 +819,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -866,7 +866,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -947,7 +947,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -1004,7 +1004,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -1048,7 +1048,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		select {
@@ -1071,7 +1071,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		_, err = svc.HandleInbound(service.NewDIDCommMsgMap(model.ProblemReport{
 			Type: ProblemReportMsgType,
-		}), "", "")
+		}), service.EmptyDIDCommContext())
 		require.Contains(t, fmt.Sprintf("%v", err), "doHandle: invalid state transition")
 	})
 }

--- a/pkg/didcomm/protocol/mediator/service.go
+++ b/pkg/didcomm/protocol/mediator/service.go
@@ -261,11 +261,11 @@ func (s *Service) sendActionEvent(msg service.DIDCommMsg, myDID, theirDID string
 }
 
 // HandleInbound handles inbound route coordination messages.
-func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
-	logger.Debugf("service.HandleInbound() input: msg=%+v myDID=%s theirDID=%s", msg, myDID, theirDID)
+func (s *Service) HandleInbound(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) {
+	logger.Debugf("service.HandleInbound() input: msg=%+v myDID=%s theirDID=%s", msg, ctx.MyDID(), ctx.TheirDID())
 
 	if triggersActionEvent(msg.Type()) {
-		return msg.ID(), s.sendActionEvent(msg, myDID, theirDID)
+		return msg.ID(), s.sendActionEvent(msg, ctx.MyDID(), ctx.TheirDID())
 	}
 
 	// perform action on inbound message asynchronously
@@ -276,7 +276,7 @@ func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) 
 		case GrantMsgType:
 			err = s.saveGrant(msg)
 		case KeylistUpdateMsgType:
-			err = s.handleKeylistUpdate(msg, myDID, theirDID)
+			err = s.handleKeylistUpdate(msg, ctx.MyDID(), ctx.TheirDID())
 		case KeylistUpdateResponseMsgType:
 			err = s.handleKeylistUpdateResponse(msg)
 		case service.ForwardMsgType:
@@ -287,7 +287,7 @@ func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) 
 
 		// mediator forward messages don't have connection established with the sender; hence skip the lookup
 		if msg.Type() != service.ForwardMsgType {
-			connectionID, connErr := s.connectionLookup.GetConnectionIDByDIDs(myDID, theirDID)
+			connectionID, connErr := s.connectionLookup.GetConnectionIDByDIDs(ctx.MyDID(), ctx.TheirDID())
 			if connErr != nil {
 				logutil.LogError(logger, Coordination, "connectionID lookup using DIDs", connErr.Error())
 			}

--- a/pkg/didcomm/protocol/mediator/service_test.go
+++ b/pkg/didcomm/protocol/mediator/service_test.go
@@ -92,7 +92,7 @@ func TestServiceHandleInbound(t *testing.T) {
 
 		msgID := randomID()
 
-		id, err := svc.HandleInbound(&service.DIDCommMsgMap{"@id": msgID}, "", "")
+		id, err := svc.HandleInbound(&service.DIDCommMsgMap{"@id": msgID}, service.EmptyDIDCommContext())
 		require.NoError(t, err)
 		require.Equal(t, msgID, id)
 	})
@@ -226,7 +226,7 @@ func TestServiceRequestMsg(t *testing.T) {
 
 		msgID := randomID()
 
-		id, err := svc.HandleInbound(generateRequestMsgPayload(t, msgID), "", "")
+		id, err := svc.HandleInbound(generateRequestMsgPayload(t, msgID), service.EmptyDIDCommContext())
 		require.NoError(t, err)
 		require.Equal(t, msgID, id)
 	})
@@ -341,7 +341,7 @@ func TestEvents(t *testing.T) {
 		msgID := randomID()
 		msg := generateRequestMsgPayload(t, msgID)
 
-		id, err := svc.HandleInbound(msg, "", "")
+		id, err := svc.HandleInbound(msg, service.EmptyDIDCommContext())
 		require.NoError(t, err)
 		require.Equal(t, msgID, id)
 
@@ -376,7 +376,7 @@ func TestEvents(t *testing.T) {
 		err = svc.RegisterActionEvent(events)
 		require.NoError(t, err)
 
-		_, err = svc.HandleInbound(generateRequestMsgPayload(t, "123"), "", "")
+		_, err = svc.HandleInbound(generateRequestMsgPayload(t, "123"), service.EmptyDIDCommContext())
 		require.NoError(t, err)
 
 		select {
@@ -416,7 +416,7 @@ func TestEvents(t *testing.T) {
 		err = svc.RegisterActionEvent(events)
 		require.NoError(t, err)
 
-		_, err = svc.HandleInbound(generateRequestMsgPayload(t, "123"), "", "")
+		_, err = svc.HandleInbound(generateRequestMsgPayload(t, "123"), service.EmptyDIDCommContext())
 		require.NoError(t, err)
 
 		select {
@@ -445,7 +445,7 @@ func TestEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = svc.HandleInbound(generateRequestMsgPayload(t, "123"), "", "")
+		_, err = svc.HandleInbound(generateRequestMsgPayload(t, "123"), service.EmptyDIDCommContext())
 		require.Error(t, err)
 	})
 
@@ -486,7 +486,7 @@ func TestEvents(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("with Options as a struct type", func(t *testing.T) {
-			_, err = svc.HandleInbound(generateRequestMsgPayload(t, randomID()), MYDID, THEIRDID)
+			_, err = svc.HandleInbound(generateRequestMsgPayload(t, randomID()), service.NewDIDCommContext(MYDID, THEIRDID, nil))
 			require.NoError(t, err)
 
 			select {
@@ -507,7 +507,7 @@ func TestEvents(t *testing.T) {
 		})
 
 		t.Run("with Options as a pointer type", func(t *testing.T) {
-			_, err = svc.HandleInbound(generateRequestMsgPayload(t, randomID()), MYDID, THEIRDID)
+			_, err = svc.HandleInbound(generateRequestMsgPayload(t, randomID()), service.NewDIDCommContext(MYDID, THEIRDID, nil))
 			require.NoError(t, err)
 
 			select {
@@ -544,7 +544,7 @@ func TestServiceGrantMsg(t *testing.T) {
 
 		msgID := randomID()
 
-		id, err := svc.HandleInbound(generateGrantMsgPayload(t, msgID), "", "")
+		id, err := svc.HandleInbound(generateGrantMsgPayload(t, msgID), service.EmptyDIDCommContext())
 		require.NoError(t, err)
 		require.Equal(t, msgID, id)
 	})
@@ -587,7 +587,7 @@ func TestServiceUpdateKeyListMsg(t *testing.T) {
 		id, err := svc.HandleInbound(generateKeyUpdateListMsgPayload(t, msgID, []Update{{
 			RecipientKey: "ABC",
 			Action:       "add",
-		}}), "", "")
+		}}), service.EmptyDIDCommContext())
 		require.NoError(t, err)
 		require.Equal(t, msgID, id)
 	})
@@ -680,7 +680,7 @@ func TestServiceKeylistUpdateResponseMsg(t *testing.T) {
 			RecipientKey: "ABC",
 			Action:       "add",
 			Result:       success,
-		}}), "", "")
+		}}), service.EmptyDIDCommContext())
 		require.NoError(t, err)
 		require.Equal(t, msgID, id)
 	})
@@ -724,7 +724,7 @@ func TestServiceForwardMsg(t *testing.T) {
 
 		msgID := randomID()
 
-		id, err := svc.HandleInbound(generateForwardMsgPayload(t, msgID, to, nil), "", "")
+		id, err := svc.HandleInbound(generateForwardMsgPayload(t, msgID, to, nil), service.EmptyDIDCommContext())
 		require.NoError(t, err)
 		require.Equal(t, msgID, id)
 	})

--- a/pkg/didcomm/protocol/messagepickup/service.go
+++ b/pkg/didcomm/protocol/messagepickup/service.go
@@ -107,7 +107,7 @@ func New(prov provider, tp transport.Provider) (*Service, error) {
 }
 
 // HandleInbound handles inbound message pick up messages.
-func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (s *Service) HandleInbound(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) {
 	// perform action asynchronously
 	go func() {
 		var err error
@@ -116,9 +116,9 @@ func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) 
 		case StatusMsgType:
 			err = s.handleStatus(msg)
 		case StatusRequestMsgType:
-			err = s.handleStatusRequest(msg, myDID, theirDID)
+			err = s.handleStatusRequest(msg, ctx.MyDID(), ctx.TheirDID())
 		case BatchPickupMsgType:
-			err = s.handleBatchPickup(msg, myDID, theirDID)
+			err = s.handleBatchPickup(msg, ctx.MyDID(), ctx.TheirDID())
 		case BatchMsgType:
 			err = s.handleBatch(msg)
 		case NoopMsgType:

--- a/pkg/didcomm/protocol/messagepickup/service_test.go
+++ b/pkg/didcomm/protocol/messagepickup/service_test.go
@@ -76,7 +76,7 @@ func TestHandleInbound(t *testing.T) {
 		statusCh := make(chan Status)
 		svc.setStatusCh(msg.ID(), statusCh)
 
-		_, err = svc.HandleInbound(msg, MYDID, THEIRDID)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(MYDID, THEIRDID, nil))
 		require.NoError(t, err)
 
 		tyme, err := time.Parse(time.RFC3339, "2019-05-01T12:00:00Z")
@@ -113,7 +113,7 @@ func TestHandleInbound(t *testing.T) {
 		statusCh := make(chan Status)
 		svc.setStatusCh(msg.ID(), statusCh)
 
-		_, err = svc.HandleInbound(msg, MYDID, THEIRDID)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(MYDID, THEIRDID, nil))
 		require.NoError(t, err)
 	})
 
@@ -183,7 +183,7 @@ func TestHandleInbound(t *testing.T) {
 		require.NoError(t, err)
 
 		go func() {
-			_, err = svc.HandleInbound(msg, MYDID, THEIRDID)
+			_, err = svc.HandleInbound(msg, service.NewDIDCommContext(MYDID, THEIRDID, nil))
 			require.NoError(t, err)
 		}()
 
@@ -277,7 +277,7 @@ func TestHandleInbound(t *testing.T) {
 		require.NoError(t, err)
 
 		go func() {
-			_, err = svc.HandleInbound(msg, MYDID, THEIRDID)
+			_, err = svc.HandleInbound(msg, service.NewDIDCommContext(MYDID, THEIRDID, nil))
 			require.NoError(t, err)
 		}()
 
@@ -384,7 +384,7 @@ func TestHandleInbound(t *testing.T) {
 		batchCh := make(chan Batch)
 		svc.setBatchCh(msg.ID(), batchCh)
 
-		_, err = svc.HandleInbound(msg, MYDID, THEIRDID)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(MYDID, THEIRDID, nil))
 		require.NoError(t, err)
 
 		select {
@@ -420,7 +420,7 @@ func TestHandleInbound(t *testing.T) {
 		msg, err := service.ParseDIDCommMsgMap([]byte(jsonStr))
 		require.NoError(t, err)
 
-		_, err = svc.HandleInbound(msg, MYDID, THEIRDID)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(MYDID, THEIRDID, nil))
 		require.NoError(t, err)
 	})
 

--- a/pkg/didcomm/protocol/outofband/service.go
+++ b/pkg/didcomm/protocol/outofband/service.go
@@ -178,7 +178,7 @@ func (s *Service) Accept(msgType string) bool {
 }
 
 // HandleInbound handles inbound messages.
-func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) { //nolint:funlen
+func (s *Service) HandleInbound(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) { //nolint:funlen
 	logger.Debugf("receive inbound message : %s", msg)
 
 	if !s.Accept(msg.Type()) {
@@ -202,8 +202,8 @@ func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) 
 		Action: Action{
 			PIID:         piid,
 			Msg:          msg.Clone(),
-			MyDID:        myDID,
-			TheirDID:     theirDID,
+			MyDID:        ctx.MyDID(),
+			TheirDID:     ctx.TheirDID(),
 			ProtocolName: Name,
 		},
 	})
@@ -233,8 +233,8 @@ func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) 
 
 				s.callbackChannel <- &callback{
 					msg:      msg,
-					myDID:    myDID,
-					theirDID: theirDID,
+					myDID:    ctx.MyDID(),
+					theirDID: ctx.TheirDID(),
 					options:  opts,
 				}
 			},
@@ -402,6 +402,7 @@ func (s *Service) SaveInvitation(i *Invitation) error {
 		ThreadID:   i.ID,
 		TheirLabel: i.Label,
 		Target:     target,
+		MediaTypes: i.Accept,
 	})
 	if err != nil {
 		return fmt.Errorf("the didexchange service failed to save the oob invitation : %w", err)

--- a/pkg/didcomm/protocol/outofband/service_test.go
+++ b/pkg/didcomm/protocol/outofband/service_test.go
@@ -115,7 +115,7 @@ func TestAccept(t *testing.T) {
 func TestHandleInbound(t *testing.T) {
 	t.Run("accepts out-of-band invitation messages", func(t *testing.T) {
 		s := newAutoService(t, testProvider())
-		_, err := s.HandleInbound(service.NewDIDCommMsgMap(newInvitation()), myDID, theirDID)
+		_, err := s.HandleInbound(service.NewDIDCommMsgMap(newInvitation()), service.NewDIDCommContext(myDID, theirDID, nil))
 		require.NoError(t, err)
 	})
 	t.Run("rejects unsupported message types", func(t *testing.T) {
@@ -123,7 +123,7 @@ func TestHandleInbound(t *testing.T) {
 		require.NoError(t, err)
 		req := newInvitation()
 		req.Type = "invalid"
-		_, err = s.HandleInbound(service.NewDIDCommMsgMap(req), myDID, theirDID)
+		_, err = s.HandleInbound(service.NewDIDCommMsgMap(req), service.NewDIDCommContext(myDID, theirDID, nil))
 		require.Error(t, err)
 	})
 	t.Run("fires off an action event", func(t *testing.T) {
@@ -133,7 +133,7 @@ func TestHandleInbound(t *testing.T) {
 		events := make(chan service.DIDCommAction)
 		err = s.RegisterActionEvent(events)
 		require.NoError(t, err)
-		_, err = s.HandleInbound(expected, myDID, theirDID)
+		_, err = s.HandleInbound(expected, service.NewDIDCommContext(myDID, theirDID, nil))
 		require.NoError(t, err)
 		select {
 		case e := <-events:
@@ -153,7 +153,7 @@ func TestHandleInbound(t *testing.T) {
 		events := make(chan service.DIDCommAction)
 		err = s.RegisterActionEvent(events)
 		require.NoError(t, err)
-		_, err = s.HandleInbound(expected, myDID, theirDID)
+		_, err = s.HandleInbound(expected, service.NewDIDCommContext(myDID, theirDID, nil))
 		require.EqualError(t, err, "threadID: threadID not found")
 	})
 	t.Run("Save transitional payload (error)", func(t *testing.T) {
@@ -167,7 +167,7 @@ func TestHandleInbound(t *testing.T) {
 		events := make(chan service.DIDCommAction)
 		err := s.RegisterActionEvent(events)
 		require.NoError(t, err)
-		_, err = s.HandleInbound(expected, myDID, theirDID)
+		_, err = s.HandleInbound(expected, service.NewDIDCommContext(myDID, theirDID, nil))
 		require.EqualError(t, err, "save transitional payload: db error")
 	})
 	t.Run("sends pre-state msg event", func(t *testing.T) {
@@ -179,7 +179,7 @@ func TestHandleInbound(t *testing.T) {
 		require.NoError(t, err)
 		err = s.RegisterActionEvent(make(chan service.DIDCommAction))
 		require.NoError(t, err)
-		_, err = s.HandleInbound(expected, myDID, theirDID)
+		_, err = s.HandleInbound(expected, service.NewDIDCommContext(myDID, theirDID, nil))
 		require.NoError(t, err)
 		select {
 		case result := <-stateMsgs:
@@ -198,7 +198,7 @@ func TestHandleInbound(t *testing.T) {
 	t.Run("fails if no listeners have been registered for action events", func(t *testing.T) {
 		s, err := New(testProvider())
 		require.NoError(t, err)
-		_, err = s.HandleInbound(service.NewDIDCommMsgMap(newInvitation()), myDID, theirDID)
+		_, err = s.HandleInbound(service.NewDIDCommMsgMap(newInvitation()), service.NewDIDCommContext(myDID, theirDID, nil))
 		require.Error(t, err)
 	})
 }
@@ -213,7 +213,7 @@ func TestService_ActionContinue(t *testing.T) {
 
 		require.NoError(t, s.RegisterActionEvent(actions))
 		s.callbackChannel = make(chan *callback, 2)
-		_, err = s.HandleInbound(msg, myDID, theirDID)
+		_, err = s.HandleInbound(msg, service.NewDIDCommContext(myDID, theirDID, nil))
 		require.NoError(t, err)
 
 		var remainingActions []Action
@@ -261,7 +261,7 @@ func TestService_ActionStop(t *testing.T) {
 
 		require.NoError(t, s.RegisterActionEvent(actions))
 		s.callbackChannel = make(chan *callback, 2)
-		_, err = s.HandleInbound(msg, myDID, theirDID)
+		_, err = s.HandleInbound(msg, service.NewDIDCommContext(myDID, theirDID, nil))
 		require.NoError(t, err)
 
 		var remainingActions []Action
@@ -301,7 +301,7 @@ func TestServiceStop(t *testing.T) {
 
 		require.NoError(t, s.RegisterActionEvent(actions))
 		s.callbackChannel = make(chan *callback, 2)
-		_, err = s.HandleInbound(msg, myDID, theirDID)
+		_, err = s.HandleInbound(msg, service.NewDIDCommContext(myDID, theirDID, nil))
 		require.NoError(t, err)
 
 		select {
@@ -327,7 +327,7 @@ func TestServiceContinue(t *testing.T) {
 
 		require.NoError(t, s.RegisterActionEvent(actions))
 		s.callbackChannel = make(chan *callback, 2)
-		_, err = s.HandleInbound(msg, myDID, theirDID)
+		_, err = s.HandleInbound(msg, service.NewDIDCommContext(myDID, theirDID, nil))
 		require.NoError(t, err)
 
 		select {

--- a/pkg/didcomm/protocol/presentproof/service.go
+++ b/pkg/didcomm/protocol/presentproof/service.go
@@ -223,8 +223,8 @@ func (s *Service) Use(items ...Middleware) {
 }
 
 // HandleInbound handles inbound message (presentproof protocol).
-func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
-	logger.Debugf("service.HandleInbound() input: msg=%+v myDID=%s theirDID=%s", msg, myDID, theirDID)
+func (s *Service) HandleInbound(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) {
+	logger.Debugf("service.HandleInbound() input: msg=%+v myDID=%s theirDID=%s", msg, ctx.MyDID(), ctx.TheirDID())
 
 	msgMap := msg.Clone()
 
@@ -242,8 +242,8 @@ func (s *Service) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) 
 		return "", fmt.Errorf("doHandle: %w", err)
 	}
 
-	md.MyDID = myDID
-	md.TheirDID = theirDID
+	md.MyDID = ctx.MyDID()
+	md.TheirDID = ctx.TheirDID()
 
 	// trigger action event based on message type for inbound messages
 	if canReply && canTriggerActionEvents(msgMap) {

--- a/pkg/didcomm/protocol/presentproof/service_test.go
+++ b/pkg/didcomm/protocol/presentproof/service_test.go
@@ -283,7 +283,7 @@ func TestService_HandleInbound(t *testing.T) {
 		svc, err := New(provider)
 		require.NoError(t, err)
 
-		_, err = svc.HandleInbound(randomInboundMessage(""), "", "")
+		_, err = svc.HandleInbound(randomInboundMessage(""), service.EmptyDIDCommContext())
 		require.Contains(t, fmt.Sprintf("%v", err), "no clients")
 	})
 
@@ -301,7 +301,7 @@ func TestService_HandleInbound(t *testing.T) {
 		}{ID: "ID", Thread: decorator.Thread{PID: "PID"}})
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
-		_, err = svc.HandleInbound(msg, "", "")
+		_, err = svc.HandleInbound(msg, service.EmptyDIDCommContext())
 		require.Contains(t, fmt.Sprintf("%v", err),
 			"doHandle: current internal data and PIID: current internal data: "+errMsg)
 	})
@@ -315,7 +315,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		require.NoError(t, svc.RegisterActionEvent(make(chan<- service.DIDCommAction)))
 
-		_, err = svc.HandleInbound(randomInboundMessage(RequestPresentationMsgType), "", "")
+		_, err = svc.HandleInbound(randomInboundMessage(RequestPresentationMsgType), service.EmptyDIDCommContext())
 		require.Contains(t, fmt.Sprintf("%v", err), "save transitional payload: "+errMsg)
 	})
 
@@ -330,7 +330,7 @@ func TestService_HandleInbound(t *testing.T) {
 		msg := service.NewDIDCommMsgMap(struct{}{})
 
 		require.NoError(t, msg.SetID(uuid.New().String()))
-		_, err = svc.HandleInbound(msg, "", "")
+		_, err = svc.HandleInbound(msg, service.EmptyDIDCommContext())
 		require.Contains(t, fmt.Sprintf("%v", err), "doHandle: nextState: unrecognized msgType: ")
 	})
 
@@ -346,7 +346,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		_, err = svc.HandleInbound(service.NewDIDCommMsgMap(model.ProblemReport{
 			Type: ProblemReportMsgType,
-		}), "", "")
+		}), service.EmptyDIDCommContext())
 		require.Contains(t, fmt.Sprintf("%v", err), "doHandle: invalid state transition")
 	})
 
@@ -383,7 +383,8 @@ func TestService_HandleInbound(t *testing.T) {
 		ch := make(chan service.DIDCommAction, 1)
 		require.NoError(t, svc.RegisterActionEvent(ch))
 
-		_, err = svc.HandleInbound(randomInboundMessage(RequestPresentationMsgType), Alice, Bob)
+		_, err = svc.HandleInbound(
+			randomInboundMessage(RequestPresentationMsgType), service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -447,7 +448,7 @@ func TestService_HandleInbound(t *testing.T) {
 		msg := randomInboundMessage(RequestPresentationMsgType)
 		msg["will_confirm"] = true
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -497,7 +498,7 @@ func TestService_HandleInbound(t *testing.T) {
 		msg := randomInboundMessage(RequestPresentationMsgType)
 		msg["will_confirm"] = true
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		actions, err := svc.Actions()
@@ -544,7 +545,8 @@ func TestService_HandleInbound(t *testing.T) {
 		ch := make(chan service.DIDCommAction, 1)
 		require.NoError(t, svc.RegisterActionEvent(ch))
 
-		_, err = svc.HandleInbound(randomInboundMessage(RequestPresentationMsgType), Alice, Bob)
+		_, err = svc.HandleInbound(
+			randomInboundMessage(RequestPresentationMsgType), service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		actions, err := svc.Actions()
@@ -601,7 +603,8 @@ func TestService_HandleInbound(t *testing.T) {
 		ch := make(chan service.DIDCommAction, 1)
 		require.NoError(t, svc.RegisterActionEvent(ch))
 
-		_, err = svc.HandleInbound(randomInboundMessage(RequestPresentationMsgType), Alice, Bob)
+		_, err = svc.HandleInbound(
+			randomInboundMessage(RequestPresentationMsgType), service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -661,7 +664,9 @@ func TestService_HandleInbound(t *testing.T) {
 		ch := make(chan service.DIDCommAction, 1)
 		require.NoError(t, svc.RegisterActionEvent(ch))
 
-		_, err = svc.HandleInbound(randomInboundMessage(ProposePresentationMsgType), Alice, Bob)
+		_, err = svc.HandleInbound(
+			randomInboundMessage(ProposePresentationMsgType),
+			service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -707,7 +712,7 @@ func TestService_HandleInbound(t *testing.T) {
 		ch := make(chan service.DIDCommAction, 1)
 		require.NoError(t, svc.RegisterActionEvent(ch))
 
-		_, err = svc.HandleInbound(randomInboundMessage(ProblemReportMsgType), Alice, Bob)
+		_, err = svc.HandleInbound(randomInboundMessage(ProblemReportMsgType), service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -753,7 +758,7 @@ func TestService_HandleInbound(t *testing.T) {
 		ch := make(chan service.DIDCommAction, 1)
 		require.NoError(t, svc.RegisterActionEvent(ch))
 
-		_, err = svc.HandleInbound(randomInboundMessage(ProblemReportMsgType), Alice, Bob)
+		_, err = svc.HandleInbound(randomInboundMessage(ProblemReportMsgType), service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -815,7 +820,9 @@ func TestService_HandleInbound(t *testing.T) {
 		ch := make(chan service.DIDCommAction, 1)
 		require.NoError(t, svc.RegisterActionEvent(ch))
 
-		_, err = svc.HandleInbound(randomInboundMessage(ProposePresentationMsgType), Alice, Bob)
+		_, err = svc.HandleInbound(
+			randomInboundMessage(ProposePresentationMsgType),
+			service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -889,7 +896,7 @@ func TestService_HandleInbound(t *testing.T) {
 		require.NoError(t, msg.SetID(uuid.New().String()))
 		msg["~thread"] = decorator.Thread{ID: uuid.New().String()}
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		action := <-ch
@@ -933,7 +940,7 @@ func TestService_HandleInbound(t *testing.T) {
 		ch := make(chan service.DIDCommAction, 1)
 		require.NoError(t, svc.RegisterActionEvent(ch))
 
-		_, err = svc.HandleInbound(randomInboundMessage(AckMsgType), Alice, Bob)
+		_, err = svc.HandleInbound(randomInboundMessage(AckMsgType), service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		select {
@@ -972,7 +979,7 @@ func TestService_HandleInbound(t *testing.T) {
 				return nil
 			})
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		select {
@@ -995,7 +1002,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		messenger.EXPECT().Send(gomock.Any(), Alice, Bob).Return(errors.New(errMsg))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.Contains(t, fmt.Sprintf("%v", err), "action request-sent: "+errMsg)
 	})
 
@@ -1027,7 +1034,7 @@ func TestService_HandleInbound(t *testing.T) {
 				return nil
 			})
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.NoError(t, err)
 
 		select {
@@ -1050,7 +1057,7 @@ func TestService_HandleInbound(t *testing.T) {
 
 		messenger.EXPECT().Send(gomock.Any(), Alice, Bob).Return(errors.New(errMsg))
 
-		_, err = svc.HandleInbound(msg, Alice, Bob)
+		_, err = svc.HandleInbound(msg, service.NewDIDCommContext(Alice, Bob, nil))
 		require.Contains(t, fmt.Sprintf("%v", err), "action proposal-sent: "+errMsg)
 	})
 }

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -84,7 +84,7 @@ func TestNewProvider(t *testing.T) {
 
 	t.Run("test inbound message handlers/dispatchers", func(t *testing.T) {
 		messengerHandler := serviceMocks.NewMockMessengerHandler(ctrl)
-		messengerHandler.EXPECT().HandleInbound(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		messengerHandler.EXPECT().HandleInbound(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 		connectionStore := didStoreMocks.NewMockConnectionStore(ctrl)
 		connectionStore.EXPECT().GetDID(gomock.Any()).Return("", nil).AnyTimes()
@@ -160,7 +160,7 @@ func TestNewProvider(t *testing.T) {
 	t.Run("inbound message handler for didexchange protocol doesn't call GetDID", func(t *testing.T) {
 		messengerHandler := serviceMocks.NewMockMessengerHandler(ctrl)
 		messengerHandler.EXPECT().
-			HandleInbound(gomock.Any(), gomock.Any(), gomock.Any()).
+			HandleInbound(gomock.Any(), gomock.Any()).
 			Return(nil).
 			AnyTimes()
 
@@ -190,7 +190,7 @@ func TestNewProvider(t *testing.T) {
 	t.Run("inbound message handler: DID not found is ok", func(t *testing.T) {
 		messengerHandler := serviceMocks.NewMockMessengerHandler(ctrl)
 		messengerHandler.EXPECT().
-			HandleInbound(gomock.Any(), gomock.Any(), gomock.Any()).
+			HandleInbound(gomock.Any(), gomock.Any()).
 			Return(nil).
 			AnyTimes()
 
@@ -221,7 +221,7 @@ func TestNewProvider(t *testing.T) {
 	t.Run("inbound message handler: failed to get my did", func(t *testing.T) {
 		messengerHandler := serviceMocks.NewMockMessengerHandler(ctrl)
 		messengerHandler.EXPECT().
-			HandleInbound(gomock.Any(), gomock.Any(), gomock.Any()).
+			HandleInbound(gomock.Any(), gomock.Any()).
 			Return(nil).
 			AnyTimes()
 
@@ -260,7 +260,7 @@ func TestNewProvider(t *testing.T) {
 	t.Run("inbound message handler: failed to get their did", func(t *testing.T) {
 		messengerHandler := serviceMocks.NewMockMessengerHandler(ctrl)
 		messengerHandler.EXPECT().
-			HandleInbound(gomock.Any(), gomock.Any(), gomock.Any()).
+			HandleInbound(gomock.Any(), gomock.Any()).
 			Return(nil).
 			AnyTimes()
 
@@ -299,7 +299,7 @@ func TestNewProvider(t *testing.T) {
 	t.Run("generic message handler: failed to get did", func(t *testing.T) {
 		messengerHandler := serviceMocks.NewMockMessengerHandler(ctrl)
 		messengerHandler.EXPECT().
-			HandleInbound(gomock.Any(), gomock.Any(), gomock.Any()).
+			HandleInbound(gomock.Any(), gomock.Any()).
 			Return(nil).
 			AnyTimes()
 
@@ -337,7 +337,7 @@ func TestNewProvider(t *testing.T) {
 
 		messengerHandler := serviceMocks.NewMockMessengerHandler(ctrl)
 		messengerHandler.EXPECT().
-			HandleInbound(gomock.Any(), gomock.Any(), gomock.Any()).
+			HandleInbound(gomock.Any(), gomock.Any()).
 			Return(errTest).
 			Times(1)
 
@@ -420,7 +420,7 @@ func TestNewProvider(t *testing.T) {
 
 		messenger := serviceMocks.NewMockMessengerHandler(ctrl)
 		messenger.EXPECT().
-			HandleInbound(gomock.Any(), gomock.Any(), gomock.Any()).
+			HandleInbound(gomock.Any(), gomock.Any()).
 			Return(nil).
 			AnyTimes()
 

--- a/pkg/internal/gomocks/client/introduce/mocks.gen.go
+++ b/pkg/internal/gomocks/client/introduce/mocks.gen.go
@@ -116,18 +116,18 @@ func (mr *MockProtocolServiceMockRecorder) Actions() *gomock.Call {
 }
 
 // HandleInbound mocks base method
-func (m *MockProtocolService) HandleInbound(arg0 service.DIDCommMsg, arg1, arg2 string) (string, error) {
+func (m *MockProtocolService) HandleInbound(arg0 service.DIDCommMsg, arg1 service.DIDCommContext) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleInbound", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "HandleInbound", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HandleInbound indicates an expected call of HandleInbound
-func (mr *MockProtocolServiceMockRecorder) HandleInbound(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockProtocolServiceMockRecorder) HandleInbound(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleInbound", reflect.TypeOf((*MockProtocolService)(nil).HandleInbound), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleInbound", reflect.TypeOf((*MockProtocolService)(nil).HandleInbound), arg0, arg1)
 }
 
 // HandleOutbound mocks base method

--- a/pkg/internal/gomocks/client/issuecredential/mocks.gen.go
+++ b/pkg/internal/gomocks/client/issuecredential/mocks.gen.go
@@ -116,18 +116,18 @@ func (mr *MockProtocolServiceMockRecorder) Actions() *gomock.Call {
 }
 
 // HandleInbound mocks base method
-func (m *MockProtocolService) HandleInbound(arg0 service.DIDCommMsg, arg1, arg2 string) (string, error) {
+func (m *MockProtocolService) HandleInbound(arg0 service.DIDCommMsg, arg1 service.DIDCommContext) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleInbound", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "HandleInbound", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HandleInbound indicates an expected call of HandleInbound
-func (mr *MockProtocolServiceMockRecorder) HandleInbound(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockProtocolServiceMockRecorder) HandleInbound(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleInbound", reflect.TypeOf((*MockProtocolService)(nil).HandleInbound), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleInbound", reflect.TypeOf((*MockProtocolService)(nil).HandleInbound), arg0, arg1)
 }
 
 // HandleOutbound mocks base method

--- a/pkg/internal/gomocks/client/presentproof/mocks.gen.go
+++ b/pkg/internal/gomocks/client/presentproof/mocks.gen.go
@@ -116,18 +116,18 @@ func (mr *MockProtocolServiceMockRecorder) Actions() *gomock.Call {
 }
 
 // HandleInbound mocks base method
-func (m *MockProtocolService) HandleInbound(arg0 service.DIDCommMsg, arg1, arg2 string) (string, error) {
+func (m *MockProtocolService) HandleInbound(arg0 service.DIDCommMsg, arg1 service.DIDCommContext) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleInbound", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "HandleInbound", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HandleInbound indicates an expected call of HandleInbound
-func (mr *MockProtocolServiceMockRecorder) HandleInbound(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockProtocolServiceMockRecorder) HandleInbound(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleInbound", reflect.TypeOf((*MockProtocolService)(nil).HandleInbound), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleInbound", reflect.TypeOf((*MockProtocolService)(nil).HandleInbound), arg0, arg1)
 }
 
 // HandleOutbound mocks base method

--- a/pkg/internal/gomocks/didcomm/common/service/mocks.gen.go
+++ b/pkg/internal/gomocks/didcomm/common/service/mocks.gen.go
@@ -34,18 +34,18 @@ func (m *MockDIDComm) EXPECT() *MockDIDCommMockRecorder {
 }
 
 // HandleInbound mocks base method
-func (m *MockDIDComm) HandleInbound(arg0 service.DIDCommMsg, arg1, arg2 string) (string, error) {
+func (m *MockDIDComm) HandleInbound(arg0 service.DIDCommMsg, arg1 service.DIDCommContext) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleInbound", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "HandleInbound", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HandleInbound indicates an expected call of HandleInbound
-func (mr *MockDIDCommMockRecorder) HandleInbound(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDIDCommMockRecorder) HandleInbound(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleInbound", reflect.TypeOf((*MockDIDComm)(nil).HandleInbound), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleInbound", reflect.TypeOf((*MockDIDComm)(nil).HandleInbound), arg0, arg1)
 }
 
 // HandleOutbound mocks base method
@@ -315,17 +315,17 @@ func (m *MockMessengerHandler) EXPECT() *MockMessengerHandlerMockRecorder {
 }
 
 // HandleInbound mocks base method
-func (m *MockMessengerHandler) HandleInbound(arg0 service.DIDCommMsgMap, arg1, arg2 string) error {
+func (m *MockMessengerHandler) HandleInbound(arg0 service.DIDCommMsgMap, arg1 service.DIDCommContext) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleInbound", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "HandleInbound", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HandleInbound indicates an expected call of HandleInbound
-func (mr *MockMessengerHandlerMockRecorder) HandleInbound(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMessengerHandlerMockRecorder) HandleInbound(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleInbound", reflect.TypeOf((*MockMessengerHandler)(nil).HandleInbound), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleInbound", reflect.TypeOf((*MockMessengerHandler)(nil).HandleInbound), arg0, arg1)
 }
 
 // ReplyTo mocks base method

--- a/pkg/mock/didcomm/protocol/didexchange/mock_didexchange.go
+++ b/pkg/mock/didcomm/protocol/didexchange/mock_didexchange.go
@@ -44,7 +44,7 @@ type MockDIDExchangeSvc struct {
 }
 
 // HandleInbound msg.
-func (m *MockDIDExchangeSvc) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (m *MockDIDExchangeSvc) HandleInbound(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) {
 	if m.HandleFunc != nil {
 		return m.HandleFunc(msg)
 	}

--- a/pkg/mock/didcomm/protocol/generic/mock_generic_svc.go
+++ b/pkg/mock/didcomm/protocol/generic/mock_generic_svc.go
@@ -36,7 +36,7 @@ type MockMessageSvc struct {
 }
 
 // HandleInbound msg.
-func (m *MockMessageSvc) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (m *MockMessageSvc) HandleInbound(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) {
 	if m.HandleFunc != nil {
 		return m.HandleFunc(&msg)
 	}

--- a/pkg/mock/didcomm/protocol/mediator/mock_mediator.go
+++ b/pkg/mock/didcomm/protocol/mediator/mock_mediator.go
@@ -33,7 +33,7 @@ type MockMediatorSvc struct {
 }
 
 // HandleInbound msg.
-func (m *MockMediatorSvc) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (m *MockMediatorSvc) HandleInbound(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) {
 	if m.HandleFunc != nil {
 		return m.HandleFunc(msg)
 	}

--- a/pkg/mock/didcomm/protocol/messagepickup/mock_messagepickup.go
+++ b/pkg/mock/didcomm/protocol/messagepickup/mock_messagepickup.go
@@ -20,7 +20,7 @@ type MockMessagePickupSvc struct {
 	StatusRequestFunc  func(connectionID string) (*messagepickup.Status, error)
 	BatchPickupErr     error
 	BatchPickupFunc    func(connectionID string, size int) (int, error)
-	HandleInboundFunc  func(msg service.DIDCommMsg, myDID, theirDID string) (string, error)
+	HandleInboundFunc  func(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error)
 	HandleOutboundFunc func(_ service.DIDCommMsg, _, _ string) (string, error)
 	AddMessageFunc     func(message *model.Envelope, theirDID string) error
 	AddMessageErr      error
@@ -65,9 +65,9 @@ func (m *MockMessagePickupSvc) BatchPickup(connectionID string, size int) (int, 
 }
 
 // HandleInbound msg.
-func (m *MockMessagePickupSvc) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (m *MockMessagePickupSvc) HandleInbound(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) {
 	if m.HandleInboundFunc != nil {
-		return m.HandleInboundFunc(msg, myDID, theirDID)
+		return m.HandleInboundFunc(msg, ctx)
 	}
 
 	return "", nil

--- a/test/bdd/pkg/messaging/messaging_sdk_steps.go
+++ b/test/bdd/pkg/messaging/messaging_sdk_steps.go
@@ -131,7 +131,7 @@ func (d *SDKSteps) sendGenericMessageReply(fromAgentID, toAgentID, msg, msgType,
 }
 
 func (d *SDKSteps) registerBasicMsgService(agentID, name string) error {
-	messageHandle := func(message basic.Message, myDID, theirDID string) error {
+	messageHandle := func(message basic.Message, _ service.DIDCommContext) error {
 		d.basicMessages[agentID] = message
 		return nil
 	}

--- a/test/bdd/pkg/messaging/msgservice.go
+++ b/test/bdd/pkg/messaging/msgservice.go
@@ -75,7 +75,7 @@ func (m *msgService) Accept(msgType string, purpose []string) bool {
 	return purposeMatched && typeMatched
 }
 
-func (m *msgService) HandleInbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+func (m *msgService) HandleInbound(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) {
 	go m.pushMessage(msg)
 	return "", nil
 }


### PR DESCRIPTION
closes #2701 

Note on implementation: 

This change could have been less disruptive if we simply handled this as a special case and add a new method to the didexchange protocol service. There is already a special case [here](https://github.com/hyperledger/aries-framework-go/blob/a4113ebda7e3e6a1918415960b09a309d86b19d3/pkg/framework/context/context.go#L181) for performance reasons; adding a new method and calling it will also make it a special case from a functional perspective. This did not sound quite right and instead I chose to refactor `HandleInbound` to accept a general purpose holder of the DIDComm context such that in the future additional cross-cutting properties can be added as needed without affecting function signatures.

Signed-off-by: George Aristy <george.aristy@securekey.com>