### PR TITLE
fix: update openapi spec for verifiable presentation

### DIFF
--- a/pkg/controller/rest/verifiable/models.go
+++ b/pkg/controller/rest/verifiable/models.go
@@ -179,6 +179,18 @@ type generatePresentationReq struct { // nolint: unused,deadcode
 	Params verifiable.PresentationRequest
 }
 
+// generatePresentationByIDReq model
+//
+// This is used to generate the verifiable presentation by id.
+//
+// swagger:parameters generatePresentationByIDReq
+type generatePresentationByIDReq struct { // nolint: unused,deadcode
+	// Params for generating the verifiable presentation by id (pass the vc document as a raw JSON)
+	//
+	// in: body
+	Params verifiable.PresentationRequestByID
+}
+
 // presentationRes model
 //
 // This is used for returning the verifiable presentation

--- a/pkg/controller/rest/verifiable/operation.go
+++ b/pkg/controller/rest/verifiable/operation.go
@@ -246,8 +246,7 @@ func (o *Operation) GeneratePresentation(rw http.ResponseWriter, req *http.Reque
 	rest.Execute(o.command.GeneratePresentation, rw, req.Body)
 }
 
-// GeneratePresentationByID swagger:route POST /verifiable/presentation/generatebyid
-// verifiable PresentationRequestByID model
+// GeneratePresentationByID swagger:route POST /verifiable/presentation/generatebyid verifiable generatePresentationByIDReq
 //
 // Generates the verifiable presentation from a stored verifiable credential.
 //


### PR DESCRIPTION
Title:
update openapi spec for verifiable presentation

Summary:
add rest API '/verifiable/presentation/generatebyid' into swagger openapi spec.