### PR TITLE
feat: add KeyAgreement to DIDDoc and variable key type

### DIFF
--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -82,16 +82,20 @@ type provider interface {
 	ServiceEndpoint() string
 	StorageProvider() storage.Provider
 	ProtocolStateStorageProvider() storage.Provider
+	KeyType() kms.KeyType
+	KeyAgreementType() kms.KeyType
 }
 
 // Client enable access to didexchange api.
 type Client struct {
 	service.Event
-	didexchangeSvc  protocolService
-	routeSvc        mediator.ProtocolService
-	kms             kms.KeyManager
-	serviceEndpoint string
-	connectionStore *connection.Recorder
+	didexchangeSvc   protocolService
+	routeSvc         mediator.ProtocolService
+	kms              kms.KeyManager
+	serviceEndpoint  string
+	connectionStore  *connection.Recorder
+	keyType          kms.KeyType
+	keyAgreementType kms.KeyType
 }
 
 // protocolService defines DID Exchange service.
@@ -141,13 +145,25 @@ func New(ctx provider) (*Client, error) {
 		return nil, err
 	}
 
+	keyType := ctx.KeyType()
+	if keyType == "" {
+		keyType = kms.ED25519Type
+	}
+
+	keyAgreementType := ctx.KeyAgreementType()
+	if keyAgreementType == "" {
+		keyAgreementType = kms.X25519ECDHKWType
+	}
+
 	return &Client{
-		Event:           didexchangeSvc,
-		didexchangeSvc:  didexchangeSvc,
-		routeSvc:        routeSvc,
-		kms:             ctx.KMS(),
-		serviceEndpoint: ctx.ServiceEndpoint(),
-		connectionStore: connectionStore,
+		Event:            didexchangeSvc,
+		didexchangeSvc:   didexchangeSvc,
+		routeSvc:         routeSvc,
+		kms:              ctx.KMS(),
+		serviceEndpoint:  ctx.ServiceEndpoint(),
+		connectionStore:  connectionStore,
+		keyType:          keyType,
+		keyAgreementType: keyAgreementType,
 	}, nil
 }
 

--- a/pkg/controller/command/didexchange/command.go
+++ b/pkg/controller/command/didexchange/command.go
@@ -91,6 +91,8 @@ type provider interface {
 	ServiceEndpoint() string
 	StorageProvider() storage.Provider
 	ProtocolStateStorageProvider() storage.Provider
+	KeyType() kms.KeyType
+	KeyAgreementType() kms.KeyType
 }
 
 // New returns new DID Exchange controller command instance.

