### PR TITLE
feat: didexchange interop with aca-py, with afgo as responder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,12 @@ agent-rest:
 	@mkdir -p ./build/bin
 	@cd ${ARIES_AGENT_REST_PATH} && go build -o ../../build/bin/aries-agent-rest main.go
 
+.PHONY: agent-rest-acapy-interop
+agent-rest-acapy-interop:
+	@echo "Building aries-agent-rest for aca-py interop"
+	@mkdir -p ./build/bin
+	@cd ${ARIES_AGENT_REST_PATH} && go build -o ../../build/bin/aries-agent-rest -tags ACAPyInterop main.go
+
 .PHONY: agent-mobile
 agent-mobile:
 	@echo "Building aries-agent-mobile"

--- a/pkg/client/messaging/client_test.go
+++ b/pkg/client/messaging/client_test.go
@@ -606,8 +606,9 @@ func TestCommand_Reply(t *testing.T) {
 
 		go func() {
 			for {
-				if len(registrar.Services()) > 0 {
-					_, e := registrar.Services()[0].HandleInbound(
+				svcs := registrar.Services()
+				if len(svcs) > 0 {
+					_, e := svcs[0].HandleInbound(
 						replyMsg, service.NewDIDCommContext("sampleDID", "sampleTheirDID", nil))
 					require.NoError(t, e)
 				}

--- a/pkg/didcomm/protocol/decorator/decorator_default.go
+++ b/pkg/didcomm/protocol/decorator/decorator_default.go
@@ -1,0 +1,13 @@
+// +build !ACAPyInterop
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package decorator
+
+const (
+	doACAPyInterop = false
+)

--- a/pkg/didcomm/protocol/decorator/decorator_interop.go
+++ b/pkg/didcomm/protocol/decorator/decorator_interop.go
@@ -1,0 +1,13 @@
+// +build ACAPyInterop
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package decorator
+
+const (
+	doACAPyInterop = true
+)

--- a/pkg/didcomm/protocol/decorator/decorator_private_test.go
+++ b/pkg/didcomm/protocol/decorator/decorator_private_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package decorator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_b64ToRawURL(t *testing.T) {
+	testCases := []struct {
+		in  []string
+		out string
+	}{
+		{
+			in:  []string{"___-_w", "___-_w==", "///+/w", "///+/w=="},
+			out: "___-_w",
+		},
+		{
+			in: []string{
+				"Y29mZmVlIMD_7iBjb2ZmZWU",
+				"Y29mZmVlIMD_7iBjb2ZmZWU=",
+				"Y29mZmVlIMD/7iBjb2ZmZWU",
+				"Y29mZmVlIMD/7iBjb2ZmZWU=",
+			},
+			out: "Y29mZmVlIMD_7iBjb2ZmZWU",
+		},
+		{
+			in: []string{
+				"ZGVhZGJlZWYg3q2-7yBkZWFkYmVlZg",
+				"ZGVhZGJlZWYg3q2-7yBkZWFkYmVlZg==",
+				"ZGVhZGJlZWYg3q2+7yBkZWFkYmVlZg",
+				"ZGVhZGJlZWYg3q2+7yBkZWFkYmVlZg==",
+			},
+			out: "ZGVhZGJlZWYg3q2-7yBkZWFkYmVlZg",
+		},
+	}
+
+	for _, testCase := range testCases {
+		for _, in := range testCase.in {
+			out := b64ToRawURL(in)
+			require.Equal(t, testCase.out, out)
+		}
+	}
+}

--- a/pkg/didcomm/protocol/decorator/decorator_test.go
+++ b/pkg/didcomm/protocol/decorator/decorator_test.go
@@ -4,14 +4,30 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package decorator
+package decorator_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/google/tink/go/keyset"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto"
+	. "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+	"github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
 )
 
 func TestAttachmentData_Fetch(t *testing.T) {
@@ -59,4 +75,291 @@ func TestAttachmentData_Fetch(t *testing.T) {
 type testStruct struct {
 	FirstName string
 	LastName  string
+}
+
+func TestSignVerify(t *testing.T) {
+	k := newKMS(t)
+
+	c, err := tinkcrypto.New()
+	require.NoError(t, err)
+
+	kid, pubKeyBytes, err := k.CreateAndExportPubKeyBytes(kms.ED25519Type)
+	require.NoError(t, err)
+
+	pubKey := ed25519.PublicKey(pubKeyBytes)
+
+	kh, err := k.Get(kid)
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		data := mockAttachmentData()
+
+		err = data.Sign(c, kh, pubKey, pubKeyBytes)
+		require.NoError(t, err)
+
+		err = data.Verify(c, k)
+		require.NoError(t, err)
+	})
+
+	t.Run("success: ecdsa keys", func(t *testing.T) {
+		testCases := []struct {
+			testName string
+			curve    elliptic.Curve
+			keyType  kms.KeyType
+		}{
+			{
+				"p256",
+				elliptic.P256(),
+				kms.ECDSAP256TypeIEEEP1363,
+			},
+			{
+				"p384",
+				elliptic.P384(),
+				kms.ECDSAP384TypeIEEEP1363,
+			},
+			{
+				"p521",
+				elliptic.P521(),
+				kms.ECDSAP521TypeIEEEP1363,
+			},
+		}
+
+		t.Parallel()
+
+		for _, testCase := range testCases {
+			t.Run(testCase.testName, func(t *testing.T) {
+				priv, err2 := ecdsa.GenerateKey(testCase.curve, rand.Reader)
+				require.NoError(t, err2)
+
+				kid2, kh2, err2 := k.ImportPrivateKey(priv, testCase.keyType)
+				require.NoError(t, err2)
+
+				pub, err2 := k.ExportPubKeyBytes(kid2)
+				require.NoError(t, err2)
+
+				data := mockAttachmentData()
+
+				err2 = data.Sign(c, kh2, &priv.PublicKey, pub)
+				require.NoError(t, err2)
+
+				err2 = data.Verify(c, k)
+				require.NoError(t, err2)
+			})
+		}
+	})
+
+	t.Run("fail to sign, not given a key handle", func(t *testing.T) {
+		data := mockAttachmentData()
+
+		err = data.Sign(c, nil, pubKey, pubKeyBytes)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signing data")
+	})
+
+	t.Run("fail to sign, invalid pub key type", func(t *testing.T) {
+		data := mockAttachmentData()
+
+		err = data.Sign(c, kh, &struct{}{}, pubKeyBytes)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "creating jwk from pub key")
+	})
+
+	t.Run("fail to verify unsigned payload", func(t *testing.T) {
+		data := mockAttachmentData()
+
+		err = data.Verify(c, k)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no signature")
+	})
+
+	t.Run("fail to verify with invalid jws json", func(t *testing.T) {
+		data := mockAttachmentData()
+
+		err = data.Sign(c, kh, pubKey, pubKeyBytes)
+		require.NoError(t, err)
+
+		data.JWS = []byte("{{{{uh oh")
+
+		err = data.Verify(c, k)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parsing jws")
+	})
+
+	t.Run("fail to verify with invalid jws kid", func(t *testing.T) {
+		data := mockAttachmentData()
+
+		err = data.Sign(c, kh, pubKey, pubKeyBytes)
+		require.NoError(t, err)
+
+		data.JWS = []byte(`{"header":{"kid":"uh oh"}}`)
+
+		err = data.Verify(c, k)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parsing did:key")
+	})
+
+	t.Run("fail to verify with invalid protected header bsae64 data", func(t *testing.T) {
+		data := mockAttachmentData()
+
+		err = data.Sign(c, kh, pubKey, pubKeyBytes)
+		require.NoError(t, err)
+
+		data.JWS = []byte(`{
+"header":{"kid":"did:key:z6MksX3A44VzNYx1MJYUddyyZBhbqKUMBqvh37t1onsrBs64"},
+"signature":"5cEth8Bwl0PGoMVryOnzTxn6y4zZTccSThLHANz0bxdNr-wS9Y0pPFRASawQyN7i_-XBCRBqAtrRNZZUOqzvCg",
+"protected":"#$#$#$ not base64 data"
+}`)
+
+		err = data.Verify(c, k)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "decoding protected header")
+	})
+
+	t.Run("fail to verify with invalid protected header json", func(t *testing.T) {
+		data := mockAttachmentData()
+
+		err = data.Sign(c, kh, pubKey, pubKeyBytes)
+		require.NoError(t, err)
+
+		data.JWS = []byte(fmt.Sprintf(`{
+"header":{"kid":"did:key:z6MksX3A44VzNYx1MJYUddyyZBhbqKUMBqvh37t1onsrBs64"},
+"signature":"5cEth8Bwl0PGoMVryOnzTxn6y4zZTccSThLHANz0bxdNr-wS9Y0pPFRASawQyN7i_-XBCRBqAtrRNZZUOqzvCg",
+"protected":"%s"
+}`,
+			base64.RawURLEncoding.EncodeToString([]byte("#$#$#$ not json data")),
+		))
+
+		err = data.Verify(c, k)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parsing protected header")
+	})
+
+	t.Run("fail to verify with invalid jwk value", func(t *testing.T) {
+		data := mockAttachmentData()
+
+		err = data.Sign(c, kh, pubKey, pubKeyBytes)
+		require.NoError(t, err)
+
+		data.JWS = []byte(fmt.Sprintf(`{
+"header":{"kid":"did:key:z6MksX3A44VzNYx1MJYUddyyZBhbqKUMBqvh37t1onsrBs64"},
+"signature":"5cEth8Bwl0PGoMVryOnzTxn6y4zZTccSThLHANz0bxdNr-wS9Y0pPFRASawQyN7i_-XBCRBqAtrRNZZUOqzvCg",
+"protected":"%s"
+}`,
+			base64.RawURLEncoding.EncodeToString(
+				[]byte(`{"jwk":"this is not a jwk, this is a string'","alg":"EdDSA"}`)),
+		))
+
+		err = data.Verify(c, k)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parsing jwk")
+	})
+
+	t.Run("fail to verify with unsupported JWK type", func(t *testing.T) {
+		data := mockAttachmentData()
+
+		err = data.Sign(c, kh, pubKey, pubKeyBytes)
+		require.NoError(t, err)
+
+		data.JWS = []byte(fmt.Sprintf(`{
+"header":{"kid":"did:key:z6MksX3A44VzNYx1MJYUddyyZBhbqKUMBqvh37t1onsrBs64"},
+"signature":"5cEth8Bwl0PGoMVryOnzTxn6y4zZTccSThLHANz0bxdNr-wS9Y0pPFRASawQyN7i_-XBCRBqAtrRNZZUOqzvCg",
+"protected":"%s"
+}`,
+			base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(
+				`{"jwk":%s,"alg":"EdDSA"}`,
+				`{
+			"kty": "RSA",
+			"e": "AQAB",
+			"use": "enc",
+			"kid": "sample@sample.id",
+			"alg": "RS256",
+			"n": "1hOl09BUnwY7jFBqoZKa4XDmIuc0YFb4y_5ThiHhLRW68aNG5Vo23n3ugND2GK3PsguZqJ_HrWCGVuVlKTmFg`+
+					`JWQD9ZnVcYqScgHpQRhxMBi86PIvXR01D_PWXZZjvTRakpvQxUT5bVBdWnaBHQoxDBt0YIVi5a7x-gXB1aDlts4RTMpfS9BPmEjX`+
+					`4lciozwS6Ow_wTO3C2YGa_Our0ptIxr-x_3sMbPCN8Fe_iaBDezeDAm39xCNjFa1E735ipXA4eUW_6SzFJ5-bM2UKba2WE6xUaEa5G1`+
+					`MDDHCG5LKKd6Mhy7SSAzPOR2FTKYj89ch2asCPlbjHTu8jS6Iy8"
+		}`, // not a supported key type
+			))),
+		))
+
+		err = data.Verify(c, k)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "getting KeyType for jwk")
+	})
+
+	validProtectedHeader := `{
+"jwk":{"kty":"OKP","kid":"did:key:z6Mkuj5M8J9kce3c4zb33xGTwJdV4h1qH9KWiwoHyziUB2o2","crv":"Ed25519",
+"x":"4uyAPkoQrHpL2e4oW2RK_ByoywNBTPPp7C-pltUFkLE"},"alg":"EdDSA"}`
+
+	t.Run("fail to verify with signature not valid raw url base64", func(t *testing.T) {
+		data := mockAttachmentData()
+
+		err = data.Sign(c, kh, pubKey, pubKeyBytes)
+		require.NoError(t, err)
+
+		data.JWS = []byte(fmt.Sprintf(`{
+"header":{"kid":"did:key:z6Mkuj5M8J9kce3c4zb33xGTwJdV4h1qH9KWiwoHyziUB2o2"},
+"signature":"!@# not a valid raw url base64 encoded value #*$&@*#",
+"protected":"%s"
+}`,
+			base64.RawURLEncoding.EncodeToString([]byte(validProtectedHeader)),
+		))
+
+		err = data.Verify(c, k)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "decoding signature")
+	})
+
+	t.Run("failed to construct pub key handle", func(t *testing.T) {
+		data := mockAttachmentData()
+
+		err = data.Sign(c, kh, pubKey, pubKeyBytes)
+		require.NoError(t, err)
+
+		expected := fmt.Errorf("test error")
+		badKMS := &mockkms.KeyManager{PubKeyBytesToHandleErr: expected}
+
+		err = data.Verify(c, badKMS)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, expected))
+	})
+
+	t.Run("verification uses wrong key", func(t *testing.T) {
+		data := mockAttachmentData()
+
+		err = data.Sign(c, kh, pubKey, pubKeyBytes)
+		require.NoError(t, err)
+
+		kid, _, err := k.CreateAndExportPubKeyBytes(kms.ED25519)
+		require.NoError(t, err)
+
+		kh, err := k.Get(kid)
+		require.NoError(t, err)
+
+		badKMS := &mockkms.KeyManager{PubKeyBytesToHandleValue: kh.(*keyset.Handle)}
+
+		err = data.Verify(c, badKMS)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signature verification")
+	})
+}
+
+func mockAttachmentData() *AttachmentData {
+	return &AttachmentData{Base64: base64.RawURLEncoding.EncodeToString([]byte(`lorem ipsum dolor sit amet`))}
+}
+
+func newKMS(t *testing.T) kms.KeyManager {
+	t.Helper()
+
+	store := &mockstorage.MockStore{Store: make(map[string]mockstorage.DBEntry)}
+	sProvider := mockstorage.NewCustomMockStoreProvider(store)
+
+	kmsProv := &protocol.MockProvider{
+		StoreProvider: sProvider,
+		CustomLock:    &noop.NoLock{},
+	}
+
+	customKMS, err := localkms.New("local-lock://primary/test/", kmsProv)
+	require.NoError(t, err)
+
+	return customKMS
 }

