### PR TITLE
Improve the order of resolving did document when signing vc or generating vp.

### DIFF
--- a/pkg/controller/command/verifiable/command.go
+++ b/pkg/controller/command/verifiable/command.go
@@ -429,20 +429,18 @@ func (o *Command) SignCredential(rw io.Writer, req io.Reader) command.Error {
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf("request decode : %w", err))
 	}
 
-	var didDoc *did.Doc
-
-	doc, err := o.ctx.VDRegistry().Resolve(request.DID)
-	//  if did not found in VDR, look through in local storage
+	//  if caches DID, local storage should be looked first
+	didDoc, err := o.didStore.GetDID(request.DID)
 	if err != nil {
-		didDoc, err = o.didStore.GetDID(request.DID)
+		doc, err := o.ctx.VDRegistry().Resolve(request.DID)
 		if err != nil {
 			logutil.LogError(logger, CommandName, SignCredentialCommandMethod,
 				"failed to get did doc from store or vdr: "+err.Error())
 
 			return command.NewValidationError(SignCredentialErrorCode,
-				fmt.Errorf("generate vp - failed to get did doc from store or vdr : %w", err))
+				fmt.Errorf("sign vc - failed to get did doc from store or vdr : %w", err))
 		}
-	} else {
+
 		didDoc = doc.DIDDocument
 	}
 
@@ -653,12 +651,10 @@ func (o *Command) GeneratePresentation(rw io.Writer, req io.Reader) command.Erro
 		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf("request decode : %w", err))
 	}
 
-	var didDoc *did.Doc
-
-	doc, err := o.ctx.VDRegistry().Resolve(request.DID)
-	//  if did not found in VDR, look through in local storage
+	//  if caches DID, local storage should be looked first
+	didDoc, err := o.didStore.GetDID(request.DID)
 	if err != nil {
-		didDoc, err = o.didStore.GetDID(request.DID)
+		doc, err := o.ctx.VDRegistry().Resolve(request.DID)
 		if err != nil {
 			logutil.LogError(logger, CommandName, GeneratePresentationCommandMethod,
 				"failed to get did doc from store or vdr: "+err.Error())
@@ -666,7 +662,7 @@ func (o *Command) GeneratePresentation(rw io.Writer, req io.Reader) command.Erro
 			return command.NewValidationError(GeneratePresentationErrorCode,
 				fmt.Errorf("generate vp - failed to get did doc from store or vdr : %w", err))
 		}
-	} else {
+
 		didDoc = doc.DIDDocument
 	}
 
@@ -716,10 +712,10 @@ func (o *Command) GeneratePresentationByID(rw io.Writer, req io.Reader) command.
 	if err != nil {
 		doc, err := o.ctx.VDRegistry().Resolve(request.DID)
 		if err != nil {
-			logutil.LogError(logger, CommandName, GeneratePresentationCommandMethod,
+			logutil.LogError(logger, CommandName, GeneratePresentationByIDCommandMethod,
 				"failed to get did doc from store or vdr: "+err.Error())
 
-			return command.NewValidationError(GeneratePresentationErrorCode,
+			return command.NewValidationError(GeneratePresentationByIDErrorCode,
 				fmt.Errorf("generate vp by id - failed to get did doc from store or vdr : %w", err))
 		}
 

--- a/pkg/controller/command/verifiable/command_test.go
+++ b/pkg/controller/command/verifiable/command_test.go
@@ -2243,7 +2243,7 @@ func TestCommand_SignCredential(t *testing.T) {
 
 		err = cmd.SignCredential(&b, bytes.NewBuffer(presReqBytes))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "generate vp - failed to get did doc from store or vdr")
+		require.Contains(t, err.Error(), "sign vc - failed to get did doc from store or vdr")
 	})
 }
 


### PR DESCRIPTION
**Title:**
Improve the order of resolving DID document when signing a VC or generating a VP.
If caches DID, local storage be looked first.

**Summary:**
Before modifying, when signing a VC or generating a VP, looked at the VDR Registry first to get the DID document, and if it's not there, looked at local storage. It can affect performance.
So, I modified that when getting the DID document, looked at the local storage first, and if it's not there, looked at VDR Registry.

+ Incorrect error codes and messages have been additionally supplemented.