--- a/pkg/controller/command/vdr/command_test.go
+++ b/pkg/controller/command/vdr/command_test.go
@@ -25,7 +25,7 @@ const sampleDIDName = "sampleDIDName"
 
 //nolint:lll
 const doc = `{
-  "@context": ["https://w3id.org/did/v1","https://w3id.org/did/v2"],
+  "@context": ["https://www.w3.org/ns/did/v1","https://w3id.org/did/v2"],
   "id": "did:peer:21tDAKCERh95uGgKbJNHYp",
   "verificationMethod": [
     {

--- a/pkg/controller/rest/didexchange/operation.go
+++ b/pkg/controller/rest/didexchange/operation.go
@@ -44,6 +44,8 @@ type provider interface {
 	ServiceEndpoint() string
 	StorageProvider() storage.Provider
 	ProtocolStateStorageProvider() storage.Provider
+	KeyType() kms.KeyType
+	KeyAgreementType() kms.KeyType
 }
 
 // New returns new DID Exchange rest client protocol instance.

--- a/pkg/crypto/eckey.go
+++ b/pkg/crypto/eckey.go
@@ -1,0 +1,41 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"fmt"
+	"math/big"
+)
+
+// ToECKey converts key to an ecdsa public key. It returns an error if the curve is invalid.
+func ToECKey(key *PublicKey) (*ecdsa.PublicKey, error) {
+	crv, err := toCurve(key.Curve)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ecdsa.PublicKey{
+		Curve: crv,
+		X:     new(big.Int).SetBytes(key.X),
+		Y:     new(big.Int).SetBytes(key.Y),
+	}, nil
+}
+
+func toCurve(crv string) (elliptic.Curve, error) {
+	switch crv {
+	case "P-256", "NIST_P256":
+		return elliptic.P256(), nil
+	case "P-384", "NIST_P384":
+		return elliptic.P384(), nil
+	case "P-521", "NIST_P521":
+		return elliptic.P521(), nil
+	}
+
+	return nil, fmt.Errorf("invalid curve '%s'", crv)
+}

--- a/pkg/crypto/eckey_test.go
+++ b/pkg/crypto/eckey_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToECKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		curve elliptic.Curve
+	}{
+		{
+			name:  "to P-256 key",
+			curve: elliptic.P256(),
+		},
+		{
+			name:  "to P-384 key",
+			curve: elliptic.P384(),
+		},
+		{
+			name:  "to P-521 key",
+			curve: elliptic.P521(),
+		},
+		{
+			name:  "invalid curve",
+			curve: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.name == "invalid curve" {
+				_, err := ToECKey(&PublicKey{
+					Curve: "undefined",
+					Type:  "EC",
+				})
+				require.EqualError(t, err, "invalid curve 'undefined'")
+
+				return
+			}
+
+			privKey, err := ecdsa.GenerateKey(tc.curve, rand.Reader)
+			require.NoError(t, err)
+
+			pubKey := &PublicKey{
+				X:     privKey.X.Bytes(),
+				Y:     privKey.Y.Bytes(),
+				Curve: tc.curve.Params().Name,
+				Type:  "EC",
+			}
+
+			pubECKey, err := ToECKey(pubKey)
+			require.NoError(t, err)
+			require.Equal(t, tc.curve.Params().Name, pubECKey.Curve.Params().Name)
+			require.EqualValues(t, privKey.X.Bytes(), pubECKey.X.Bytes())
+			require.EqualValues(t, privKey.Y.Bytes(), pubECKey.Y.Bytes())
+		})
+	}
+}

--- a/pkg/crypto/tinkcrypto/primitive/composite/keyio/composite_key_export.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/keyio/composite_key_export.go
@@ -146,6 +146,9 @@ func buildCompositeKey(kid, keyType, curve string, x, y []byte) (*cryptoapi.Publ
 		if curve != commonpb.EllipticCurveType_CURVE25519.String() {
 			return nil, fmt.Errorf("invalid OKP curve: %s", curve)
 		}
+
+		// use JWK curve name when exporting the key.
+		curve = "X25519"
 	default:
 		return nil, fmt.Errorf("invalid keyType: %s", keyType)
 	}
@@ -318,7 +321,7 @@ func getCurveProto(c string) (commonpb.EllipticCurveType, error) {
 		return commonpb.EllipticCurveType_NIST_P384, nil
 	case "secp521r1", "NIST_P521", "P-521", "EllipticCurveType_NIST_P521":
 		return commonpb.EllipticCurveType_NIST_P521, nil
-	case commonpb.EllipticCurveType_CURVE25519.String():
+	case commonpb.EllipticCurveType_CURVE25519.String(), "X25519":
 		return commonpb.EllipticCurveType_CURVE25519, nil
 	default:
 		return commonpb.EllipticCurveType_UNKNOWN_CURVE, errors.New("unsupported curve")

--- a/pkg/didcomm/common/service/destination_test.go
+++ b/pkg/didcomm/common/service/destination_test.go
@@ -237,7 +237,7 @@ func createDIDDocWithKey(pub string) *did.Doc {
 	}
 	createdTime := time.Now()
 	didDoc := &did.Doc{
-		Context:            []string{did.Context},
+		Context:            []string{did.ContextV1},
 		ID:                 id,
 		VerificationMethod: []did.VerificationMethod{pubKey},
 		Service:            services,

--- a/pkg/didcomm/protocol/didexchange/keys.go
+++ b/pkg/didcomm/protocol/didexchange/keys.go
@@ -1,0 +1,155 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didexchange
+
+import (
+	"encoding/json"
+	"fmt"
+
+	gojose "github.com/square/go-jose/v3"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+)
+
+func createNewKeyAndVM(didDoc *did.Doc, keyType, keyAgreementType kms.KeyType, keyManager kms.KeyManager) error {
+	vm, err := createSigningVM(keyManager, getVerMethodType(keyType), keyType)
+	if err != nil {
+		return err
+	}
+
+	kaVM, err := createEncryptionVM(keyManager, getVerMethodType(keyAgreementType), keyAgreementType)
+	if err != nil {
+		return err
+	}
+
+	didDoc.VerificationMethod = append(didDoc.VerificationMethod, *vm)
+
+	didDoc.Authentication = append(didDoc.Authentication, *did.NewReferencedVerification(vm, did.Authentication))
+	didDoc.KeyAgreement = append(didDoc.KeyAgreement, *did.NewReferencedVerification(kaVM, did.KeyAgreement))
+
+	return nil
+}
+
+func createSigningVM(km kms.KeyManager, vmType string, keyType kms.KeyType) (*did.VerificationMethod, error) {
+	kid, pubKeyBytes, err := km.CreateAndExportPubKeyBytes(keyType)
+	if err != nil {
+		return nil, fmt.Errorf("createSigningVM: %w", err)
+	}
+
+	vmID := "#" + kid
+
+	switch vmType {
+	case ed25519VerificationKey2018, bls12381G2Key2020:
+		return did.NewVerificationMethodFromBytes(vmID, vmType, "", pubKeyBytes), nil
+	case jsonWebKey2020:
+		jwk, err := jose.PubKeyBytesToJWK(pubKeyBytes, keyType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert public key to JWK for VM: %w", err)
+		}
+
+		return did.NewVerificationMethodFromJWK(vmID, vmType, "", jwk)
+	default:
+		return nil, fmt.Errorf("unsupported verification method: '%s'", vmType)
+	}
+}
+
+func createEncryptionVM(km kms.KeyManager, vmType string, keyType kms.KeyType) (*did.VerificationMethod, error) {
+	kaID, kaPubKeyBytes, err := km.CreateAndExportPubKeyBytes(keyType)
+	if err != nil {
+		return nil, fmt.Errorf("createEncryptionVM: %w", err)
+	}
+
+	vmID := "#" + kaID
+
+	switch vmType {
+	case x25519KeyAgreementKey2019:
+		key := &crypto.PublicKey{}
+
+		err = json.Unmarshal(kaPubKeyBytes, key)
+		if err != nil {
+			return nil, fmt.Errorf("createEncryptionVM: unable to unmarshal X25519 key: %w", err)
+		}
+
+		return did.NewVerificationMethodFromBytes(vmID, vmType, "", key.X), nil
+	case jsonWebKey2020:
+		jwk, err := buildJWKFromBytes(kaPubKeyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("createEncryptionVM: %w", err)
+		}
+
+		vm, err := did.NewVerificationMethodFromJWK(vmID, vmType, "", jwk)
+		if err != nil {
+			return nil, fmt.Errorf("createEncryptionVM: %w", err)
+		}
+
+		return vm, nil
+	default:
+		return nil, fmt.Errorf("unsupported verification method for KeyAgreement: '%s'", vmType)
+	}
+}
+
+func buildJWKFromBytes(pubKeyBytes []byte) (*jose.JWK, error) {
+	pubKey := &crypto.PublicKey{}
+
+	err := json.Unmarshal(pubKeyBytes, pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JWK for KeyAgreement: %w", err)
+	}
+
+	var jwk *jose.JWK
+
+	switch pubKey.Type {
+	case "EC":
+		ecKey, err := crypto.ToECKey(pubKey)
+		if err != nil {
+			return nil, err
+		}
+
+		jwk = &jose.JWK{
+			JSONWebKey: gojose.JSONWebKey{
+				Key:   ecKey,
+				KeyID: pubKey.KID,
+			},
+			Kty: pubKey.Type,
+			Crv: pubKey.Curve,
+		}
+	case "OKP":
+		jwk = &jose.JWK{
+			JSONWebKey: gojose.JSONWebKey{
+				Key:   pubKey.X,
+				KeyID: pubKey.KID,
+			},
+			Kty: pubKey.Type,
+			Crv: pubKey.Curve,
+		}
+	}
+
+	return jwk, nil
+}
+
+// nolint:gochecknoglobals
+var vmType = map[kms.KeyType]string{
+	kms.ED25519Type:            ed25519VerificationKey2018,
+	kms.BLS12381G2Type:         bls12381G2Key2020,
+	kms.ECDSAP256TypeDER:       jsonWebKey2020,
+	kms.ECDSAP256TypeIEEEP1363: jsonWebKey2020,
+	kms.ECDSAP384TypeDER:       jsonWebKey2020,
+	kms.ECDSAP384TypeIEEEP1363: jsonWebKey2020,
+	kms.ECDSAP521TypeDER:       jsonWebKey2020,
+	kms.ECDSAP521TypeIEEEP1363: jsonWebKey2020,
+	kms.X25519ECDHKWType:       x25519KeyAgreementKey2019,
+	kms.NISTP256ECDHKWType:     jsonWebKey2020,
+	kms.NISTP384ECDHKWType:     jsonWebKey2020,
+	kms.NISTP521ECDHKWType:     jsonWebKey2020,
+}
+
+func getVerMethodType(kt kms.KeyType) string {
+	return vmType[kt]
+}

--- a/pkg/didcomm/protocol/didexchange/keys_test.go
+++ b/pkg/didcomm/protocol/didexchange/keys_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didexchange
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+)
+
+func TestCreateNewKeyAndVM(t *testing.T) {
+	k := newKMS(t, mockstorage.NewMockStoreProvider())
+
+	t.Run("createNewKeyAndVM success", func(t *testing.T) {
+		didDoc := &did.Doc{}
+
+		err := createNewKeyAndVM(didDoc, kms.ED25519, kms.X25519ECDHKWType, k)
+		require.NoError(t, err)
+		require.Equal(t, ed25519VerificationKey2018, didDoc.VerificationMethod[0].Type)
+		require.Equal(t, x25519KeyAgreementKey2019, didDoc.KeyAgreement[0].VerificationMethod.Type)
+	})
+
+	t.Run("createNewKeyAndVM invalid keyType export signing key", func(t *testing.T) {
+		didDoc := &did.Doc{}
+
+		err := createNewKeyAndVM(didDoc, kms.HMACSHA256Tag256Type, kms.X25519ECDHKWType, k)
+		require.EqualError(t, err, "createSigningVM: createAndExportPubKeyBytes: failed to export new public key bytes: "+
+			"exportPubKeyBytes: failed to export marshalled key: exportPubKeyBytes: failed to get public keyset "+
+			"handle: keyset.Handle: keyset.Handle: keyset contains a non-private key")
+		require.Empty(t, didDoc.VerificationMethod)
+		require.Empty(t, didDoc.KeyAgreement)
+	})
+}
+
+func TestCreateSigningVM(t *testing.T) {
+	k := newKMS(t, mockstorage.NewMockStoreProvider())
+
+	t.Run("createSigningVM success", func(t *testing.T) {
+		svm, err := createSigningVM(k, ed25519VerificationKey2018, kms.ED25519)
+		require.NoError(t, err)
+		require.NotEmpty(t, svm)
+	})
+
+	t.Run("createSigningVM with empty vmType", func(t *testing.T) {
+		svm, err := createSigningVM(k, "", kms.ED25519)
+		require.EqualError(t, err, "unsupported verification method: ''")
+		require.Empty(t, svm)
+	})
+}
+
+func TestCreateEncryptionVM(t *testing.T) {
+	k := newKMS(t, mockstorage.NewMockStoreProvider())
+
+	t.Run("createEncryptionVM success", func(t *testing.T) {
+		evm, err := createEncryptionVM(k, x25519KeyAgreementKey2019, kms.X25519ECDHKW)
+		require.NoError(t, err)
+		require.NotEmpty(t, evm)
+	})
+
+	t.Run("createEncryptionVM success with X25519 as jsonwebk2020", func(t *testing.T) {
+		evm, err := createEncryptionVM(k, jsonWebKey2020, kms.X25519ECDHKW)
+		require.NoError(t, err)
+		require.NotEmpty(t, evm)
+	})
+
+	t.Run("createEncryptionVM with empty vmType", func(t *testing.T) {
+		evm, err := createEncryptionVM(k, "", kms.X25519ECDHKWType)
+		require.EqualError(t, err, "unsupported verification method for KeyAgreement: ''")
+		require.Empty(t, evm)
+	})
+
+	t.Run("createEncryptionVM with unsupported keyType", func(t *testing.T) {
+		evm, err := createEncryptionVM(k, jsonWebKey2020, kms.HMACSHA256Tag256Type)
+		require.EqualError(t, err, "createEncryptionVM: createAndExportPubKeyBytes: failed to export new public key "+
+			"bytes: exportPubKeyBytes: failed to export marshalled key: exportPubKeyBytes: failed to get public "+
+			"keyset handle: keyset.Handle: keyset.Handle: keyset contains a non-private key")
+		require.Empty(t, evm)
+	})
+}

--- a/pkg/didcomm/protocol/didexchange/states.go
+++ b/pkg/didcomm/protocol/didexchange/states.go
@@ -7,10 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package didexchange
 
 import (
-	"crypto/ecdsa"
 	"crypto/ed25519"
-	"crypto/elliptic"
-	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -58,6 +55,7 @@ const (
 	bls12381G2Key2020          = "Bls12381G2Key2020"
 	jsonWebKey2020             = "JsonWebKey2020"
 	didMethod                  = "peer"
+	x25519KeyAgreementKey2019  = "X25519KeyAgreementKey2019"
 )
 
 var errVerKeyNotFound = errors.New("verkey not found")
@@ -633,7 +631,7 @@ func (ctx *context) getDIDDocAndConnection(pubDID string, routerConnections []st
 
 	newDID := &did.Doc{Service: services}
 
-	err := createNewKeyAndVerificationMethod(newDID, kms.ED25519, ctx.kms)
+	err := createNewKeyAndVM(newDID, ctx.keyType, ctx.keyAgreementType, ctx.kms)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create and export public key: %w", err)
 	}
@@ -670,99 +668,6 @@ func (ctx *context) getDIDDocAndConnection(pubDID string, routerConnections []st
 	}
 
 	return docResolution.DIDDocument, connection, nil
-}
-
-func createNewKeyAndVerificationMethod(didDoc *did.Doc, keyType kms.KeyType, keyManager kms.KeyManager) error {
-	vmType := getVerMethodType(keyType)
-
-	kid, pubKeyBytes, err := keyManager.CreateAndExportPubKeyBytes(keyType)
-	if err != nil {
-		return err
-	}
-
-	pubKeyBytes, err = convertPubKeyBytes(pubKeyBytes, keyType)
-	if err != nil {
-		return err
-	}
-
-	vm := did.VerificationMethod{
-		ID:    "#" + kid,
-		Type:  vmType,
-		Value: pubKeyBytes,
-	}
-
-	didDoc.VerificationMethod = append(didDoc.VerificationMethod, vm)
-
-	// TODO replace below authentication with a KeyAgreement method when/if DID attachment doesn't require to be signed
-	//  as per https://github.com/hyperledger/aries-rfcs/pull/626. If the PR is declined, then only remove this comment.
-	//  KeyAgreement is needed for envelope encryption regardless. It must be added in a future change.
-	didDoc.Authentication = append(didDoc.Authentication, *did.NewReferencedVerification(&vm, did.Authentication))
-
-	return nil
-}
-
-/* func extractKeyTypeFromOpts(createDIDOpts *vdrapi.DIDMethodOpts) (kms.KeyType, error) {
-	var keyType kms.KeyType
-
-	k := createDIDOpts.Values[keyvdr.KeyType]
-	if k != nil {
-		var ok bool
-		keyType, ok = k.(kms.KeyType)
-
-		if !ok {
-			return "", errors.New("keyType is not kms.KeyType")
-		}
-
-		return keyType, nil
-	}
-
-	return "", errors.New("keyType option is needed for empty didDoc.VerificationMethod")
-} */
-
-// convertPubKeyBytes converts marshalled bytes into 'did:key' ready to use public key bytes. This is mainly useful for
-// ECDSA keys. The elliptic.Marshal() function returns 65 bytes (for P-256 curves) where the first byte is the
-// compression point, it must be truncated to build a proper public key for did:key construction. It must be set back
-// when building a public key from did:key (using default compression point value is 4 for non compressed marshalling,
-// see: https://github.com/golang/go/blob/master/src/crypto/elliptic/elliptic.go#L319).
-func convertPubKeyBytes(bytes []byte, keyType kms.KeyType) ([]byte, error) {
-	switch keyType {
-	case kms.ED25519Type, kms.BLS12381G2Type: // no conversion needed for non ECDSA keys.
-		return bytes, nil
-	case kms.ECDSAP256TypeIEEEP1363, kms.ECDSAP384TypeIEEEP1363, kms.ECDSAP521TypeIEEEP1363:
-		// truncate first byte to remove compression point.
-		return bytes[1:], nil
-	case kms.ECDSAP256TypeDER, kms.ECDSAP384TypeDER, kms.ECDSAP521TypeDER:
-		pubKey, err := x509.ParsePKIXPublicKey(bytes)
-		if err != nil {
-			return nil, err
-		}
-
-		ecKey, ok := pubKey.(*ecdsa.PublicKey)
-		if !ok {
-			return nil, errors.New("invalid EC key")
-		}
-
-		// truncate first byte to remove compression point.
-		return elliptic.Marshal(ecKey.Curve, ecKey.X, ecKey.Y)[1:], nil
-	default:
-		return nil, errors.New("invalid key type")
-	}
-}
-
-// nolint:gochecknoglobals
-var vmType = map[kms.KeyType]string{
-	kms.ED25519Type:            ed25519VerificationKey2018,
-	kms.BLS12381G2Type:         bls12381G2Key2020,
-	kms.ECDSAP256TypeDER:       jsonWebKey2020,
-	kms.ECDSAP256TypeIEEEP1363: jsonWebKey2020,
-	kms.ECDSAP384TypeDER:       jsonWebKey2020,
-	kms.ECDSAP384TypeIEEEP1363: jsonWebKey2020,
-	kms.ECDSAP521TypeDER:       jsonWebKey2020,
-	kms.ECDSAP521TypeIEEEP1363: jsonWebKey2020,
-}
-
-func getVerMethodType(kt kms.KeyType) string {
-	return vmType[kt]
 }
 
 func (ctx *context) resolveDidDocFromConnection(conn *Connection) (*did.Doc, error) {
@@ -823,7 +728,7 @@ func (ctx *context) prepareConnectionSignature(connection *Connection,
 		return nil, fmt.Errorf("failed to extract pubKeyBytes from did:key [%s]: %w", didKey, err)
 	}
 
-	signingKID, err := localkms.CreateKID(pubKeyBytes, kms.ED25519Type)
+	signingKID, err := localkms.CreateKID(pubKeyBytes, ctx.keyType)
 	if err != nil {
 		return nil, fmt.Errorf("prepareConnectionSignature: failed to generate KID from public key: %w", err)
 	}

--- a/pkg/didcomm/protocol/didexchange/states_test.go
+++ b/pkg/didcomm/protocol/didexchange/states_test.go
@@ -301,173 +301,436 @@ func TestRequestedState_Execute(t *testing.T) {
 		}
 	})
 	t.Run("handle inbound invitations", func(t *testing.T) {
-		ctx := getContext(t, &prov)
-		msg, err := service.ParseDIDCommMsgMap(invitationPayloadBytes)
-		require.NoError(t, err)
-		thid, err := msg.ThreadID()
-		require.NoError(t, err)
-		connRec, _, _, e := (&requested{}).ExecuteInbound(&stateMachineMsg{
-			DIDCommMsg: msg,
-			connRecord: &connection.Record{},
-		}, thid, ctx)
-		require.NoError(t, e)
-		require.NotNil(t, connRec.MyDID)
+		tests := []struct {
+			name string
+			ctx  *context
+		}{
+			{
+				name: "using context with ED25519 main VM and X25519 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType),
+			},
+			{
+				name: "using context with P-256 main VM and P-256 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP256TypeIEEEP1363, kms.NISTP256ECDHKWType),
+			},
+			{
+				name: "using context with P-384 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP384TypeIEEEP1363, kms.NISTP384ECDHKWType),
+			},
+			{
+				name: "using context with P-521 main VM and P-521 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP521TypeIEEEP1363, kms.NISTP521ECDHKWType),
+			},
+			{
+				name: "using context with ED25519 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.NISTP384ECDHKWType),
+			},
+		}
+
+		for _, tt := range tests {
+			tc := tt
+			t.Run(tc.name, func(t *testing.T) {
+				msg, err := service.ParseDIDCommMsgMap(invitationPayloadBytes)
+				require.NoError(t, err)
+				thid, err := msg.ThreadID()
+				require.NoError(t, err)
+				connRec, _, _, e := (&requested{}).ExecuteInbound(&stateMachineMsg{
+					DIDCommMsg: msg,
+					connRecord: &connection.Record{},
+				}, thid, tc.ctx)
+				require.NoError(t, e)
+				require.NotNil(t, connRec.MyDID)
+			})
+		}
 	})
 	t.Run("handle inbound oob invitations", func(t *testing.T) {
-		ctx := getContext(t, &prov)
-		connRec, followup, action, err := (&requested{}).ExecuteInbound(&stateMachineMsg{
-			DIDCommMsg: service.NewDIDCommMsgMap(&OOBInvitation{
-				ID:         uuid.New().String(),
-				Type:       oobMsgType,
-				ThreadID:   uuid.New().String(),
-				TheirLabel: "test",
-				Target: &diddoc.Service{
-					ID:              uuid.New().String(),
-					Type:            "did-communication",
-					Priority:        0,
-					RecipientKeys:   []string{"key"},
-					ServiceEndpoint: "http://test.com",
-				},
-			}),
-			connRecord: &connection.Record{},
-		}, "", ctx)
-		require.NoError(t, err)
-		require.NotEmpty(t, connRec.MyDID)
-		require.Equal(t, &noOp{}, followup)
-		require.NotNil(t, action)
+		tests := []struct {
+			name string
+			ctx  *context
+		}{
+			{
+				name: "using context with ED25519 main VM and X25519 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType),
+			},
+			{
+				name: "using context with P-256 main VM and P-256 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP256TypeIEEEP1363, kms.NISTP256ECDHKWType),
+			},
+			{
+				name: "using context with P-384 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP384TypeIEEEP1363, kms.NISTP384ECDHKWType),
+			},
+			{
+				name: "using context with P-521 main VM and P-521 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP521TypeIEEEP1363, kms.NISTP521ECDHKWType),
+			},
+			{
+				name: "using context with ED25519 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.NISTP384ECDHKWType),
+			},
+		}
+
+		for _, tt := range tests {
+			tc := tt
+			t.Run(tc.name, func(t *testing.T) {
+				connRec, followup, action, err := (&requested{}).ExecuteInbound(&stateMachineMsg{
+					DIDCommMsg: service.NewDIDCommMsgMap(&OOBInvitation{
+						ID:         uuid.New().String(),
+						Type:       oobMsgType,
+						ThreadID:   uuid.New().String(),
+						TheirLabel: "test",
+						Target: &diddoc.Service{
+							ID:              uuid.New().String(),
+							Type:            "did-communication",
+							Priority:        0,
+							RecipientKeys:   []string{"key"},
+							ServiceEndpoint: "http://test.com",
+						},
+					}),
+					connRecord: &connection.Record{},
+				}, "", tc.ctx)
+				require.NoError(t, err)
+				require.NotEmpty(t, connRec.MyDID)
+				require.Equal(t, &noOp{}, followup)
+				require.NotNil(t, action)
+			})
+		}
+	})
+	t.Run("handle inbound oob invitations", func(t *testing.T) {
+		tests := []struct {
+			name string
+			ctx  *context
+		}{
+			{
+				name: "using context with ED25519 main VM and X25519 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType),
+			},
+			{
+				name: "using context with P-256 main VM and P-256 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP256TypeIEEEP1363, kms.NISTP256ECDHKWType),
+			},
+			{
+				name: "using context with P-384 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP384TypeIEEEP1363, kms.NISTP384ECDHKWType),
+			},
+			{
+				name: "using context with P-521 main VM and P-521 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP521TypeIEEEP1363, kms.NISTP521ECDHKWType),
+			},
+			{
+				name: "using context with ED25519 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.NISTP384ECDHKWType),
+			},
+		}
+
+		for _, tt := range tests {
+			tc := tt
+			t.Run(tc.name, func(t *testing.T) {
+				connRec, followup, action, err := (&requested{}).ExecuteInbound(&stateMachineMsg{
+					DIDCommMsg: service.NewDIDCommMsgMap(&OOBInvitation{
+						ID:         uuid.New().String(),
+						Type:       oobMsgType,
+						ThreadID:   uuid.New().String(),
+						TheirLabel: "test",
+						Target: &diddoc.Service{
+							ID:              uuid.New().String(),
+							Type:            "did-communication",
+							Priority:        0,
+							RecipientKeys:   []string{"key"},
+							ServiceEndpoint: "http://test.com",
+						},
+					}),
+					connRecord: &connection.Record{},
+				}, "", tc.ctx)
+				require.NoError(t, err)
+				require.NotEmpty(t, connRec.MyDID)
+				require.Equal(t, &noOp{}, followup)
+				require.NotNil(t, action)
+			})
+		}
 	})
 	t.Run("handle inbound oob invitations with label", func(t *testing.T) {
 		expected := "my test label"
 		dispatched := false
-		ctx := getContext(t, &prov)
-		ctx.outboundDispatcher = &mockdispatcher.MockOutbound{
-			ValidateSend: func(msg interface{}, _ string, _ *service.Destination) error {
-				dispatched = true
-				result, ok := msg.(*Request)
-				require.True(t, ok)
-				require.Equal(t, expected, result.Label)
-				return nil
+		tests := []struct {
+			name string
+			ctx  *context
+		}{
+			{
+				name: "using context with ED25519 main VM and X25519 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType),
+			},
+			{
+				name: "using context with P-256 main VM and P-256 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP256TypeIEEEP1363, kms.NISTP256ECDHKWType),
+			},
+			{
+				name: "using context with P-384 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP384TypeIEEEP1363, kms.NISTP384ECDHKWType),
+			},
+			{
+				name: "using context with P-521 main VM and P-521 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP521TypeIEEEP1363, kms.NISTP521ECDHKWType),
+			},
+			{
+				name: "using context with ED25519 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.NISTP384ECDHKWType),
 			},
 		}
-		inv := newOOBInvite(newServiceBlock())
-		inv.MyLabel = expected
-		_, _, action, err := (&requested{}).ExecuteInbound(&stateMachineMsg{
-			DIDCommMsg: service.NewDIDCommMsgMap(inv),
-			connRecord: &connection.Record{},
-		}, "", ctx)
-		require.NoError(t, err)
-		require.NotNil(t, action)
-		err = action()
-		require.NoError(t, err)
-		require.True(t, dispatched)
+
+		for _, tt := range tests {
+			tc := tt
+			t.Run(tc.name, func(t *testing.T) {
+				tc.ctx.outboundDispatcher = &mockdispatcher.MockOutbound{
+					ValidateSend: func(msg interface{}, _ string, _ *service.Destination) error {
+						dispatched = true
+						result, ok := msg.(*Request)
+						require.True(t, ok)
+						require.Equal(t, expected, result.Label)
+						return nil
+					},
+				}
+				inv := newOOBInvite(newServiceBlock())
+				inv.MyLabel = expected
+				_, _, action, err := (&requested{}).ExecuteInbound(&stateMachineMsg{
+					DIDCommMsg: service.NewDIDCommMsgMap(inv),
+					connRecord: &connection.Record{},
+				}, "", tc.ctx)
+				require.NoError(t, err)
+				require.NotNil(t, action)
+				err = action()
+				require.NoError(t, err)
+				require.True(t, dispatched)
+			})
+		}
 	})
 	t.Run("handle inbound oob invitations - register recipient keys in router", func(t *testing.T) {
 		expected := "my test key"
 		registered := false
-		ctx := getContext(t, &prov)
-		doc := createDIDDoc(t, prov.CustomKMS)
-		doc.Service = []diddoc.Service{{
-			Type:            "did-communication",
-			ServiceEndpoint: "http://test.com",
-			RecipientKeys:   []string{expected},
-		}}
-		ctx.vdRegistry = &mockvdr.MockVDRegistry{
-			CreateValue: doc,
-		}
-		ctx.routeSvc = &mockroute.MockMediatorSvc{
-			Connections:    []string{"xyz"},
-			RoutingKeys:    []string{expected},
-			RouterEndpoint: "http://blah.com",
-			AddKeyFunc: func(result string) error {
-				require.Equal(t, expected, result)
-				registered = true
-				return nil
+		tests := []struct {
+			name string
+			ctx  *context
+		}{
+			{
+				name: "using context with ED25519 main VM and X25519 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType),
+			},
+			{
+				name: "using context with P-256 main VM and P-256 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP256TypeIEEEP1363, kms.NISTP256ECDHKWType),
+			},
+			{
+				name: "using context with P-384 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP384TypeIEEEP1363, kms.NISTP384ECDHKWType),
+			},
+			{
+				name: "using context with P-521 main VM and P-521 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP521TypeIEEEP1363, kms.NISTP521ECDHKWType),
+			},
+			{
+				name: "using context with ED25519 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.NISTP384ECDHKWType),
 			},
 		}
-		_, _, _, err := (&requested{}).ExecuteInbound(&stateMachineMsg{
-			options:    &options{routerConnections: []string{"xyz"}},
-			DIDCommMsg: service.NewDIDCommMsgMap(newOOBInvite(newServiceBlock())),
-			connRecord: &connection.Record{},
-		}, "", ctx)
-		require.NoError(t, err)
-		require.True(t, registered)
+
+		for _, tt := range tests {
+			tc := tt
+			t.Run(tc.name, func(t *testing.T) {
+				doc := createDIDDoc(t, tc.ctx)
+				doc.Service = []diddoc.Service{{
+					Type:            "did-communication",
+					ServiceEndpoint: "http://test.com",
+					RecipientKeys:   []string{expected},
+				}}
+				tc.ctx.vdRegistry = &mockvdr.MockVDRegistry{
+					CreateValue: doc,
+				}
+				tc.ctx.routeSvc = &mockroute.MockMediatorSvc{
+					Connections:    []string{"xyz"},
+					RoutingKeys:    []string{expected},
+					RouterEndpoint: "http://blah.com",
+					AddKeyFunc: func(result string) error {
+						require.Equal(t, expected, result)
+						registered = true
+						return nil
+					},
+				}
+				_, _, _, err := (&requested{}).ExecuteInbound(&stateMachineMsg{
+					options:    &options{routerConnections: []string{"xyz"}},
+					DIDCommMsg: service.NewDIDCommMsgMap(newOOBInvite(newServiceBlock())),
+					connRecord: &connection.Record{},
+				}, "", tc.ctx)
+				require.NoError(t, err)
+				require.True(t, registered)
+			})
+		}
 	})
 	t.Run("handle inbound oob invitations - use routing info to create my did", func(t *testing.T) {
 		expected := mediator.NewConfig("http://test.com", []string{"my-test-key"})
 		created := false
-		ctx := getContext(t, &prov)
-		ctx.routeSvc = &mockroute.MockMediatorSvc{
-			Connections:    []string{"xyz"},
-			RouterEndpoint: expected.Endpoint(),
-			RoutingKeys:    expected.Keys(),
-		}
-		ctx.vdRegistry = &mockvdr.MockVDRegistry{
-			CreateFunc: func(_ string, didDoc *diddoc.Doc,
-				options ...vdrapi.DIDMethodOption) (*diddoc.DocResolution, error) {
-				created = true
-
-				require.Equal(t, expected.Keys(), didDoc.Service[0].RoutingKeys)
-				require.Equal(t, expected.Endpoint(), didDoc.Service[0].ServiceEndpoint)
-				return &diddoc.DocResolution{DIDDocument: createDIDDoc(t, prov.CustomKMS)}, nil
+		tests := []struct {
+			name string
+			ctx  *context
+		}{
+			{
+				name: "using context with ED25519 main VM and X25519 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType),
+			},
+			{
+				name: "using context with P-256 main VM and P-256 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP256TypeIEEEP1363, kms.NISTP256ECDHKWType),
+			},
+			{
+				name: "using context with P-384 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP384TypeIEEEP1363, kms.NISTP384ECDHKWType),
+			},
+			{
+				name: "using context with P-521 main VM and P-521 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP521TypeIEEEP1363, kms.NISTP521ECDHKWType),
+			},
+			{
+				name: "using context with ED25519 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.NISTP384ECDHKWType),
 			},
 		}
-		_, _, _, err := (&requested{}).ExecuteInbound(&stateMachineMsg{
-			options:    &options{routerConnections: []string{"xyz"}},
-			DIDCommMsg: service.NewDIDCommMsgMap(newOOBInvite(newServiceBlock())),
-			connRecord: &connection.Record{},
-		}, "", ctx)
-		require.NoError(t, err)
-		require.True(t, created)
+
+		for _, tt := range tests {
+			tc := tt
+			t.Run(tc.name, func(t *testing.T) {
+				tc.ctx.routeSvc = &mockroute.MockMediatorSvc{
+					Connections:    []string{"xyz"},
+					RouterEndpoint: expected.Endpoint(),
+					RoutingKeys:    expected.Keys(),
+				}
+				tc.ctx.vdRegistry = &mockvdr.MockVDRegistry{
+					CreateFunc: func(_ string, didDoc *diddoc.Doc,
+						options ...vdrapi.DIDMethodOption) (*diddoc.DocResolution, error) {
+						created = true
+
+						require.Equal(t, expected.Keys(), didDoc.Service[0].RoutingKeys)
+						require.Equal(t, expected.Endpoint(), didDoc.Service[0].ServiceEndpoint)
+						return &diddoc.DocResolution{DIDDocument: createDIDDoc(t, tc.ctx)}, nil
+					},
+				}
+				_, _, _, err := (&requested{}).ExecuteInbound(&stateMachineMsg{
+					options:    &options{routerConnections: []string{"xyz"}},
+					DIDCommMsg: service.NewDIDCommMsgMap(newOOBInvite(newServiceBlock())),
+					connRecord: &connection.Record{},
+				}, "", tc.ctx)
+				require.NoError(t, err)
+				require.True(t, created)
+			})
+		}
 	})
 	t.Run("handling invitations fails if my diddoc does not have a valid didcomm service", func(t *testing.T) {
 		msg, err := service.ParseDIDCommMsgMap(invitationPayloadBytes)
 		require.NoError(t, err)
-		ctx := getContext(t, &prov)
-		myDoc := createDIDDoc(t, ctx.kms)
-		myDoc.Service = []diddoc.Service{{
-			ID:              uuid.New().String(),
-			Type:            "invalid",
-			Priority:        0,
-			RecipientKeys:   nil,
-			RoutingKeys:     nil,
-			ServiceEndpoint: "",
-		}}
-		ctx.vdRegistry = &mockvdr.MockVDRegistry{CreateValue: myDoc}
-		_, _, _, err = (&requested{}).ExecuteInbound(&stateMachineMsg{
-			DIDCommMsg: msg,
-			connRecord: &connection.Record{},
-		}, "", ctx)
-		require.Error(t, err)
+		tests := []struct {
+			name string
+			ctx  *context
+		}{
+			{
+				name: "using context with ED25519 main VM and X25519 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType),
+			},
+			{
+				name: "using context with P-256 main VM and P-256 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP256TypeIEEEP1363, kms.NISTP256ECDHKWType),
+			},
+			{
+				name: "using context with P-384 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP384TypeIEEEP1363, kms.NISTP384ECDHKWType),
+			},
+			{
+				name: "using context with P-521 main VM and P-521 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP521TypeIEEEP1363, kms.NISTP521ECDHKWType),
+			},
+			{
+				name: "using context with ED25519 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.NISTP384ECDHKWType),
+			},
+		}
+
+		for _, tt := range tests {
+			tc := tt
+			t.Run(tc.name, func(t *testing.T) {
+				myDoc := createDIDDoc(t, tc.ctx)
+				myDoc.Service = []diddoc.Service{{
+					ID:              uuid.New().String(),
+					Type:            "invalid",
+					Priority:        0,
+					RecipientKeys:   nil,
+					RoutingKeys:     nil,
+					ServiceEndpoint: "",
+				}}
+				tc.ctx.vdRegistry = &mockvdr.MockVDRegistry{CreateValue: myDoc}
+				_, _, _, err = (&requested{}).ExecuteInbound(&stateMachineMsg{
+					DIDCommMsg: msg,
+					connRecord: &connection.Record{},
+				}, "", tc.ctx)
+				require.Error(t, err)
+			})
+		}
 	})
 	t.Run("handling OOB invitations fails if my diddoc does not have a valid didcomm service", func(t *testing.T) {
-		ctx := getContext(t, &prov)
-		myDoc := createDIDDoc(t, ctx.kms)
-		myDoc.Service = []diddoc.Service{{
-			ID:              uuid.New().String(),
-			Type:            "invalid",
-			Priority:        0,
-			RecipientKeys:   nil,
-			RoutingKeys:     nil,
-			ServiceEndpoint: "",
-		}}
-		ctx.vdRegistry = &mockvdr.MockVDRegistry{CreateValue: myDoc}
-		_, _, _, err := (&requested{}).ExecuteInbound(&stateMachineMsg{
-			DIDCommMsg: service.NewDIDCommMsgMap(&OOBInvitation{
-				ID:         uuid.New().String(),
-				Type:       oobMsgType,
-				ThreadID:   uuid.New().String(),
-				TheirLabel: "test",
-				Target: &diddoc.Service{
+		tests := []struct {
+			name string
+			ctx  *context
+		}{
+			{
+				name: "using context with ED25519 main VM and X25519 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType),
+			},
+			{
+				name: "using context with P-256 main VM and P-256 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP256TypeIEEEP1363, kms.NISTP256ECDHKWType),
+			},
+			{
+				name: "using context with P-384 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP384TypeIEEEP1363, kms.NISTP384ECDHKWType),
+			},
+			{
+				name: "using context with P-521 main VM and P-521 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ECDSAP521TypeIEEEP1363, kms.NISTP521ECDHKWType),
+			},
+			{
+				name: "using context with ED25519 main VM and P-384 keyAgreement",
+				ctx:  getContext(t, &prov, kms.ED25519Type, kms.NISTP384ECDHKWType),
+			},
+		}
+
+		for _, tt := range tests {
+			tc := tt
+			t.Run(tc.name, func(t *testing.T) {
+				myDoc := createDIDDoc(t, tc.ctx)
+				myDoc.Service = []diddoc.Service{{
 					ID:              uuid.New().String(),
-					Type:            "did-communication",
+					Type:            "invalid",
 					Priority:        0,
-					RecipientKeys:   []string{"key"},
-					ServiceEndpoint: "http://test.com",
-				},
-			}),
-			connRecord: &connection.Record{},
-		}, "", ctx)
-		require.Error(t, err)
+					RecipientKeys:   nil,
+					RoutingKeys:     nil,
+					ServiceEndpoint: "",
+				}}
+				tc.ctx.vdRegistry = &mockvdr.MockVDRegistry{CreateValue: myDoc}
+				_, _, _, err := (&requested{}).ExecuteInbound(&stateMachineMsg{
+					DIDCommMsg: service.NewDIDCommMsgMap(&OOBInvitation{
+						ID:         uuid.New().String(),
+						Type:       oobMsgType,
+						ThreadID:   uuid.New().String(),
+						TheirLabel: "test",
+						Target: &diddoc.Service{
+							ID:              uuid.New().String(),
+							Type:            "did-communication",
+							Priority:        0,
+							RecipientKeys:   []string{"key"},
+							ServiceEndpoint: "http://test.com",
+						},
+					}),
+					connRecord: &connection.Record{},
+				}, "", tc.ctx)
+				require.Error(t, err)
+			})
+		}
 	})
 	t.Run("inbound request unmarshalling error", func(t *testing.T) {
 		_, followup, _, err := (&requested{}).ExecuteInbound(&stateMachineMsg{
@@ -494,85 +757,116 @@ func TestRequestedState_Execute(t *testing.T) {
 
 func TestRespondedState_Execute(t *testing.T) {
 	prov := getProvider(t)
-	ctx := getContext(t, &prov)
-	request, err := createRequest(t, ctx)
-	require.NoError(t, err)
-	requestPayloadBytes, err := json.Marshal(request)
-	require.NoError(t, err)
-	response, err := createResponse(request, ctx)
-	require.NoError(t, err)
-	responsePayloadBytes, err := json.Marshal(response)
-	require.NoError(t, err)
+	tests := []struct {
+		name string
+		ctx  *context
+	}{
+		{
+			name: "using context with ED25519 main VM and X25519 keyAgreement",
+			ctx:  getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType),
+		},
+		{
+			name: "using context with P-256 main VM and P-256 keyAgreement",
+			ctx:  getContext(t, &prov, kms.ECDSAP256TypeIEEEP1363, kms.NISTP256ECDHKWType),
+		},
+		{
+			name: "using context with P-384 main VM and P-384 keyAgreement",
+			ctx:  getContext(t, &prov, kms.ECDSAP384TypeIEEEP1363, kms.NISTP384ECDHKWType),
+		},
+		{
+			name: "using context with P-521 main VM and P-521 keyAgreement",
+			ctx:  getContext(t, &prov, kms.ECDSAP521TypeIEEEP1363, kms.NISTP521ECDHKWType),
+		},
+		{
+			name: "using context with ED25519 main VM and P-384 keyAgreement",
+			ctx:  getContext(t, &prov, kms.ED25519Type, kms.NISTP384ECDHKWType),
+		},
+	}
 
-	t.Run("rejects messages other than requests and responses", func(t *testing.T) {
-		others := []service.DIDCommMsg{
-			service.NewDIDCommMsgMap(Invitation{Type: InvitationMsgType}),
-			service.NewDIDCommMsgMap(model.Ack{Type: AckMsgType}),
-		}
-		for _, msg := range others {
-			_, _, _, e := (&responded{}).ExecuteInbound(&stateMachineMsg{
-				DIDCommMsg: msg,
-			}, "", &context{})
-			require.Error(t, e)
-			require.Contains(t, e.Error(), "illegal msg type")
-		}
-	})
-	t.Run("no followup for inbound requests", func(t *testing.T) {
-		connRec, followup, _, e := (&responded{}).ExecuteInbound(&stateMachineMsg{
-			DIDCommMsg: bytesToDIDCommMsg(t, requestPayloadBytes),
-			connRecord: &connection.Record{},
-		}, "", ctx)
-		require.NoError(t, e)
-		require.NotNil(t, connRec)
-		require.IsType(t, &noOp{}, followup)
-	})
-	t.Run("followup to 'completed' on inbound responses", func(t *testing.T) {
-		connRec := &connection.Record{
-			State:        (&responded{}).Name(),
-			ThreadID:     request.ID,
-			ConnectionID: "123",
-		}
-		err = ctx.connectionRecorder.SaveConnectionRecord(connRec)
-		require.NoError(t, err)
-		err = ctx.connectionRecorder.SaveNamespaceThreadID(request.ID, findNamespace(ResponseMsgType), connRec.ConnectionID)
-		require.NoError(t, err)
-		connRec, followup, _, e := (&responded{}).ExecuteInbound(
-			&stateMachineMsg{
-				DIDCommMsg: bytesToDIDCommMsg(t, responsePayloadBytes),
-				connRecord: connRec,
-			}, "", ctx)
-		require.NoError(t, e)
-		require.NotNil(t, connRec)
-		require.Equal(t, (&completed{}).Name(), followup.Name())
-	})
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			request, err := createRequest(t, tc.ctx)
+			require.NoError(t, err)
+			requestPayloadBytes, err := json.Marshal(request)
+			require.NoError(t, err)
+			response, err := createResponse(request, tc.ctx)
+			require.NoErrorf(t, err, fmt.Sprintf("for %s", tc.name))
+			responsePayloadBytes, err := json.Marshal(response)
+			require.NoError(t, err)
 
-	t.Run("handle inbound request unmarshalling error", func(t *testing.T) {
-		_, followup, _, err := (&responded{}).ExecuteInbound(&stateMachineMsg{
-			DIDCommMsg: service.DIDCommMsgMap{"@id": map[int]int{}, "@type": RequestMsgType},
-		}, "", &context{})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "JSON unmarshalling of request")
-		require.Nil(t, followup)
-	})
+			t.Run("rejects messages other than requests and responses", func(t *testing.T) {
+				others := []service.DIDCommMsg{
+					service.NewDIDCommMsgMap(Invitation{Type: InvitationMsgType}),
+					service.NewDIDCommMsgMap(model.Ack{Type: AckMsgType}),
+				}
+				for _, msg := range others {
+					_, _, _, e := (&responded{}).ExecuteInbound(&stateMachineMsg{
+						DIDCommMsg: msg,
+					}, "", &context{})
+					require.Error(t, e)
+					require.Contains(t, e.Error(), "illegal msg type")
+				}
+			})
+			t.Run("no followup for inbound requests", func(t *testing.T) {
+				connRec, followup, _, e := (&responded{}).ExecuteInbound(&stateMachineMsg{
+					DIDCommMsg: bytesToDIDCommMsg(t, requestPayloadBytes),
+					connRecord: &connection.Record{},
+				}, "", tc.ctx)
+				require.NoError(t, e)
+				require.NotNil(t, connRec)
+				require.IsType(t, &noOp{}, followup)
+			})
+			t.Run("followup to 'completed' on inbound responses", func(t *testing.T) {
+				connRec := &connection.Record{
+					State:        (&responded{}).Name(),
+					ThreadID:     request.ID,
+					ConnectionID: "123",
+				}
+				err = tc.ctx.connectionRecorder.SaveConnectionRecord(connRec)
+				require.NoError(t, err)
+				err = tc.ctx.connectionRecorder.SaveNamespaceThreadID(request.ID, findNamespace(ResponseMsgType),
+					connRec.ConnectionID)
+				require.NoError(t, err)
+				connRec, followup, _, e := (&responded{}).ExecuteInbound(
+					&stateMachineMsg{
+						DIDCommMsg: bytesToDIDCommMsg(t, responsePayloadBytes),
+						connRecord: connRec,
+					}, "", tc.ctx)
+				require.NoError(t, e)
+				require.NotNil(t, connRec)
+				require.Equal(t, (&completed{}).Name(), followup.Name())
+			})
 
-	t.Run("fails if my did has an invalid didcomm service entry", func(t *testing.T) {
-		ctx := getContext(t, &prov)
-		myDoc := createDIDDoc(t, ctx.kms)
-		myDoc.Service = []diddoc.Service{{
-			ID:              uuid.New().String(),
-			Type:            "invalid",
-			Priority:        0,
-			RecipientKeys:   nil,
-			RoutingKeys:     nil,
-			ServiceEndpoint: "",
-		}}
-		ctx.vdRegistry = &mockvdr.MockVDRegistry{CreateValue: myDoc}
-		_, _, _, err := (&responded{}).ExecuteInbound(&stateMachineMsg{
-			DIDCommMsg: bytesToDIDCommMsg(t, requestPayloadBytes),
-			connRecord: &connection.Record{},
-		}, "", ctx)
-		require.Error(t, err)
-	})
+			t.Run("handle inbound request unmarshalling error", func(t *testing.T) {
+				_, followup, _, err := (&responded{}).ExecuteInbound(&stateMachineMsg{
+					DIDCommMsg: service.DIDCommMsgMap{"@id": map[int]int{}, "@type": RequestMsgType},
+				}, "", &context{})
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "JSON unmarshalling of request")
+				require.Nil(t, followup)
+			})
+
+			t.Run("fails if my did has an invalid didcomm service entry", func(t *testing.T) {
+				ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
+				myDoc := createDIDDoc(t, ctx)
+				myDoc.Service = []diddoc.Service{{
+					ID:              uuid.New().String(),
+					Type:            "invalid",
+					Priority:        0,
+					RecipientKeys:   nil,
+					RoutingKeys:     nil,
+					ServiceEndpoint: "",
+				}}
+				ctx.vdRegistry = &mockvdr.MockVDRegistry{CreateValue: myDoc}
+				_, _, _, err := (&responded{}).ExecuteInbound(&stateMachineMsg{
+					DIDCommMsg: bytesToDIDCommMsg(t, requestPayloadBytes),
+					connRecord: &connection.Record{},
+				}, "", ctx)
+				require.Error(t, err)
+			})
+		})
+	}
 }
 
 func TestAbandonedState_Execute(t *testing.T) {
@@ -590,17 +884,20 @@ func TestAbandonedState_Execute(t *testing.T) {
 func TestCompletedState_Execute(t *testing.T) {
 	prov := getProvider(t)
 	customKMS := newKMS(t, prov.StoreProvider)
-	pubKey, encKey := newED25519AndX25519DIDKey(t, customKMS)
+	ctx := &context{
+		crypto:           &tinkcrypto.Crypto{},
+		kms:              customKMS,
+		keyType:          kms.ED25519Type,
+		keyAgreementType: kms.X25519ECDHKWType,
+	}
+	pubKey, encKey := newSigningAndEncryptionDIDKeys(t, ctx)
 	connRec, err := connection.NewRecorder(&prov)
 
 	require.NoError(t, err)
 	require.NotNil(t, connRec)
 
-	ctx := &context{
-		crypto:             &tinkcrypto.Crypto{},
-		connectionRecorder: connRec,
-		kms:                customKMS,
-	}
+	ctx.connectionRecorder = connRec
+
 	newDIDDoc := createDIDDocWithKey(pubKey, encKey)
 	c := &Connection{
 		DID:    newDIDDoc.ID,
@@ -762,17 +1059,20 @@ func TestCompletedState_Execute(t *testing.T) {
 
 func TestVerifySignature(t *testing.T) {
 	prov := getProvider(t)
-	pubKey, encKey := newED25519AndX25519DIDKey(t, prov.KMS())
+	ctx := &context{
+		crypto:           &tinkcrypto.Crypto{},
+		kms:              prov.KMS(),
+		keyType:          kms.ED25519Type,
+		keyAgreementType: kms.X25519ECDHKWType,
+	}
+	pubKey, encKey := newSigningAndEncryptionDIDKeys(t, ctx)
 	connRec, err := connection.NewRecorder(&prov)
 
 	require.NoError(t, err)
 	require.NotNil(t, connRec)
 
-	ctx := &context{
-		crypto:             &tinkcrypto.Crypto{},
-		connectionRecorder: connRec,
-		kms:                prov.KMS(),
-	}
+	ctx.connectionRecorder = connRec
+
 	newDIDDoc := createDIDDocWithKey(pubKey, encKey)
 	c := &Connection{
 		DID:    newDIDDoc.ID,
@@ -829,7 +1129,7 @@ func TestVerifySignature(t *testing.T) {
 		require.NoError(t, err)
 
 		// generate different key and assign it to signature verification key
-		pubKey2, _ := newED25519AndX25519DIDKey(t, prov.CustomKMS)
+		pubKey2, _ := newSigningAndEncryptionDIDKeys(t, ctx)
 		con, err := verifySignature(connectionSignature, pubKey2)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "ed25519: invalid signature")
@@ -847,7 +1147,7 @@ func TestVerifySignature(t *testing.T) {
 		require.NoError(t, err)
 
 		// simulate kid generation from public signature verification key bytes
-		kid, err := localkms.CreateKID(pubKeyBytes, kms.ED25519)
+		kid, err := localkms.CreateKID(pubKeyBytes, ctx.keyType)
 		require.NoError(t, err)
 
 		kh, err := prov.KMS().Get(kid)
@@ -878,7 +1178,7 @@ func TestVerifySignature(t *testing.T) {
 		require.NoError(t, err)
 
 		// simulate kid generation from public signature verification key bytes
-		kid, err := localkms.CreateKID(pubKeyBytes, kms.ED25519)
+		kid, err := localkms.CreateKID(pubKeyBytes, ctx.keyType)
 		require.NoError(t, err)
 
 		kh, err := prov.KMS().Get(kid)
@@ -904,8 +1204,8 @@ func TestVerifySignature(t *testing.T) {
 
 func TestPrepareConnectionSignature(t *testing.T) {
 	prov := getProvider(t)
-	verPubKey, _ := newED25519AndX25519DIDKey(t, prov.CustomKMS)
-	ctx := getContext(t, &prov)
+	ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
+	verPubKey, _ := newSigningAndEncryptionDIDKeys(t, ctx)
 	invitation, err := createMockInvitation(verPubKey, ctx)
 	require.NoError(t, err)
 	doc, err := ctx.vdRegistry.Create(testMethod, nil)
@@ -939,6 +1239,8 @@ func TestPrepareConnectionSignature(t *testing.T) {
 			crypto:             &tinkcrypto.Crypto{},
 			connectionRecorder: connRec,
 			kms:                prov.CustomKMS,
+			keyType:            ctx.keyType,
+			keyAgreementType:   ctx.keyAgreementType,
 		}
 		connectionSignature, err := ctx2.prepareConnectionSignature(c, doc.DIDDocument.ID)
 		require.NoError(t, err)
@@ -973,17 +1275,19 @@ func TestPrepareConnectionSignature(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, connRec)
 
-		ctx := &context{
+		ctx2 := &context{
 			crypto: &mockcrypto.Crypto{
 				SignErr: errors.New("sign error"),
 			},
 			connectionRecorder: connRec,
 			kms:                prov.KMS(),
+			keyType:            ctx.keyType,
+			keyAgreementType:   ctx.keyAgreementType,
 		}
-		c := &Connection{
+		c2 := &Connection{
 			DIDDoc: mockdiddoc.GetMockDIDDoc(t),
 		}
-		connectionSignature, err := ctx.prepareConnectionSignature(c, invitation.ID)
+		connectionSignature, err := ctx2.prepareConnectionSignature(c2, invitation.ID)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "sign error")
 		require.Nil(t, connectionSignature)
@@ -1002,23 +1306,52 @@ func TestNewRequestFromInvitation(t *testing.T) {
 
 	t.Run("successful new request from invitation", func(t *testing.T) {
 		prov := getProvider(t)
-		ctx := getContext(t, &prov)
+		ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
 		_, connRec, err := ctx.handleInboundInvitation(invitation, invitation.ID, &options{}, &connection.Record{})
 		require.NoError(t, err)
 		require.NotNil(t, connRec.MyDID)
 	})
 	t.Run("successful response to invitation with public did", func(t *testing.T) {
 		prov := getProvider(t)
-		doc := createDIDDoc(t, prov.CustomKMS)
+		ctx := &context{
+			kms:              prov.CustomKMS,
+			keyType:          kms.ED25519Type,
+			keyAgreementType: kms.X25519ECDHKWType,
+		}
+		doc := createDIDDoc(t, ctx)
 		connRec, err := connection.NewRecorder(&protocol.MockProvider{})
 		require.NoError(t, err)
 		didConnStore, err := didstore.NewConnectionStore(&protocol.MockProvider{})
 		require.NoError(t, err)
-		ctx := context{
-			vdRegistry:         &mockvdr.MockVDRegistry{ResolveValue: doc},
-			connectionRecorder: connRec,
-			connectionStore:    didConnStore,
+
+		ctx.vdRegistry = &mockvdr.MockVDRegistry{ResolveValue: doc}
+		ctx.connectionRecorder = connRec
+		ctx.connectionStore = didConnStore
+
+		_, connRecord, err := ctx.handleInboundInvitation(invitation, invitation.ID, &options{publicDID: doc.ID},
+			&connection.Record{})
+		require.NoError(t, err)
+		require.NotNil(t, connRecord.MyDID)
+		require.Equal(t, connRecord.MyDID, doc.ID)
+	})
+	t.Run("successful response to invitation with public did using P-384 key type", func(t *testing.T) {
+		prov := getProvider(t)
+		ctx := &context{
+			kms:              prov.CustomKMS,
+			keyType:          kms.ECDSAP384TypeIEEEP1363,
+			keyAgreementType: kms.NISTP384ECDHKWType,
 		}
+
+		doc := createDIDDoc(t, ctx)
+		connRec, err := connection.NewRecorder(&protocol.MockProvider{})
+		require.NoError(t, err)
+		didConnStore, err := didstore.NewConnectionStore(&protocol.MockProvider{})
+		require.NoError(t, err)
+
+		ctx.vdRegistry = &mockvdr.MockVDRegistry{ResolveValue: doc}
+		ctx.connectionRecorder = connRec
+		ctx.connectionStore = didConnStore
+
 		_, connRecord, err := ctx.handleInboundInvitation(invitation, invitation.ID, &options{publicDID: doc.ID},
 			&connection.Record{})
 		require.NoError(t, err)
@@ -1031,8 +1364,28 @@ func TestNewRequestFromInvitation(t *testing.T) {
 
 		ctx := &context{
 			kms:                customKMS,
-			outboundDispatcher: prov.OutboundDispatcher(), routeSvc: &mockroute.MockMediatorSvc{},
-			vdRegistry: &mockvdr.MockVDRegistry{CreateErr: fmt.Errorf("create DID error")},
+			outboundDispatcher: prov.OutboundDispatcher(),
+			routeSvc:           &mockroute.MockMediatorSvc{},
+			vdRegistry:         &mockvdr.MockVDRegistry{CreateErr: fmt.Errorf("create DID error")},
+			keyType:            kms.ED25519Type,
+			keyAgreementType:   kms.X25519ECDHKWType,
+		}
+		_, connRec, err := ctx.handleInboundInvitation(invitation, invitation.ID, &options{}, &connection.Record{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "create DID error")
+		require.Nil(t, connRec)
+	})
+	t.Run("unsuccessful new request from invitation with P-384 key as KW", func(t *testing.T) {
+		prov := protocol.MockProvider{}
+		customKMS := newKMS(t, prov.StoreProvider)
+
+		ctx := &context{
+			kms:                customKMS,
+			outboundDispatcher: prov.OutboundDispatcher(),
+			routeSvc:           &mockroute.MockMediatorSvc{},
+			vdRegistry:         &mockvdr.MockVDRegistry{CreateErr: fmt.Errorf("create DID error")},
+			keyType:            kms.ED25519Type,
+			keyAgreementType:   kms.NISTP384ECDHKWType,
 		}
 		_, connRec, err := ctx.handleInboundInvitation(invitation, invitation.ID, &options{}, &connection.Record{})
 		require.Error(t, err)
@@ -1043,9 +1396,11 @@ func TestNewRequestFromInvitation(t *testing.T) {
 
 func TestNewResponseFromRequest(t *testing.T) {
 	prov := getProvider(t)
+	store := mockstorage.NewMockStoreProvider()
+	k := newKMS(t, store)
 
 	t.Run("successful new response from request", func(t *testing.T) {
-		ctx := getContext(t, &prov)
+		ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
 		request, err := createRequest(t, ctx)
 		require.NoError(t, err)
 		_, connRec, err := ctx.handleInboundRequest(request, &options{}, &connection.Record{})
@@ -1055,7 +1410,7 @@ func TestNewResponseFromRequest(t *testing.T) {
 	})
 
 	t.Run("unsuccessful new response from request due to get connection error", func(t *testing.T) {
-		ctx := getContext(t, &prov)
+		ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
 		request, err := createRequest(t, ctx)
 		require.NoError(t, err)
 
@@ -1084,7 +1439,7 @@ func TestNewResponseFromRequest(t *testing.T) {
 	})
 
 	t.Run("unsuccessful new response from request due to getDIDDocAndConnection error", func(t *testing.T) {
-		ctx := getContext(t, &prov)
+		ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
 		ctx.connectionStore = &mockConnectionStore{saveDIDFromDocErr: fmt.Errorf("save did error")}
 
 		request, err := createRequest(t, ctx)
@@ -1111,6 +1466,8 @@ func TestNewResponseFromRequest(t *testing.T) {
 			connectionStore:    didConnStore,
 			routeSvc:           &mockroute.MockMediatorSvc{},
 			kms:                prov.CustomKMS,
+			keyType:            kms.ED25519Type,
+			keyAgreementType:   kms.X25519ECDHKWType,
 		}
 
 		request, err := createRequest(t, ctx)
@@ -1131,10 +1488,10 @@ func TestNewResponseFromRequest(t *testing.T) {
 	})
 
 	t.Run("unsuccessful new response from request due to invalid did for creating destination", func(t *testing.T) {
-		mockDoc := newPeerDID(t)
+		mockDoc := newPeerDID(t, k)
 		mockDoc.Service = nil
 
-		ctx := getContext(t, &prov)
+		ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
 
 		request, err := createRequest(t, ctx)
 		require.NoError(t, err)
@@ -1152,7 +1509,7 @@ func TestPrepareResponse(t *testing.T) {
 	prov := getProvider(t)
 
 	t.Run("successful new response from request", func(t *testing.T) {
-		ctx := getContext(t, &prov)
+		ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
 		request, err := createRequest(t, ctx)
 		require.NoError(t, err)
 
@@ -1161,7 +1518,7 @@ func TestPrepareResponse(t *testing.T) {
 	})
 
 	t.Run("successful new response from request, in interop mode", func(t *testing.T) {
-		ctx := getContext(t, &prov)
+		ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
 		ctx.doACAPyInterop = true
 
 		request, err := createRequest(t, ctx)
@@ -1172,7 +1529,7 @@ func TestPrepareResponse(t *testing.T) {
 	})
 
 	t.Run("failed verification of request doc", func(t *testing.T) {
-		ctx := getContext(t, &prov)
+		ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
 		ctx.doACAPyInterop = true
 
 		request, err := createRequest(t, ctx)
@@ -1193,7 +1550,7 @@ func TestPrepareResponse(t *testing.T) {
 
 	t.Run("wraps error from connection store", func(t *testing.T) {
 		expected := errors.New("test")
-		ctx := getContext(t, &prov)
+		ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
 		ctx.doACAPyInterop = true
 
 		pr := testProvider()
@@ -1216,7 +1573,7 @@ func TestPrepareResponse(t *testing.T) {
 
 	t.Run("failed fetch of doc signing key", func(t *testing.T) {
 		expected := errors.New("test")
-		ctx := getContext(t, &prov)
+		ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
 		ctx.doACAPyInterop = true
 
 		request, err := createRequest(t, ctx)
@@ -1230,7 +1587,7 @@ func TestPrepareResponse(t *testing.T) {
 	})
 
 	t.Run("failed doc signing", func(t *testing.T) {
-		ctx := getContext(t, &prov)
+		ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
 		ctx.doACAPyInterop = true
 
 		request, err := createRequest(t, ctx)
@@ -1249,8 +1606,9 @@ func TestPrepareResponse(t *testing.T) {
 
 func TestHandleInboundResponse(t *testing.T) {
 	prov := getProvider(t)
-	_, encKey := newED25519AndX25519DIDKey(t, prov.CustomKMS)
-	ctx := getContext(t, &prov)
+	ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
+	_, encKey := newSigningAndEncryptionDIDKeys(t, ctx)
+
 	_, err := createMockInvitation(encKey, ctx)
 	require.NoError(t, err)
 	request, err := createRequest(t, ctx)
@@ -1283,7 +1641,7 @@ func TestHandleInboundResponse(t *testing.T) {
 
 func TestGetInvitationRecipientKey(t *testing.T) {
 	prov := getProvider(t)
-	ctx := getContext(t, &prov)
+	ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
 
 	t.Run("successfully getting invitation recipient key", func(t *testing.T) {
 		invitation := &Invitation{
@@ -1328,7 +1686,7 @@ func TestGetPublicKey(t *testing.T) {
 	k := newKMS(t, mockstorage.NewMockStoreProvider())
 	t.Run("successfully getting public key by id", func(t *testing.T) {
 		prov := protocol.MockProvider{CustomKMS: k}
-		ctx := getContext(t, &prov)
+		ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
 		doc, err := ctx.vdRegistry.Create(testMethod, nil)
 		require.NoError(t, err)
 		pubkey, ok := diddoc.LookupPublicKey(doc.DIDDocument.VerificationMethod[0].ID, doc.DIDDocument)
@@ -1337,7 +1695,7 @@ func TestGetPublicKey(t *testing.T) {
 	})
 	t.Run("failed to get public key", func(t *testing.T) {
 		prov := protocol.MockProvider{CustomKMS: k}
-		ctx := getContext(t, &prov)
+		ctx := getContext(t, &prov, kms.ED25519Type, kms.X25519ECDHKWType)
 		doc, err := ctx.vdRegistry.Create(testMethod, nil)
 		require.NoError(t, err)
 		pubkey, ok := diddoc.LookupPublicKey("invalid-key", doc.DIDDocument)
@@ -1348,8 +1706,14 @@ func TestGetPublicKey(t *testing.T) {
 
 func TestGetDIDDocAndConnection(t *testing.T) {
 	k := newKMS(t, mockstorage.NewMockStoreProvider())
+	ctx := &context{
+		kms:              k,
+		keyType:          kms.ED25519Type,
+		keyAgreementType: kms.X25519ECDHKWType,
+	}
+
 	t.Run("successfully getting did doc and connection for public did", func(t *testing.T) {
-		doc := createDIDDoc(t, k)
+		doc := createDIDDoc(t, ctx)
 		connRec, err := connection.NewRecorder(&protocol.MockProvider{})
 		require.NoError(t, err)
 		didConnStore, err := didstore.NewConnectionStore(&protocol.MockProvider{})
@@ -1378,9 +1742,11 @@ func TestGetDIDDocAndConnection(t *testing.T) {
 	t.Run("error creating peer did", func(t *testing.T) {
 		customKMS := newKMS(t, mockstorage.NewMockStoreProvider())
 		ctx := context{
-			kms:        customKMS,
-			vdRegistry: &mockvdr.MockVDRegistry{CreateErr: errors.New("creator error")},
-			routeSvc:   &mockroute.MockMediatorSvc{},
+			kms:              customKMS,
+			vdRegistry:       &mockvdr.MockVDRegistry{CreateErr: errors.New("creator error")},
+			routeSvc:         &mockroute.MockMediatorSvc{},
+			keyType:          kms.ED25519Type,
+			keyAgreementType: kms.X25519ECDHKWType,
 		}
 		didDoc, conn, err := ctx.getDIDDocAndConnection("", nil)
 		require.Error(t, err)
@@ -1400,6 +1766,8 @@ func TestGetDIDDocAndConnection(t *testing.T) {
 			connectionRecorder: connRec,
 			connectionStore:    didConnStore,
 			routeSvc:           &mockroute.MockMediatorSvc{},
+			keyType:            kms.ED25519Type,
+			keyAgreementType:   kms.X25519ECDHKWType,
 		}
 		didDoc, conn, err := ctx.getDIDDocAndConnection("", nil)
 		require.NoError(t, err)
@@ -1439,6 +1807,8 @@ func TestGetDIDDocAndConnection(t *testing.T) {
 				Connections: []string{"xyz"},
 				AddKeyErr:   errors.New("router add key error"),
 			},
+			keyType:          kms.ED25519Type,
+			keyAgreementType: kms.X25519ECDHKWType,
 		}
 		didDoc, conn, err := ctx.getDIDDocAndConnection("", []string{"xyz"})
 		require.Error(t, err)
@@ -1450,12 +1820,17 @@ func TestGetDIDDocAndConnection(t *testing.T) {
 
 func TestGetVerKey(t *testing.T) {
 	k := newKMS(t, mockstorage.NewMockStoreProvider())
+	ctx := &context{
+		kms:              k,
+		keyType:          kms.ED25519Type,
+		keyAgreementType: kms.X25519ECDHKWType,
+	}
+
 	t.Run("returns verkey from explicit oob invitation", func(t *testing.T) {
 		expected := newServiceBlock()
 		invitation := newOOBInvite(expected)
-		ctx := &context{
-			connectionRecorder: connRecorder(t, testProvider()),
-		}
+		ctx.connectionRecorder = connRecorder(t, testProvider())
+
 		err := ctx.connectionRecorder.SaveInvitation(invitation.ThreadID, invitation)
 		require.NoError(t, err)
 
@@ -1464,14 +1839,13 @@ func TestGetVerKey(t *testing.T) {
 		require.Equal(t, expected.RecipientKeys[0], result)
 	})
 	t.Run("returns verkey from implicit oob invitation", func(t *testing.T) {
-		publicDID := createDIDDoc(t, k)
+		publicDID := createDIDDoc(t, ctx)
 		invitation := newOOBInvite(publicDID.ID)
-		ctx := &context{
-			connectionRecorder: connRecorder(t, testProvider()),
-			vdRegistry: &mockvdr.MockVDRegistry{
-				ResolveValue: publicDID,
-			},
+		ctx.connectionRecorder = connRecorder(t, testProvider())
+		ctx.vdRegistry = &mockvdr.MockVDRegistry{
+			ResolveValue: publicDID,
 		}
+
 		err := ctx.connectionRecorder.SaveInvitation(invitation.ThreadID, invitation)
 		require.NoError(t, err)
 
@@ -1479,12 +1853,12 @@ func TestGetVerKey(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, publicDID.Service[0].RecipientKeys[0], result)
 	})
+
 	t.Run("returns verkey from explicit didexchange invitation", func(t *testing.T) {
 		expected := newServiceBlock()
 		invitation := newDidExchangeInvite("", expected)
-		ctx := &context{
-			connectionRecorder: connRecorder(t, testProvider()),
-		}
+		ctx.connectionRecorder = connRecorder(t, testProvider())
+
 		err := ctx.connectionRecorder.SaveInvitation(invitation.ID, invitation)
 		require.NoError(t, err)
 
@@ -1492,13 +1866,12 @@ func TestGetVerKey(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expected.RecipientKeys[0], result)
 	})
+
 	t.Run("returns verkey from implicit didexchange invitation", func(t *testing.T) {
-		publicDID := createDIDDoc(t, k)
-		ctx := &context{
-			connectionRecorder: connRecorder(t, testProvider()),
-			vdRegistry: &mockvdr.MockVDRegistry{
-				ResolveValue: publicDID,
-			},
+		publicDID := createDIDDoc(t, ctx)
+		ctx.connectionRecorder = connRecorder(t, testProvider())
+		ctx.vdRegistry = &mockvdr.MockVDRegistry{
+			ResolveValue: publicDID,
 		}
 
 		svc, found := diddoc.LookupService(publicDID, "did-communication")
@@ -1508,17 +1881,18 @@ func TestGetVerKey(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, svc.RecipientKeys[0], result)
 	})
+
 	t.Run("fails for oob invitation with no target", func(t *testing.T) {
 		invalid := newOOBInvite(nil)
-		ctx := &context{
-			connectionRecorder: connRecorder(t, testProvider()),
-		}
+		ctx.connectionRecorder = connRecorder(t, testProvider())
+
 		err := ctx.connectionRecorder.SaveInvitation(invalid.ThreadID, invalid)
 		require.NoError(t, err)
 
 		_, err = ctx.getVerKey(invalid.ThreadID)
 		require.Error(t, err)
 	})
+
 	t.Run("wraps error from store", func(t *testing.T) {
 		expected := errors.New("test")
 		pr := testProvider()
@@ -1528,9 +1902,7 @@ func TestGetVerKey(t *testing.T) {
 				ErrGet: expected,
 			},
 		}
-		ctx := &context{
-			connectionRecorder: connRecorder(t, pr),
-		}
+		ctx.connectionRecorder = connRecorder(t, pr)
 
 		invitation := newOOBInvite(newServiceBlock())
 		err := ctx.connectionRecorder.SaveInvitation(invitation.ID, invitation)
@@ -1539,13 +1911,12 @@ func TestGetVerKey(t *testing.T) {
 		_, err = ctx.getVerKey(invitation.ID)
 		require.Error(t, err)
 	})
+
 	t.Run("wraps error from vdr resolution", func(t *testing.T) {
 		expected := errors.New("test")
-		ctx := &context{
-			connectionRecorder: connRecorder(t, testProvider()),
-			vdRegistry: &mockvdr.MockVDRegistry{
-				ResolveErr: expected,
-			},
+		ctx.connectionRecorder = connRecorder(t, testProvider())
+		ctx.vdRegistry = &mockvdr.MockVDRegistry{
+			ResolveErr: expected,
 		}
 
 		_, err := ctx.getVerKey("did:example:123")
@@ -1554,10 +1925,10 @@ func TestGetVerKey(t *testing.T) {
 	})
 }
 
-func createDIDDoc(t *testing.T, k kms.KeyManager) *diddoc.Doc {
+func createDIDDoc(t *testing.T, ctx *context) *diddoc.Doc {
 	t.Helper()
 
-	pubKey, encPubKey := newED25519AndX25519DIDKey(t, k)
+	pubKey, encPubKey := newSigningAndEncryptionDIDKeys(t, ctx)
 
 	return createDIDDocWithKey(pubKey, encPubKey)
 }
@@ -1602,7 +1973,7 @@ func createDIDDocWithKey(verPubKey, encPubKey string) *diddoc.Doc {
 	}
 	createdTime := time.Now()
 	didDoc := &diddoc.Doc{
-		Context:            []string{diddoc.Context},
+		Context:            []string{diddoc.ContextV1},
 		ID:                 id,
 		VerificationMethod: []diddoc.VerificationMethod{verPubKeyVM, encKeyV.VerificationMethod},
 		KeyAgreement:       []diddoc.Verification{encKeyV},
@@ -1627,31 +1998,36 @@ func getProvider(t *testing.T) protocol.MockProvider {
 	}
 }
 
-func getContext(t *testing.T, prov *protocol.MockProvider) *context {
+func getContext(t *testing.T, prov *protocol.MockProvider, keyType, keyAgreementType kms.KeyType) *context {
 	t.Helper()
 
-	pubKey, encKey := newED25519AndX25519DIDKey(t, prov.KMS())
+	ctx := &context{
+		outboundDispatcher: prov.OutboundDispatcher(),
+		crypto:             &tinkcrypto.Crypto{},
+		routeSvc:           &mockroute.MockMediatorSvc{},
+		kms:                prov.KMS(),
+		keyType:            keyType,
+		keyAgreementType:   keyAgreementType,
+	}
+
+	pubKey, encKey := newSigningAndEncryptionDIDKeys(t, ctx)
 	connRec, err := connection.NewRecorder(prov)
 	require.NoError(t, err)
 
 	didConnStore, err := didstore.NewConnectionStore(prov)
 	require.NoError(t, err)
 
-	return &context{
-		outboundDispatcher: prov.OutboundDispatcher(),
-		vdRegistry:         &mockvdr.MockVDRegistry{CreateValue: createDIDDocWithKey(pubKey, encKey)},
-		crypto:             &tinkcrypto.Crypto{},
-		connectionRecorder: connRec,
-		connectionStore:    didConnStore,
-		routeSvc:           &mockroute.MockMediatorSvc{},
-		kms:                prov.KMS(),
-	}
+	ctx.vdRegistry = &mockvdr.MockVDRegistry{CreateValue: createDIDDocWithKey(pubKey, encKey)}
+	ctx.connectionRecorder = connRec
+	ctx.connectionStore = didConnStore
+
+	return ctx
 }
 
 func createRequest(t *testing.T, ctx *context) (*Request, error) {
 	t.Helper()
 
-	pubKey, encKey := newED25519AndX25519DIDKey(t, ctx.kms)
+	pubKey, encKey := newSigningAndEncryptionDIDKeys(t, ctx)
 
 	invitation, err := createMockInvitation(pubKey, ctx)
 	if err != nil {
@@ -1713,7 +2089,7 @@ func saveMockConnectionRecord(t *testing.T, request *Request, ctx *context) (*Re
 		return nil, err
 	}
 
-	_, encKey := newED25519AndX25519DIDKey(t, ctx.kms)
+	_, encKey := newSigningAndEncryptionDIDKeys(t, ctx)
 	connRec := &connection.Record{
 		State:         (&responded{}).Name(),
 		ThreadID:      response.Thread.ID,

--- a/pkg/doc/did/doc.go
+++ b/pkg/doc/did/doc.go
@@ -25,8 +25,10 @@ import (
 )
 
 const (
-	// Context of the DID document.
-	Context             = "https://w3id.org/did/v1"
+	// ContextV1 of the DID document is the current V1 context name.
+	ContextV1 = "https://www.w3.org/ns/did/v1"
+	// ContextV1Old of the DID document representing the old/legacy V1 context name.
+	ContextV1Old        = "https://w3id.org/did/v1"
 	contextV011         = "https://w3id.org/did/v0.11"
 	contextV12019       = "https://www.w3.org/2019/did/v1"
 	jsonldType          = "type"
@@ -417,7 +419,7 @@ func requiresLegacyHandling(raw *rawDoc) bool {
 	context, _ := parseContext(raw.Context)
 
 	for _, ctx := range context {
-		if ctx == Context { // docs that state they use v1 format but still have a top-level publicKey array
+		if ctx == ContextV1Old { // docs that state they use v1 format but still have a top-level publicKey array
 			return true
 		}
 	}
@@ -668,7 +670,7 @@ func getVerificationsByKeyID(didID, baseURI string, vm []VerificationMethod, rel
 		}
 
 		if !keyExist {
-			return nil, fmt.Errorf("key %s not exist in did doc verification method", keyID)
+			return nil, fmt.Errorf("key %s does not exist in did doc verification method", keyID)
 		}
 	}
 
@@ -947,7 +949,7 @@ func (docResolution *DocResolution) JSONBytes() ([]byte, error) {
 
 // JSONBytes converts document to json bytes.
 func (doc *Doc) JSONBytes() ([]byte, error) {
-	context := Context
+	context := ContextV1
 
 	if len(doc.Context) > 0 {
 		context = doc.Context[0]
@@ -1299,10 +1301,17 @@ func WithAuthentication(auth []Verification) DocOption {
 	}
 }
 
-// WithAssertion sets the verification methods for assertion: https://w3c.github.io/did-core/#assertionmethod.
+// WithAssertion sets the verification methods for assertion: https://w3c.github.io/did-core/#assertion.
 func WithAssertion(assertion []Verification) DocOption {
 	return func(opts *Doc) {
 		opts.AssertionMethod = assertion
+	}
+}
+
+// WithKeyAgreement sets the verification methods for KeyAgreement: https://w3c.github.io/did-core/#key-agreement.
+func WithKeyAgreement(keyAgreement []Verification) DocOption {
+	return func(opts *Doc) {
+		opts.KeyAgreement = keyAgreement
 	}
 }
 
@@ -1330,7 +1339,7 @@ func WithUpdatedTime(t time.Time) DocOption {
 // BuildDoc creates the DID Doc from options.
 func BuildDoc(opts ...DocOption) *Doc {
 	doc := &Doc{}
-	doc.Context = []string{Context}
+	doc.Context = []string{ContextV1}
 
 	for _, opt := range opts {
 		opt(doc)

--- a/pkg/doc/did/doc_test.go
+++ b/pkg/doc/did/doc_test.go
@@ -80,7 +80,7 @@ func TestValidWithDocBase(t *testing.T) {
 		doc, err := ParseDocument([]byte(d))
 		require.NoError(t, err)
 		require.NotNil(t, doc)
-		require.Contains(t, doc.Context[0], "https://w3id.org/did/v")
+		require.Contains(t, doc.Context[0], "https://www.w3.org/ns/did/v")
 
 		// test doc id
 		require.Equal(t, doc.ID, "did:example:123456789abcdefghi")
@@ -200,7 +200,7 @@ func TestValid(t *testing.T) {
 		doc, err := ParseDocument([]byte(d))
 		require.NoError(t, err)
 		require.NotNil(t, doc)
-		require.Contains(t, doc.Context[0], "https://w3id.org/did/v")
+		require.Contains(t, doc.Context[0], "https://www.w3.org/ns/did/v")
 
 		// test doc id
 		require.Equal(t, doc.ID, "did:example:21tDAKCERh95uGgKbJNHYp")
@@ -321,7 +321,7 @@ func TestValidWithProof(t *testing.T) {
 func TestInvalidEncodingInProof(t *testing.T) {
 	proofKey := []string{jsonldProofValue, jsonldSignatureValue}
 	for _, v := range proofKey {
-		c := Context
+		c := ContextV1
 		if v == jsonldSignatureValue {
 			c = contextV011
 		}
@@ -363,7 +363,7 @@ func TestPopulateAuthentications(t *testing.T) {
 		_, err = ParseDocument(bytes)
 		require.Error(t, err)
 
-		expected := fmt.Sprintf("key %s not exist in did doc verification method", missingPubKeyID)
+		expected := fmt.Sprintf("key %s does not exist in did doc verification method", missingPubKeyID)
 		require.Contains(t, err.Error(), expected)
 	})
 
@@ -379,13 +379,13 @@ func TestPopulateAuthentications(t *testing.T) {
 		_, err = ParseDocument(bytes)
 		require.Error(t, err)
 
-		expected := fmt.Sprintf("key %s not exist in did doc verification method", missingPubKeyID)
+		expected := fmt.Sprintf("key %s does not exist in did doc verification method", missingPubKeyID)
 		require.Contains(t, err.Error(), expected)
 	})
 }
 
 func TestPopulateAssertionMethods(t *testing.T) {
-	t.Run("test key not exist", func(t *testing.T) {
+	t.Run("test key does not exist", func(t *testing.T) {
 		raw := &rawDoc{}
 		require.NoError(t, json.Unmarshal([]byte(docV011WithVerificationRelationships), &raw))
 
@@ -396,7 +396,7 @@ func TestPopulateAssertionMethods(t *testing.T) {
 		_, err = ParseDocument(bytes)
 		require.Error(t, err)
 
-		expected := fmt.Sprintf("key %s not exist in did doc verification method", missingPubKeyID)
+		expected := fmt.Sprintf("key %s does not exist in did doc verification method", missingPubKeyID)
 		require.Contains(t, err.Error(), expected)
 	})
 }
@@ -413,7 +413,7 @@ func TestPopulateCapabilityDelegations(t *testing.T) {
 		_, err = ParseDocument(bytes)
 		require.Error(t, err)
 
-		expected := fmt.Sprintf("key %s not exist in did doc verification method", missingPubKeyID)
+		expected := fmt.Sprintf("key %s does not exist in did doc verification method", missingPubKeyID)
 		require.Contains(t, err.Error(), expected)
 	})
 }
@@ -430,7 +430,7 @@ func TestPopulateCapabilityInvocations(t *testing.T) {
 		_, err = ParseDocument(bytes)
 		require.Error(t, err)
 
-		expected := fmt.Sprintf("key %s not exist in did doc verification method", missingPubKeyID)
+		expected := fmt.Sprintf("key %s does not exist in did doc verification method", missingPubKeyID)
 		require.Contains(t, err.Error(), expected)
 	})
 }
@@ -445,10 +445,8 @@ func TestPopulateKeyAgreements(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = ParseDocument(bytes)
-		require.Error(t, err)
-
-		expected := fmt.Sprintf("key %s not exist in did doc verification method", missingPubKeyID)
-		require.Contains(t, err.Error(), expected)
+		require.EqualError(t, err, fmt.Sprintf("populate key agreements failed: key %s does not exist in did doc"+
+			" verification method", missingPubKeyID))
 	})
 }
 

--- a/pkg/doc/did/testdata/invalid_doc.jsonld
+++ b/pkg/doc/did/testdata/invalid_doc.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": ["https://w3id.org/did/v1"],
+  "@context": ["https://www.w3.org/ns/did/v1"],
   "id": "did:example:21tDAKCERh95uGgKbJNHYp",
   "publicKey": [
     {

--- a/pkg/doc/did/testdata/valid_doc.jsonld
+++ b/pkg/doc/did/testdata/valid_doc.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": ["https://w3id.org/did/v1"],
+  "@context": ["https://www.w3.org/ns/did/v1"],
   "id": "did:example:21tDAKCERh95uGgKbJNHYp",
   "verificationMethod": [
     {

--- a/pkg/doc/did/testdata/valid_doc_with_base.jsonld
+++ b/pkg/doc/did/testdata/valid_doc_with_base.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": ["https://w3id.org/did/v1",
+  "@context": ["https://www.w3.org/ns/did/v1",
    { "@base": "did:example:123456789abcdefghi"}],
   "id": "did:example:123456789abcdefghi",
   "verificationMethod": [

--- a/pkg/doc/util/kmsdidkey/kmsdidkey.go
+++ b/pkg/doc/util/kmsdidkey/kmsdidkey.go
@@ -1,0 +1,75 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package kmsdidkey
+
+import (
+	"crypto/elliptic"
+	"encoding/json"
+	"fmt"
+
+	cryptoapi "github.com/hyperledger/aries-framework-go/pkg/crypto"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
+)
+
+// keyTypeCodecs maps kms.KeyType to did:key codec.
+// nolint: gochecknoglobals
+var keyTypeCodecs = map[kms.KeyType]uint64{
+	// signing keys
+	kms.ED25519:                fingerprint.ED25519PubKeyMultiCodec,
+	kms.BLS12381G2Type:         fingerprint.BLS12381g2PubKeyMultiCodec,
+	kms.ECDSAP256TypeIEEEP1363: fingerprint.P256PubKeyMultiCodec,
+	kms.ECDSAP256TypeDER:       fingerprint.P256PubKeyMultiCodec,
+	kms.ECDSAP384TypeIEEEP1363: fingerprint.P384PubKeyMultiCodec,
+	kms.ECDSAP384TypeDER:       fingerprint.P384PubKeyMultiCodec,
+	kms.ECDSAP521TypeIEEEP1363: fingerprint.P521PubKeyMultiCodec,
+	kms.ECDSAP521TypeDER:       fingerprint.P521PubKeyMultiCodec,
+
+	// encryption keys
+	kms.X25519ECDHKWType:   fingerprint.X25519PubKeyMultiCodec,
+	kms.NISTP256ECDHKW:     fingerprint.P256PubKeyMultiCodec,
+	kms.NISTP384ECDHKWType: fingerprint.P384PubKeyMultiCodec,
+	kms.NISTP521ECDHKWType: fingerprint.P521PubKeyMultiCodec,
+}
+
+// BuildDIDKeyByKMSKeyType creates a did key for pubKeyBytes based on the kms keyType.
+func BuildDIDKeyByKMSKeyType(pubKeyBytes []byte, keyType kms.KeyType) (string, error) {
+	switch keyType {
+	case kms.X25519ECDHKW:
+		pubKey := &cryptoapi.PublicKey{}
+
+		err := json.Unmarshal(pubKeyBytes, pubKey)
+		if err != nil {
+			return "", fmt.Errorf("buildDIDkeyByKMSKeyType failed to unmarshal key type %v: %w", keyType, err)
+		}
+
+		pubKeyBytes = make([]byte, len(pubKey.X))
+		copy(pubKeyBytes, pubKey.X)
+	case kms.NISTP256ECDHKWType, kms.NISTP384ECDHKWType, kms.NISTP521ECDHKWType:
+		pubKey := &cryptoapi.PublicKey{}
+
+		err := json.Unmarshal(pubKeyBytes, pubKey)
+		if err != nil {
+			return "", fmt.Errorf("buildDIDkeyByKMSKeyType failed to unmarshal key type %v: %w", keyType, err)
+		}
+
+		ecKey, err := cryptoapi.ToECKey(pubKey)
+		if err != nil {
+			return "", fmt.Errorf("buildDIDkeyByKMSKeyType failed to unmarshal key type %v: %w", keyType, err)
+		}
+
+		pubKeyBytes = elliptic.Marshal(ecKey.Curve, ecKey.X, ecKey.Y)
+	}
+
+	if codec, ok := keyTypeCodecs[keyType]; ok {
+		kid, _ := fingerprint.CreateDIDKeyByCode(codec, pubKeyBytes)
+
+		return kid, nil
+	}
+
+	return "", fmt.Errorf("keyType '%s' does not have a multi-base codec", keyType)
+}

--- a/pkg/doc/util/kmsdidkey/kmsdidkey_test.go
+++ b/pkg/doc/util/kmsdidkey/kmsdidkey_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package kmsdidkey
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+	"github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol"
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+)
+
+func TestBuildDIDKeyByKMSKeyType(t *testing.T) {
+	sp := mockstorage.NewMockStoreProvider()
+	k := newKMS(t, sp)
+
+	_, ed25519Key, err := k.CreateAndExportPubKeyBytes(kms.ED25519Type)
+	require.NoError(t, err)
+
+	_, bbsKey, err := k.CreateAndExportPubKeyBytes(kms.BLS12381G2Type)
+	require.NoError(t, err)
+
+	_, p256IEEEKey, err := k.CreateAndExportPubKeyBytes(kms.ECDSAP256TypeIEEEP1363)
+	require.NoError(t, err)
+
+	_, p256DERKey, err := k.CreateAndExportPubKeyBytes(kms.ECDSAP256TypeDER)
+	require.NoError(t, err)
+
+	_, p384IEEEKey, err := k.CreateAndExportPubKeyBytes(kms.ECDSAP384TypeIEEEP1363)
+	require.NoError(t, err)
+
+	_, p384DERKey, err := k.CreateAndExportPubKeyBytes(kms.ECDSAP384TypeDER)
+	require.NoError(t, err)
+
+	_, p521IEEEKey, err := k.CreateAndExportPubKeyBytes(kms.ECDSAP521TypeIEEEP1363)
+	require.NoError(t, err)
+
+	_, p521DERKey, err := k.CreateAndExportPubKeyBytes(kms.ECDSAP521TypeDER)
+	require.NoError(t, err)
+
+	_, x25519Key, err := k.CreateAndExportPubKeyBytes(kms.X25519ECDHKWType)
+	require.NoError(t, err)
+
+	_, p256KWKey, err := k.CreateAndExportPubKeyBytes(kms.NISTP256ECDHKW)
+	require.NoError(t, err)
+
+	_, p384KWKey, err := k.CreateAndExportPubKeyBytes(kms.NISTP384ECDHKWType)
+	require.NoError(t, err)
+
+	_, p521KWKey, err := k.CreateAndExportPubKeyBytes(kms.NISTP521ECDHKWType)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		keyBytes []byte
+		keyType  kms.KeyType
+	}{
+		{
+			name:     "test ED25519 key",
+			keyBytes: ed25519Key,
+			keyType:  kms.ED25519Type,
+		},
+		{
+			name:     "test BLS12381G2 key",
+			keyBytes: bbsKey,
+			keyType:  kms.BLS12381G2Type,
+		},
+		{
+			name:     "test ECDSAP256TypeIEEEP1363 key",
+			keyBytes: p256IEEEKey,
+			keyType:  kms.ECDSAP256TypeIEEEP1363,
+		},
+		{
+			name:     "test ECDSAP256TypeDER key",
+			keyBytes: p256DERKey,
+			keyType:  kms.ECDSAP256TypeDER,
+		},
+		{
+			name:     "test ECDSAP384TypeIEEEP1363 key",
+			keyBytes: p384IEEEKey,
+			keyType:  kms.ECDSAP384TypeIEEEP1363,
+		},
+		{
+			name:     "test ECDSAP384TypeDER key",
+			keyBytes: p384DERKey,
+			keyType:  kms.ECDSAP384TypeDER,
+		},
+		{
+			name:     "test ECDSAP521TypeIEEEP1363 key",
+			keyBytes: p521IEEEKey,
+			keyType:  kms.ECDSAP521TypeIEEEP1363,
+		},
+		{
+			name:     "test ECDSAP521TypeDER key",
+			keyBytes: p521DERKey,
+			keyType:  kms.ECDSAP521TypeDER,
+		},
+		{
+			name:     "test X25519ECDHKWType key",
+			keyBytes: x25519Key,
+			keyType:  kms.X25519ECDHKWType,
+		},
+		{
+			name:     "test NISTP256ECDHKW key",
+			keyBytes: p256KWKey,
+			keyType:  kms.NISTP256ECDHKW,
+		},
+		{
+			name:     "test NISTP384ECDHKW key",
+			keyBytes: p384KWKey,
+			keyType:  kms.NISTP384ECDHKW,
+		},
+		{
+			name:     "test NISTP521ECDHKW key",
+			keyBytes: p521KWKey,
+			keyType:  kms.NISTP521ECDHKW,
+		},
+		{
+			name:     "test invalid key",
+			keyBytes: []byte{},
+			keyType:  "undefined",
+		},
+		{
+			name:     "test invalid X25519 key",
+			keyBytes: []byte("wrongKey."),
+			keyType:  kms.X25519ECDHKWType,
+		},
+		{
+			name:     "test invalid NISTP256ECDHKW key",
+			keyBytes: []byte("wrongKey."),
+			keyType:  kms.NISTP256ECDHKW,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			didKey, err := BuildDIDKeyByKMSKeyType(tc.keyBytes, tc.keyType)
+			if tc.name == "test invalid key" {
+				require.EqualError(t, err, "keyType 'undefined' does not have a multi-base codec")
+
+				return
+			}
+
+			if tc.name == "test invalid X25519 key" {
+				require.EqualError(t, err, "buildDIDkeyByKMSKeyType failed to unmarshal key type X25519ECDHKW:"+
+					" invalid character 'w' looking for beginning of value")
+
+				return
+			}
+
+			if tc.name == "test invalid NISTP256ECDHKW key" {
+				require.EqualError(t, err, "buildDIDkeyByKMSKeyType failed to unmarshal key type NISTP256ECDHKW:"+
+					" invalid character 'w' looking for beginning of value")
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Contains(t, didKey, "did:key:z")
+		})
+	}
+}
+
+func newKMS(t *testing.T, store storage.Provider) kms.KeyManager {
+	t.Helper()
+
+	kmsProv := &protocol.MockProvider{
+		StoreProvider: store,
+		CustomLock:    &noop.NoLock{},
+	}
+
+	customKMS, err := localkms.New("local-lock://primary/test/", kmsProv)
+	require.NoError(t, err)
+
+	return customKMS
+}

--- a/pkg/doc/verifiable/credential_jwt_proof_test.go
+++ b/pkg/doc/verifiable/credential_jwt_proof_test.go
@@ -246,7 +246,7 @@ func createDIDKeyFetcher(t *testing.T, pub ed25519.PublicKey, didID string) Publ
 	}
 	createdTime := time.Now()
 	didDoc := &did.Doc{
-		Context:            []string{did.Context},
+		Context:            []string{did.ContextV1},
 		ID:                 id,
 		VerificationMethod: []did.VerificationMethod{*pubKey},
 		Service:            services,

--- a/pkg/framework/aries/api/protocol.go
+++ b/pkg/framework/aries/api/protocol.go
@@ -45,6 +45,8 @@ type Provider interface {
 	VerifiableStore() verifiable.Store
 	DIDConnectionStore() did.ConnectionStore
 	JSONLDDocumentLoader() ld.DocumentLoader
+	KeyType() kms.KeyType
+	KeyAgreementType() kms.KeyType
 }
 
 // ProtocolSvcCreator method to create new protocol service.

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -81,12 +81,6 @@ func defFrameworkOpts(frameworkOpts *Aries) error {
 		}
 	}
 
-	if frameworkOpts.kmsCreator == nil {
-		frameworkOpts.kmsCreator = func(provider kms.Provider) (kms.KeyManager, error) {
-			return localkms.New(defaultMasterKeyURI, provider)
-		}
-	}
-
 	return setAdditionalDefaultOpts(frameworkOpts)
 }
 
@@ -158,10 +152,10 @@ func newOutOfBandSvc() api.ProtocolSvcCreator {
 	}
 }
 
-func setAdditionalDefaultOpts(frameworkOpts *Aries) error {
+func setDefaultKMSCryptOpts(frameworkOpts *Aries) error {
 	if frameworkOpts.kmsCreator == nil {
 		frameworkOpts.kmsCreator = func(provider kms.Provider) (kms.KeyManager, error) {
-			return localkms.New("local-lock://", provider)
+			return localkms.New(defaultMasterKeyURI, provider)
 		}
 	}
 
@@ -173,6 +167,23 @@ func setAdditionalDefaultOpts(frameworkOpts *Aries) error {
 		}
 
 		frameworkOpts.crypto = cr
+	}
+
+	return nil
+}
+
+func setAdditionalDefaultOpts(frameworkOpts *Aries) error {
+	err := setDefaultKMSCryptOpts(frameworkOpts)
+	if err != nil {
+		return err
+	}
+
+	if frameworkOpts.keyType == "" {
+		frameworkOpts.keyType = kms.ED25519Type
+	}
+
+	if frameworkOpts.keyAgreementType == "" {
+		frameworkOpts.keyAgreementType = kms.X25519ECDHKWType
 	}
 
 	if frameworkOpts.packerCreator == nil {

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -68,6 +68,8 @@ type Aries struct {
 	jsonldDocumentLoader       ld.DocumentLoader
 	transportReturnRoute       string
 	id                         string
+	keyType                    kms.KeyType
+	keyAgreementType           kms.KeyType
 }
 
 // Option configures the framework.
@@ -293,6 +295,22 @@ func WithJSONLDDocumentLoader(loader ld.DocumentLoader) Option {
 	}
 }
 
+// WithKeyType injects a default signing key type.
+func WithKeyType(keyType kms.KeyType) Option {
+	return func(opts *Aries) error {
+		opts.keyType = keyType
+		return nil
+	}
+}
+
+// WithKeyAgreementType injects a default encryption key type.
+func WithKeyAgreementType(keyAgreementType kms.KeyType) Option {
+	return func(opts *Aries) error {
+		opts.keyAgreementType = keyAgreementType
+		return nil
+	}
+}
+
 // Context provides a handle to the framework context.
 func (a *Aries) Context() (*context.Provider, error) {
 	return context.New(
@@ -316,6 +334,8 @@ func (a *Aries) Context() (*context.Provider, error) {
 		context.WithVerifiableStore(a.verifiableStore),
 		context.WithDIDConnectionStore(a.didConnectionStore),
 		context.WithJSONLDDocumentLoader(a.jsonldDocumentLoader),
+		context.WithKeyType(a.keyType),
+		context.WithKeyAgreementType(a.keyAgreementType),
 	)
 }
 

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -56,7 +56,7 @@ import (
 
 //nolint:lll
 const doc = `{
-  "@context": ["https://w3id.org/did/v1","https://w3id.org/did/v2"],
+  "@context": ["https://www.w3.org/ns/did/v1","https://www.w3.org/ns/did/v2"],
   "id": "did:peer:21tDAKCERh95uGgKbJNHYp",
   "verificationMethod": [
     {
@@ -629,6 +629,13 @@ func TestFramework(t *testing.T) {
 		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "document loader creation failed")
+	})
+
+	t.Run("test KeyType and KeyAgreement option", func(t *testing.T) {
+		aries, err := New(WithKeyType(kms.BLS12381G2Type), WithKeyAgreementType(kms.NISTP384ECDHKWType))
+		require.NoError(t, err)
+		require.Equal(t, kms.BLS12381G2Type, aries.keyType)
+		require.Equal(t, kms.NISTP384ECDHKWType, aries.keyAgreementType)
 	})
 }
 

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -24,6 +24,7 @@ import (
 	didStoreMocks "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/store/did"
 	verifiableStoreMocks "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/store/verifiable"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/jsonldtest"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	mockcrypto "github.com/hyperledger/aries-framework-go/pkg/mock/crypto"
 	mockdidcomm "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm"
 	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/dispatcher"
@@ -600,5 +601,23 @@ func TestNewProvider(t *testing.T) {
 		prov, err := New(WithAriesFrameworkID(frameworkID))
 		require.NoError(t, err)
 		require.Equal(t, frameworkID, prov.AriesFrameworkID())
+	})
+
+	t.Run("test new with KeyType", func(t *testing.T) {
+		prov, err := New(WithKeyType(kms.ECDSAP256TypeIEEEP1363))
+		require.NoError(t, err)
+		require.EqualValues(t, kms.ECDSAP256TypeIEEEP1363, prov.KeyType())
+
+		_, err = New(WithKeyType(kms.XChaCha20Poly1305Type))
+		require.EqualError(t, err, "option failed: invalid authentication key type: XChaCha20Poly1305")
+	})
+
+	t.Run("test new with KeyType for KeyAgreement", func(t *testing.T) {
+		prov, err := New(WithKeyAgreementType(kms.NISTP256ECDHKWType))
+		require.NoError(t, err)
+		require.Equal(t, kms.NISTP256ECDHKWType, prov.KeyAgreementType())
+
+		_, err = New(WithKeyAgreementType(kms.XChaCha20Poly1305Type))
+		require.EqualError(t, err, "option failed: invalid KeyAgreement key type: XChaCha20Poly1305")
 	})
 }

