### PR TITLE
feat: VC wallet - support for key model

### DIFF
--- a/pkg/client/vcwallet/client.go
+++ b/pkg/client/vcwallet/client.go
@@ -166,7 +166,12 @@ func (c *Client) Import(auth string, contents json.RawMessage) error {
 //
 // TODO: (#2433) support for correlation between wallet contents (ex: credentials to a profile/collection).
 func (c *Client) Add(contentType wallet.ContentType, content json.RawMessage) error {
-	return c.wallet.Add(contentType, content)
+	auth, err := c.auth()
+	if err != nil {
+		return err
+	}
+
+	return c.wallet.Add(auth, contentType, content)
 }
 
 // Remove removes wallet content by content ID.

--- a/pkg/client/vcwallet/client_test.go
+++ b/pkg/client/vcwallet/client_test.go
@@ -42,6 +42,7 @@ const (
 	toBeImplementedErr  = "to be implemented"
 	sampleClientErr     = "sample client err"
 	sampleDIDKey        = "did:key:z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5"
+	sampleDIDKey2       = "did:key:z6MkwFKUCsf8wvn6eSSu1WFAKatN1yexiDM7bf7pZLSFjdz6"
 	sampleContentValid  = `{
   			"@context": ["https://w3id.org/wallet/v1"],
   		  	"id": "did:example:123456789abcdefghi",
@@ -184,6 +185,64 @@ const (
     	"@context": ["https://w3id.org/did/v1"],
     	"id": "did:example:sampleInvalidDIDContent"
 		}`
+
+	sampleKeyContentBase58 = `{
+  			"@context": ["https://w3id.org/wallet/v1"],
+  		  	"id": "did:key:z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5#z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5",
+  		  	"controller": "did:example:123456789abcdefghi",
+			"type": "Ed25519VerificationKey2018",
+			"privateKeyBase58":"2MP5gWCnf67jvW3E4Lz8PpVrDWAXMYY1sDxjnkEnKhkkbKD7yP2mkVeyVpu5nAtr3TeDgMNjBPirk2XcQacs3dvZ"
+  		}`
+
+	sampleDIDResolutionResponse = `{
+    "@context": [
+        "https://w3id.org/wallet/v1",
+        "https://w3id.org/did-resolution/v1"
+    ],
+    "id": "did:key:z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5",
+    "type": ["DIDResolutionResponse"],
+    "name": "Farming Sensor DID Document",
+    "image": "https://via.placeholder.com/150",
+    "description": "An IoT device in the middle of a corn field.",
+    "tags": ["professional"],
+    "correlation": ["4058a72a-9523-11ea-bb37-0242ac130002"],
+    "created": "2017-06-18T21:19:10Z",
+    "expires": "2026-06-18T21:19:10Z",
+    "didDocument": {
+        "@context": [
+            "https://w3id.org/did/v0.11"
+        ],
+        "id": "did:key:z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5",
+        "publicKey": [
+            {
+                "id": "did:key:z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5#z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5",
+                "type": "Ed25519VerificationKey2018",
+                "controller": "did:key:z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5",
+                "publicKeyBase58": "8jkuMBqmu1TRA6is7TT5tKBksTZamrLhaXrg9NAczqeh"
+            }
+        ],
+        "authentication": [
+            "did:key:z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5#z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5"
+        ],
+        "assertionMethod": [
+            "did:key:z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5#z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5"
+        ],
+        "capabilityDelegation": [
+            "did:key:z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5#z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5"
+        ],
+        "capabilityInvocation": [
+            "did:key:z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5#z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5"
+        ],
+        "keyAgreement": [
+            {
+                "id": "did:key:z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5#z6LSmjNfS5FC9W59JtPZq7fHgrjThxsidjEhZeMxCarbR998",
+                "type": "X25519KeyAgreementKey2019",
+                "controller": "did:key:z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5",
+                "publicKeyBase58": "B4CVumSL43MQDW1oJU9LNGWyrpLbw84YgfeGi8D4hmNN"
+            }
+        ]
+    }
+}`
 )
 
 func TestCreateProfile(t *testing.T) {
@@ -595,7 +654,7 @@ func TestClient_Add(t *testing.T) {
 	err := CreateProfile(sampleUserID, mockctx, wallet.WithKeyServerURL(sampleKeyServerURL))
 	require.NoError(t, err)
 
-	vcWalletClient, err := New(sampleUserID, mockctx)
+	vcWalletClient, err := New(sampleUserID, mockctx, wallet.WithUnlockByPassphrase(samplePassPhrase))
 	require.NotEmpty(t, vcWalletClient)
 	require.NoError(t, err)
 
@@ -608,7 +667,7 @@ func TestClient_Get(t *testing.T) {
 	err := CreateProfile(sampleUserID, mockctx, wallet.WithKeyServerURL(sampleKeyServerURL))
 	require.NoError(t, err)
 
-	vcWalletClient, err := New(sampleUserID, mockctx)
+	vcWalletClient, err := New(sampleUserID, mockctx, wallet.WithUnlockByPassphrase(samplePassPhrase))
 	require.NotEmpty(t, vcWalletClient)
 	require.NoError(t, err)
 
@@ -626,7 +685,7 @@ func TestClient_Remove(t *testing.T) {
 	err := CreateProfile(sampleUserID, mockctx, wallet.WithKeyServerURL(sampleKeyServerURL))
 	require.NoError(t, err)
 
-	vcWalletClient, err := New(sampleUserID, mockctx)
+	vcWalletClient, err := New(sampleUserID, mockctx, wallet.WithUnlockByPassphrase(samplePassPhrase))
 	require.NotEmpty(t, vcWalletClient)
 	require.NoError(t, err)
 
@@ -686,6 +745,26 @@ func TestClient_Issue(t *testing.T) {
 	err := CreateProfile(sampleUserID, mockctx, wallet.WithPassphrase(samplePassPhrase))
 	require.NoError(t, err)
 
+	t.Run("Test VC wallet client issue using controller - success", func(t *testing.T) {
+		vcWalletClient, err := New(sampleUserID, mockctx, wallet.WithUnlockByPassphrase(samplePassPhrase))
+		require.NotEmpty(t, vcWalletClient)
+		require.NoError(t, err)
+
+		defer vcWalletClient.Close()
+
+		// save a DID & corresponding key
+		require.NoError(t, vcWalletClient.Add(wallet.Key, []byte(sampleKeyContentBase58)))
+		require.NoError(t, vcWalletClient.Add(wallet.DIDResolutionResponse, []byte(sampleDIDResolutionResponse)))
+
+		result, err := vcWalletClient.Issue([]byte(sampleUDCVC), &wallet.ProofOptions{
+			Controller: sampleDIDKey,
+		})
+
+		require.NoError(t, err)
+		require.NotEmpty(t, result)
+		require.NotEmpty(t, result.Proofs)
+	})
+
 	t.Run("Test VC wallet client issue using controller - failure", func(t *testing.T) {
 		vcWalletClient, err := New(sampleUserID, mockctx, wallet.WithUnlockByPassphrase(samplePassPhrase))
 		require.NotEmpty(t, vcWalletClient)
@@ -695,7 +774,7 @@ func TestClient_Issue(t *testing.T) {
 
 		// sign with just controller
 		result, err := vcWalletClient.Issue([]byte(sampleUDCVC), &wallet.ProofOptions{
-			Controller: sampleDIDKey,
+			Controller: sampleDIDKey2,
 		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to read json keyset from reader")
@@ -744,6 +823,27 @@ func TestClient_Prove(t *testing.T) {
 	err := CreateProfile(sampleUserID, mockctx, wallet.WithPassphrase(samplePassPhrase))
 	require.NoError(t, err)
 
+	t.Run("Test VC wallet client prove using controller - success", func(t *testing.T) {
+		vcWalletClient, err := New(sampleUserID, mockctx, wallet.WithUnlockByPassphrase(samplePassPhrase))
+		require.NotEmpty(t, vcWalletClient)
+		require.NoError(t, err)
+
+		defer vcWalletClient.Close()
+
+		// save a credential, DID & key
+		require.NoError(t, vcWalletClient.Add(wallet.Credential, []byte(sampleUDCVC)))
+		require.NoError(t, vcWalletClient.Add(wallet.Key, []byte(sampleKeyContentBase58)))
+		require.NoError(t, vcWalletClient.Add(wallet.DIDResolutionResponse, []byte(sampleDIDResolutionResponse)))
+
+		result, err := vcWalletClient.Prove(&wallet.ProofOptions{Controller: sampleDIDKey},
+			wallet.WithStoredCredentialsToPresent("http://example.edu/credentials/1872"),
+			wallet.WithRawCredentialsToPresent([]byte(sampleUDCVC)),
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, result)
+		require.NotEmpty(t, result.Proofs)
+	})
+
 	t.Run("Test VC wallet client prove using controller - failure", func(t *testing.T) {
 		vcWalletClient, err := New(sampleUserID, mockctx, wallet.WithUnlockByPassphrase(samplePassPhrase))
 		require.NotEmpty(t, vcWalletClient)
@@ -751,9 +851,10 @@ func TestClient_Prove(t *testing.T) {
 
 		defer vcWalletClient.Close()
 
+		require.NoError(t, vcWalletClient.Remove(wallet.Credential, "http://example.edu/credentials/1872"))
 		require.NoError(t, vcWalletClient.Add(wallet.Credential, []byte(sampleUDCVC)))
 
-		result, err := vcWalletClient.Prove(&wallet.ProofOptions{Controller: sampleDIDKey},
+		result, err := vcWalletClient.Prove(&wallet.ProofOptions{Controller: sampleDIDKey2},
 			wallet.WithStoredCredentialsToPresent("http://example.edu/credentials/1872"),
 			wallet.WithRawCredentialsToPresent([]byte(sampleUDCVC)),
 		)
@@ -763,7 +864,7 @@ func TestClient_Prove(t *testing.T) {
 	})
 
 	t.Run("Test VC wallet client prove using controller - wallet locked", func(t *testing.T) {
-		vcWalletClient, err := New(sampleUserID, mockctx)
+		vcWalletClient, err := New(sampleUserID, mockctx, wallet.WithUnlockByPassphrase(samplePassPhrase))
 		require.NotEmpty(t, vcWalletClient)
 		require.NoError(t, err)
 
@@ -771,6 +872,8 @@ func TestClient_Prove(t *testing.T) {
 
 		require.NoError(t, vcWalletClient.Remove(wallet.Credential, "http://example.edu/credentials/1872"))
 		require.NoError(t, vcWalletClient.Add(wallet.Credential, []byte(sampleUDCVC)))
+
+		vcWalletClient.Close()
 
 		result, err := vcWalletClient.Prove(&wallet.ProofOptions{Controller: sampleDIDKey},
 			wallet.WithStoredCredentialsToPresent("http://example.edu/credentials/1872"),
@@ -917,7 +1020,7 @@ func TestWallet_Derive(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(sampleFrame), &frameDoc))
 
 	t.Run("Test derive a credential from wallet - success", func(t *testing.T) {
-		walletInstance, err := New(sampleUserID, mockctx)
+		walletInstance, err := New(sampleUserID, mockctx, wallet.WithUnlockByPassphrase(samplePassPhrase))
 		require.NoError(t, err)
 		require.NotEmpty(t, walletInstance)
 
@@ -970,7 +1073,7 @@ func TestWallet_Derive(t *testing.T) {
 	})
 
 	t.Run("Test derive credential failures", func(t *testing.T) {
-		walletInstance, err := New(sampleUserID, mockctx)
+		walletInstance, err := New(sampleUserID, mockctx, wallet.WithUnlockByPassphrase(samplePassPhrase))
 		require.NotEmpty(t, walletInstance)
 		require.NoError(t, err)
 

--- a/pkg/wallet/kmsclient_test.go
+++ b/pkg/wallet/kmsclient_test.go
@@ -8,12 +8,14 @@ package wallet
 
 import (
 	"crypto/sha256"
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	kmsapi "github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/mock/kms"
 	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/secretlock/local/masterlock/pbkdf2"
 )
@@ -22,6 +24,7 @@ const (
 	samplePassPhrase    = "fakepassphrase"
 	sampleRemoteKMSAuth = "sample-auth-token"
 	keyNotFoundErr      = "Key not found."
+	sampleKeyMgrErr     = "sample-keymgr-err"
 )
 
 func TestKeyManagerStore(t *testing.T) {
@@ -52,9 +55,9 @@ func TestKeyManager(t *testing.T) {
 		require.NotEmpty(t, tkn)
 
 		// get key manager
-		kms, err := keyManager().getKeyManger(tkn)
+		kmgr, err := keyManager().getKeyManger(tkn)
 		require.NoError(t, err)
-		require.NotEmpty(t, kms)
+		require.NotEmpty(t, kmgr)
 
 		// try to create again before expiry
 		tkn, err = keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
@@ -84,9 +87,9 @@ func TestKeyManager(t *testing.T) {
 		require.NotEmpty(t, tkn)
 
 		// get key manager
-		kms, err := keyManager().getKeyManger(tkn)
+		kmgr, err := keyManager().getKeyManger(tkn)
 		require.NoError(t, err)
-		require.NotEmpty(t, kms)
+		require.NotEmpty(t, kmgr)
 
 		// try to create again before expiry
 		tkn, err = keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
@@ -118,8 +121,8 @@ func TestKeyManager(t *testing.T) {
 		require.Contains(t, err.Error(), "message authentication failed")
 
 		// get key manager
-		kms, err := keyManager().getKeyManger(tkn)
-		require.Empty(t, kms)
+		kmgr, err := keyManager().getKeyManger(tkn)
+		require.Empty(t, kmgr)
 		require.Error(t, err)
 		require.EqualError(t, err, keyNotFoundErr)
 	})
@@ -149,8 +152,8 @@ func TestKeyManager(t *testing.T) {
 		require.Contains(t, err.Error(), "message authentication failed")
 
 		// get key manager
-		kms, err := keyManager().getKeyManger(tkn)
-		require.Empty(t, kms)
+		kmgr, err := keyManager().getKeyManger(tkn)
+		require.Empty(t, kmgr)
 		require.Error(t, err)
 		require.EqualError(t, err, keyNotFoundErr)
 	})
@@ -195,8 +198,8 @@ func TestKeyManager(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid wallet profile")
 
 		// get key manager
-		kms, err := keyManager().getKeyManger(tkn)
-		require.Empty(t, kms)
+		kmgr, err := keyManager().getKeyManger(tkn)
+		require.Empty(t, kmgr)
 		require.Error(t, err)
 		require.EqualError(t, err, keyNotFoundErr)
 	})
@@ -245,5 +248,331 @@ func TestKeyManager(t *testing.T) {
 		kmgr, err = keyManager().getKeyManger(tkn)
 		require.NoError(t, err)
 		require.NotEmpty(t, kmgr)
+	})
+}
+
+func TestImportKeyJWK(t *testing.T) {
+	sampleUser := uuid.New().String()
+	masterLock, err := getDefaultSecretLock(samplePassPhrase)
+	require.NoError(t, err)
+
+	masterLockCipherText, err := createMasterLock(masterLock)
+	require.NoError(t, err)
+	require.NotEmpty(t, masterLockCipherText)
+
+	profileInfo := &profile{
+		User:             sampleUser,
+		MasterLockCipher: masterLockCipherText,
+	}
+
+	tkn, err := keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
+		&unlockOpts{passphrase: samplePassPhrase})
+	require.NoError(t, err)
+	require.NotEmpty(t, tkn)
+
+	t.Run("test successful jwk key imports", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			sampleJWK []byte
+			ID        string
+			error     string
+		}{
+			{
+				name: "import Ed25519",
+				sampleJWK: []byte(`{
+							"kty": "OKP",
+							"d":"Dq5t2WS3OMzcpkh8AyVxJs5r9v4L39ocIz9CpUOqM40",
+							"crv": "Ed25519",
+							"x": "ODaPFurJgFcoVCUYEmgOJpWOtPlOYbHSugasscKWqDM",
+							"kid":"z6MkiEh8RQL83nkPo8ehDeE7"
+				}`),
+				ID: "did:example:123#z6MkiEh8RQL83nkPo8ehDeE7",
+			},
+			{
+				name: "import Ed25519, use document id for missing kid",
+				sampleJWK: []byte(`{
+							"kty": "OKP",
+							"d":"Dq5t2WS3OMzcpkh8AyVxJs5r9v4L39ocIz9CpUOqM40",
+							"crv": "Ed25519",
+							"x": "ODaPFurJgFcoVCUYEmgOJpWOtPlOYbHSugasscKWqDM"
+				}`),
+				ID: "did:example:123#z6MkiEh8RQL83nkPo8ehDeE8",
+			},
+			{
+				name: "import P-256",
+				sampleJWK: []byte(`{
+                        	"kty": "EC",
+                        	"kid": "z6MkiEh8RQL83nkPo8ehDeE9",
+                        	"crv": "P-256",
+                        	"alg": "EdDSA",
+                        	"x": "POTofegIPtEJ4ctuYJ9qY1GZepxAqEcx-RjoYJghW5U",
+                        	"y": "C0STSwXZ-krV5CYdqU4yKh7NiKKjwmAkIMXfeyo3Irw",
+                        	"d": "GeJ0tppbkfJl8Jci00L3WBIopiE6p6cnkPdT_l9xKmk"
+                    }`),
+				ID: "did:example:123#z6MkiEh8RQL83nkPo8ehDeE9",
+			},
+			{
+				name: "import P-384",
+				sampleJWK: []byte(`{
+      					"kty": "EC",
+      					"crv": "P-384",
+      					"x": "eQbMauiHc9HuiqXT894gW5XTCrOpeY8cjLXAckfRtdVBLzVHKaiXAAxBFeVrSB75",
+      					"y": "YOjxhMkdH9QnNmGCGuGXJrjAtk8CQ1kTmEEi9cg2R9ge-zh8SFT1Xu6awoUjK5Bv",
+      					"d": "dXghMAzYZmv46SNRuxmfDIuAlv7XIhvlkPzW3vXsopB1ihWp47tx0hqjZmYO6fJa"
+    				}`),
+				ID: "did:example:123#z6MkiEh8RQL83nkPo8ehDeE10",
+			},
+			{
+				name: "import Ed25519 failure - invalid jwk",
+				sampleJWK: []byte(`{
+							"invalid":"test"
+				}`),
+				ID:    "did:example:123#z6MkiEh8RQL83nkPo8ehDeE7",
+				error: " unknown json web key type",
+			},
+			{
+				name: "import secp256k1 failure - unsupported curve",
+				sampleJWK: []byte(`{
+					"kty": "EC",
+      				"crv": "secp256k1",
+      				"x": "GBMxavme-AfIVDKqI6WBJ4V5wZItsxJ9muhxPByllHQ",
+      				"y": "SChlfVBhTXG_sRGc9ZdFeCYzI3Kbph3ivE12OFVk4jo",
+      				"d": "m5N7gTItgWz6udWjuqzJsqX-vksUnxJrNjD5OilScBc"
+    				}`),
+				ID:    "did:example:123#z6MkiEh8RQL83nkPo8ehDeE7",
+				error: "unsupported Key type secp256k1",
+			},
+			{
+				name: "import Ed25519 failure - incorrect key type",
+				sampleJWK: []byte(`{
+				    "kty": "OKP",
+        			"crv": "Ed25519",
+					"x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ"
+      				}`),
+				ID:    "did:example:123#z6MkiEh8RQL83nkPo8ehDeE7",
+				error: "mport private key does not support this key type or key is public",
+			},
+		}
+
+		t.Parallel()
+
+		for _, test := range tests {
+			tc := test
+			t.Run(tc.name, func(t *testing.T) {
+				if tc.error != "" {
+					err := importKeyJWK(tkn, &keyContent{PrivateKeyJwk: tc.sampleJWK, ID: tc.ID})
+					require.Error(t, err)
+					require.Contains(t, err.Error(), tc.error)
+
+					return
+				}
+
+				err := importKeyJWK(tkn, &keyContent{PrivateKeyJwk: tc.sampleJWK, ID: tc.ID})
+				require.NoError(t, err)
+
+				kmgr, err := keyManager().getKeyManger(tkn)
+				require.NoError(t, err)
+
+				handle, err := kmgr.Get(getKID(tc.ID))
+				require.NoError(t, err)
+				require.NotEmpty(t, handle)
+			})
+		}
+	})
+
+	t.Run("test key ID already exists", func(t *testing.T) {
+		err := importKeyJWK(tkn, &keyContent{PrivateKeyJwk: []byte(`{
+							"kty": "OKP",
+							"d":"Dq5t2WS3OMzcpkh8AyVxJs5r9v4L39ocIz9CpUOqM40",
+							"crv": "Ed25519",
+							"x": "ODaPFurJgFcoVCUYEmgOJpWOtPlOYbHSugasscKWqDM",
+							"kid":"z6MkiEh8RQL83nkPo8ehDeX7"
+				}`), ID: "did:example:123#z6MkiEh8RQL83nkPo8ehDeX7"})
+		require.NoError(t, err)
+
+		// import different key with same key ID
+		err = importKeyJWK(tkn, &keyContent{PrivateKeyJwk: []byte(`{
+      						"kty": "EC",
+      						"crv": "P-384",
+      						"x": "eQbMauiHc9HuiqXT894gW5XTCrOpeY8cjLXAckfRtdVBLzVHKaiXAAxBFeVrSB75",
+      						"y": "YOjxhMkdH9QnNmGCGuGXJrjAtk8CQ1kTmEEi9cg2R9ge-zh8SFT1Xu6awoUjK5Bv",
+      						"d": "dXghMAzYZmv46SNRuxmfDIuAlv7XIhvlkPzW3vXsopB1ihWp47tx0hqjZmYO6fJa",
+							"kid": "z6MkiEh8RQL83nkPo8ehDeX7"
+    					}`), ID: "did:example:123#z6MkiEh8RQL83nkPo8ehDeX8"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "requested ID 'z6MkiEh8RQL83nkPo8ehDeX7' already exists")
+
+		// import different key with same content ID (missing kid)
+		err = importKeyJWK(tkn, &keyContent{PrivateKeyJwk: []byte(`{
+      						"kty": "EC",
+      						"crv": "P-384",
+      						"x": "eQbMauiHc9HuiqXT894gW5XTCrOpeY8cjLXAckfRtdVBLzVHKaiXAAxBFeVrSB75",
+      						"y": "YOjxhMkdH9QnNmGCGuGXJrjAtk8CQ1kTmEEi9cg2R9ge-zh8SFT1Xu6awoUjK5Bv",
+      						"d": "dXghMAzYZmv46SNRuxmfDIuAlv7XIhvlkPzW3vXsopB1ihWp47tx0hqjZmYO6fJa"
+    					}`), ID: "did:example:123#z6MkiEh8RQL83nkPo8ehDeX7"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "requested ID 'z6MkiEh8RQL83nkPo8ehDeX7' already exists")
+
+		// no KID
+		err = importKeyJWK(tkn, &keyContent{PrivateKeyJwk: []byte(`{
+							"kty": "OKP",
+							"d":"Dq5t2WS3OMzcpkh8AyVxJs5r9v4L39ocIz9CpUOqM40",
+							"crv": "Ed25519",
+							"x": "ODaPFurJgFcoVCUYEmgOJpWOtPlOYbHSugasscKWqDM"
+				}`)})
+		require.NoError(t, err)
+	})
+
+	t.Run("test key manager errors", func(t *testing.T) {
+		err := importKeyJWK(tkn+"invalid", &keyContent{PrivateKeyJwk: []byte(`{
+							"kty": "OKP",
+							"d":"Dq5t2WS3OMzcpkh8AyVxJs5r9v4L39ocIz9CpUOqM40",
+							"crv": "Ed25519",
+							"x": "ODaPFurJgFcoVCUYEmgOJpWOtPlOYbHSugasscKWqDM",
+							"kid":"z6MkiEh8RQL83nkPo8ehDeX7"
+				}`), ID: "did:example:123#z6MkiEh8RQL83nkPo8ehDeX7"})
+		require.True(t, errors.Is(err, ErrWalletLocked))
+	})
+}
+
+func TestImportKeyBase58(t *testing.T) {
+	sampleUser := uuid.New().String()
+	masterLock, e := getDefaultSecretLock(samplePassPhrase)
+	require.NoError(t, e)
+
+	masterLockCipherText, e := createMasterLock(masterLock)
+	require.NoError(t, e)
+	require.NotEmpty(t, masterLockCipherText)
+
+	profileInfo := &profile{
+		User:             sampleUser,
+		MasterLockCipher: masterLockCipherText,
+	}
+
+	tkn, e := keyManager().createKeyManager(profileInfo, mockstorage.NewMockStoreProvider(),
+		&unlockOpts{passphrase: samplePassPhrase})
+	require.NoError(t, e)
+	require.NotEmpty(t, tkn)
+
+	t.Run("test successful base58 key imports", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			keyBase58 string
+			keyType   string
+			ID        string
+			error     string
+		}{
+			{
+				name:      "import Ed25519VerificationKey2018",
+				keyBase58: "zJRjGFZydU5DBdS2p5qbiUzDFAxbXTkjiDuGPksMBbY5TNyEsGfK4a4WGKjBCh1zeNryeuKtPotp8W1ESnwP71y",
+				keyType:   "Ed25519VerificationKey2018",
+				ID:        "did:example:123#z6MkiEh8RQL83nkPo8ehDeE1",
+			},
+			{
+				name:      "import Bls12381G1Key2020",
+				keyBase58: "6gsgGpdx7p1nYoKJ4b5fKt1xEomWdnemg9nJFX6mqNCh",
+				keyType:   "Bls12381G1Key2020",
+				ID:        "did:example:123#z6MkiEh8RQL83nkPo8ehDeE2",
+			},
+			{
+				name:      "import Ed25519VerificationKey2018 failure",
+				keyBase58: "6gsgGpdx7p1nYoKJ4b5fKt1xEomWdnemg9nJFX6mqNCh",
+				keyType:   "GpgVerificationKey2020",
+				ID:        "did:example:123#z6MkiEh8RQL83nkPo8ehDeE3",
+				error:     "only Ed25519VerificationKey2018 &  Bls12381G1Key2020 are supported in base58 format",
+			},
+			{
+				name:      "import Bls12381G1Key2020",
+				keyBase58: "6gsgGpdx7p1nYossKJ4b5fKt1xEomWdnemg9nJFX6mqNCh",
+				keyType:   "Bls12381G1Key2020",
+				ID:        "did:example:123#z6MkiEh8RQL83nkPo8ehDeE2",
+				error:     "invalid size of private key",
+			},
+		}
+
+		t.Parallel()
+
+		for _, test := range tests {
+			tc := test
+			t.Run(tc.name, func(t *testing.T) {
+				if tc.error != "" {
+					err := importKeyBase58(tkn, &keyContent{
+						ID:               tc.ID,
+						PrivateKeyBase58: tc.keyBase58,
+						KeyType:          tc.keyType,
+					})
+					require.Error(t, err)
+					require.Contains(t, err.Error(), tc.error)
+
+					return
+				}
+
+				err := importKeyBase58(tkn, &keyContent{
+					ID:               tc.ID,
+					PrivateKeyBase58: tc.keyBase58,
+					KeyType:          tc.keyType,
+				})
+				require.NoError(t, err)
+
+				kmgr, err := keyManager().getKeyManger(tkn)
+				require.NoError(t, err)
+
+				handle, err := kmgr.Get(getKID(tc.ID))
+				require.NoError(t, err)
+				require.NotEmpty(t, handle)
+			})
+		}
+	})
+
+	t.Run("test key ID already exists", func(t *testing.T) {
+		err := importKeyBase58(tkn, &keyContent{
+			ID:               "did:example:123#z6MkiEh8RQL83nkPo8ehDeE4",
+			PrivateKeyBase58: "zJRjGFZydU5DBdS2p5qbiUzDFAxbXTkjiDuGPksMBbY5TNyEsGfK4a4WGKjBCh1zeNryeuKtPotp8W1ESnwP71y",
+			KeyType:          "Ed25519VerificationKey2018",
+		})
+		require.NoError(t, err)
+
+		err = importKeyBase58(tkn, &keyContent{
+			ID:               "did:example:123#z6MkiEh8RQL83nkPo8ehDeE4",
+			PrivateKeyBase58: "zJRjGFZydU5DBdS2p5qbiUzDFAxbXTkjiDuGPksMBbY5TNyEsGfK4a4WGKjBCh1zeNryeuKtPotp8W1ESnwP71y",
+			KeyType:          "Ed25519VerificationKey2018",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "requested ID 'z6MkiEh8RQL83nkPo8ehDeE4' already exists")
+	})
+
+	t.Run("test key manager errors", func(t *testing.T) {
+		err := importKeyBase58(tkn+"invalid", &keyContent{
+			ID:               "did:example:123#z6MkiEh8RQL83nkPo8ehDeE5",
+			PrivateKeyBase58: "zJRjGFZydU5DBdS2p5qbiUzDFAxbXTkjiDuGPksMBbY5TNyEsGfK4a4WGKjBCh1zeNryeuKtPotp8W1ESnwP71y",
+			KeyType:          "Ed25519VerificationKey2018",
+		})
+		require.True(t, errors.Is(err, ErrWalletLocked))
+	})
+
+	t.Run("test import errors", func(t *testing.T) {
+		mockToken := "mock-token"
+
+		sampleErr := errors.New(sampleKeyMgrErr)
+		wkmgr := keyManager()
+		err := wkmgr.saveKeyManger(uuid.New().String(), mockToken,
+			&kms.KeyManager{ImportPrivateKeyErr: sampleErr}, 0)
+		require.NoError(t, err)
+
+		err = importKeyBase58(mockToken, &keyContent{
+			ID:               "did:example:123#z6MkiEh8RQL83nkPo8ehDeE5",
+			PrivateKeyBase58: "zJRjGFZydU5DBdS2p5qbiUzDFAxbXTkjiDuGPksMBbY5TNyEsGfK4a4WGKjBCh1zeNryeuKtPotp8W1ESnwP71y",
+			KeyType:          "Ed25519VerificationKey2018",
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, sampleErr))
+
+		err = importKeyBase58(mockToken, &keyContent{
+			ID:               "did:example:123#z6MkiEh8RQL83nkPo8ehDeE5",
+			PrivateKeyBase58: "6gsgGpdx7p1nYoKJ4b5fKt1xEomWdnemg9nJFX6mqNCh",
+			KeyType:          "Bls12381G1Key2020",
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, sampleErr))
 	})
 }

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -240,8 +240,8 @@ func (c *Wallet) Import(auth string, contents json.RawMessage) error {
 //	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
 //
 // TODO: (#2433) support for correlation between wallet contents (ex: credentials to a profile/collection).
-func (c *Wallet) Add(contentType ContentType, content json.RawMessage) error {
-	return c.contents.Save(contentType, content)
+func (c *Wallet) Add(authToken string, contentType ContentType, content json.RawMessage) error {
+	return c.contents.Save(authToken, contentType, content)
 }
 
 // Remove removes wallet content by content ID.

--- a/pkg/wallet/wallet_test.go
+++ b/pkg/wallet/wallet_test.go
@@ -525,7 +525,7 @@ func TestWallet_Add(t *testing.T) {
 	require.NotEmpty(t, walletInstance)
 	require.NoError(t, err)
 
-	err = walletInstance.Add(Metadata, []byte(sampleContentValid))
+	err = walletInstance.Add(sampleFakeTkn, Metadata, []byte(sampleContentValid))
 	require.NoError(t, err)
 }
 
@@ -538,7 +538,7 @@ func TestWallet_Get(t *testing.T) {
 	require.NotEmpty(t, walletInstance)
 	require.NoError(t, err)
 
-	err = walletInstance.Add(Metadata, []byte(sampleContentValid))
+	err = walletInstance.Add(sampleFakeTkn, Metadata, []byte(sampleContentValid))
 	require.NoError(t, err)
 
 	content, err := walletInstance.Get(Metadata, "did:example:123456789abcdefghi")
@@ -556,7 +556,7 @@ func TestWallet_Remove(t *testing.T) {
 	require.NotEmpty(t, walletInstance)
 	require.NoError(t, err)
 
-	err = walletInstance.Add(Metadata, []byte(sampleContentValid))
+	err = walletInstance.Add(sampleFakeTkn, Metadata, []byte(sampleContentValid))
 	require.NoError(t, err)
 
 	content, err := walletInstance.Get(Metadata, "did:example:123456789abcdefghi")
@@ -780,7 +780,7 @@ func TestWallet_Issue(t *testing.T) {
 		kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
 
 		// save DID Resolution response
-		err = walletInstance.Add(DIDResolutionResponse, []byte(sampleDocResolutionResponse))
+		err = walletInstance.Add(sampleFakeTkn, DIDResolutionResponse, []byte(sampleDocResolutionResponse))
 		require.NoError(t, err)
 
 		// sign with just controller
@@ -1131,7 +1131,7 @@ func TestWallet_Prove(t *testing.T) {
 		require.Contains(t, err.Error(), "data not found")
 
 		// save invalid VC in store
-		require.NoError(t, walletInstance.Add(Credential, []byte(sampleInvalidDIDContent)))
+		require.NoError(t, walletInstance.Add(sampleFakeTkn, Credential, []byte(sampleInvalidDIDContent)))
 		result, err = walletInstance.Prove(sampleFakeTkn, &ProofOptions{},
 			WithStoredCredentialsToPresent("did:example:sampleInvalidDIDContent"))
 		require.Empty(t, result)
@@ -1319,7 +1319,7 @@ func TestWallet_Verify(t *testing.T) {
 		// save it in store
 		vcBytes, err := sampleVC.MarshalJSON()
 		require.NoError(t, err)
-		require.NoError(t, walletInstance.Add(Credential, vcBytes))
+		require.NoError(t, walletInstance.Add(sampleFakeTkn, Credential, vcBytes))
 
 		// verify stored credential
 		ok, err := walletInstance.Verify(WithStoredCredentialToVerify(sampleVC.ID))
@@ -1360,7 +1360,7 @@ func TestWallet_Verify(t *testing.T) {
 		tamperedVC.Issuer.ID += "."
 		vcBytes, err := tamperedVC.MarshalJSON()
 		require.NoError(t, err)
-		require.NoError(t, walletInstance.Add(Credential, vcBytes))
+		require.NoError(t, walletInstance.Add(sampleFakeTkn, Credential, vcBytes))
 
 		ok, err := walletInstance.Verify(WithStoredCredentialToVerify("http://example.edu/credentials/1872"))
 		require.Error(t, err)
@@ -1523,7 +1523,7 @@ func TestWallet_Derive(t *testing.T) {
 		// save BBS VC in store
 		vcBytes, err := vcs["bbsvc"].MarshalJSON()
 		require.NoError(t, err)
-		require.NoError(t, walletInstance.Add(Credential, vcBytes))
+		require.NoError(t, walletInstance.Add(sampleFakeTkn, Credential, vcBytes))
 
 		sampleNonce := uuid.New().String()
 
@@ -1582,7 +1582,7 @@ func TestWallet_Derive(t *testing.T) {
 		require.Contains(t, err.Error(), "data not found")
 
 		// invalid credential in store
-		require.NoError(t, walletInstance.Add(Credential, []byte(sampleInvalidDIDContent)))
+		require.NoError(t, walletInstance.Add(sampleFakeTkn, Credential, []byte(sampleInvalidDIDContent)))
 
 		vc, err = walletInstance.Derive(FromStoredCredential("did:example:sampleInvalidDIDContent"), &DeriveOptions{})
 		require.Empty(t, vc)
@@ -1631,7 +1631,7 @@ func addCredentialsToWallet(t *testing.T, walletInstance *Wallet, vcs ...*verifi
 		vcBytes, err := vc.MarshalJSON()
 		require.NoError(t, err)
 		require.NoError(t, walletInstance.Remove(Credential, vc.ID))
-		require.NoError(t, walletInstance.Add(Credential, vcBytes))
+		require.NoError(t, walletInstance.Add(sampleFakeTkn, Credential, vcBytes))
 	}
 
 	return func() {


### PR DESCRIPTION
- Support for key Data model from
https://w3c-ccg.github.io/universal-wallet-interop-spec/#Key
- Wallet will never save key data model in content store, instead it will extract and import private key into user profile kms.
- For base58 import, support for Ed25519VerificationKey2018 &
Bls12381G1Key2020
- For jwk import, support for Curves - Ed25519, P-256, P-384,
BLS12381G2
- KID logic: for jwk, `jwk.kid` will be used (fallback to key document
`id` fragment)
- KID logic: for base58, key document `id` fragment
- added key, did, vc data model based issue/prove tests in client tests
- closes #2707

TODO: BLS12381G2 private key jwk support

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
