### PR TITLE
feat: collections data model & content mapping

### DIFF
--- a/pkg/client/vcwallet/client.go
+++ b/pkg/client/vcwallet/client.go
@@ -170,13 +170,13 @@ func (c *Client) Import(auth string, contents json.RawMessage) error {
 //	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Key
 //
 // TODO: (#2433) support for correlation between wallet contents (ex: credentials to a profile/collection).
-func (c *Client) Add(contentType wallet.ContentType, content json.RawMessage) error {
+func (c *Client) Add(contentType wallet.ContentType, content json.RawMessage, options ...wallet.AddContentOptions) error { //nolint: lll
 	auth, err := c.auth()
 	if err != nil {
 		return err
 	}
 
-	return c.wallet.Add(auth, contentType, content)
+	return c.wallet.Add(auth, contentType, content, options...)
 }
 
 // Remove removes wallet content by content ID.
@@ -214,8 +214,8 @@ func (c *Client) Get(contentType wallet.ContentType, contentID string) (json.Raw
 //	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#meta-data
 //	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
 //
-func (c *Client) GetAll(contentType wallet.ContentType) (map[string]json.RawMessage, error) {
-	return c.wallet.GetAll(contentType)
+func (c *Client) GetAll(contentType wallet.ContentType, options ...wallet.GetAllContentsOptions) (map[string]json.RawMessage, error) { //nolint: lll
+	return c.wallet.GetAll(contentType, options...)
 }
 
 // Query runs query against wallet credential contents and returns presentation containing credential results.

--- a/pkg/mock/storage/mock_store.go
+++ b/pkg/mock/storage/mock_store.go
@@ -102,6 +102,7 @@ type MockStore struct {
 	ErrQuery  error
 	ErrNext   error
 	ErrValue  error
+	ErrKey    error
 	ErrBatch  error
 }
 
@@ -174,7 +175,7 @@ func (s *MockStore) Query(expression string, _ ...storage.QueryOption) (storage.
 
 		keys, dbEntries := s.getMatchingKeysAndDBEntries(expressionTagName, "")
 
-		return &iterator{keys: keys, dbEntries: dbEntries, errNext: s.ErrNext, errValue: s.ErrValue}, nil
+		return &iterator{keys: keys, dbEntries: dbEntries, errNext: s.ErrNext, errValue: s.ErrValue, errKey: s.ErrKey}, nil
 	case expressionTagNameAndValueLength:
 		expressionTagName := expressionSplit[0]
 		expressionTagValue := expressionSplit[1]
@@ -184,7 +185,7 @@ func (s *MockStore) Query(expression string, _ ...storage.QueryOption) (storage.
 
 		keys, dbEntries := s.getMatchingKeysAndDBEntries(expressionTagName, expressionTagValue)
 
-		return &iterator{keys: keys, dbEntries: dbEntries, errNext: s.ErrNext, errValue: s.ErrValue}, nil
+		return &iterator{keys: keys, dbEntries: dbEntries, errNext: s.ErrNext, errValue: s.ErrValue, errKey: s.ErrKey}, nil
 	default:
 		return nil, errInvalidQueryExpressionFormat
 	}
@@ -260,6 +261,7 @@ type iterator struct {
 	dbEntries      []DBEntry
 	errNext        error
 	errValue       error
+	errKey         error
 }
 
 func (m *iterator) Next() (bool, error) {
@@ -280,6 +282,10 @@ func (m *iterator) Next() (bool, error) {
 }
 
 func (m *iterator) Key() (string, error) {
+	if m.errKey != nil {
+		return "", m.errKey
+	}
+
 	if len(m.dbEntries) == 0 {
 		return "", errIteratorExhausted
 	}

--- a/pkg/wallet/options.go
+++ b/pkg/wallet/options.go
@@ -212,3 +212,35 @@ func FromCredential(cred *verifiable.Credential) CredentialToDerive {
 		opts.credential = cred
 	}
 }
+
+// AddContentOptions is option for adding contents to wallet.
+type AddContentOptions func(opts *addContentOpts)
+
+// addContentOpts contains options for adding contents to wallet.
+type addContentOpts struct {
+	// ID of the collection to which the content belongs.
+	collectionID string
+}
+
+// AddByCollection option for grouping wallet contents by collection ID.
+func AddByCollection(collectionID string) AddContentOptions {
+	return func(opts *addContentOpts) {
+		opts.collectionID = collectionID
+	}
+}
+
+// GetAllContentsOptions is option for getting all contents from wallet.
+type GetAllContentsOptions func(opts *getAllContentsOpts)
+
+// getAllContentsOpts contains options for getting all contents from wallet.
+type getAllContentsOpts struct {
+	// ID of the collection to filter get all results by collection.
+	collectionID string
+}
+
+// FilterByCollection option for getting all contents by collection from wallet.
+func FilterByCollection(collectionID string) GetAllContentsOptions {
+	return func(opts *getAllContentsOpts) {
+		opts.collectionID = collectionID
+	}
+}

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -245,8 +245,8 @@ func (c *Wallet) Import(auth string, contents json.RawMessage) error {
 //	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Key
 //
 // TODO: (#2433) support for correlation between wallet contents (ex: credentials to a profile/collection).
-func (c *Wallet) Add(authToken string, contentType ContentType, content json.RawMessage) error {
-	return c.contents.Save(authToken, contentType, content)
+func (c *Wallet) Add(authToken string, contentType ContentType, content json.RawMessage, options ...AddContentOptions) error { //nolint: lll
+	return c.contents.Save(authToken, contentType, content, options...)
 }
 
 // Remove removes wallet content by content ID.
@@ -285,7 +285,17 @@ func (c *Wallet) Get(contentType ContentType, contentID string) (json.RawMessage
 //	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#meta-data
 //	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
 //
-func (c *Wallet) GetAll(contentType ContentType) (map[string]json.RawMessage, error) {
+func (c *Wallet) GetAll(contentType ContentType, options ...GetAllContentsOptions) (map[string]json.RawMessage, error) {
+	opts := &getAllContentsOpts{}
+
+	for _, option := range options {
+		option(opts)
+	}
+
+	if opts.collectionID != "" {
+		return c.contents.GetAllByCollection(contentType, opts.collectionID)
+	}
+
 	return c.contents.GetAll(contentType)
 }
 


### PR DESCRIPTION
- added collection data model data mapping to VC wallet
- all wallet contents can be mapped to an existing collection in wallet
content store
- fixed issue in getAll which exposes db key prefix in list of wallet
contents
- Closes #2741

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