--- a/pkg/mock/didcomm/protocol/mock_protocol.go
+++ b/pkg/mock/didcomm/protocol/mock_protocol.go
@@ -40,6 +40,8 @@ type MockProvider struct {
 	ServiceMap                   map[string]interface{}
 	InboundMsgHandler            transport.InboundMessageHandler
 	InboundDIDCommMsgHandlerFunc func() service.InboundHandler
+	KeyTypeValue                 kms.KeyType
+	KeyAgreementTypeValue        kms.KeyType
 }
 
 // OutboundDispatcher is mock outbound dispatcher for DID exchange service.
@@ -132,6 +134,16 @@ func (p *MockProvider) InboundDIDCommMessageHandler() func() service.InboundHand
 // DIDConnectionStore returns DID connection store.
 func (p *MockProvider) DIDConnectionStore() did.ConnectionStore {
 	return &mockConnectionStore{}
+}
+
+// KeyType returns a mocked keyType value for authentication (signing).
+func (p *MockProvider) KeyType() kms.KeyType {
+	return p.KeyTypeValue
+}
+
+// KeyAgreementType returns a mocked keyType value for KeyAgreement.
+func (p *MockProvider) KeyAgreementType() kms.KeyType {
+	return p.KeyAgreementTypeValue
 }
 
 type mockConnectionStore struct{}

