### PR TITLE
feat: VC Wallet - QueryByFrame & QueryByExample

### DIFF
--- a/pkg/client/vcwallet/client.go
+++ b/pkg/client/vcwallet/client.go
@@ -214,7 +214,7 @@ func (c *Client) Get(contentType wallet.ContentType, contentID string) (json.Raw
 //	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#meta-data
 //	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
 //
-func (c *Client) GetAll(contentType wallet.ContentType) ([]json.RawMessage, error) {
+func (c *Client) GetAll(contentType wallet.ContentType) (map[string]json.RawMessage, error) {
 	return c.wallet.GetAll(contentType)
 }
 
@@ -227,8 +227,8 @@ func (c *Client) GetAll(contentType wallet.ContentType) ([]json.RawMessage, erro
 // 	- https://identity.foundation/presentation-exchange
 // 	- https://w3c-ccg.github.io/vp-request-spec/#query-by-example
 //
-func (c *Client) Query(params *wallet.QueryParams) (*verifiable.Presentation, error) {
-	return c.wallet.Query(params)
+func (c *Client) Query(params ...*wallet.QueryParams) ([]*verifiable.Presentation, error) {
+	return c.wallet.Query(params...)
 }
 
 // Issue adds proof to a Verifiable Credential.

--- a/pkg/doc/presexch/definition.go
+++ b/pkg/doc/presexch/definition.go
@@ -334,7 +334,8 @@ func (pd *PresentationDefinition) CreateVP(credentials []*verifiable.Credential,
 	return vp, nil
 }
 
-var errNoCredentials = errors.New("credentials do not satisfy requirements")
+// ErrNoCredentials when any credentials do not satisfy requirements.
+var ErrNoCredentials = errors.New("credentials do not satisfy requirements")
 
 // nolint: gocyclo,funlen,gocognit
 func applyRequirement(req *requirement, creds []*verifiable.Credential,
@@ -359,7 +360,7 @@ func applyRequirement(req *requirement, creds []*verifiable.Credential,
 			return result, nil
 		}
 
-		return nil, errNoCredentials
+		return nil, ErrNoCredentials
 	}
 
 	var nestedResult []map[string][]*verifiable.Credential
@@ -369,7 +370,7 @@ func applyRequirement(req *requirement, creds []*verifiable.Credential,
 
 	for _, r := range req.Nested {
 		res, err := applyRequirement(r, creds, opts...)
-		if errors.Is(err, errNoCredentials) {
+		if errors.Is(err, ErrNoCredentials) {
 			continue
 		}
 

--- a/pkg/wallet/models.go
+++ b/pkg/wallet/models.go
@@ -13,17 +13,15 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 )
 
-// QueryParams model
-//
-// Parameters for querying vc wallet contents.
-//
+// QueryParams contains credential queries for querying credential from wallet.
+// Refer https://w3c-ccg.github.io/vp-request-spec/#format for more details.
 type QueryParams struct {
 	// Type of the query.
 	// Allowed values  'QueryByExample', 'QueryByFrame', 'PresentationExchange'
-	Type string
+	Type string `json:"type"`
 
-	// Wallet content query.
-	Query json.RawMessage
+	// Query can contain one or more credential queries.
+	Query []json.RawMessage `json:"credentialQuery"`
 }
 
 // ProofOptions model
@@ -61,4 +59,36 @@ type DeriveOptions struct {
 	Frame map[string]interface{} `json:"frame,omitempty"`
 	// Nonce to prove uniqueness or freshness of the proof.
 	Nonce string `json:"nonce,omitempty"`
+}
+
+// QueryByExampleDefinition is model for QueryByExample query type.
+// https://w3c-ccg.github.io/vp-request-spec/#query-by-example
+type QueryByExampleDefinition struct {
+	Example *ExampleDefinition `json:"example"`
+}
+
+// QueryByFrameDefinition is model for QueryByExample query type.
+// https://w3c-ccg.github.io/vp-request-spec/
+// TODO QueryByExampleDefinition model is not yet finalized - https://github.com/w3c-ccg/vp-request-spec/issues/8
+type QueryByFrameDefinition struct {
+	Frame         map[string]interface{}    `json:"frame"`
+	TrustedIssuer []TrustedIssuerDefinition `json:"trustedIssuer"`
+}
+
+// ExampleDefinition frame for QueryByExample.
+// Refer - https://w3c-ccg.github.io/vp-request-spec/#example-2-a-query-by-example-query
+// TODO currently `IssuerQuery` is ignored.
+type ExampleDefinition struct {
+	Context           []string                  `json:"@context"`
+	Type              interface{}               `json:"type"`
+	CredentialSubject map[string]string         `json:"credentialSubject"`
+	CredentialSchema  map[string]string         `json:"credentialSchema"`
+	TrustedIssuer     []TrustedIssuerDefinition `json:"trustedIssuer"`
+	IssuerQuery       map[string]interface{}    `json:"issuerQuery"`
+}
+
+// TrustedIssuerDefinition is model for trusted issuer component in QueryByFrame & QueryByExample.
+type TrustedIssuerDefinition struct {
+	Issuer   string `json:"issuer"`
+	Required bool   `json:"required"`
 }

--- a/pkg/wallet/query.go
+++ b/pkg/wallet/query.go
@@ -35,30 +35,6 @@ const (
 	PresentationExchange
 )
 
-// GeneratePresentation runs given query and generates presentation from query result.
-func (q QueryType) GeneratePresentation(credentials []json.RawMessage, query json.RawMessage) (*verifiable.Presentation, error) { // nolint: lll
-	vcs, err := parseCredentials(credentials)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(vcs) == 0 {
-		return nil, ErrQueryNoResultFound
-	}
-
-	switch q {
-	case QueryByExample:
-		return nil, fmt.Errorf("to be implemented")
-	case QueryByFrame:
-		return nil, fmt.Errorf("to be implemented")
-	case PresentationExchange:
-		return queryByPresentationExchange(vcs, query)
-	default:
-		return nil, fmt.Errorf("unsupported query type, supported types - (%s, %s, %s)",
-			QueryByExample.Name(), QueryByFrame.Name(), PresentationExchange.Name())
-	}
-}
-
 // Name returns name of the query.
 func (q QueryType) Name() string {
 	return []string{"", "QueryByExample", "QueryByFrame", "PresentationExchange"}[q]
@@ -79,11 +55,215 @@ func GetQueryType(name string) (QueryType, error) {
 	}
 }
 
+// Query performs wallet credential queries, currently supporting all the QueryTypes defined in QueryType.
+type Query struct {
+	publicKeyFetcher verifiable.PublicKeyFetcher
+	params           []*QueryParams
+}
+
+// NewQuery returns new wallet query instance.
+func NewQuery(pkFetcher verifiable.PublicKeyFetcher, queries ...*QueryParams) *Query {
+	return &Query{publicKeyFetcher: pkFetcher, params: queries}
+}
+
+// PerformQuery performs credential query on given credentials.
+// nolint:gocyclo
+func (q *Query) PerformQuery(credentials map[string]json.RawMessage) ([]*verifiable.Presentation, error) {
+	if len(credentials) == 0 {
+		return nil, ErrQueryNoResultFound
+	}
+
+	vcs, err := parseCredentialContents(credentials)
+	if err != nil {
+		return nil, err
+	}
+
+	// using map to remove duplicates from results
+	credResults := make(map[*verifiable.Credential]struct{}, len(credentials))
+
+	var results []*verifiable.Presentation
+
+	for _, param := range q.params {
+		qType, err := GetQueryType(param.Type)
+		if err != nil {
+			return nil, err
+		}
+
+		credentials, err := q.getCredentials(qType, vcs, param.Query...)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, cred := range credentials {
+			credResults[cred] = struct{}{}
+		}
+
+		presentations, err := q.getPresentation(qType, vcs, param.Query...)
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, presentations...)
+	}
+
+	if len(credResults) > 0 {
+		presentation, err := preparePresentation(credResults)
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, presentation)
+	}
+
+	if len(results) == 0 {
+		return nil, ErrQueryNoResultFound
+	}
+
+	return results, nil
+}
+
+// getCredentials runs given query and returns query result as credentials.
+func (q *Query) getCredentials(qType QueryType, vcs []*verifiable.Credential, query ...json.RawMessage) ([]*verifiable.Credential, error) { // nolint: lll
+	switch qType {
+	case QueryByExample:
+		return queryByExample(vcs, query...)
+	case QueryByFrame:
+		return queryByFrame(vcs, q.publicKeyFetcher, query...)
+	default:
+		return []*verifiable.Credential{}, nil
+	}
+}
+
+// getPresentation runs given query and returns query result as presentation.
+func (q *Query) getPresentation(qType QueryType, vcs []*verifiable.Credential, query ...json.RawMessage) ([]*verifiable.Presentation, error) { // nolint: lll
+	switch qType {
+	case PresentationExchange:
+		return queryByPresentationExchange(vcs, query...)
+	default:
+		return []*verifiable.Presentation{}, nil
+	}
+}
+
+type credentialMatcher struct {
+	example *ExampleDefinition
+	frame   *QueryByFrameDefinition
+}
+
+func (cm *credentialMatcher) MatchExample(credential *verifiable.Credential) bool { // nolint: funlen,gocognit,gocyclo
+	// Match context
+	if !contains(credential.Context, cm.example.Context) {
+		return false
+	}
+
+	// Match type
+	if !contains(credential.Types, cm.example.Type) {
+		return false
+	}
+
+	// Issuer match
+	issuerMatched := len(cm.example.TrustedIssuer) == 0
+
+	for _, ti := range cm.example.TrustedIssuer {
+		matched := strings.EqualFold(credential.Issuer.ID, ti.Issuer)
+
+		// if not matched & this trusted issuer required then return false
+		if !matched && ti.Required {
+			return false
+		}
+
+		issuerMatched = issuerMatched || matched
+	}
+
+	// if none matched then return false
+	if !issuerMatched {
+		return false
+	}
+
+	// Match Credential Schema ID
+	if schemaID, ok := cm.example.CredentialSchema["id"]; ok {
+		schemaIDMatched := false
+
+		for _, schema := range credential.Schemas {
+			if schemaID == schema.ID {
+				schemaIDMatched = true
+			}
+		}
+
+		if !schemaIDMatched {
+			return false
+		}
+	}
+
+	// Match Credential Schema Type
+	if schemaType, ok := cm.example.CredentialSchema["type"]; ok {
+		schemaTypeMatched := false
+
+		for _, schema := range credential.Schemas {
+			if strings.EqualFold(schemaType, schema.Type) {
+				schemaTypeMatched = true
+			}
+		}
+
+		if !schemaTypeMatched {
+			return false
+		}
+	}
+
+	// Match credential subject
+	if cm.example.CredentialSubject != nil {
+		credSubjID, err := verifiable.SubjectID(credential.Subject)
+		if err != nil {
+			return false
+		}
+
+		if querySubjectID, ok := cm.example.CredentialSubject["id"]; ok && credSubjID != querySubjectID {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (cm *credentialMatcher) MatchFrame(credential *verifiable.Credential) bool {
+	// Issuer match
+	issuerMatched := len(cm.frame.TrustedIssuer) == 0
+
+	for _, ti := range cm.frame.TrustedIssuer {
+		matched := strings.EqualFold(credential.Issuer.ID, ti.Issuer)
+
+		// if not matched & this trusted issuer required then return false
+		if !matched && ti.Required {
+			return false
+		}
+
+		issuerMatched = issuerMatched || matched
+	}
+
+	// also check if VC has bbs signature
+	for _, proof := range credential.Proofs {
+		if proof["type"] == BbsBlsSignature2020 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func preparePresentation(credentials map[*verifiable.Credential]struct{}) (*verifiable.Presentation, error) {
+	var opts []verifiable.CreatePresentationOpt
+
+	for cred := range credentials {
+		opts = append(opts, verifiable.WithCredentials(cred))
+	}
+
+	return verifiable.NewPresentation(opts...)
+}
+
 // proof check is disabled while resolving credentials from raw bytes. A wallet implementation may or may not choose to
 // show credentials as verified. If a wallet implementation chooses to show credentials as 'verified' it
 // may to call 'wallet.Verify()' for each credential being presented.
 // (More details can be found in issue #2677).
-func parseCredentials(raws []json.RawMessage) ([]*verifiable.Credential, error) {
+func parseCredentialContents(raws map[string]json.RawMessage) ([]*verifiable.Credential, error) {
 	var result []*verifiable.Credential
 
 	for _, raw := range raws {
@@ -98,14 +278,179 @@ func parseCredentials(raws []json.RawMessage) ([]*verifiable.Credential, error) 
 	return result, nil
 }
 
-// queryByPresentationExchange generates presentation submission result based on given query.
-func queryByPresentationExchange(vcs []*verifiable.Credential, def json.RawMessage) (*verifiable.Presentation, error) {
-	var presDefinition presexch.PresentationDefinition
+func parseQueryByExample(defs ...json.RawMessage) ([]*QueryByExampleDefinition, error) {
+	definitions := make([]*QueryByExampleDefinition, len(defs))
 
-	err := json.Unmarshal(def, &presDefinition)
-	if err != nil {
-		return nil, err
+	for i, def := range defs {
+		var query QueryByExampleDefinition
+
+		err := json.Unmarshal(def, &query)
+		if err != nil {
+			return nil, err
+		}
+
+		if query.Example == nil {
+			return nil, errors.New("invalid QueryByExample, 'example' is required")
+		}
+
+		if query.Example.Context == nil {
+			return nil, errors.New("invalid QueryByExample, 'example.context' is required")
+		}
+
+		if isEmpty(query.Example.Type) {
+			return nil, errors.New("invalid QueryByExample, 'example.type' is required")
+		}
+
+		definitions[i] = &query
 	}
 
-	return presDefinition.CreateVP(vcs, verifiable.WithDisabledProofCheck())
+	return definitions, nil
+}
+
+func parseQueryByFrame(defs ...json.RawMessage) ([]*QueryByFrameDefinition, error) {
+	definitions := make([]*QueryByFrameDefinition, len(defs))
+
+	for i, def := range defs {
+		var query QueryByFrameDefinition
+
+		err := json.Unmarshal(def, &query)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(query.Frame) == 0 {
+			return nil, errors.New("invalid QueryByFrame, 'frame' is required")
+		}
+
+		definitions[i] = &query
+	}
+
+	return definitions, nil
+}
+
+func queryByExample(vcs []*verifiable.Credential, defs ...json.RawMessage) ([]*verifiable.Credential, error) {
+	definitions, err := parseQueryByExample(defs...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse QueryByExample query: %w", err)
+	}
+
+	var result []*verifiable.Credential
+
+	for _, vc := range vcs {
+		for _, definition := range definitions {
+			matcher := &credentialMatcher{example: definition.Example}
+
+			if matcher.MatchExample(vc) {
+				result = append(result, vc)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func queryByFrame(vcs []*verifiable.Credential, publicKeyFetcher verifiable.PublicKeyFetcher, defs ...json.RawMessage) ([]*verifiable.Credential, error) { // nolint:lll
+	definitions, err := parseQueryByFrame(defs...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse QueryByFrame query: %w", err)
+	}
+
+	var result []*verifiable.Credential
+
+	for _, vc := range vcs {
+		for _, definition := range definitions {
+			matcher := &credentialMatcher{frame: definition}
+
+			// match trusted issuer
+			if !matcher.MatchFrame(vc) {
+				continue
+			}
+
+			// match frame
+			bbsVC, err := vc.GenerateBBSSelectiveDisclosure(definition.Frame, nil,
+				verifiable.WithPublicKeyFetcher(publicKeyFetcher))
+			if err != nil {
+				continue
+			}
+
+			result = append(result, bbsVC)
+		}
+	}
+
+	return result, nil
+}
+
+// queryByPresentationExchange generates presentation submission result based on given query.
+func queryByPresentationExchange(vcs []*verifiable.Credential, defs ...json.RawMessage) ([]*verifiable.Presentation, error) { // nolint:lll
+	var results []*verifiable.Presentation
+
+	for _, def := range defs {
+		var presDefinition presexch.PresentationDefinition
+
+		err := json.Unmarshal(def, &presDefinition)
+		if err != nil {
+			return nil, err
+		}
+
+		result, err := presDefinition.CreateVP(vcs, verifiable.WithDisabledProofCheck())
+
+		if errors.Is(err, presexch.ErrNoCredentials) {
+			continue
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, result)
+	}
+
+	return results, nil
+}
+
+func contains(slice []string, item interface{}) bool {
+	set := make(map[string]struct{}, len(slice))
+	for _, s := range slice {
+		set[s] = struct{}{}
+	}
+
+	switch itemVal := item.(type) {
+	case string:
+		_, ok := set[itemVal]
+
+		return ok
+	case []interface{}:
+		for _, val := range itemVal {
+			_, ok := set[val.(string)]
+			if !ok {
+				return false
+			}
+		}
+
+		return true
+	case []string:
+		for _, val := range itemVal {
+			_, ok := set[val]
+			if !ok {
+				return false
+			}
+		}
+
+		return true
+	default:
+		return false
+	}
+}
+
+func isEmpty(item interface{}) bool {
+	switch itemVal := item.(type) {
+	case string:
+		return itemVal == ""
+	case []interface{}:
+		return len(itemVal) == 0
+	case []string:
+		return len(itemVal) == 0
+	default:
+		return itemVal == nil
+	}
 }

--- a/pkg/wallet/query_test.go
+++ b/pkg/wallet/query_test.go
@@ -8,17 +8,169 @@ package wallet
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/presexch"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	vdrapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
+	mockvdr "github.com/hyperledger/aries-framework-go/pkg/mock/vdr"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/key"
+)
+
+// nolint: lll
+const (
+	sampleVCFmt = `{
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/2018/credentials/examples/v1",
+		"https://w3id.org/security/bbs/v1"
+      ],
+     "credentialSchema": [{"id": "%s", "type": "JsonSchemaValidator2018"}],
+      "credentialSubject": {
+        "degree": {
+          "type": "BachelorDegree",
+          "university": "MIT"
+        },
+        "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+        "name": "Jayden Doe",
+        "spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
+      },
+      "expirationDate": "2020-01-01T19:23:24Z",
+      "id": "http://example.edu/credentials/1872",
+      "issuanceDate": "2010-01-01T19:23:24Z",
+      "issuer": {
+        "id": "did:example:76e12ec712ebc6f1c221ebfeb1f",
+        "name": "Example University"
+      },
+      "referenceNumber": 83294847,
+      "type": [
+        "VerifiableCredential",
+        "UniversityDegreeCredential"
+      ]
+    }`
+	samplePRCVC = `{
+	 	"@context": [
+	   		"https://www.w3.org/2018/credentials/v1",
+	   		"https://w3id.org/citizenship/v1",
+	   		"https://w3id.org/security/bbs/v1"
+	 	],
+	 	"id": "https://issuer.oidp.uscis.gov/credentials/83627465",
+	 	"type": [
+	   		"VerifiableCredential",
+	   		"PermanentResidentCard"
+	 	],
+	 	"issuer": "did:example:489398593",
+	 	"identifier": "83627465",
+	 	"name": "Permanent Resident Card",
+	 	"description": "Government of Example Permanent Resident Card.",
+	 	"issuanceDate": "2019-12-03T12:19:52Z",
+	 	"expirationDate": "2029-12-03T12:19:52Z",
+		"credentialSchema": [],
+	 	"credentialSubject": {
+	   		"id": "did:example:b34ca6cd37bbf23",
+	   		"type": [
+	     		"PermanentResident",
+	     		"Person"
+	   		],
+	   		"givenName": "JOHN",
+	   		"familyName": "SMITH",
+	   		"gender": "Male",
+	   		"image": "data:image/png;base64,iVBORw0KGgokJggg==",
+	   		"residentSince": "2015-01-01",
+	   		"lprCategory": "C09",
+	   		"lprNumber": "999-999-999",
+	   		"commuterClassification": "C1",
+	   		"birthCountry": "Bahamas",
+	   		"birthDate": "1958-07-17"
+	 	}
+	}`
+	sampleBBSVC = `{
+            "@context": ["https://www.w3.org/2018/credentials/v1", "https://www.w3.org/2018/credentials/examples/v1", "https://w3id.org/security/bbs/v1"],
+            "credentialSubject": {
+                "degree": {"type": "BachelorDegree", "university": "MIT"},
+                "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+                "name": "Jayden Doe",
+                "spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
+            },
+            "expirationDate": "2020-01-01T19:23:24Z",
+            "id": "http://example.edu/credentials/1872",
+            "issuanceDate": "2010-01-01T19:23:24Z",
+            "issuer": {"id": "did:example:76e12ec712ebc6f1c221ebfeb1f", "name": "Example University"},
+            "proof": {
+                "created": "2021-03-29T13:27:36.483097-04:00",
+                "proofPurpose": "assertionMethod",
+                "proofValue": "rw7FeV6K1wimnYogF9qd-N0zmq5QlaIoszg64HciTca-mK_WU4E1jIusKTT6EnN2GZz04NVPBIw4yhc0kTwIZ07etMvfWUlHt_KMoy2CfTw8FBhrf66q4h7Qcqxh_Kxp6yCHyB4A-MmURlKKb8o-4w",
+                "type": "BbsBlsSignature2020",
+                "verificationMethod": "did:key:zUC72c7u4BYVmfYinDceXkNAwzPEyuEE23kUmJDjLy8495KH3pjLwFhae1Fww9qxxRdLnS2VNNwni6W3KbYZKsicDtiNNEp76fYWR6HCD8jAz6ihwmLRjcHH6kB294Xfg1SL1qQ#zUC72c7u4BYVmfYinDceXkNAwzPEyuEE23kUmJDjLy8495KH3pjLwFhae1Fww9qxxRdLnS2VNNwni6W3KbYZKsicDtiNNEp76fYWR6HCD8jAz6ihwmLRjcHH6kB294Xfg1SL1qQ"
+            },
+            "referenceNumber": 83294847,
+            "type": ["VerifiableCredential", "UniversityDegreeCredential"]
+        }`
+	sampleQueryByExFmt = `{
+                        "reason": "Please present your identity document.",
+                        "example": {
+                            "@context": [
+								"https://www.w3.org/2018/credentials/v1",
+								"https://www.w3.org/2018/credentials/examples/v1",
+								"https://w3id.org/security/bbs/v1"
+                            ],
+                            "type": ["UniversityDegreeCredential"],
+							"trustedIssuer": [
+              					{
+                					"issuer": "urn:some:required:issuer"
+              					},
+								{
+                					"required": true,
+                					"issuer": "did:example:76e12ec712ebc6f1c221ebfeb1f"
+              					}
+							],
+							"credentialSubject": {
+								"id": "did:example:ebfeb1f712ebc6f1c276e12ec21"	
+							},
+							"credentialSchema": {
+								"id": "%s",
+								"type": "JsonSchemaValidator2018"
+							}
+                        }
+                	}`
+	sampleQueryByFrame = `{
+                    "reason": "Please provide your Passport details.",
+                    "frame": {
+                        "@context": [
+                            "https://www.w3.org/2018/credentials/v1",
+                            "https://w3id.org/citizenship/v1",
+                            "https://w3id.org/security/bbs/v1"
+                        ],
+                        "type": ["VerifiableCredential", "PermanentResidentCard"],
+                        "@explicit": true,
+                        "identifier": {},
+                        "issuer": {},
+                        "issuanceDate": {},
+                        "credentialSubject": {
+                            "@explicit": true,
+                            "name": {},
+                            "spouse": {}
+                        }
+                    },
+                    "trustedIssuer": [
+                        {
+                            "issuer": "did:example:76e12ec712ebc6f1c221ebfeb1f",
+                            "required": true
+                        }
+                    ],
+                    "required": true
+                }`
 )
 
 // nolint: gochecknoglobals
@@ -93,7 +245,7 @@ func TestGetQueryType(t *testing.T) {
 	})
 }
 
-func TestGeneratePresentation(t *testing.T) {
+func TestQuery_PerformQuery(t *testing.T) {
 	vc1, err := (&verifiable.Credential{
 		Context: []string{verifiable.ContextURI},
 		Types:   []string{verifiable.VCType},
@@ -115,6 +267,7 @@ func TestGeneratePresentation(t *testing.T) {
 	}).MarshalJSON()
 	require.NoError(t, err)
 
+	// presentation exchange query
 	pd := &presexch.PresentationDefinition{
 		ID: uuid.New().String(),
 		InputDescriptors: []*presexch.InputDescriptor{{
@@ -130,76 +283,214 @@ func TestGeneratePresentation(t *testing.T) {
 		}},
 	}
 
+	// query by example
+	queryByExample := []byte(fmt.Sprintf(sampleQueryByExFmt, schemaURI))
+	// query by frame
+	queryByFrame := []byte(sampleQueryByFrame)
+
 	pdJSON, err := json.Marshal(pd)
 	require.NoError(t, err)
 	require.NotEmpty(t, pdJSON)
 
-	t.Run("test query generate presentation", func(t *testing.T) {
+	udcVC := []byte(sampleUDCVC)
+	vcForQuery := []byte(fmt.Sprintf(sampleVCFmt, schemaURI))
+	vcForDerive := []byte(sampleBBSVC)
+
+	customVDR := &mockvdr.MockVDRegistry{
+		ResolveFunc: func(didID string, opts ...vdrapi.DIDMethodOption) (*did.DocResolution, error) {
+			if strings.HasPrefix(didID, "did:key:") {
+				k := key.New()
+
+				d, e := k.Read(didID)
+				if e != nil {
+					return nil, e
+				}
+
+				return d, nil
+			}
+
+			return nil, fmt.Errorf("did not found")
+		},
+	}
+	pubKeyFetcher := verifiable.NewVDRKeyResolver(customVDR).PublicKeyFetcher()
+
+	t.Run("test wallet queries", func(t *testing.T) {
 		tests := []struct {
 			name        string
-			queryType   QueryType
-			query       json.RawMessage
-			creds       []json.RawMessage
+			query       []*QueryParams
+			credentials []json.RawMessage
 			resultCount int
+			vcCount     map[int]int
 			error       string
 		}{
+			// Presentation Exchange tests
 			{
-				name:        "query by presentation exchange - success",
-				queryType:   PresentationExchange,
-				query:       pdJSON,
-				creds:       []json.RawMessage{vc1},
+				name: "query by presentation exchange - success",
+				query: []*QueryParams{
+					{Type: "PresentationExchange", Query: []json.RawMessage{pdJSON}},
+				},
+				credentials: []json.RawMessage{vc1, udcVC, vcForQuery, vcForDerive},
 				resultCount: 1,
+				vcCount:     map[int]int{0: 1},
 			},
 			{
-				name:      "query by presentation exchange - no results",
-				queryType: PresentationExchange,
-				query:     pdJSON,
-				creds:     []json.RawMessage{[]byte(sampleUDCVC)},
-				error:     "credentials do not satisfy requirements",
+				name: "query by presentation exchange - multi query frame - success",
+				query: []*QueryParams{
+					{Type: "PresentationExchange", Query: []json.RawMessage{pdJSON, pdJSON}},
+				},
+				credentials: []json.RawMessage{vc1, udcVC, vcForQuery, vcForDerive},
+				resultCount: 2,
+				vcCount:     map[int]int{0: 1, 1: 1},
 			},
 			{
-				name:      "query by presentation exchange - invalid frame",
-				queryType: PresentationExchange,
-				query:     []byte(sampleInvalidDIDContent),
-				creds:     []json.RawMessage{[]byte(sampleUDCVC)},
-				error:     "input_descriptors is required",
+				name: "query by presentation exchange - multiple - success",
+				query: []*QueryParams{
+					{Type: "PresentationExchange", Query: []json.RawMessage{pdJSON, pdJSON}},
+					{Type: "PresentationExchange", Query: []json.RawMessage{pdJSON}},
+				},
+				credentials: []json.RawMessage{vc1, udcVC, vcForQuery, vcForDerive},
+				resultCount: 3,
+				vcCount:     map[int]int{0: 1, 1: 1, 2: 1},
 			},
 			{
-				name:      "query by presentation exchange - frame unmarshal error",
-				queryType: PresentationExchange,
-				query:     []byte("--"),
-				creds:     []json.RawMessage{[]byte(sampleUDCVC)},
-				error:     "invalid character",
+				name: "query by presentation exchange - no results",
+				query: []*QueryParams{
+					{Type: "PresentationExchange", Query: []json.RawMessage{pdJSON}},
+				},
+				credentials: []json.RawMessage{udcVC, vcForQuery, vcForDerive},
+				resultCount: 0,
+				error:       ErrQueryNoResultFound.Error(),
 			},
 			{
-				name:      "invalid credential",
-				queryType: QueryByFrame,
-				creds:     []json.RawMessage{[]byte(sampleInvalidDIDContent)},
-				error:     "credential type of unknown structure",
+				name: "query by presentation exchange - invalid definition",
+				query: []*QueryParams{
+					{Type: "PresentationExchange", Query: []json.RawMessage{[]byte(sampleInvalidDIDContent)}},
+				},
+				credentials: []json.RawMessage{vc1, udcVC, vcForQuery, vcForDerive},
+				resultCount: 0,
+				error:       "input_descriptors is required",
 			},
 			{
-				name:      "no record found",
-				queryType: QueryByExample,
-				creds:     []json.RawMessage{},
-				error:     ErrQueryNoResultFound.Error(),
+				name: "query by presentation exchange - invalid query frame",
+				query: []*QueryParams{
+					{Type: "PresentationExchange", Query: []json.RawMessage{[]byte("---")}},
+				},
+				credentials: []json.RawMessage{vc1, udcVC, vcForQuery, vcForDerive},
+				resultCount: 0,
+				error:       "invalid character",
+			},
+			// QueryByExample tests
+			{
+				name: "query by example - success",
+				query: []*QueryParams{
+					{Type: "QueryByExample", Query: []json.RawMessage{queryByExample}},
+				},
+				credentials: []json.RawMessage{vc1, udcVC, vcForQuery, vcForDerive},
+				resultCount: 1,
+				vcCount:     map[int]int{0: 1},
 			},
 			{
-				name:      "unsupported query type",
-				queryType: QueryType(0),
-				creds:     []json.RawMessage{[]byte(sampleUDCVC)},
-				error:     "unsupported query type",
+				name: "query by example - success & normalize results",
+				query: []*QueryParams{
+					{Type: "QueryByExample", Query: []json.RawMessage{queryByExample, queryByExample}},
+					{Type: "QueryByExample", Query: []json.RawMessage{queryByExample}},
+				},
+				credentials: []json.RawMessage{vc1, udcVC, vcForQuery, vcForDerive},
+				resultCount: 1,
+				vcCount:     map[int]int{0: 1},
 			},
 			{
-				name:      "QueryByFrame - to be implemented",
-				queryType: QueryByFrame,
-				creds:     []json.RawMessage{[]byte(sampleUDCVC)},
-				error:     "to be implemented",
+				name: "query by example - invalid query",
+				query: []*QueryParams{
+					{Type: "QueryByExample", Query: []json.RawMessage{[]byte(sampleInvalidDIDContent)}},
+				},
+				credentials: []json.RawMessage{vc1, udcVC, vcForQuery, vcForDerive},
+				resultCount: 0,
+				error:       "failed to parse QueryByExample query",
+			},
+			// QueryByFrame tests
+			{
+				name: "query by frame - success",
+				query: []*QueryParams{
+					{Type: "QueryByFrame", Query: []json.RawMessage{queryByFrame}},
+				},
+				credentials: []json.RawMessage{vc1, udcVC, vcForQuery, vcForDerive},
+				resultCount: 1,
+				vcCount:     map[int]int{0: 1},
 			},
 			{
-				name:      "QueryByExample - to be implemented",
-				queryType: QueryByExample,
-				creds:     []json.RawMessage{[]byte(sampleUDCVC)},
-				error:     "to be implemented",
+				name: "query by frame - multiple results",
+				query: []*QueryParams{
+					{Type: "QueryByFrame", Query: []json.RawMessage{queryByFrame, queryByFrame}},
+					{Type: "QueryByFrame", Query: []json.RawMessage{queryByFrame}},
+				},
+				credentials: []json.RawMessage{vc1, udcVC, vcForQuery, vcForDerive},
+				resultCount: 1,
+				vcCount:     map[int]int{0: 3},
+			},
+			{
+				name: "query by frame - invalid query",
+				query: []*QueryParams{
+					{Type: "QueryByFrame", Query: []json.RawMessage{[]byte(sampleInvalidDIDContent)}},
+				},
+				credentials: []json.RawMessage{vc1, udcVC, vcForQuery, vcForDerive},
+				resultCount: 0,
+				error:       "failed to parse QueryByFrame query",
+			},
+
+			// Mixed Query Types
+			{
+				name: "query by PresentationExchange,QueryByExample,QueryByFrame - success",
+				query: []*QueryParams{
+					{Type: "PresentationExchange", Query: []json.RawMessage{pdJSON}},
+					{Type: "QueryByExample", Query: []json.RawMessage{queryByExample}},
+					{Type: "QueryByFrame", Query: []json.RawMessage{queryByFrame}},
+				},
+				credentials: []json.RawMessage{vc1, udcVC, vcForQuery, vcForDerive},
+				resultCount: 2,
+				vcCount:     map[int]int{0: 1, 1: 2},
+			},
+			{
+				name: "query by PresentationExchange,QueryByExample,QueryByFrame - normalized result - success",
+				query: []*QueryParams{
+					{Type: "PresentationExchange", Query: []json.RawMessage{pdJSON}},
+					{Type: "QueryByExample", Query: []json.RawMessage{queryByExample}},
+					{Type: "QueryByExample", Query: []json.RawMessage{queryByExample}},
+					{Type: "QueryByExample", Query: []json.RawMessage{queryByExample}},
+					{Type: "QueryByFrame", Query: []json.RawMessage{queryByFrame}},
+				},
+				credentials: []json.RawMessage{vc1, udcVC, vcForQuery, vcForDerive},
+				resultCount: 2,
+				vcCount:     map[int]int{0: 1, 1: 2},
+			},
+
+			// Validations
+			{
+				name: "unsupported query type",
+				query: []*QueryParams{
+					{Type: "QueryByInvalid", Query: []json.RawMessage{queryByExample}},
+				},
+				credentials: []json.RawMessage{vc1, udcVC, vcForQuery, vcForDerive},
+				resultCount: 0,
+				error:       "unsupported query type",
+			},
+			{
+				name: "empty credentials",
+				query: []*QueryParams{
+					{Type: "QueryByExample", Query: []json.RawMessage{queryByExample}},
+				},
+				credentials: []json.RawMessage{},
+				resultCount: 0,
+				error:       ErrQueryNoResultFound.Error(),
+			},
+			{
+				name: "credential parsing error",
+				query: []*QueryParams{
+					{Type: "QueryByExample", Query: []json.RawMessage{queryByExample}},
+				},
+				credentials: []json.RawMessage{[]byte("----")},
+				resultCount: 0,
+				error:       "unmarshal new credential",
 			},
 		}
 
@@ -208,21 +499,622 @@ func TestGeneratePresentation(t *testing.T) {
 		for _, test := range tests {
 			tc := test
 			t.Run(tc.name, func(t *testing.T) {
-				presentation, err := tc.queryType.GeneratePresentation(tc.creds, tc.query)
+				credentials := make(map[string]json.RawMessage)
+				for i, v := range tc.credentials {
+					credentials[strconv.Itoa(i)] = v
+				}
+
+				results, err := NewQuery(pubKeyFetcher, tc.query...).PerformQuery(credentials)
 
 				if tc.error != "" {
-					require.Empty(t, presentation)
+					require.Empty(t, results)
 					require.Error(t, err)
 					require.Contains(t, err.Error(), tc.error)
+					require.Len(t, results, tc.resultCount)
 
 					return
 				}
 
 				require.NoError(t, err)
-				require.NotEmpty(t, presentation)
-				require.Empty(t, presentation.Proofs)
-				require.Len(t, presentation.Credentials(), tc.resultCount)
+				require.Len(t, results, tc.resultCount)
+
+				for i, result := range results {
+					require.Len(t, result.Credentials(), tc.vcCount[i])
+				}
 			})
 		}
 	})
+}
+
+func TestQueryByExample(t *testing.T) {
+	vc1, err := verifiable.ParseCredential([]byte(fmt.Sprintf(sampleVCFmt, schemaURI)),
+		verifiable.WithDisabledProofCheck())
+	require.NoError(t, err)
+
+	vc2, err := verifiable.ParseCredential([]byte(samplePRCVC), verifiable.WithDisabledProofCheck())
+	require.NoError(t, err)
+
+	// sample queries
+	queryByExampleAll := []byte(fmt.Sprintf(sampleQueryByExFmt, schemaURI))
+
+	queryByExampleContext1 := `{
+                        "reason": "Please present your identity document.",
+                        "example": {
+                            "@context": [
+								"https://www.w3.org/2018/credentials/v1"
+                            ],
+                            "type": "VerifiableCredential",
+							"trustedIssuer": [],
+							"credentialSubject": {},
+							"credentialSchema": {}
+                        }
+                	}`
+
+	queryByExampleContext2 := `{
+                        "reason": "Please present your identity document.",
+                        "example": {
+                            "@context": [
+								"https://www.w3.org/2018/credentials/v1",
+								"https://w3id.org/citizenship/v1"
+                            ],
+							"type": "VerifiableCredential"
+                        }
+                	}`
+
+	queryByExampleContextType1 := `{
+                        "reason": "Please present your identity document.",
+                        "example": {
+                            "@context": [
+								"https://www.w3.org/2018/credentials/v1",
+								"https://w3id.org/citizenship/v1"
+                            ],
+                            "type": "PermanentResidentCard",
+							"trustedIssuer": [],
+							"credentialSubject": {},
+							"credentialSchema": {}
+                        }
+                	}`
+
+	queryByExampleContextType2 := `{
+                        "reason": "Please present your identity document.",
+                        "example": {
+                            "@context": [
+								"https://www.w3.org/2018/credentials/v1",
+								"https://www.w3.org/2018/credentials/examples/v1"
+                            ],
+                            "type": ["UniversityDegreeCredential"],
+							"trustedIssuer": [],
+							"credentialSubject": {},
+							"credentialSchema": {}
+                        }
+                	}`
+
+	queryByExampleContextTypeIssuer1 := `{
+                        "reason": "Please present your identity document.",
+                        "example": {
+                            "@context": [
+								"https://www.w3.org/2018/credentials/v1",
+								"https://www.w3.org/2018/credentials/examples/v1"
+                            ],
+                            "type": ["UniversityDegreeCredential"],
+							"trustedIssuer": [
+              					{
+                					"issuer": "urn:some:required:issuer"
+              					},
+								{
+                					"required": true,
+                					"issuer": "did:example:76e12ec712ebc6f1c221ebfeb1f"
+              					}
+							]
+                        }
+                	}`
+
+	queryByExampleContextTypeIssuer2 := `{
+                        "reason": "Please present your identity document.",
+                        "example": {
+                            "@context": [
+								"https://www.w3.org/2018/credentials/v1"
+                            ],
+                            "type": ["PermanentResidentCard"],
+							"trustedIssuer": [
+								{
+                					"required": true,
+                					"issuer": "did:example:489398593"
+              					}
+							]
+                        }
+                	}`
+
+	queryByExampleContextTypeIssuer3 := `{
+                        "reason": "Please present your identity document.",
+                        "example": {
+                            "@context": [
+								"https://www.w3.org/2018/credentials/v1"
+                            ],
+                            "type": ["PermanentResidentCard"],
+							"trustedIssuer": [
+								{
+                					"issuer": "did:example:489398593"
+              					},
+								{
+                					"required": true,
+                					"issuer": "did:example:1234"
+              					}
+							]
+                        }
+                	}`
+
+	queryByExampleContextTypeIssuer4 := `{
+                        "reason": "Please present your identity document.",
+                        "example": {
+                            "@context": [
+								"https://www.w3.org/2018/credentials/v1"
+                            ],
+                            "type": ["PermanentResidentCard"],
+							"trustedIssuer": [
+								{
+                					"issuer": "did:example:7777"
+              					},
+								{
+                					"issuer": "did:example:1234"
+              					}
+							]
+                        }
+                	}`
+
+	queryByExampleContextTypeCredSubject1 := `{
+                        "reason": "Please present your identity document.",
+                        "example": {
+                            "@context": [
+								"https://www.w3.org/2018/credentials/v1"
+                            ],
+                            "type": ["PermanentResidentCard"],
+							"trustedIssuer": [
+								{
+                					"required": true,
+                					"issuer": "did:example:489398593"
+              					}
+							],
+							"credentialSubject": {
+								"id": "did:example:b34ca6cd37bbf23"	
+							},
+							"credentialSchema": {}
+                        }
+                	}`
+
+	queryByExampleContextTypeCredSubject2 := `{
+                        "reason": "Please present your identity document.",
+                        "example": {
+                            "@context": [
+								"https://www.w3.org/2018/credentials/v1"
+                            ],
+                            "type": ["UniversityDegreeCredential"],
+							"trustedIssuer": [
+								{
+                					"required": true,
+                					"issuer": "did:example:76e12ec712ebc6f1c221ebfeb1f"
+              					}
+							],
+							"credentialSubject": {
+								"id": "did:example:ebfeb1f712ebc6f1c276e12ec21"	
+							},
+							"credentialSchema": {}
+                        }
+                	}`
+
+	queryByExampleContextTypeCredSubject3 := `{
+                        "reason": "Please present your identity document.",
+                        "example": {
+                            "@context": [
+								"https://www.w3.org/2018/credentials/v1"
+                            ],
+                            "type": ["UniversityDegreeCredential"],
+							"trustedIssuer": [
+								{
+                					"required": true,
+                					"issuer": "did:example:76e12ec712ebc6f1c221ebfeb1f"
+              					}
+							],
+							"credentialSubject": {
+								"id": "did:example:ebfeb1f712ebc6f1c276e12ec22"	
+							},
+							"credentialSchema": {}
+                        }
+                	}`
+
+	queryByExampleContextTypeCredSchema1 := fmt.Sprintf(`{
+                        "reason": "Please present your identity document.",
+                        "example": {
+                            "@context": [
+								"https://www.w3.org/2018/credentials/v1"
+                            ],
+                            "type": "UniversityDegreeCredential",
+							"credentialSubject": {
+								"id": "did:example:ebfeb1f712ebc6f1c276e12ec21"	
+							},
+							"credentialSchema": {
+								"id": "%s",
+								"type": "JsonSchemaValidator2018"
+							}
+                        }
+                	}`, schemaURI)
+
+	queryByExampleContextTypeCredSchema2 := fmt.Sprintf(`{
+                        "reason": "Please present your identity document.",
+                        "example": {
+                            "@context": [
+								"https://www.w3.org/2018/credentials/v1"
+                            ],
+                            "type": "UniversityDegreeCredential",
+							"credentialSubject": {
+								"id": "did:example:ebfeb1f712ebc6f1c276e12ec21"	
+							},
+							"credentialSchema": {
+								"id": "%s",
+								"type": "JsonSchemaValidator2020"
+							}
+                        }
+                	}`, schemaURI)
+
+	queryByExampleInvalid1 := `{
+                        "reason": "Please present your identity document.",
+                        "example": {
+							"trustedIssuer": [
+								{
+                					"required": true,
+                					"issuer": "did:example:489398593"
+              					}
+							],
+							"credentialSubject": {
+								"id": "did:example:ebfeb1f712ebc6f1c276e12ec21"	
+							},
+							"credentialSchema": {}
+                        }
+                	}`
+
+	queryByExampleInvalid2 := `{
+                        "reason": "Please present your identity document.",
+                        "example": {
+							"@context": [
+								"https://www.w3.org/2018/credentials/v1"
+                            ],
+                            "type": []
+                        }
+                	}`
+
+	queryByExampleInvalid3 := `{
+                        "reason": "Please present your identity document.",
+                        "example": {
+							"credentialSubject": "invalid",
+							"credentialSchema": true
+                        }
+                	}`
+
+	vc3 := &verifiable.Credential{
+		Context: []string{verifiable.ContextURI},
+		Types:   []string{verifiable.VCType},
+		ID:      "http://example.edu/credentials/9999",
+		Schemas: []verifiable.TypedID{{
+			ID:   schemaURI,
+			Type: "JsonSchemaValidator2018",
+		}},
+		CustomFields: map[string]interface{}{
+			"first_name": "Jesse",
+		},
+		Issued: &util.TimeWithTrailingZeroMsec{
+			Time: time.Now(),
+		},
+		Issuer: verifiable.Issuer{
+			ID: "did:example:76e12ec712ebc6f1c221ebfeb1f",
+		},
+		Subject: uuid.New().String(),
+	}
+
+	t.Run("test query", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			credentials []*verifiable.Credential
+			example     []json.RawMessage
+			resultCount int
+			error       string
+			skip        bool
+		}{
+			{
+				name:        "QueryByExample all criteria matched - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{queryByExampleAll},
+				resultCount: 1,
+			},
+			{
+				name:        "QueryByExample  multiple query frame - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{queryByExampleAll, queryByExampleAll},
+				resultCount: 2,
+			},
+			{
+				name:        "QueryByExample context matching #1 - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleContext1)},
+				resultCount: 3,
+			},
+			{
+				name:        "QueryByExample context matching #2 - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleContext2)},
+				resultCount: 1,
+			},
+			{
+				name:        "QueryByExample context & type matching #1 - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleContextType1)},
+				resultCount: 1,
+			},
+			{
+				name:        "QueryByExample context & type matching #2 - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleContextType2)},
+				resultCount: 1,
+			},
+			{
+				name:        "QueryByExample context, type & issuer matching #1 - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleContextTypeIssuer1)},
+				resultCount: 1,
+			},
+			{
+				name:        "QueryByExample context, type & issuer matching #2 - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleContextTypeIssuer2)},
+				resultCount: 1,
+			},
+			{
+				name:        "QueryByExample context, type & issuer matching #3 - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleContextTypeIssuer3)},
+				resultCount: 0,
+			},
+			{
+				name:        "QueryByExample context, type & issuer matching #4 - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleContextTypeIssuer4)},
+				resultCount: 0,
+			},
+			{
+				name:        "QueryByExample context, type, issuer & subject matching #1 - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleContextTypeCredSubject1)},
+				resultCount: 1,
+			},
+			{
+				name:        "QueryByExample context, type, issuer & subject matching #2 - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleContextTypeCredSubject2)},
+				resultCount: 1,
+			},
+			{
+				name:        "QueryByExample context, type, issuer & subject matching #3 - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleContextTypeCredSubject3)},
+				resultCount: 0,
+			},
+			{
+				name:        "QueryByExample context, type, issuer, schema matching #1 - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleContextTypeCredSchema1)},
+				resultCount: 1,
+			},
+			{
+				name:        "QueryByExample context, type, issuer, schema matching #2- success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleContextTypeCredSchema2)},
+				resultCount: 0,
+			},
+			{
+				name:        "QueryByExample invalid query #1",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleInvalid1)},
+				resultCount: 0,
+				error:       "failed to parse QueryByExample query",
+			},
+			{
+				name:        "QueryByExample invalid query #2",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleInvalid2)},
+				resultCount: 0,
+				error:       "failed to parse QueryByExample query",
+			},
+			{
+				name:        "QueryByExample invalid query #3",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByExampleInvalid3)},
+				resultCount: 0,
+				error:       "failed to parse QueryByExample query",
+			},
+		}
+
+		t.Parallel()
+
+		for _, test := range tests {
+			tc := test
+			t.Run(tc.name, func(t *testing.T) {
+				if tc.skip {
+					return
+				}
+
+				results, err := queryByExample(tc.credentials, tc.example...)
+
+				if tc.error != "" {
+					require.Empty(t, results)
+					require.Error(t, err)
+					require.Contains(t, err.Error(), tc.error)
+					require.Len(t, results, tc.resultCount)
+
+					return
+				}
+
+				require.NoError(t, err)
+				require.Len(t, results, tc.resultCount)
+			})
+		}
+	})
+}
+
+func TestQueryByFrame(t *testing.T) {
+	vc1, err := verifiable.ParseCredential([]byte(fmt.Sprintf(sampleVCFmt, schemaURI)),
+		verifiable.WithDisabledProofCheck())
+	require.NoError(t, err)
+
+	vc2, err := verifiable.ParseCredential([]byte(samplePRCVC), verifiable.WithDisabledProofCheck())
+	require.NoError(t, err)
+
+	vc3, err := verifiable.ParseCredential([]byte(sampleBBSVC), verifiable.WithDisabledProofCheck())
+	require.NoError(t, err)
+
+	tampered := strings.ReplaceAll(sampleBBSVC, `rw7FeV6K1wimnYogF9qd-N0zmq5QlaIoszg64HciTca`, ``)
+	vc4, err := verifiable.ParseCredential([]byte(tampered), verifiable.WithDisabledProofCheck())
+	require.NoError(t, err)
+
+	queryByFrameExampleNoIssuer := `{
+	                "reason": "Please provide your Passport details.",
+	                "frame": {
+	                    "@context": [
+	                        "https://www.w3.org/2018/credentials/v1",
+	                        "https://w3id.org/citizenship/v1",
+	                        "https://w3id.org/security/bbs/v1"
+	                    ],
+	                    "type": ["VerifiableCredential", "PermanentResidentCard"],
+	                    "@explicit": true,
+	                    "identifier": {},
+	                    "issuer": {},
+	                    "issuanceDate": {},
+	                    "credentialSubject": {
+	                        "@explicit": true,
+	                        "name": {},
+	                        "spouse": {}
+	                    }
+	                }
+	            }`
+
+	queryByFrameExampleIssuerNotMatched := strings.ReplaceAll(sampleQueryByFrame,
+		"did:example:76e12ec712ebc6f1c221ebfeb1f", "1234")
+
+	customVDR := &mockvdr.MockVDRegistry{
+		ResolveFunc: func(didID string, opts ...vdrapi.DIDMethodOption) (*did.DocResolution, error) {
+			if strings.HasPrefix(didID, "did:key:") {
+				k := key.New()
+
+				d, e := k.Read(didID)
+				if e != nil {
+					return nil, e
+				}
+
+				return d, nil
+			}
+
+			return nil, fmt.Errorf("did not found")
+		},
+	}
+	pubKeyFetcher := verifiable.NewVDRKeyResolver(customVDR).PublicKeyFetcher()
+
+	t.Run("test query", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			credentials []*verifiable.Credential
+			example     []json.RawMessage
+			resultCount int
+			error       string
+			skip        bool
+		}{
+			{
+				name:        "QueryByFrame all criteria matched - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(sampleQueryByFrame)},
+				resultCount: 1,
+			},
+			{
+				name:        "QueryByFrame multiple query - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example: []json.RawMessage{
+					[]byte(sampleQueryByFrame), []byte(sampleQueryByFrame),
+					[]byte(sampleQueryByFrame),
+				},
+				resultCount: 3,
+			},
+			{
+				name:        "QueryByFrame without issuer criteria - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByFrameExampleNoIssuer)},
+				resultCount: 1,
+			},
+			{
+				name:        "QueryByFrame issuer not matched - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc3},
+				example:     []json.RawMessage{[]byte(queryByFrameExampleIssuerNotMatched)},
+				resultCount: 0,
+			},
+			{
+				name:        "QueryByFrame NO BBS signature - success",
+				credentials: []*verifiable.Credential{vc1, vc2},
+				example:     []json.RawMessage{[]byte(queryByFrameExampleIssuerNotMatched)},
+				resultCount: 0,
+			},
+			{
+				name:        "QueryByFrame invalid BBS signature - success",
+				credentials: []*verifiable.Credential{vc1, vc2, vc4},
+				example:     []json.RawMessage{[]byte(sampleQueryByFrame)},
+				resultCount: 0,
+			},
+			{
+				name:        "QueryByFrame invalid query - success",
+				credentials: []*verifiable.Credential{vc1, vc3},
+				example:     []json.RawMessage{[]byte(sampleInvalidDIDContent)},
+				error:       "failed to parse QueryByFrame query",
+			},
+			{
+				name:        "QueryByFrame parse query error - success",
+				credentials: []*verifiable.Credential{vc1, vc3},
+				example:     []json.RawMessage{[]byte("---")},
+				error:       "failed to parse QueryByFrame query",
+			},
+		}
+
+		t.Parallel()
+
+		for _, test := range tests {
+			tc := test
+			t.Run(tc.name, func(t *testing.T) {
+				if tc.skip {
+					return
+				}
+
+				results, err := queryByFrame(tc.credentials, pubKeyFetcher, tc.example...)
+
+				if tc.error != "" {
+					require.Empty(t, results)
+					require.Error(t, err)
+					require.Contains(t, err.Error(), tc.error)
+					require.Len(t, results, tc.resultCount)
+
+					return
+				}
+
+				require.NoError(t, err)
+				require.Len(t, results, tc.resultCount)
+			})
+		}
+	})
+}
+
+func TestUtilFunctions(t *testing.T) {
+	require.True(t, isEmpty(""))
+	require.True(t, isEmpty([]string{}))
+	require.True(t, isEmpty([]interface{}{}))
+	require.True(t, isEmpty(nil))
+
+	require.False(t, isEmpty("x"))
+	require.False(t, isEmpty([]string{""}))
+	require.False(t, isEmpty([]interface{}{&QueryParams{}}))
+	require.False(t, isEmpty(&QueryParams{}))
+
+	require.False(t, contains([]string{"a", "b"}, nil))
 }


### PR DESCRIPTION
- Support for QueryByFrame & QueryByExample credential queries.
- Support for mixed and multiple query support

inline with universal wallet query, vp-request-spec credential queries.

TODO: Adding proof to result & DID Auth support

Closes #2717

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
