### PR TITLE
feat: auth based access wallet store

### DIFF
--- a/pkg/mock/storage/mock_store.go
+++ b/pkg/mock/storage/mock_store.go
@@ -104,6 +104,7 @@ type MockStore struct {
 	ErrValue  error
 	ErrKey    error
 	ErrBatch  error
+	ErrClose  error
 }
 
 // Put stores the key and the record.
@@ -226,7 +227,7 @@ func (s *MockStore) Flush() error {
 
 // Close is not implemented.
 func (s *MockStore) Close() error {
-	panic("implement me")
+	return s.ErrClose
 }
 
 func (s *MockStore) getMatchingKeysAndDBEntries(tagName, tagValue string) ([]string, []DBEntry) {

--- a/pkg/wallet/kmsclient.go
+++ b/pkg/wallet/kmsclient.go
@@ -67,6 +67,9 @@ var (
 
 	// WalletLocked when key manager operation is attempted without unlocking wallet.
 	ErrWalletLocked = errors.New("wallet locked")
+
+	// ErrInvalidAuthToken when auth token provided to wallet is unable to unlock key manager.
+	ErrInvalidAuthToken = errors.New("invalid auth token")
 )
 
 // walletKMSInstance is key manager store singleton - access only via keyManager()

--- a/pkg/wallet/options.go
+++ b/pkg/wallet/options.go
@@ -14,37 +14,41 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
 )
 
-// kmsOpts contains options for creating verifiable credential wallet.
-type kmsOpts struct {
+// profileOpts contains options for creating verifiable credential wallet.
+type profileOpts struct {
 	// local kms options
 	secretLockSvc secretlock.Service
 	passphrase    string
 
 	// remote(web) kms options
 	keyServerURL string
+
+	// EDV options
+	edvServerURL string
+	vaultID      string
 }
 
-// ProfileKeyManagerOptions is option for verifiable credential wallet key manager.
-type ProfileKeyManagerOptions func(opts *kmsOpts)
+// ProfileOptions is option for verifiable credential wallet key manager.
+type ProfileOptions func(opts *profileOpts)
 
 // WithSecretLockService option, when provided then wallet will use local kms for key operations.
-func WithSecretLockService(svc secretlock.Service) ProfileKeyManagerOptions {
-	return func(opts *kmsOpts) {
+func WithSecretLockService(svc secretlock.Service) ProfileOptions {
+	return func(opts *profileOpts) {
 		opts.secretLockSvc = svc
 	}
 }
 
 // WithPassphrase option to provide passphrase for local kms for key operations.
-func WithPassphrase(passphrase string) ProfileKeyManagerOptions {
-	return func(opts *kmsOpts) {
+func WithPassphrase(passphrase string) ProfileOptions {
+	return func(opts *profileOpts) {
 		opts.passphrase = passphrase
 	}
 }
 
 // WithKeyServerURL option, when provided then wallet will use remote kms for key operations.
 // This option will be ignore if provided with 'WithSecretLockService' option.
-func WithKeyServerURL(url string) ProfileKeyManagerOptions {
-	return func(opts *kmsOpts) {
+func WithKeyServerURL(url string) ProfileOptions {
+	return func(opts *profileOpts) {
 		opts.keyServerURL = url
 	}
 }

--- a/pkg/wallet/profile.go
+++ b/pkg/wallet/profile.go
@@ -38,17 +38,25 @@ type profile struct {
 
 	// KeyServerURL for remotekms.
 	KeyServerURL string
+
+	// EDVServerURL for encrypted data vault storage of wallet contents.
+	EDVServerURL string
+
+	// VaultID for encrypted data vault storage of wallet contents.
+	VaultID string
 }
 
 // createProfile creates new verifiable credential wallet profile for given user and saves it in store.
 // This profile is required for creating verifiable credential wallet client.
-func createProfile(user, passphrase string, secretLockSvc secretlock.Service, keyServerURL string) (*profile, error) {
+func createProfile(user string, opts *profileOpts) (*profile, error) {
 	profile := &profile{User: user, ID: uuid.New().String()}
 
-	err := profile.setKMSOptions(passphrase, secretLockSvc, keyServerURL)
+	err := profile.setKMSOptions(opts.passphrase, opts.secretLockSvc, opts.keyServerURL)
 	if err != nil {
 		return nil, err
 	}
+
+	profile.setEDVOptions(opts.edvServerURL, opts.vaultID)
 
 	return profile, nil
 }
@@ -84,6 +92,11 @@ func (pr *profile) setKMSOptions(passphrase string, secretLockSvc secretlock.Ser
 	}
 
 	return nil
+}
+
+func (pr *profile) setEDVOptions(edvServerURL, vaultID string) {
+	pr.EDVServerURL = edvServerURL
+	pr.VaultID = vaultID
 }
 
 func (pr *profile) resetKMSOptions() {

--- a/pkg/wallet/profile_test.go
+++ b/pkg/wallet/profile_test.go
@@ -25,7 +25,8 @@ const (
 
 func TestCreateNewProfile(t *testing.T) {
 	t.Run("test create new profile with key server URL", func(t *testing.T) {
-		profile, err := createProfile(sampleProfileUser, "", nil, sampleKeyServerURL)
+		profile, err := createProfile(sampleProfileUser,
+			&profileOpts{passphrase: "", secretLockSvc: nil, keyServerURL: sampleKeyServerURL})
 
 		require.NoError(t, err)
 		require.NotEmpty(t, profile)
@@ -35,7 +36,8 @@ func TestCreateNewProfile(t *testing.T) {
 	})
 
 	t.Run("test create new profile with passphrase", func(t *testing.T) {
-		profile, err := createProfile(sampleProfileUser, samplePassPhrase, nil, "")
+		profile, err := createProfile(sampleProfileUser,
+			&profileOpts{passphrase: samplePassPhrase, secretLockSvc: nil, keyServerURL: sampleKeyServerURL})
 
 		require.NoError(t, err)
 		require.NotEmpty(t, profile)
@@ -45,9 +47,10 @@ func TestCreateNewProfile(t *testing.T) {
 	})
 
 	t.Run("test create new profile with secret lock service", func(t *testing.T) {
-		profile, err := createProfile(sampleProfileUser, "", &secretlock.MockSecretLock{
-			ValEncrypt: sampleMasterCipherText,
-		}, sampleKeyServerURL)
+		profile, err := createProfile(sampleProfileUser,
+			&profileOpts{passphrase: "", secretLockSvc: &secretlock.MockSecretLock{
+				ValEncrypt: sampleMasterCipherText,
+			}, keyServerURL: sampleKeyServerURL})
 
 		require.NoError(t, err)
 		require.NotEmpty(t, profile)
@@ -58,16 +61,18 @@ func TestCreateNewProfile(t *testing.T) {
 
 	t.Run("test create new profile failure", func(t *testing.T) {
 		// invalid profile option
-		profile, err := createProfile(sampleProfileUser, "", nil, "")
+		profile, err := createProfile(sampleProfileUser,
+			&profileOpts{passphrase: "", secretLockSvc: nil, keyServerURL: ""})
 
 		require.Empty(t, profile)
 		require.Error(t, err)
 		require.EqualError(t, err, "invalid create profile options")
 
 		// secret lock service error
-		profile, err = createProfile(sampleProfileUser, "", &secretlock.MockSecretLock{
-			ErrEncrypt: fmt.Errorf(sampleCustomProfileErr),
-		}, "")
+		profile, err = createProfile(sampleProfileUser,
+			&profileOpts{passphrase: "", secretLockSvc: &secretlock.MockSecretLock{
+				ErrEncrypt: fmt.Errorf(sampleCustomProfileErr),
+			}, keyServerURL: ""})
 
 		require.Empty(t, profile)
 		require.Error(t, err)


### PR DESCRIPTION
- for upcoming EDV integration, wallet interfaces expectes auth token
for accessing wallet contents too.
- `storage.openStore()` occurs during `wallet.Open()` and `store.cloe()`
occurs during `wallet.Close()`
- wallet open will unlock key manager and open database.
- wallet close will remove keyemaner and close database.
- all wallet interfaces now requires auth token.
- wallet content based VDR will expect auth token.
- Closes #2745

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