--- a/pkg/mock/provider/mock_provider.go
+++ b/pkg/mock/provider/mock_provider.go
@@ -33,6 +33,8 @@ type Provider struct {
 	VDRegistryValue                   vdrapi.Registry
 	CryptoValue                       crypto.Crypto
 	JSONLDDocumentLoaderValue         ld.DocumentLoader
+	KeyTypeValue                      kms.KeyType
+	KeyAgreementTypeValue             kms.KeyType
 }
 
 // Service return service.
@@ -106,4 +108,14 @@ func (p *Provider) VDRegistry() vdrapi.Registry {
 // JSONLDDocumentLoader returns JSON-LD document loader.
 func (p *Provider) JSONLDDocumentLoader() ld.DocumentLoader {
 	return p.JSONLDDocumentLoaderValue
+}
+
+// KeyType returns a mocked keyType value for authentication (signing).
+func (p *Provider) KeyType() kms.KeyType {
+	return p.KeyTypeValue
+}
+
+// KeyAgreementType returns a mocked keyType value for KeyAgreement.
+func (p *Provider) KeyAgreementType() kms.KeyType {
+	return p.KeyAgreementTypeValue
 }

--- a/pkg/store/did/store_test.go
+++ b/pkg/store/did/store_test.go
@@ -264,7 +264,7 @@ func createDIDDocWithKey(pub string) *did.Doc {
 	}
 	createdTime := time.Now()
 	didDoc := &did.Doc{
-		Context:            []string{did.Context},
+		Context:            []string{did.ContextV1},
 		ID:                 id,
 		VerificationMethod: []did.VerificationMethod{pubKey},
 		Service:            services,

--- a/pkg/vdr/peer/creator_test.go
+++ b/pkg/vdr/peer/creator_test.go
@@ -7,24 +7,32 @@ SPDX-License-Identifier: Apache-2.0
 package peer
 
 import (
+	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util/jwkkid"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+	mockprotocol "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol"
 	"github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
 	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
-)
-
-const (
-	keyType = ed25519VerificationKey2018
+	spi "github.com/hyperledger/aries-framework-go/spi/storage"
 )
 
 func TestDIDCreator(t *testing.T) {
+	sProvider := storage.NewMockStoreProvider()
+	km := newKMS(t, sProvider)
+
 	t.Run("test create without service type", func(t *testing.T) {
-		c, err := New(storage.NewMockStoreProvider())
+		c, err := New(sProvider)
 		require.NoError(t, err)
 		require.NotNil(t, c)
 
@@ -36,8 +44,30 @@ func TestDIDCreator(t *testing.T) {
 		require.Empty(t, docResolution.DIDDocument.Service)
 	})
 
+	t.Run("test create using didDoc without VerificationMethod", func(t *testing.T) {
+		c, err := New(sProvider)
+		require.NoError(t, err)
+		require.NotNil(t, c)
+
+		_, err = c.Create(&did.Doc{})
+		require.EqualError(t, err, "create peer DID : verification method and key agreement are empty, at "+
+			"least one should be set")
+	})
+
+	t.Run("test create using didDoc with VerificationMethod having undefined Type", func(t *testing.T) {
+		c, err := New(sProvider)
+		require.NoError(t, err)
+		require.NotNil(t, c)
+
+		vm := getSigningKey()
+		vm.Type = "undefined"
+
+		_, err = c.Create(&did.Doc{VerificationMethod: []did.VerificationMethod{vm}})
+		require.EqualError(t, err, "create peer DID : not supported VerificationMethod public key type: undefined")
+	})
+
 	t.Run("test request overrides", func(t *testing.T) {
-		c, err := New(storage.NewMockStoreProvider())
+		c, err := New(sProvider)
 		require.NoError(t, err)
 		require.NotNil(t, c)
 
@@ -59,8 +89,40 @@ func TestDIDCreator(t *testing.T) {
 		require.Equal(t, routingKeys, docResolution.DIDDocument.Service[0].RoutingKeys)
 	})
 
+	t.Run("test request overrides with keyAgreement", func(t *testing.T) {
+		c, err := New(sProvider)
+		require.NoError(t, err)
+		require.NotNil(t, c)
+
+		sVM, eVM := getSigningAndKeyAgreementKey(t, false, km)
+
+		routingKeys := []string{"abc", "xyz"}
+		docResolution, err := c.Create(
+			&did.Doc{
+				VerificationMethod: []did.VerificationMethod{sVM}, Service: []did.Service{{
+					ServiceEndpoint: "request-endpoint",
+					Type:            "request-type",
+					RoutingKeys:     routingKeys,
+				}},
+				KeyAgreement: []did.Verification{eVM},
+			})
+
+		require.NoError(t, err)
+		require.NotNil(t, docResolution.DIDDocument)
+
+		// verify service not empty, type and endpoint from request options
+		require.NotEmpty(t, docResolution.DIDDocument.Service)
+		require.Equal(t, "request-type", docResolution.DIDDocument.Service[0].Type)
+		require.Equal(t, "request-endpoint", docResolution.DIDDocument.Service[0].ServiceEndpoint)
+		require.Equal(t, routingKeys, docResolution.DIDDocument.Service[0].RoutingKeys)
+
+		// verify KeyAgreement
+		require.Len(t, docResolution.DIDDocument.KeyAgreement, 1)
+		require.EqualValues(t, eVM, docResolution.DIDDocument.KeyAgreement[0])
+	})
+
 	t.Run("test accept", func(t *testing.T) {
-		c, err := New(&storage.MockStoreProvider{})
+		c, err := New(sProvider)
 		require.NoError(t, err)
 		require.NotNil(t, c)
 
@@ -73,15 +135,107 @@ func TestDIDCreator(t *testing.T) {
 }
 
 func TestBuild(t *testing.T) {
+	sProvider := storage.NewMockStoreProvider()
+	km := newKMS(t, sProvider)
 	t.Run("inlined recipient keys for didcomm", func(t *testing.T) {
 		expected := getSigningKey()
-		c, err := New(storage.NewMockStoreProvider())
+		c, err := New(sProvider)
 		require.NoError(t, err)
 
 		result, err := c.Create(
 			&did.Doc{VerificationMethod: []did.VerificationMethod{expected}, Service: []did.Service{{
 				Type: "did-communication",
 			}}})
+
+		expectedDIDKey, _ := fingerprint.CreateDIDKey(expected.Value)
+
+		require.NoError(t, err)
+		require.NotEmpty(t, result.DIDDocument.Service)
+		require.NotEmpty(t, result.DIDDocument.Service[0].RecipientKeys)
+		require.Equal(t, expectedDIDKey,
+			result.DIDDocument.Service[0].RecipientKeys[0])
+	})
+
+	t.Run("create using Service with empty type and bad DefaultServiceType opt (not string)", func(t *testing.T) {
+		expected, keyAgreement := getSigningAndKeyAgreementKey(t, false, km)
+		c, err := New(sProvider)
+		require.NoError(t, err)
+
+		_, err = c.Create(
+			&did.Doc{
+				VerificationMethod: []did.VerificationMethod{expected},
+				Service: []did.Service{{
+					Type: "",
+				}},
+				KeyAgreement: []did.Verification{keyAgreement},
+			},
+			vdr.WithOption(DefaultServiceType, []byte{}))
+		require.EqualError(t, err, "create peer DID : defaultServiceType not string")
+	})
+
+	t.Run("create using Service with bad store option (not bool)", func(t *testing.T) {
+		expected, keyAgreement := getSigningAndKeyAgreementKey(t, false, km)
+		c, err := New(sProvider)
+		require.NoError(t, err)
+
+		_, err = c.Create(
+			&did.Doc{
+				VerificationMethod: []did.VerificationMethod{expected},
+				Service: []did.Service{{
+					Type: "",
+				}},
+				KeyAgreement: []did.Verification{keyAgreement},
+			},
+			vdr.WithOption("store", []byte{}))
+		require.EqualError(t, err, "store opt not boolean")
+	})
+
+	t.Run("create using Service with bad DefaultServiceEndpoint option (not string)", func(t *testing.T) {
+		expected, keyAgreement := getSigningAndKeyAgreementKey(t, false, km)
+		c, err := New(sProvider)
+		require.NoError(t, err)
+
+		_, err = c.Create(
+			&did.Doc{
+				VerificationMethod: []did.VerificationMethod{expected},
+				Service: []did.Service{{
+					Type: "did-communication",
+				}},
+				KeyAgreement: []did.Verification{keyAgreement},
+			})
+		require.NoError(t, err, "create peer DID : defaultServiceEndpoint not string")
+	})
+
+	t.Run("create using Service with bad DefaultServiceEndpoint option (not string)", func(t *testing.T) {
+		expected, keyAgreement := getSigningAndKeyAgreementKey(t, false, km)
+		c, err := New(sProvider)
+		require.NoError(t, err)
+
+		_, err = c.Create(
+			&did.Doc{
+				VerificationMethod: []did.VerificationMethod{expected},
+				Service: []did.Service{{
+					Type: "did-communication",
+				}},
+				KeyAgreement: []did.Verification{keyAgreement},
+			},
+			vdr.WithOption(DefaultServiceEndpoint, []byte{}))
+		require.EqualError(t, err, "create peer DID : defaultServiceEndpoint not string")
+	})
+
+	t.Run("create using Service with P-256 keys as jsonWebKey2020 - should pass", func(t *testing.T) {
+		expected, keyAgreement := getSigningAndKeyAgreementKey(t, true, km)
+		c, err := New(sProvider)
+		require.NoError(t, err)
+
+		result, err := c.Create(
+			&did.Doc{
+				VerificationMethod: []did.VerificationMethod{expected},
+				Service: []did.Service{{
+					Type: "did-communication",
+				}},
+				KeyAgreement: []did.Verification{keyAgreement},
+			})
 
 		expectedDIDKey, _ := fingerprint.CreateDIDKey(expected.Value)
 
@@ -99,5 +253,61 @@ func getSigningKey() did.VerificationMethod {
 		panic(err)
 	}
 
-	return did.VerificationMethod{Value: pub[:], Type: keyType}
+	return did.VerificationMethod{Value: pub[:], Type: ed25519VerificationKey2018}
+}
+
+func getSigningAndKeyAgreementKey(t *testing.T, useJWK bool, km kms.KeyManager) (did.VerificationMethod, did.Verification) { // nolint:lll
+	if !useJWK {
+		signingPub, _, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		encPub := make([]byte, 32)
+
+		_, err = rand.Read(encPub)
+		require.NoError(t, err)
+
+		return did.VerificationMethod{Value: signingPub[:], Type: ed25519VerificationKey2018}, did.Verification{
+			VerificationMethod: did.VerificationMethod{Value: encPub, Type: x25519KeyAgreementKey2019},
+			Relationship:       did.KeyAgreement,
+		}
+	}
+
+	crv := elliptic.P256()
+	privateKey, err := ecdsa.GenerateKey(crv, rand.Reader)
+	require.NoError(t, err)
+
+	keyBytes := elliptic.Marshal(crv, privateKey.X, privateKey.Y)
+	signingJWK, err := jwkkid.BuildJWK(keyBytes, kms.ECDSAP256TypeIEEEP1363)
+	require.NoError(t, err)
+
+	kid, encKeyBytes, err := km.CreateAndExportPubKeyBytes(kms.NISTP256ECDHKWType)
+	require.NoError(t, err)
+
+	encryptionJWK, err := jwkkid.BuildJWK(encKeyBytes, kms.NISTP256ECDHKWType)
+	require.NoError(t, err)
+
+	signingVM, err := did.NewVerificationMethodFromJWK("", jsonWebKey2020, "", signingJWK)
+	require.NoError(t, err)
+
+	kaVM, err := did.NewVerificationMethodFromJWK("#"+kid, jsonWebKey2020, "", encryptionJWK)
+	require.NoError(t, err)
+
+	return *signingVM, did.Verification{
+		VerificationMethod: *kaVM,
+		Relationship:       did.KeyAgreement,
+	}
+}
+
+func newKMS(t *testing.T, store spi.Provider) kms.KeyManager {
+	t.Helper()
+
+	kmsProv := &mockprotocol.MockProvider{
+		StoreProvider: store,
+		CustomLock:    &noop.NoLock{},
+	}
+
+	customKMS, err := localkms.New("local-lock://primary/test/", kmsProv)
+	require.NoError(t, err)
+
+	return customKMS
 }

--- a/pkg/vdr/registry.go
+++ b/pkg/vdr/registry.go
@@ -101,8 +101,6 @@ func (r *Registry) Create(didMethod string, did *diddoc.Doc,
 	opts ...vdrapi.DIDMethodOption) (*diddoc.DocResolution, error) {
 	docOpts := &vdrapi.DIDMethodOpts{Values: make(map[string]interface{})}
 
-	// TODO add EncryptionKey as option in docOpts here to support Anoncrypt/Authcrypt packing
-
 	for _, opt := range opts {
 		opt(docOpts)
 	}

--- a/test/aries-js-worker/test/vdr/vdr.js
+++ b/test/aries-js-worker/test/vdr/vdr.js
@@ -33,7 +33,7 @@ describe("VDR", function () {
         for (let i = 0; i < agents.length; i++) {
             let resp;
             try {
-                resp = await agents[i].vdr.createDID({"method": "peer","did":{"@context":["https://w3id.org/did/v1"],"id":"c1ffe6e5-16ad-4dd3-a6d3-df5bba841892","verificationMethod":[{"controller":"","id":"","publicKeyBase58":"2keDRdS4b9gjFKKoWhSwMpPWWqbx5HRywi9M7sGk2am8","type":"Ed25519VerificationKey2018"}]}})
+                resp = await agents[i].vdr.createDID({"method": "peer","did":{"@context":["https://www.w3.org/ns/did/v1"],"id":"c1ffe6e5-16ad-4dd3-a6d3-df5bba841892","verificationMethod":[{"controller":"","id":"","publicKeyBase58":"2keDRdS4b9gjFKKoWhSwMpPWWqbx5HRywi9M7sGk2am8","type":"Ed25519VerificationKey2018"}]}})
             }catch (e) {
                 assert.fail(e.message);
             }


### PR DESCRIPTION
This change adds the following features:
    1. A new encryption key is added into the DID doc in DIDcomm, stored as a KeyAgreement verification.
    2. Includes variable key types for authentication (signing) and encryption keys in the framework and the DIDExchange service.
    3. Introduces a new JWK helper function (PubKeyBytesToJWK) to create a JWK from raw key bytes and a kms key type.
    4. Finally it updates the DID doc context to the official V1 schema url "https://www.w3.org/ns/did/v1".

closes #1993, #2682

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
