### PR TITLE
Add resolving DID document in VDR Registry when generating presentation by id.

### DIFF
--- a/pkg/controller/command/verifiable/command.go
+++ b/pkg/controller/command/verifiable/command.go
@@ -711,7 +711,7 @@ func (o *Command) GeneratePresentationByID(rw io.Writer, req io.Reader) command.
 		return command.NewValidationError(GeneratePresentationByIDErrorCode, fmt.Errorf("get vc by id : %w", err))
 	}
 
-  var didDoc *did.Doc
+	var didDoc *did.Doc
 
 	doc, err := o.ctx.VDRegistry().Resolve(request.DID)
 	//  if did not found in VDR, look through in local storage


### PR DESCRIPTION
**Title:**
Add resolving DID Document in VDR Registry.

**Summary:**
When generating a presentation by ID, DID Documents are searched only in local storage, so even though DID Documents are in the VDR Registry, the process of storing DID Documents in local storage should have been additionally performed.
So, I added the process of finding DID Document in VDR Registry.