--- a/pkg/didcomm/protocol/didexchange/didex_default.go
+++ b/pkg/didcomm/protocol/didexchange/didex_default.go
@@ -1,0 +1,24 @@
+// +build !ACAPyInterop
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didexchange
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+)
+
+const (
+	doACAPyInterop = false
+)
+
+// TODO interop: this is a stub method, that is substituted for special functionality
+//   when the ACAPyInterop flag is enabled.
+//   This can be removed when https://github.com/hyperledger/aries-cloudagent-python/issues/1048 is fixed.
+func convertPeerToSov(doc *did.Doc) (*did.Doc, error) {
+	return doc, nil
+}

--- a/pkg/didcomm/protocol/didexchange/didex_interop.go
+++ b/pkg/didcomm/protocol/didexchange/didex_interop.go
@@ -1,0 +1,54 @@
+// +build ACAPyInterop
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didexchange
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btcutil/base58"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+)
+
+const (
+	doACAPyInterop = true
+)
+
+// Interop: convert a peer did doc to a "sov-like" did doc, to accommodate current behaviour in aca-py,
+//          where sovrin dids are used as peer dids.
+// TODO interop: aca-py issue https://github.com/hyperledger/aries-cloudagent-python/issues/1048
+func convertPeerToSov(doc *did.Doc) (*did.Doc, error) {
+	if doc == nil {
+		return doc, nil
+	}
+
+	didParts := strings.Split(doc.ID, ":")
+	if len(didParts) != 3 {
+		return nil, fmt.Errorf("peer did not in 3 parts")
+	}
+
+	id := base58.Encode(base58.Decode(didParts[2])[:16])
+
+	newDID := fmt.Sprintf("did:sov:%s", id)
+
+	docBytes, err := doc.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	docBytes = bytes.Replace(docBytes, []byte(doc.ID), []byte(newDID), -1)
+	err = doc.UnmarshalJSON(docBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return doc, nil
+}

--- a/pkg/didcomm/protocol/didexchange/models.go
+++ b/pkg/didcomm/protocol/didexchange/models.go
@@ -93,6 +93,12 @@ type Response struct {
 	ID                  string               `json:"@id,omitempty"`
 	ConnectionSignature *ConnectionSignature `json:"connection~sig,omitempty"`
 	Thread              *decorator.Thread    `json:"~thread,omitempty"`
+	// DID the did of the responder.
+	// Mandatory in did-exchange, but optional for backwards-compatibility with rfc 0160 connection protocol.
+	DID string `json:"did,omitempty"`
+	// DocAttach an attachment containing the did doc of the responder.
+	// Optional, a responder may provide a publicly-resolvable DID, rather than including an attached did doc.
+	DocAttach *decorator.Attachment `json:"did_doc~attach,omitempty"`
 }
 
 // ConnectionSignature connection signature.
@@ -107,4 +113,12 @@ type ConnectionSignature struct {
 type Connection struct {
 	DID    string   `json:"did,omitempty"`
 	DIDDoc *did.Doc `json:"did_doc,omitempty"`
+}
+
+// Complete defines a2a DID exchange complete message.
+// https://github.com/hyperledger/aries-rfcs/tree/master/features/0023-did-exchange#3-exchange-complete
+type Complete struct {
+	Type   string            `json:"@type,omitempty"`
+	ID     string            `json:"@id,omitempty"`
+	Thread *decorator.Thread `json:"~thread,omitempty"`
 }

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -536,6 +536,7 @@ func TestService_Accept(t *testing.T) {
 	require.Equal(t, true, s.Accept("https://didcomm.org/didexchange/1.0/request"))
 	require.Equal(t, true, s.Accept("https://didcomm.org/didexchange/1.0/response"))
 	require.Equal(t, true, s.Accept("https://didcomm.org/didexchange/1.0/ack"))
+	require.Equal(t, true, s.Accept("https://didcomm.org/didexchange/1.0/complete"))
 	require.Equal(t, false, s.Accept("unsupported msg type"))
 }
 

--- a/pkg/doc/did/doc.go
+++ b/pkg/doc/did/doc.go
@@ -1159,7 +1159,7 @@ func populateRawServices(services []Service, didID, baseURI string) []map[string
 		recipientKeys := make([]string, 0)
 
 		for _, v := range services[i].RecipientKeys {
-			if services[i].routingKeysRelativeURL[v] {
+			if services[i].recipientKeysRelativeURL[v] {
 				recipientKeys = append(recipientKeys, makeRelativeDIDURL(v, baseURI, didID))
 				continue
 			}

--- a/pkg/doc/did/doc_test.go
+++ b/pkg/doc/did/doc_test.go
@@ -1757,6 +1757,20 @@ func TestDoc_VerificationMethods(t *testing.T) {
 	require.Len(t, methods[VerificationRelationshipGeneral], 4)
 }
 
+func TestDoc_SerializeInterop(t *testing.T) {
+	doc, err := ParseDocument([]byte(validDoc))
+	require.NoError(t, err)
+
+	docJSON, err := doc.JSONBytes()
+	require.NoError(t, err)
+
+	docInteropJSON, err := doc.SerializeInterop()
+	require.NoError(t, err)
+
+	// in default mode, SerializeInterop should return the regular did doc
+	require.Equal(t, docJSON, docInteropJSON)
+}
+
 func createDidDocumentWithSigningKey(pubKey []byte) *Doc {
 	const (
 		didContext      = "https://www.w3.org/ns/did/v1"

--- a/pkg/doc/did/serialize_default.go
+++ b/pkg/doc/did/serialize_default.go
@@ -1,0 +1,13 @@
+// +build !ACAPyInterop
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package did
+
+// SerializeInterop serializes the DID doc, using normal serialization unless the `interop` build flag is set.
+func (doc *Doc) SerializeInterop() ([]byte, error) {
+	return doc.JSONBytes()
+}

--- a/pkg/doc/did/serialize_interop.go
+++ b/pkg/doc/did/serialize_interop.go
@@ -1,0 +1,222 @@
+// +build ACAPyInterop
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package did
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btcutil/base58"
+)
+
+/*
+This file contains interop fixes for DID doc serialization, that break compliance with the DID spec.
+As interop partners continue their interop work, these fixes should stop being necessary.
+*/
+
+func populateRawVerificationInterop(context, baseURI, didID string, verifications []Verification) ([]interface{}, error) {
+	var rawVerifications []interface{}
+
+	for _, v := range verifications {
+		if v.Embedded {
+			vm, err := populateRawVerificationMethod(context, didID, baseURI, &v.VerificationMethod)
+			if err != nil {
+				return nil, err
+			}
+
+			rawVerifications = append(rawVerifications, vm)
+		} else {
+			// Interop: emit key reference as {"publicKey":<key reference>} instead of <key reference>
+			// see aca-py issue https://github.com/hyperledger/aries-cloudagent-python/issues/1104
+			keyRef := map[string]string{}
+
+			if v.VerificationMethod.relativeURL {
+				keyRef["publicKey"] = makeRelativeDIDURL(v.VerificationMethod.ID, baseURI, didID)
+			} else {
+				keyRef["publicKey"] = v.VerificationMethod.ID
+			}
+
+			rawVerifications = append(rawVerifications, keyRef)
+		}
+	}
+
+	return rawVerifications, nil
+}
+
+func populateRawServicesInterop(services []Service, didID, baseURI string) []map[string]interface{} {
+	var rawServices []map[string]interface{}
+
+	for i := range services {
+		rawService := make(map[string]interface{})
+
+		for k, v := range services[i].Properties {
+			rawService[k] = v
+		}
+
+		routingKeys := make([]string, 0)
+
+		for _, v := range services[i].RoutingKeys {
+			if services[i].routingKeysRelativeURL[v] {
+				routingKeys = append(routingKeys, makeRelativeDIDURL(v, baseURI, didID))
+				continue
+			}
+
+			// Interop: convert did:key to raw base58 key
+			// aca-py issue: https://github.com/hyperledger/aries-cloudagent-python/issues/1106
+			if strings.HasPrefix(v, "did:key:") {
+				key, err := pubKeyFromDIDKey(v)
+				if err != nil {
+					return nil
+				}
+
+				routingKeys = append(routingKeys, base58.Encode(key))
+			} else {
+				routingKeys = append(routingKeys, v)
+			}
+
+		}
+
+		recipientKeys := make([]string, 0)
+
+		for _, v := range services[i].RecipientKeys {
+			if services[i].recipientKeysRelativeURL[v] {
+				recipientKeys = append(recipientKeys, makeRelativeDIDURL(v, baseURI, didID))
+				continue
+			}
+
+			// Interop: convert did:key to raw base58 key
+			// aca-py issue: https://github.com/hyperledger/aries-cloudagent-python/issues/1106
+			if strings.HasPrefix(v, "did:key:") {
+				key, err := pubKeyFromDIDKey(v)
+				if err != nil {
+					return nil
+				}
+
+				recipientKeys = append(recipientKeys, base58.Encode(key))
+			} else {
+				recipientKeys = append(recipientKeys, v)
+			}
+		}
+
+		rawService[jsonldID] = services[i].ID
+		if services[i].relativeURL {
+			rawService[jsonldID] = makeRelativeDIDURL(services[i].ID, baseURI, didID)
+		}
+
+		rawService[jsonldType] = services[i].Type
+		rawService[jsonldServicePoint] = services[i].ServiceEndpoint
+		rawService[jsonldRecipientKeys] = recipientKeys
+		rawService[jsonldRoutingKeys] = routingKeys
+		rawService[jsonldPriority] = services[i].Priority
+
+		rawServices = append(rawServices, rawService)
+	}
+
+	return rawServices
+}
+
+// fingerprint.PubKeyFromDIDKey and fingerprint.PubKeyFromFingerprint are copied here to avoid an import cycle
+
+func pubKeyFromDIDKey(didKey string) ([]byte, error) {
+	id, err := Parse(didKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse did:key [%s]: %w", didKey, err)
+	}
+
+	fingerprint := id.MethodSpecificID
+
+	const maxMulticodecBytes = 9
+
+	if len(fingerprint) < 2 || fingerprint[0] != 'z' {
+		return nil, errors.New("unknown key encoding")
+	}
+
+	mc := base58.Decode(fingerprint[1:]) // skip leading "z"
+
+	_, br := binary.Uvarint(mc)
+	if br == 0 {
+		return nil, errors.New("unknown key encoding")
+	}
+
+	if br > maxMulticodecBytes {
+		return nil, errors.New("code exceeds maximum size")
+	}
+
+	return mc[br:], nil
+}
+
+// SerializeInterop serializes the DID doc, using normal serialization unless the `interop` build flag is set.
+// Verifications are serialized to accommodate aca-py issue #1104:
+//   https://github.com/hyperledger/aries-cloudagent-python/issues/1104
+// Services are serialized to accommodate aca-py issue #1106:
+//   https://github.com/hyperledger/aries-cloudagent-python/issues/1106
+func (doc *Doc) SerializeInterop() ([]byte, error) {
+	context := contextV011
+
+	if len(doc.Context) > 0 {
+		context = doc.Context[0]
+	}
+
+	vm, err := populateRawVM(context, doc.ID, doc.processingMeta.baseURI, doc.VerificationMethod)
+	if err != nil {
+		return nil, fmt.Errorf("JSON unmarshalling of Verification Method failed: %w", err)
+	}
+
+	auths, err := populateRawVerificationInterop(context, doc.processingMeta.baseURI, doc.ID, doc.Authentication)
+	if err != nil {
+		return nil, fmt.Errorf("JSON unmarshalling of Authentication failed: %w", err)
+	}
+
+	assertionMethods, err := populateRawVerificationInterop(context, doc.processingMeta.baseURI, doc.ID,
+		doc.AssertionMethod)
+	if err != nil {
+		return nil, fmt.Errorf("JSON unmarshalling of AssertionMethod failed: %w", err)
+	}
+
+	capabilityDelegations, err := populateRawVerificationInterop(context, doc.processingMeta.baseURI, doc.ID,
+		doc.CapabilityDelegation)
+	if err != nil {
+		return nil, fmt.Errorf("JSON unmarshalling of CapabilityDelegation failed: %w", err)
+	}
+
+	capabilityInvocations, err := populateRawVerificationInterop(context, doc.processingMeta.baseURI, doc.ID,
+		doc.CapabilityInvocation)
+	if err != nil {
+		return nil, fmt.Errorf("JSON unmarshalling of CapabilityInvocation failed: %w", err)
+	}
+
+	keyAgreements, err := populateRawVerificationInterop(context, doc.processingMeta.baseURI, doc.ID, doc.KeyAgreement)
+	if err != nil {
+		return nil, fmt.Errorf("JSON unmarshalling of KeyAgreement failed: %w", err)
+	}
+
+	// TODO: populate services using base58 raw key value instead of did:key
+	services := populateRawServicesInterop(doc.Service, doc.ID, doc.processingMeta.baseURI)
+
+	raw := &rawDoc{
+		Context: doc.Context, ID: doc.ID, VerificationMethod: vm,
+		Authentication: auths, AssertionMethod: assertionMethods, CapabilityDelegation: capabilityDelegations,
+		CapabilityInvocation: capabilityInvocations, KeyAgreement: keyAgreements,
+		Service: services, Created: doc.Created,
+		Proof: populateRawProofs(context, doc.ID, doc.processingMeta.baseURI, doc.Proof), Updated: doc.Updated,
+	}
+
+	if doc.processingMeta.baseURI != "" {
+		raw.Context = contextWithBase(doc)
+	}
+
+	byteDoc, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("JSON unmarshalling of document failed: %w", err)
+	}
+
+	return byteDoc, nil
+}

--- a/pkg/doc/jose/jwk_test.go
+++ b/pkg/doc/jose/jwk_test.go
@@ -7,10 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package jose
 
 import (
+	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -21,6 +23,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/primitive/bbs12381g2pub"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/cryptoutil"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
 
 func TestHeaders_GetJWK(t *testing.T) {
@@ -530,5 +533,191 @@ func TestJWK_BBSKeyValidation(t *testing.T) {
 
 		err = jwk4.UnmarshalJSON([]byte(goodJWK))
 		require.EqualError(t, err, "unable to read BBS+ JWE: invalid JWK")
+	})
+}
+
+func TestJWK_KeyType(t *testing.T) {
+	t.Run("success: get KeyType from JWK", func(t *testing.T) {
+		testCases := []struct {
+			jwk     string
+			keyType kms.KeyType
+		}{
+			{
+				jwk: `{
+					"kty": "OKP",
+					"use": "enc",
+					"crv": "Ed25519",
+					"kid": "sample@sample.id",
+					"x": "sEHL6KXs8bUz9Ss2qSWWjhhRMHVjrog0lzFENM132R8",
+					"alg": "EdDSA"
+				}`,
+				keyType: kms.ED25519Type,
+			},
+			{
+				jwk: `{
+					"kty": "OKP",
+					"use": "enc",
+					"crv": "X25519",
+					"kid": "sample@sample.id",
+					"x": "sEHL6KXs8bUz9Ss2qSWWjhhRMHVjrog0lzFENM132R8"
+				}`,
+				keyType: kms.X25519ECDHKWType,
+			},
+			{
+				//nolint:lll
+				jwk: `{
+					"kty": "OKP",
+					"use": "enc",
+					"crv": "BLS12381G2",
+					"kid": "sample@sample.id",
+					"x": "tKWJu0SOY7onl4tEyOOH11XBriQN2JgzV-UmjgBMSsNkcAx3_l97SVYViSDBouTVBkBfrLh33C5icDD-4UEDxNO3Wn1ijMHvn2N63DU4pkezA3kGN81jGbwbrsMPpiOF"
+				}`,
+				keyType: kms.BLS12381G2Type,
+			},
+			{
+				jwk: `{
+					"kty": "EC",
+					"use": "enc",
+					"crv": "secp256k1",
+					"kid": "sample@sample.id",
+					"x": "YRrvJocKf39GpdTnd-zBFE0msGDqawR-Cmtc6yKoFsM",
+					"y": "kE-dMH9S3mxnTXo0JFEhraCU_tVYFDfpu9tpP1LfVKQ",
+					"alg": "ES256K"
+				}`,
+				keyType: kms.ECDSASecp256k1TypeIEEEP1363,
+			},
+			{
+				jwk: `{
+					"kty": "EC",
+					"use": "enc",
+					"crv": "P-256",
+					"kid": "sample@sample.id",
+					"x": "JR7nhI47w7bxrNkp7Xt1nbmozNn-RB2Q-PWi7KHT8J0",
+					"y": "iXmKtH0caOgB1vV0CQwinwK999qdDvrssKhdbiAz9OI",
+					"alg": "ES256"
+				}`,
+				keyType: kms.ECDSAP256TypeIEEEP1363,
+			},
+			{
+				jwk: `{
+					"kty": "EC",
+					"kid": "sample@sample.id",
+					"crv": "P-384",
+					"x": "SNJT8Q-irydV5yppI-blGNuRTPf8sCYuL_tO92SLrufdlEgDll9cRuBLACrlBz2x",
+					"y": "zIYfra2_y2hnc35sIwA1jiDx5rKmG3mX6162HkAodTJIpUYxw2rz1qHiwVcaU2tY",
+					"alg": "ES384"
+				}`,
+				keyType: kms.ECDSAP384TypeIEEEP1363,
+			},
+			{
+				jwk: `{
+					"kty": "EC",
+					"kid": "sample@sample.id",
+					"crv": "P-521",
+					"d": "AfcmEHp9Nd_X005hBoKEs8bvMzIH0OMYodQUw8xRWpUGOq31cyXV1dUvX-S8uSaBIbh2w-fy_OaolBmvTe3Il5Rw",
+					"x": "AMIjmQpOT7oz5e8CJZQVi3cxCdF0gdmnNE8qmi5Y3_1-6gRzHoaXGs_TBcAvNgD8UCYhk3FWA8aLChJ9BjEUi44m",
+					"y": "AIfNzFdbyI1rfRrcY7orl3wTXT-C_kWhyWdr3K3rSS8WbwXhqg9jb29iEoE8izpCnuoJbC_FsMf2WbI_1iNomfB4",
+					"alg": "ES512"
+				}`,
+				keyType: kms.ECDSAP521TypeIEEEP1363,
+			},
+		}
+
+		t.Parallel()
+
+		for _, testCase := range testCases {
+			t.Run(fmt.Sprintf("KeyType %s", testCase.keyType), func(t *testing.T) {
+				j := JWK{}
+				e := j.UnmarshalJSON([]byte(testCase.jwk))
+				require.NoError(t, e)
+
+				kt, e := j.KeyType()
+				require.NoError(t, e)
+				require.Equal(t, testCase.keyType, kt)
+			})
+		}
+	})
+
+	t.Run("fail to get KeyType from JWK", func(t *testing.T) {
+		// RSA keys not currently supported by JWK.KeyType(), replace with another if RSA gets supported
+		keyJSON := `{
+			"kty": "RSA",
+			"e": "AQAB",
+			"use": "enc",
+			"kid": "sample@sample.id",
+			"alg": "RS256",
+			"n": "1hOl09BUnwY7jFBqoZKa4XDmIuc0YFb4y_5ThiHhLRW68aNG5Vo23n3ugND2GK3PsguZqJ_HrWCGVuVlKTmFg` +
+			`JWQD9ZnVcYqScgHpQRhxMBi86PIvXR01D_PWXZZjvTRakpvQxUT5bVBdWnaBHQoxDBt0YIVi5a7x-gXB1aDlts4RTMpfS9BPmEjX` +
+			`4lciozwS6Ow_wTO3C2YGa_Our0ptIxr-x_3sMbPCN8Fe_iaBDezeDAm39xCNjFa1E735ipXA4eUW_6SzFJ5-bM2UKba2WE6xUaEa5G1` +
+			`MDDHCG5LKKd6Mhy7SSAzPOR2FTKYj89ch2asCPlbjHTu8jS6Iy8"
+		}`
+
+		j := JWK{}
+		e := j.UnmarshalJSON([]byte(keyJSON))
+		require.NoError(t, e)
+
+		kt, e := j.KeyType()
+		require.Error(t, e)
+		require.Equal(t, kms.KeyType(""), kt)
+		require.Contains(t, e.Error(), "no keytype recognized for jwk")
+	})
+
+	t.Run("test ed25519 with []byte key material", func(t *testing.T) {
+		jwkJSON := `{
+			"kty": "OKP",
+			"use": "enc",
+			"crv": "Ed25519",
+			"kid": "sample@sample.id",
+			"x": "sEHL6KXs8bUz9Ss2qSWWjhhRMHVjrog0lzFENM132R8",
+			"alg": "EdDSA"
+		}`
+
+		j := JWK{}
+		e := j.UnmarshalJSON([]byte(jwkJSON))
+		require.NoError(t, e)
+
+		k, err := j.PublicKeyBytes()
+		require.NoError(t, err)
+
+		j.Key = k
+
+		kt, e := j.KeyType()
+		require.NoError(t, e)
+		require.Equal(t, kms.ED25519Type, kt)
+	})
+
+	t.Run("test secp256k1 with []byte key material", func(t *testing.T) {
+		jwkJSON := `{
+			"kty": "EC",
+			"use": "enc",
+			"crv": "secp256k1",
+			"kid": "sample@sample.id",
+			"x": "YRrvJocKf39GpdTnd-zBFE0msGDqawR-Cmtc6yKoFsM",
+			"y": "kE-dMH9S3mxnTXo0JFEhraCU_tVYFDfpu9tpP1LfVKQ",
+			"alg": "ES256K"
+		}`
+
+		j := JWK{}
+		e := j.UnmarshalJSON([]byte(jwkJSON))
+		require.NoError(t, e)
+
+		pkb, err := j.PublicKeyBytes()
+		require.NoError(t, err)
+
+		j.Key = pkb
+
+		kt, e := j.KeyType()
+		require.NoError(t, e)
+		require.Equal(t, kms.ECDSASecp256k1TypeIEEEP1363, kt)
+	})
+
+	t.Run("fail to get ecdsa keytype for (unsupported) p-224", func(t *testing.T) {
+		eckey, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+		require.NoError(t, err)
+
+		kt, err := ecdsaPubKeyType(&eckey.PublicKey)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no keytype recognized for ecdsa jwk")
+		require.Equal(t, kms.KeyType(""), kt)
 	})
 }


### PR DESCRIPTION
Part of #2495:
- DID exchange `completed` state
- Attachment signatures: Sign/Verify methods for attachment decorators
  that use base64 payloads.
- Additional fixes that are locked behind a build flag.

The build flag `interop` enables "breaking" interop fixes - fixes
  for interop that break compliance with specs/RFCs, and are
  temporary workarounds to allow for interop testing before
  interop partners fully update their implementations.

The fixes behind the flag are:
- Accept did:sov did doc in didexchange request, and store it like
  a peer did
- Generate a did:sov did doc as a peer did for didexchange response
- DID Doc method to serialize into a non-spec-compliant 'hybrid' format
  when attaching it to a didexchange message.

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>
