### PR TITLE
fix: media types not fetched from connection when initiating protocol

### DIFF
--- a/pkg/client/outofband/client.go
+++ b/pkg/client/outofband/client.go
@@ -38,6 +38,23 @@ const (
 	HandshakeReuseAcceptedMsgType = outofband.HandshakeReuseAcceptedMsgType
 )
 
+const (
+	// MediaTypeProfileDIDCommAIP1 is the encryption envelope, signing mechanism, plaintext conventions,
+	// and routing algorithms embodied in Aries AIP 1.0, circa 2020. Defined in RFC 0044.
+	MediaTypeProfileDIDCommAIP1 = outofband.MediaTypeProfileDIDCommAIP1
+	// MediaTypeProfileDIDCommAIP2RFC19 is the signing mechanism, plaintext conventions, and routing
+	// algorithms embodied in Aries AIP 2.0, circa 2021 -- with the old-style encryption envelope from
+	// Aries RFC 0019. Defined in RFC 0044.
+	MediaTypeProfileDIDCommAIP2RFC19 = outofband.MediaTypeProfileDIDCommAIP2RFC19
+	// MediaTypeProfileAIP2RFC587 is the signing mechanism, plaintext conventions, and routing algorithms
+	// embodied in Aries AIP 2.0, circa 2021 -- with the new-style encryption envelope from Aries RFC 0587.
+	// Defined in RFC 0044.
+	MediaTypeProfileAIP2RFC587 = outofband.MediaTypeProfileAIP2RFC587
+	// MediaTypeProfileDIDCommV2 is the encryption envelope, signing mechanism, plaintext conventions,
+	// and routing algorithms embodied in the DIDComm messaging spec. Defined in RFC 0044.
+	MediaTypeProfileDIDCommV2 = outofband.MediaTypeProfileDIDCommV2
+)
+
 // EventOptions are is a container of options that you can pass to an event's
 // Continue function to customize the reaction to incoming out-of-band messages.
 type EventOptions struct {
@@ -302,7 +319,8 @@ func WithAttachments(a ...*decorator.Attachment) MessageOption {
 	}
 }
 
-// WithAccept will set the given media types in the Invitation's `accept` property.
+// WithAccept will set the given media type profiles in the Invitation's `accept` property.
+// Only valid values from RFC 0044 are supported.
 func WithAccept(a ...string) MessageOption {
 	return func(m *message) {
 		m.Accept = a

--- a/pkg/didcomm/common/service/destination.go
+++ b/pkg/didcomm/common/service/destination.go
@@ -22,7 +22,7 @@ type Destination struct {
 	ServiceEndpoint      string
 	RoutingKeys          []string
 	TransportReturnRoute string
-	MediaTypes           []string
+	MediaTypeProfiles    []string
 }
 
 const (
@@ -60,10 +60,10 @@ func CreateDestination(didDoc *diddoc.Doc) (*Destination, error) {
 	}
 
 	return &Destination{
-		RecipientKeys:   didCommService.RecipientKeys,
-		ServiceEndpoint: didCommService.ServiceEndpoint,
-		RoutingKeys:     didCommService.RoutingKeys,
-		MediaTypes:      didCommService.Accept,
+		RecipientKeys:     didCommService.RecipientKeys,
+		ServiceEndpoint:   didCommService.ServiceEndpoint,
+		RoutingKeys:       didCommService.RoutingKeys,
+		MediaTypeProfiles: didCommService.Accept,
 	}, nil
 }
 

--- a/pkg/didcomm/common/service/messenger.go
+++ b/pkg/didcomm/common/service/messenger.go
@@ -6,9 +6,6 @@ SPDX-License-Identifier: Apache-2.0
 
 package service
 
-// DIDCommContextEnvelopeMediaTypeKey is DIDCommContext property key holding the DIDComm envelope's media type.
-const DIDCommContextEnvelopeMediaTypeKey = "DIDCommContextEnvelopeMediaType"
-
 // DIDCommMsg describes message interface.
 type DIDCommMsg interface {
 	ID() string

--- a/pkg/didcomm/packager/package_test.go
+++ b/pkg/didcomm/packager/package_test.go
@@ -156,10 +156,10 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 
 		// PackMessage should pass with both value from and to keys
 		packMsg, err := packager.PackMessage(&transport.Envelope{
-			MediaType: transport.MediaTypeV1EncryptedEnvelope,
-			Message:   []byte("msg1"),
-			FromKey:   []byte(fromKID), // authcrypt uses sender's KID as Fromkey value
-			ToKeys:    []string{didKey},
+			MediaTypeProfile: transport.MediaTypeV1EncryptedEnvelope,
+			Message:          []byte("msg1"),
+			FromKey:          []byte(fromKID), // authcrypt uses sender's KID as Fromkey value
+			ToKeys:           []string{didKey},
 		})
 		require.NoError(t, err)
 
@@ -223,10 +223,10 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 
 		// now try to pack with non empty envelope - should pass
 		packMsg, err = packager.PackMessage(&transport.Envelope{
-			MediaType: transport.MediaTypeV1EncryptedEnvelope,
-			Message:   []byte("msg1"),
-			FromKey:   []byte(fromKID),
-			ToKeys:    []string{didKey},
+			MediaTypeProfile: transport.MediaTypeV1EncryptedEnvelope,
+			Message:          []byte("msg1"),
+			FromKey:          []byte(fromKID),
+			ToKeys:           []string{didKey},
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, packMsg)
@@ -246,10 +246,10 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 		packager, err = New(mockedProviders)
 		require.NoError(t, err)
 		packMsg, err = packager.PackMessage(&transport.Envelope{
-			MediaType: transport.MediaTypeV1EncryptedEnvelope,
-			Message:   []byte("msg1"),
-			FromKey:   []byte(fromKID),
-			ToKeys:    []string{didKey},
+			MediaTypeProfile: transport.MediaTypeV1EncryptedEnvelope,
+			Message:          []byte("msg1"),
+			FromKey:          []byte(fromKID),
+			ToKeys:           []string{didKey},
 		})
 		require.Error(t, err)
 		require.Empty(t, packMsg)
@@ -297,10 +297,10 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 
 		// pack an non empty envelope - should pass
 		packMsg, err := packager.PackMessage(&transport.Envelope{
-			MediaType: transport.MediaTypeV1EncryptedEnvelope,
-			Message:   []byte("msg1"),
-			FromKey:   []byte(fromKID),
-			ToKeys:    []string{didKey},
+			MediaTypeProfile: transport.MediaTypeV1EncryptedEnvelope,
+			Message:          []byte("msg1"),
+			FromKey:          []byte(fromKID),
+			ToKeys:           []string{didKey},
 		})
 		require.NoError(t, err)
 
@@ -331,10 +331,10 @@ func TestBaseKMSInPackager_UnpackMessage(t *testing.T) {
 		legacyDIDKey, _ := fingerprint.CreateDIDKey(toKey)
 
 		packMsg, err = packager2.PackMessage(&transport.Envelope{
-			MediaType: transport.MediaTypeV1EncryptedEnvelope,
-			Message:   []byte("msg2"),
-			FromKey:   fromKey,
-			ToKeys:    []string{legacyDIDKey},
+			MediaTypeProfile: transport.MediaTypeV1EncryptedEnvelope,
+			Message:          []byte("msg2"),
+			FromKey:          fromKey,
+			ToKeys:           []string{legacyDIDKey},
 		})
 		require.NoError(t, err)
 

--- a/pkg/didcomm/packager/packager.go
+++ b/pkg/didcomm/packager/packager.go
@@ -112,7 +112,7 @@ func (bp *Packager) PackMessage(messageEnvelope *transport.Envelope) ([]byte, er
 
 	// TODO find a way to dynamically select a packer based on FromKey, recipients and their types.
 	//      https://github.com/hyperledger/aries-framework-go/issues/1112 Configurable packing
-	//      Use transport.Envelope.MediaType for this.
+	//      Use transport.Envelope.MediaTypeProfile for this.
 	bytes, err := bp.primaryPacker.Pack(cty, messageEnvelope.Message, messageEnvelope.FromKey, recipients)
 	if err != nil {
 		return nil, fmt.Errorf("packMessage: failed to pack: %w", err)

--- a/pkg/didcomm/packer/anoncrypt/pack_test.go
+++ b/pkg/didcomm/packer/anoncrypt/pack_test.go
@@ -45,95 +45,82 @@ func TestAnoncryptPackerSuccess(t *testing.T) {
 	k := createKMS(t)
 
 	tests := []struct {
-		name      string
-		keyType   kms.KeyType
-		encAlg    afgjose.EncAlg
-		cty       string
-		mediaType string
+		name    string
+		keyType kms.KeyType
+		encAlg  afgjose.EncAlg
+		cty     string
 	}{
 		{
-			name:      "anoncrypt using NISTP256ECDHKW and AES256-GCM",
-			keyType:   kms.NISTP256ECDHKWType,
-			encAlg:    afgjose.A256GCM,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "anoncrypt using NISTP256ECDHKW and AES256-GCM",
+			keyType: kms.NISTP256ECDHKWType,
+			encAlg:  afgjose.A256GCM,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "anoncrypt using NISTP384ECDHKW and AES256-GCM",
-			keyType:   kms.NISTP384ECDHKWType,
-			encAlg:    afgjose.A256GCM,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "anoncrypt using NISTP384ECDHKW and AES256-GCM",
+			keyType: kms.NISTP384ECDHKWType,
+			encAlg:  afgjose.A256GCM,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "anoncrypt using NISTP521ECDHKW and AES256-GCM",
-			keyType:   kms.NISTP521ECDHKWType,
-			encAlg:    afgjose.A256GCM,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "anoncrypt using NISTP521ECDHKW and AES256-GCM",
+			keyType: kms.NISTP521ECDHKWType,
+			encAlg:  afgjose.A256GCM,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "anoncrypt using X25519ECDHKWType and AES256-GCM",
-			keyType:   kms.X25519ECDHKWType,
-			encAlg:    afgjose.A256GCM,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "anoncrypt using X25519ECDHKWType and AES256-GCM",
+			keyType: kms.X25519ECDHKWType,
+			encAlg:  afgjose.A256GCM,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "anoncrypt using NISTP256ECDHKW and XChacha20Poly1305",
-			keyType:   kms.NISTP256ECDHKW,
-			encAlg:    afgjose.XC20P,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "anoncrypt using NISTP256ECDHKW and XChacha20Poly1305",
+			keyType: kms.NISTP256ECDHKW,
+			encAlg:  afgjose.XC20P,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "anoncrypt using NISTP384ECDHKW and XChacha20Poly1305",
-			keyType:   kms.NISTP384ECDHKW,
-			encAlg:    afgjose.XC20P,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "anoncrypt using NISTP384ECDHKW and XChacha20Poly1305",
+			keyType: kms.NISTP384ECDHKW,
+			encAlg:  afgjose.XC20P,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "anoncrypt using NISTP521ECDHKW and XChacha20Poly1305",
-			keyType:   kms.NISTP521ECDHKW,
-			encAlg:    afgjose.XC20P,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "anoncrypt using NISTP521ECDHKW and XChacha20Poly1305",
+			keyType: kms.NISTP521ECDHKW,
+			encAlg:  afgjose.XC20P,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "anoncrypt using X25519ECDHKW and XChacha20Poly1305",
-			keyType:   kms.X25519ECDHKWType,
-			encAlg:    afgjose.XC20P,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "anoncrypt using X25519ECDHKW and XChacha20Poly1305",
+			keyType: kms.X25519ECDHKWType,
+			encAlg:  afgjose.XC20P,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "anoncrypt using NISTP256ECDHKW and AES256-GCM without cty",
-			keyType:   kms.NISTP256ECDHKWType,
-			encAlg:    afgjose.A256GCM,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "anoncrypt using NISTP256ECDHKW and AES256-GCM without cty",
+			keyType: kms.NISTP256ECDHKWType,
+			encAlg:  afgjose.A256GCM,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "anoncrypt using X25519ECDHKW and XChacha20Poly1305 without cty",
-			keyType:   kms.X25519ECDHKWType,
-			encAlg:    afgjose.XC20P,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "anoncrypt using X25519ECDHKW and XChacha20Poly1305 without cty",
+			keyType: kms.X25519ECDHKWType,
+			encAlg:  afgjose.XC20P,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "anoncrypt using NISTP256ECDHKW and XChacha20Poly1305 without cty",
-			keyType:   kms.NISTP256ECDHKWType,
-			encAlg:    afgjose.XC20P,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "anoncrypt using NISTP256ECDHKW and XChacha20Poly1305 without cty",
+			keyType: kms.NISTP256ECDHKWType,
+			encAlg:  afgjose.XC20P,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "anoncrypt using X25519ECDHKW and AES256-GCM without cty",
-			keyType:   kms.X25519ECDHKWType,
-			encAlg:    afgjose.A256GCM,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "anoncrypt using X25519ECDHKW and AES256-GCM without cty",
+			keyType: kms.X25519ECDHKWType,
+			encAlg:  afgjose.A256GCM,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 	}
 
@@ -167,7 +154,7 @@ func TestAnoncryptPackerSuccess(t *testing.T) {
 			recKey, err := exportPubKeyBytes(keyHandles[0])
 			require.NoError(t, err)
 
-			require.EqualValues(t, &transport.Envelope{MediaType: tc.mediaType, Message: origMsg, ToKey: recKey}, msg)
+			require.EqualValues(t, &transport.Envelope{Message: origMsg, ToKey: recKey}, msg)
 
 			jweJSON, err := afgjose.Deserialize(string(ct))
 			require.NoError(t, err)
@@ -190,7 +177,7 @@ func TestAnoncryptPackerSuccess(t *testing.T) {
 			msg, err = anonPacker.Unpack(ct)
 			require.NoError(t, err)
 
-			require.EqualValues(t, &transport.Envelope{MediaType: tc.mediaType, Message: origMsg, ToKey: recKey}, msg)
+			require.EqualValues(t, &transport.Envelope{Message: origMsg, ToKey: recKey}, msg)
 
 			verifyJWETypes(t, tc.cty, jweJSON.ProtectedHeaders)
 		})
@@ -253,9 +240,8 @@ func TestAnoncryptPackerSuccessWithDifferentCurvesSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	require.EqualValues(t, &transport.Envelope{
-		MediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
-		Message:   origMsg,
-		ToKey:     recKey,
+		Message: origMsg,
+		ToKey:   recKey,
 	}, msg)
 
 	// try with only 1 recipient
@@ -266,9 +252,8 @@ func TestAnoncryptPackerSuccessWithDifferentCurvesSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	require.EqualValues(t, &transport.Envelope{
-		MediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
-		Message:   origMsg,
-		ToKey:     recKey,
+		Message: origMsg,
+		ToKey:   recKey,
 	}, msg)
 }
 

--- a/pkg/didcomm/packer/authcrypt/pack.go
+++ b/pkg/didcomm/packer/authcrypt/pack.go
@@ -179,9 +179,10 @@ func unmarshalRecipientKeys(keys [][]byte) ([]*cryptoapi.PublicKey, []byte, erro
 
 // Unpack will decode the envelope using a standard format.
 func (p *Packer) Unpack(envelope []byte) (*transport.Envelope, error) {
-	jwe, mediaType, err := getJWEAndMediaType(envelope)
+	// TODO validate `typ` and `cty` values
+	jwe, _, _, err := deserializeEnvelope(envelope)
 	if err != nil {
-		return nil, fmt.Errorf("authcrypt.Unpack: failed to get JWE envelope and mediaType: %w", err)
+		return nil, fmt.Errorf("failed to deserialize envelope: %w", err)
 	}
 
 	for i := range jwe.Recipients {
@@ -232,27 +233,12 @@ func (p *Packer) Unpack(envelope []byte) (*transport.Envelope, error) {
 		}
 
 		return &transport.Envelope{
-			MediaType: mediaType,
-			Message:   pt,
-			ToKey:     ecdh1puPubKeyByes,
+			Message: pt,
+			ToKey:   ecdh1puPubKeyByes,
 		}, nil
 	}
 
 	return nil, fmt.Errorf("authcrypt Unpack: no matching recipient in envelope")
-}
-
-func getJWEAndMediaType(envelope []byte) (*jose.JSONWebEncryption, string, error) {
-	jwe, typ, cty, err := deserializeEnvelope(envelope)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to deserialize envelope: %w", err)
-	}
-
-	mediaType, err := transport.EnvelopeMediaTypeFor(typ, cty)
-	if err != nil {
-		return nil, "", fmt.Errorf("unsupported envelope format: %w", err)
-	}
-
-	return jwe, mediaType, nil
 }
 
 func deserializeEnvelope(envelope []byte) (*jose.JSONWebEncryption, string, string, error) {

--- a/pkg/didcomm/packer/authcrypt/pack_test.go
+++ b/pkg/didcomm/packer/authcrypt/pack_test.go
@@ -47,95 +47,82 @@ func TestAuthcryptPackerSuccess(t *testing.T) {
 	k := createKMS(t)
 
 	tests := []struct {
-		name      string
-		keyType   kms.KeyType
-		encAlg    afgjose.EncAlg
-		cty       string
-		mediaType string
+		name    string
+		keyType kms.KeyType
+		encAlg  afgjose.EncAlg
+		cty     string
 	}{
 		{
-			name:      "authcrypt using NISTP256ECDHKW and AES256-GCM",
-			keyType:   kms.NISTP256ECDHKWType,
-			encAlg:    afgjose.A256GCM,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "authcrypt using NISTP256ECDHKW and AES256-GCM",
+			keyType: kms.NISTP256ECDHKWType,
+			encAlg:  afgjose.A256GCM,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "authcrypt using NISTP384ECDHKW and AES256-GCM",
-			keyType:   kms.NISTP384ECDHKWType,
-			encAlg:    afgjose.A256GCM,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "authcrypt using NISTP384ECDHKW and AES256-GCM",
+			keyType: kms.NISTP384ECDHKWType,
+			encAlg:  afgjose.A256GCM,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "authcrypt using NISTP521ECDHKW and AES256-GCM",
-			keyType:   kms.NISTP521ECDHKWType,
-			encAlg:    afgjose.A256GCM,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "authcrypt using NISTP521ECDHKW and AES256-GCM",
+			keyType: kms.NISTP521ECDHKWType,
+			encAlg:  afgjose.A256GCM,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "authcrypt using X25519ECDHKWType and AES256-GCM",
-			keyType:   kms.X25519ECDHKWType,
-			encAlg:    afgjose.A256GCM,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "authcrypt using X25519ECDHKWType and AES256-GCM",
+			keyType: kms.X25519ECDHKWType,
+			encAlg:  afgjose.A256GCM,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "authcrypt using NISTP256ECDHKW and XChacha20Poly1305",
-			keyType:   kms.NISTP256ECDHKW,
-			encAlg:    afgjose.XC20P,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "authcrypt using NISTP256ECDHKW and XChacha20Poly1305",
+			keyType: kms.NISTP256ECDHKW,
+			encAlg:  afgjose.XC20P,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "authcrypt using NISTP384ECDHKW and XChacha20Poly1305",
-			keyType:   kms.NISTP384ECDHKW,
-			encAlg:    afgjose.XC20P,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "authcrypt using NISTP384ECDHKW and XChacha20Poly1305",
+			keyType: kms.NISTP384ECDHKW,
+			encAlg:  afgjose.XC20P,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "authcrypt using NISTP521ECDHKW and XChacha20Poly1305",
-			keyType:   kms.NISTP521ECDHKW,
-			encAlg:    afgjose.XC20P,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "authcrypt using NISTP521ECDHKW and XChacha20Poly1305",
+			keyType: kms.NISTP521ECDHKW,
+			encAlg:  afgjose.XC20P,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "authcrypt using X25519ECDHKWType and XChacha20Poly1305",
-			keyType:   kms.X25519ECDHKWType,
-			encAlg:    afgjose.XC20P,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "authcrypt using X25519ECDHKWType and XChacha20Poly1305",
+			keyType: kms.X25519ECDHKWType,
+			encAlg:  afgjose.XC20P,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "authcrypt using NISTP256ECDHKW and AES256-GCM without cty",
-			keyType:   kms.NISTP256ECDHKWType,
-			encAlg:    afgjose.A256GCM,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "authcrypt using NISTP256ECDHKW and AES256-GCM without cty",
+			keyType: kms.NISTP256ECDHKWType,
+			encAlg:  afgjose.A256GCM,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "authcrypt using X25519ECDHKW and XChacha20Poly1305 without cty",
-			keyType:   kms.X25519ECDHKWType,
-			encAlg:    afgjose.XC20P,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "authcrypt using X25519ECDHKW and XChacha20Poly1305 without cty",
+			keyType: kms.X25519ECDHKWType,
+			encAlg:  afgjose.XC20P,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "authcrypt using NISTP256ECDHKW and XChacha20Poly1305 without cty",
-			keyType:   kms.NISTP256ECDHKWType,
-			encAlg:    afgjose.XC20P,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "authcrypt using NISTP256ECDHKW and XChacha20Poly1305 without cty",
+			keyType: kms.NISTP256ECDHKWType,
+			encAlg:  afgjose.XC20P,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 		{
-			name:      "authcrypt using X25519ECDHKW and AES256-GCM without cty",
-			keyType:   kms.X25519ECDHKWType,
-			encAlg:    afgjose.A256GCM,
-			cty:       transport.MediaTypeV1PlaintextPayload,
-			mediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			name:    "authcrypt using X25519ECDHKW and AES256-GCM without cty",
+			keyType: kms.X25519ECDHKWType,
+			encAlg:  afgjose.A256GCM,
+			cty:     transport.MediaTypeV1PlaintextPayload,
 		},
 	}
 
@@ -181,7 +168,7 @@ func TestAuthcryptPackerSuccess(t *testing.T) {
 			recKey, err := exportPubKeyBytes(keyHandles[0])
 			require.NoError(t, err)
 
-			require.EqualValues(t, &transport.Envelope{MediaType: tc.mediaType, Message: origMsg, ToKey: recKey}, msg)
+			require.EqualValues(t, &transport.Envelope{Message: origMsg, ToKey: recKey}, msg)
 
 			jweJSON, err := afgjose.Deserialize(string(ct))
 			require.NoError(t, err)
@@ -204,7 +191,7 @@ func TestAuthcryptPackerSuccess(t *testing.T) {
 			msg, err = authPacker.Unpack(ct)
 			require.NoError(t, err)
 
-			require.EqualValues(t, &transport.Envelope{MediaType: tc.mediaType, Message: origMsg, ToKey: recKey}, msg)
+			require.EqualValues(t, &transport.Envelope{Message: origMsg, ToKey: recKey}, msg)
 
 			verifyJWETypes(t, tc.cty, jweJSON.ProtectedHeaders)
 		})
@@ -273,9 +260,8 @@ func TestAuthcryptPackerUsingKeysWithDifferentCurvesSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	require.EqualValues(t, &transport.Envelope{
-		MediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
-		Message:   origMsg,
-		ToKey:     recKey,
+		Message: origMsg,
+		ToKey:   recKey,
 	}, msg)
 
 	// try with only 1 recipient
@@ -286,9 +272,8 @@ func TestAuthcryptPackerUsingKeysWithDifferentCurvesSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	require.EqualValues(t, &transport.Envelope{
-		MediaType: transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
-		Message:   origMsg,
-		ToKey:     recKey,
+		Message: origMsg,
+		ToKey:   recKey,
 	}, msg)
 
 	jweJSON, err := afgjose.Deserialize(string(ct))

--- a/pkg/didcomm/packer/legacy/authcrypt/unpack.go
+++ b/pkg/didcomm/packer/legacy/authcrypt/unpack.go
@@ -62,10 +62,9 @@ func (p *Packer) Unpack(envelope []byte) (*transport.Envelope, error) {
 	data, err := p.decodeCipherText(cek, &envelopeData)
 
 	return &transport.Envelope{
-		MediaType: transport.MediaTypeV1EncryptedEnvelope,
-		Message:   data,
-		FromKey:   senderKey,
-		ToKey:     recKey,
+		Message: data,
+		FromKey: senderKey,
+		ToKey:   recKey,
 	}, err
 }
 

--- a/pkg/didcomm/protocol/didexchange/models.go
+++ b/pkg/didcomm/protocol/didexchange/models.go
@@ -30,8 +30,9 @@ type OOBInvitation struct {
 	// - a string with a valid DID
 	// - a valid `did.Service`
 	Target interface{}
-	// MediaTypes are the message formats supported by the sender of this invitation.
-	MediaTypes []string
+	// MediaTypeProfiles are the message format profiles supported by the sender of this invitation
+	// as defined in RFC 0044.
+	MediaTypeProfiles []string
 }
 
 // Invitation model

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -1154,7 +1154,7 @@ func TestConnectionRecord(t *testing.T) {
 	require.NoError(t, err)
 
 	conn, err := svc.connectionRecord(generateRequestMsgPayload(t, &protocol.MockProvider{},
-		randomString(), randomString()), service.EmptyDIDCommContext())
+		randomString(), randomString()))
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 
@@ -1166,7 +1166,7 @@ func TestConnectionRecord(t *testing.T) {
 	msg, err := service.ParseDIDCommMsgMap(requestBytes)
 	require.NoError(t, err)
 
-	_, err = svc.connectionRecord(msg, service.EmptyDIDCommContext())
+	_, err = svc.connectionRecord(msg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid message type")
 }
@@ -1324,7 +1324,7 @@ func TestRequestRecord(t *testing.T) {
 
 		didcommMsg := generateRequestMsgPayload(t, &protocol.MockProvider{}, randomString(), uuid.New().String())
 		require.NotEmpty(t, didcommMsg.ParentThreadID())
-		conn, err := svc.requestMsgRecord(didcommMsg, service.EmptyDIDCommContext())
+		conn, err := svc.requestMsgRecord(didcommMsg)
 		require.NoError(t, err)
 		require.NotNil(t, conn)
 		require.Equal(t, didcommMsg.ParentThreadID(), conn.InvitationID)
@@ -1343,7 +1343,7 @@ func TestRequestRecord(t *testing.T) {
 		delete(didcommMsg, "connection")
 		didcommMsg["did"] = "did:test:abc"
 
-		conn, err := svc.requestMsgRecord(didcommMsg, service.EmptyDIDCommContext())
+		conn, err := svc.requestMsgRecord(didcommMsg)
 		require.NoError(t, err)
 		require.NotNil(t, conn)
 		require.Equal(t, didcommMsg.ParentThreadID(), conn.InvitationID)
@@ -1363,7 +1363,7 @@ func TestRequestRecord(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = svc.requestMsgRecord(generateRequestMsgPayload(t, &protocol.MockProvider{},
-			randomString(), uuid.New().String()), service.EmptyDIDCommContext())
+			randomString(), uuid.New().String()))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "save connection record")
 	})
@@ -1379,7 +1379,7 @@ func TestRequestRecord(t *testing.T) {
 		parentThreadID := ""
 		didcommMsg := generateRequestMsgPayload(t, &protocol.MockProvider{}, randomString(), parentThreadID)
 		require.Empty(t, didcommMsg.ParentThreadID())
-		_, err = svc.requestMsgRecord(didcommMsg, service.EmptyDIDCommContext())
+		_, err = svc.requestMsgRecord(didcommMsg)
 		require.Error(t, err)
 	})
 }

--- a/pkg/didcomm/protocol/didexchange/states.go
+++ b/pkg/didcomm/protocol/didexchange/states.go
@@ -330,9 +330,10 @@ func (ctx *context) handleInboundOOBInvitation(
 	}
 
 	dest := &service.Destination{
-		RecipientKeys:   svc.RecipientKeys,
-		ServiceEndpoint: svc.ServiceEndpoint,
-		RoutingKeys:     svc.RoutingKeys,
+		RecipientKeys:     svc.RecipientKeys,
+		ServiceEndpoint:   svc.ServiceEndpoint,
+		RoutingKeys:       svc.RoutingKeys,
+		MediaTypeProfiles: svc.Accept,
 	}
 
 	recipientKey, err := recipientKey(myDID)
@@ -432,6 +433,10 @@ func (ctx *context) handleInboundRequest(request *Request, options *options,
 	destination, err := service.CreateDestination(requestDidDoc)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if len(destination.MediaTypeProfiles) > 0 {
+		connRec.MediaTypeProfiles = destination.MediaTypeProfiles
 	}
 
 	senderVerKey, err := recipientKey(responseDidDoc)
@@ -948,6 +953,12 @@ func (ctx *context) getServiceBlock(i *OOBInvitation) (*did.Service, error) {
 		block = &s
 	default:
 		return nil, fmt.Errorf("unsupported target type: %+v", svc)
+	}
+
+	if len(i.MediaTypeProfiles) > 0 {
+		// RFC0587: In case the accept property is set in both the DID service block and the out-of-band message,
+		// the out-of-band property takes precedence.
+		block.Accept = i.MediaTypeProfiles
 	}
 
 	logger.Debugf("extracted service block=%+v", block)

--- a/pkg/didcomm/protocol/didexchange/states_test.go
+++ b/pkg/didcomm/protocol/didexchange/states_test.go
@@ -1414,6 +1414,7 @@ func createDIDDocWithKey(verPubKey, encPubKey string) *diddoc.Doc {
 			ServiceEndpoint: "http://localhost:58416",
 			Priority:        0,
 			RecipientKeys:   []string{verPubKey},
+			Accept:          []string{"didcomm/v2"},
 		},
 	}
 	createdTime := time.Now()
@@ -1610,11 +1611,12 @@ func newDidExchangeInvite(publicDID string, svc *diddoc.Service) *Invitation {
 
 func newOOBInvite(target interface{}) *OOBInvitation {
 	return &OOBInvitation{
-		ID:         uuid.New().String(),
-		Type:       oobMsgType,
-		ThreadID:   uuid.New().String(),
-		TheirLabel: "test",
-		Target:     target,
+		ID:                uuid.New().String(),
+		Type:              oobMsgType,
+		ThreadID:          uuid.New().String(),
+		TheirLabel:        "test",
+		Target:            target,
+		MediaTypeProfiles: []string{"didcomm/v2"},
 	}
 }
 

--- a/pkg/didcomm/protocol/outofband/service_test.go
+++ b/pkg/didcomm/protocol/outofband/service_test.go
@@ -847,6 +847,15 @@ func TestAcceptInvitation(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, errors.Is(err, expected))
 	})
+	t.Run("error if invitation has invalid accept values", func(t *testing.T) {
+		provider := testProvider()
+		s := newAutoService(t, provider)
+		inv := newInvitation()
+		inv.Accept = []string{"INVALID"}
+		_, err := s.AcceptInvitation(inv, &userOptions{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid media type profile")
+	})
 }
 
 func TestSaveInvitation(t *testing.T) {
@@ -1059,6 +1068,7 @@ func newAck(pthid ...string) *model.Ack {
 }
 
 type testDIDCommMsg struct {
+	msgType   string
 	errDecode error
 }
 
@@ -1071,7 +1081,7 @@ func (t *testDIDCommMsg) SetID(id string) error {
 }
 
 func (t *testDIDCommMsg) Type() string {
-	panic("implement me")
+	return t.msgType
 }
 
 func (t *testDIDCommMsg) ThreadID() (string, error) {

--- a/pkg/didcomm/transport/media_type.go
+++ b/pkg/didcomm/transport/media_type.go
@@ -6,9 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package transport
 
-import "fmt"
-
 const (
+	// MediaTypeRFC0019EncryptedEnvelope is the original media type for DIDComm V1 encrypted envelopes as per
+	// Aries RFC 0019.
+	MediaTypeRFC0019EncryptedEnvelope = "JWM/1.0"
 	// MediaTypeV1EncryptedEnvelope is the media type for DIDComm V1 encrypted envelopes as per Aries RFC 0044.
 	MediaTypeV1EncryptedEnvelope = "application/didcomm-enc-env"
 	// MediaTypeV1PlaintextPayload is the media type for DIDComm V1 JWE payloads as per Aries RFC 0044.
@@ -20,23 +21,3 @@ const (
 	// V1 plaintext payload as per Aries RFC 0587.
 	MediaTypeV2EncryptedEnvelopeV1PlaintextPayload = MediaTypeV2EncryptedEnvelope + ";cty=" + MediaTypeV1PlaintextPayload
 )
-
-// EnvelopeMediaTypeFor returns the media type that corresponds with a DIDComm envelope given 'typ'
-// and optionally 'cty'.
-func EnvelopeMediaTypeFor(typ, cty string) (string, error) {
-	if cty == "" {
-		switch typ {
-		case MediaTypeV1EncryptedEnvelope, MediaTypeV2EncryptedEnvelope:
-			return typ, nil
-		default:
-			return "", fmt.Errorf("unsupported: typ=%s", typ)
-		}
-	}
-
-	m := fmt.Sprintf("%s;cty=%s", typ, cty)
-	if m != MediaTypeV2EncryptedEnvelopeV1PlaintextPayload {
-		return "", fmt.Errorf("unsupported: typ=%s cty=%s", typ, cty)
-	}
-
-	return m, nil
-}

--- a/pkg/didcomm/transport/transport_interface.go
+++ b/pkg/didcomm/transport/transport_interface.go
@@ -29,9 +29,9 @@ type OutboundTransport interface {
 
 // Envelope holds message data and metadata for inbound and outbound messaging.
 type Envelope struct {
-	MediaType string
-	Message   []byte
-	FromKey   []byte
+	MediaTypeProfile string
+	Message          []byte
+	FromKey          []byte
 	// ToKeys stores keys for an outbound message packing
 	ToKeys []string
 	// ToKey holds the key that was used to decrypt an inbound message

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -426,12 +426,17 @@ func createOutboundDispatcher(frameworkOpts *Aries) error {
 		context.WithPackager(frameworkOpts.packager),
 		context.WithTransportReturnRoute(frameworkOpts.transportReturnRoute),
 		context.WithVDRegistry(frameworkOpts.vdrRegistry),
+		context.WithStorageProvider(frameworkOpts.storeProvider),
+		context.WithProtocolStateStorageProvider(frameworkOpts.protocolStateStoreProvider),
 	)
 	if err != nil {
 		return fmt.Errorf("context creation failed: %w", err)
 	}
 
-	frameworkOpts.outboundDispatcher = dispatcher.NewOutbound(ctx)
+	frameworkOpts.outboundDispatcher, err = dispatcher.NewOutbound(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to init outbound dispatcher: %w", err)
+	}
 
 	return nil
 }

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -186,11 +186,7 @@ func (p *Provider) InboundMessageHandler() transport.InboundMessageHandler {
 					}
 				}
 
-				_, err = svc.HandleInbound(msg, service.NewDIDCommContext(myDID, theirDID,
-					map[string]interface{}{
-						service.DIDCommContextEnvelopeMediaTypeKey: envelope.MediaType,
-					},
-				))
+				_, err = svc.HandleInbound(msg, service.NewDIDCommContext(myDID, theirDID, nil))
 
 				return err
 			}
@@ -214,12 +210,7 @@ func (p *Provider) InboundMessageHandler() transport.InboundMessageHandler {
 					return fmt.Errorf("inbound message handler: %w", err)
 				}
 
-				return p.tryToHandle(svc, msg, service.NewDIDCommContext(
-					myDID, theirDID,
-					map[string]interface{}{
-						service.DIDCommContextEnvelopeMediaTypeKey: envelope.MediaType,
-					},
-				))
+				return p.tryToHandle(svc, msg, service.NewDIDCommContext(myDID, theirDID, nil))
 			}
 		}
 

--- a/pkg/store/connection/connection_lookup.go
+++ b/pkg/store/connection/connection_lookup.go
@@ -44,21 +44,21 @@ type provider interface {
 
 // Record contain info about did exchange connection.
 type Record struct {
-	ConnectionID    string
-	State           string
-	ThreadID        string
-	ParentThreadID  string
-	TheirLabel      string
-	TheirDID        string
-	MyDID           string
-	ServiceEndPoint string
-	RecipientKeys   []string
-	RoutingKeys     []string
-	InvitationID    string
-	InvitationDID   string
-	Implicit        bool
-	Namespace       string
-	MediaTypes      []string
+	ConnectionID      string
+	State             string
+	ThreadID          string
+	ParentThreadID    string
+	TheirLabel        string
+	TheirDID          string
+	MyDID             string
+	ServiceEndPoint   string
+	RecipientKeys     []string
+	RoutingKeys       []string
+	InvitationID      string
+	InvitationDID     string
+	Implicit          bool
+	Namespace         string
+	MediaTypeProfiles []string
 }
 
 // NewLookup returns new connection lookup instance.

--- a/pkg/store/connection/connection_lookup_test.go
+++ b/pkg/store/connection/connection_lookup_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
-	"github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol"
 	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 	"github.com/hyperledger/aries-framework-go/spi/storage"
 )
@@ -357,7 +356,7 @@ func TestGetConnectionIDByDIDs(t *testing.T) {
 	theirDID := "did:theirdid:789"
 
 	t.Run("get connection record by did - success", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 
 		require.NotNil(t, recorder)
@@ -378,7 +377,7 @@ func TestGetConnectionIDByDIDs(t *testing.T) {
 	})
 
 	t.Run("get connection record by did - no mapping found", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 
 		connectionID, err := recorder.GetConnectionIDByDIDs(myDID, theirDID)

--- a/pkg/store/connection/connection_recorder_test.go
+++ b/pkg/store/connection/connection_recorder_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
-	"github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol"
 	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 	"github.com/hyperledger/aries-framework-go/spi/storage"
 )
@@ -30,7 +29,7 @@ const (
 
 func Test_NewConnectionRecorder(t *testing.T) {
 	t.Run("create create new recorder - success", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 	})
@@ -73,7 +72,7 @@ func Test_ComputeHash(t *testing.T) {
 
 func Test_RemoveMappings(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 
@@ -85,7 +84,7 @@ func Test_RemoveMappings(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("test failed - empty bytes", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 
@@ -99,11 +98,11 @@ func Test_RemoveMappings(t *testing.T) {
 	})
 	t.Run("test failed to delete the record", func(t *testing.T) {
 		const errMsg = "get error"
-		recorder, err := NewRecorder(&protocol.MockProvider{
-			StoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
+		recorder, err := NewRecorder(&mockProvider{
+			store: &mockstorage.MockStore{
 				Store:     make(map[string]mockstorage.DBEntry),
 				ErrDelete: fmt.Errorf(errMsg),
-			}),
+			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
@@ -137,8 +136,8 @@ func Test_RemoveConnectionRecordsForStates(t *testing.T) {
 			record, store)
 		require.NoError(t, err)
 
-		recorder, err := NewRecorder(&protocol.MockProvider{
-			ProtocolStateStoreProvider: mockstorage.NewCustomMockStoreProvider(store),
+		recorder, err := NewRecorder(&mockProvider{
+			protocolStateStore: store,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
@@ -169,8 +168,8 @@ func Test_RemoveConnectionRecordsForStates(t *testing.T) {
 			})
 		require.NoError(t, err)
 
-		recorder, err := NewRecorder(&protocol.MockProvider{
-			ProtocolStateStoreProvider: mockstorage.NewCustomMockStoreProvider(store),
+		recorder, err := NewRecorder(&mockProvider{
+			protocolStateStore: store,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
@@ -186,8 +185,8 @@ func TestConnectionStore_SaveInvitation(t *testing.T) {
 
 	t.Run("test save invitation success", func(t *testing.T) {
 		store := &mockstorage.MockStore{Store: make(map[string]mockstorage.DBEntry)}
-		recorder, err := NewRecorder(&protocol.MockProvider{
-			StoreProvider: mockstorage.NewCustomMockStoreProvider(store),
+		recorder, err := NewRecorder(&mockProvider{
+			store: store,
 		})
 		require.NoError(t, err)
 
@@ -222,8 +221,8 @@ func TestConnectionStore_SaveInvitation(t *testing.T) {
 
 	t.Run("test save invitation failure due to invalid key", func(t *testing.T) {
 		store := &mockstorage.MockStore{Store: make(map[string]mockstorage.DBEntry)}
-		recorder, err := NewRecorder(&protocol.MockProvider{
-			StoreProvider: mockstorage.NewCustomMockStoreProvider(store),
+		recorder, err := NewRecorder(&mockProvider{
+			store: store,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
@@ -239,7 +238,7 @@ func TestConnectionStore_SaveInvitation(t *testing.T) {
 
 func TestConnectionStore_GetInvitation(t *testing.T) {
 	t.Run("test get invitation - success", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 
@@ -258,7 +257,7 @@ func TestConnectionStore_GetInvitation(t *testing.T) {
 	})
 
 	t.Run("test get invitation - not found scenario", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 
@@ -269,7 +268,7 @@ func TestConnectionStore_GetInvitation(t *testing.T) {
 	})
 
 	t.Run("test get invitation - invalid key scenario", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 
@@ -282,7 +281,7 @@ func TestConnectionStore_GetInvitation(t *testing.T) {
 
 func TestConnectionStore_SaveAndGetEventData(t *testing.T) {
 	t.Run("test save and get event data - success", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 
@@ -297,7 +296,7 @@ func TestConnectionStore_SaveAndGetEventData(t *testing.T) {
 	})
 
 	t.Run("test get invitation - not found scenario", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 
@@ -308,7 +307,7 @@ func TestConnectionStore_SaveAndGetEventData(t *testing.T) {
 	})
 
 	t.Run("test get invitation - invalid key scenario", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 
@@ -320,7 +319,7 @@ func TestConnectionStore_SaveAndGetEventData(t *testing.T) {
 }
 
 func TestConnectionRecordByState(t *testing.T) {
-	recorder, err := NewRecorder(&protocol.MockProvider{})
+	recorder, err := NewRecorder(&mockProvider{})
 	require.NoError(t, err)
 
 	connRec := &Record{
@@ -359,7 +358,7 @@ func TestConnectionRecordByState(t *testing.T) {
 
 func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 	t.Run("save connection record with invited state - success", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 
@@ -388,7 +387,7 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 	})
 
 	t.Run("save connection record with invited state - completed", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 
@@ -422,11 +421,11 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 
 	t.Run("save connection record error scenario 1", func(t *testing.T) {
 		const errMsg = "get error"
-		record, err := NewRecorder(&protocol.MockProvider{
-			ProtocolStateStoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
+		record, err := NewRecorder(&mockProvider{
+			protocolStateStore: &mockstorage.MockStore{
 				Store:  make(map[string]mockstorage.DBEntry),
 				ErrPut: fmt.Errorf(errMsg),
-			}),
+			},
 		})
 		require.NoError(t, err)
 		connRec := &Record{
@@ -439,11 +438,11 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 
 	t.Run("save connection record error scenario 2", func(t *testing.T) {
 		const errMsg = "get error"
-		record, err := NewRecorder(&protocol.MockProvider{
-			StoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
+		record, err := NewRecorder(&mockProvider{
+			store: &mockstorage.MockStore{
 				Store:  make(map[string]mockstorage.DBEntry),
 				ErrPut: fmt.Errorf(errMsg),
-			}),
+			},
 		})
 		require.NoError(t, err)
 		connRec := &Record{
@@ -457,7 +456,7 @@ func TestConnectionRecorder_SaveConnectionRecord(t *testing.T) {
 
 func TestConnectionRecorder_RemoveConnection(t *testing.T) {
 	t.Run("save and remove connection record with invited state - completed", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 
@@ -510,7 +509,7 @@ func TestConnectionRecorder_RemoveConnection(t *testing.T) {
 		require.Contains(t, err.Error(), "data not found")
 	})
 	t.Run("try to remove unexisting connection record", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 
@@ -529,11 +528,11 @@ func TestConnectionRecorder_RemoveConnection(t *testing.T) {
 	})
 	t.Run("save and remove connection record - failed to delete from the store", func(t *testing.T) {
 		const errMsg = "get error"
-		recorder, err := NewRecorder(&protocol.MockProvider{
-			StoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
+		recorder, err := NewRecorder(&mockProvider{
+			store: &mockstorage.MockStore{
 				Store:     make(map[string]mockstorage.DBEntry),
 				ErrDelete: fmt.Errorf(errMsg),
-			}),
+			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
@@ -555,11 +554,11 @@ func TestConnectionRecorder_RemoveConnection(t *testing.T) {
 	})
 	t.Run("save and remove connection record - failed to delete from the protocol state store", func(t *testing.T) {
 		const errMsg = "get error"
-		recorder, err := NewRecorder(&protocol.MockProvider{
-			ProtocolStateStoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
+		recorder, err := NewRecorder(&mockProvider{
+			protocolStateStore: &mockstorage.MockStore{
 				Store:     make(map[string]mockstorage.DBEntry),
 				ErrDelete: fmt.Errorf(errMsg),
-			}),
+			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
@@ -580,7 +579,7 @@ func TestConnectionRecorder_RemoveConnection(t *testing.T) {
 		require.Contains(t, err.Error(), errMsg)
 	})
 	t.Run("save and remove connection record - failed to delete connection mapping record", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 
@@ -603,7 +602,7 @@ func TestConnectionRecorder_RemoveConnection(t *testing.T) {
 
 func TestConnectionRecorder_ConnectionRecordMappings(t *testing.T) {
 	t.Run("get connection record by namespace threadID in my namespace", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 
 		require.NotNil(t, recorder)
@@ -622,7 +621,7 @@ func TestConnectionRecorder_ConnectionRecordMappings(t *testing.T) {
 		require.Equal(t, connRec, storedRecord)
 	})
 	t.Run("get connection record by namespace threadID their namespace", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 		connRec := &Record{
@@ -640,7 +639,7 @@ func TestConnectionRecorder_ConnectionRecordMappings(t *testing.T) {
 		require.Equal(t, connRec, storedRecord)
 	})
 	t.Run("save connection record with mapping - validation failure", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 
 		require.NotNil(t, recorder)
@@ -654,11 +653,11 @@ func TestConnectionRecorder_ConnectionRecordMappings(t *testing.T) {
 	})
 	t.Run("save connection record with mapping - store failure", func(t *testing.T) {
 		const errMsg = "put error"
-		recorder, err := NewRecorder(&protocol.MockProvider{
-			ProtocolStateStoreProvider: mockstorage.NewCustomMockStoreProvider(&mockstorage.MockStore{
+		recorder, err := NewRecorder(&mockProvider{
+			protocolStateStore: &mockstorage.MockStore{
 				Store:  make(map[string]mockstorage.DBEntry),
 				ErrPut: fmt.Errorf(errMsg),
-			}),
+			},
 		})
 
 		require.NotNil(t, recorder)
@@ -673,7 +672,7 @@ func TestConnectionRecorder_ConnectionRecordMappings(t *testing.T) {
 		require.Contains(t, err.Error(), errMsg)
 	})
 	t.Run("save connection record with mapping - namespace error", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 
 		require.NotNil(t, recorder)
@@ -686,7 +685,7 @@ func TestConnectionRecorder_ConnectionRecordMappings(t *testing.T) {
 		require.Contains(t, err.Error(), "namespace not supported")
 	})
 	t.Run("data not found error due to missing input parameter", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, recorder)
 		connRec, err := recorder.GetConnectionRecordByNSThreadID("")
@@ -709,7 +708,7 @@ func TestConnectionRecorder_CreateNSKeys(t *testing.T) {
 
 func TestConnectionRecorder_SaveNamespaceThreadID(t *testing.T) {
 	t.Run("missing required parameters", func(t *testing.T) {
-		recorder, err := NewRecorder(&protocol.MockProvider{})
+		recorder, err := NewRecorder(&mockProvider{})
 		require.NoError(t, err)
 
 		require.NotNil(t, recorder)


### PR DESCRIPTION
This PR makes the outbound dispatcher fetch the receiving agent's supported media types from the existing connection record.

Other changes:

* Renamed "MediaTypes" -> "MediaTypeProfiles"
* the framework was falling back to the envelope media type in the inbound didexchange `request` message if the did doc embedded in the message did not contain an `accept` property. This behaviour has been removed. The media type profile is solely determined by either a) the OOB invitation (has precedence), or b) the `service` block's `accept` property

Signed-off-by: George Aristy <george.aristy@securekey.com>