### PR TITLE
fix: presentation-exchange schema.uri matching

### DIFF
--- a/pkg/client/vcwallet/client_test.go
+++ b/pkg/client/vcwallet/client_test.go
@@ -941,7 +941,7 @@ func TestClient_Query(t *testing.T) {
 		InputDescriptors: []*presexch.InputDescriptor{{
 			ID: uuid.New().String(),
 			Schema: []*presexch.Schema{{
-				URI: verifiable.ContextURI,
+				URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 			}},
 			Constraints: &presexch.Constraints{
 				Fields: []*presexch.Field{{

--- a/pkg/didcomm/protocol/middleware/presentproof/middlewares_test.go
+++ b/pkg/didcomm/protocol/middleware/presentproof/middlewares_test.go
@@ -471,7 +471,7 @@ func TestPresentationDefinition(t *testing.T) {
 							InputDescriptors: []*presexch.InputDescriptor{{
 								ID: uuid.New().String(),
 								Schema: []*presexch.Schema{{
-									URI: verifiable.ContextURI,
+									URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 								}},
 								Constraints: &presexch.Constraints{
 									Fields: []*presexch.Field{{
@@ -542,7 +542,7 @@ func TestPresentationDefinition(t *testing.T) {
 							InputDescriptors: []*presexch.InputDescriptor{{
 								ID: uuid.New().String(),
 								Schema: []*presexch.Schema{{
-									URI: verifiable.ContextURI,
+									URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 								}},
 								Constraints: &presexch.Constraints{
 									Fields: []*presexch.Field{{

--- a/pkg/doc/presexch/api_test.go
+++ b/pkg/doc/presexch/api_test.go
@@ -39,7 +39,7 @@ func TestPresentationDefinition_Match(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: uri,
+					URI: fmt.Sprintf("%s#%s", uri, verifiable.VCType),
 				}},
 			}},
 		}
@@ -67,7 +67,7 @@ func TestPresentationDefinition_Match(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: uri,
+					URI: fmt.Sprintf("%s#%s", uri, verifiable.VCType),
 				}},
 			}},
 		}
@@ -295,18 +295,20 @@ func TestPresentationDefinition_Match(t *testing.T) {
 }
 
 func TestE2E(t *testing.T) {
+	baseSchemaURI := randomURI()
+
 	// verifier sends their presentation definitions to the holder
 	verifierDefinitions := &PresentationDefinition{
 		InputDescriptors: []*InputDescriptor{{
 			ID: uuid.New().String(),
 			Schema: []*Schema{{
-				URI: randomURI(),
+				URI: fmt.Sprintf("%s#%s", baseSchemaURI, verifiable.VCType),
 			}},
 		}},
 	}
 
 	// holder builds their presentation submission against the verifier's definitions
-	holderCredential := newVC([]string{verifierDefinitions.InputDescriptors[0].Schema[0].URI})
+	holderCredential := newVC([]string{baseSchemaURI})
 	vp := newVP(t,
 		&PresentationSubmission{DescriptorMap: []*InputDescriptorMapping{{
 			ID:   verifierDefinitions.InputDescriptors[0].ID,
@@ -319,7 +321,7 @@ func TestE2E(t *testing.T) {
 	vpBytes := marshal(t, vp)
 
 	// load json-ld context
-	loader := createTestDocumentLoader(t, verifierDefinitions.InputDescriptors[0].Schema[0].URI)
+	loader := createTestDocumentLoader(t, baseSchemaURI)
 
 	// verifier parses the vp
 	receivedVP, err := verifiable.ParsePresentation(vpBytes,

--- a/pkg/doc/presexch/definition.go
+++ b/pkg/doc/presexch/definition.go
@@ -883,7 +883,7 @@ func filterSchema(schemas []*Schema, credentials []*verifiable.Credential) []*ve
 		var applicable bool
 
 		for _, schema := range schemas {
-			applicable = stringsContain(credential.Context, schema.URI)
+			applicable = schemaURIMatch(credential.Context, credential.Types, schema.URI)
 			if schema.Required && !applicable {
 				break
 			}

--- a/pkg/doc/presexch/definition_test.go
+++ b/pkg/doc/presexch/definition_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -109,7 +110,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 				ID:    uuid.New().String(),
 				Group: []string{"A"},
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				Constraints: &Constraints{
 					SubjectIsIssuer: &subIsIssuerRequired,
@@ -121,7 +122,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 				ID:    uuid.New().String(),
 				Group: []string{"child"},
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				Constraints: &Constraints{
 					SubjectIsIssuer: &subIsIssuerRequired,
@@ -138,7 +139,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 				ID:    uuid.New().String(),
 				Group: []string{"teenager"},
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				Constraints: &Constraints{
 					SubjectIsIssuer: &subIsIssuerRequired,
@@ -155,7 +156,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 				ID:    uuid.New().String(),
 				Group: []string{"adult"},
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				Constraints: &Constraints{
 					SubjectIsIssuer: &subIsIssuerRequired,
@@ -282,7 +283,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				Constraints: &Constraints{
 					Fields: []*Field{{
@@ -337,7 +338,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				Constraints: &Constraints{
 					LimitDisclosure: &required,
@@ -394,7 +395,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			ID: uuid.New().String(),
 			InputDescriptors: []*InputDescriptor{{
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				ID: uuid.New().String(),
 				Constraints: &Constraints{
@@ -500,7 +501,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			ID: uuid.New().String(),
 			InputDescriptors: []*InputDescriptor{{
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				ID: uuid.New().String(),
 				Constraints: &Constraints{
@@ -716,7 +717,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				Constraints: &Constraints{
 					SubjectIsIssuer: &subIsIssuerRequired,
@@ -770,7 +771,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				Constraints: &Constraints{
 					SubjectIsIssuer: &subIsIssuerRequired,
@@ -881,7 +882,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				Constraints: &Constraints{
 					LimitDisclosure: &required,
@@ -899,6 +900,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 		vp, err := pd.CreateVP([]*verifiable.Credential{
 			{
 				Context: []string{verifiable.ContextURI},
+				Types:   []string{verifiable.VCType},
 				ID:      uuid.New().String(),
 				Issuer:  verifiable.Issuer{CustomFields: map[string]interface{}{"k": "v"}},
 				CustomFields: map[string]interface{}{
@@ -920,7 +922,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				Constraints: &Constraints{
 					SubjectIsIssuer: &subIsIssuerRequired,
@@ -974,7 +976,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				Constraints: &Constraints{
 					SubjectIsIssuer: &subIsIssuerRequired,
@@ -1023,7 +1025,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				Constraints: &Constraints{
 					SubjectIsIssuer: &subIsIssuerRequired,
@@ -1034,7 +1036,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			}, {
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				Constraints: &Constraints{
 					Fields: []*Field{{
@@ -1082,7 +1084,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 				Constraints: &Constraints{
 					Fields: []*Field{{
@@ -1126,7 +1128,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 			}},
 		}
@@ -1158,7 +1160,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: "https://www.w3.org/2018/credentials/examples/v1",
+					URI: "https://www.w3.org/2018/credentials/examples/v1#UniversityDegreeCredential",
 				}},
 			}},
 		}
@@ -1171,7 +1173,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			},
 			{
 				Context: []string{verifiable.ContextURI, "https://www.w3.org/2018/credentials/examples/v1"},
-				Types:   []string{verifiable.VCType},
+				Types:   []string{verifiable.VCType, "UniversityDegreeCredential"},
 				ID:      uuid.New().String(),
 			},
 		})
@@ -1224,12 +1226,12 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: "https://www.w3.org/2018/credentials/examples/v1",
+					URI: "https://www.w3.org/2018/credentials/examples/v1#UniversityDegreeCredential",
 				}},
 			}, {
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: "https://trustbloc.github.io/context/vc/examples-v1.jsonld",
+					URI: "https://trustbloc.github.io/context/vc/examples-v1.jsonld#DocumentVerification",
 				}},
 			}},
 		}
@@ -1237,12 +1239,12 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 		vp, err := pd.CreateVP([]*verifiable.Credential{
 			{
 				Context: []string{verifiable.ContextURI, "https://www.w3.org/2018/credentials/examples/v1"},
-				Types:   []string{verifiable.VCType},
+				Types:   []string{verifiable.VCType, "UniversityDegreeCredential"},
 				ID:      uuid.New().String(),
 			},
 			{
 				Context: []string{verifiable.ContextURI, "https://trustbloc.github.io/context/vc/examples-v1.jsonld"},
-				Types:   []string{verifiable.VCType},
+				Types:   []string{verifiable.VCType, "DocumentVerification"},
 				ID:      uuid.New().String(),
 			},
 		})
@@ -1344,14 +1346,14 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: "https://trustbloc.github.io/context/vc/examples-v1.jsonld",
+					URI: "https://trustbloc.github.io/context/vc/examples-v1.jsonld#DocumentVerification",
 				}},
 			}, {
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
 					URI: "https://www.w3.org/TR/vc-data-model/2.0/#types",
 				}, {
-					URI:      verifiable.ContextURI,
+					URI:      fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 					Required: true,
 				}},
 			}},
@@ -1364,7 +1366,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			},
 			{
 				Context: []string{verifiable.ContextURI, "https://trustbloc.github.io/context/vc/examples-v1.jsonld"},
-				Types:   []string{verifiable.VCType},
+				Types:   []string{verifiable.VCType, "DocumentVerification"},
 				ID:      uuid.New().String(),
 			},
 		})
@@ -1383,15 +1385,15 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 			InputDescriptors: []*InputDescriptor{{
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI: verifiable.ContextURI,
+					URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 				}},
 			}, {
 				ID: uuid.New().String(),
 				Schema: []*Schema{{
-					URI:      "https://www.w3.org/2018/credentials/examples/v1",
+					URI:      "https://www.w3.org/2018/credentials/examples/v1#UniversityDegreeCredential",
 					Required: true,
 				}, {
-					URI:      "https://trustbloc.github.io/context/vc/examples-v1.jsonld",
+					URI:      "https://trustbloc.github.io/context/vc/examples-v1.jsonld#DocumentVerification",
 					Required: true,
 				}},
 			}},
@@ -1412,7 +1414,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 					"https://www.w3.org/2018/credentials/examples/v1",
 					"https://trustbloc.github.io/context/vc/examples-v1.jsonld",
 				},
-				Types: []string{verifiable.VCType},
+				Types: []string{verifiable.VCType, "UniversityDegreeCredential", "DocumentVerification"},
 				ID:    uuid.New().String(),
 			},
 		})

--- a/pkg/doc/presexch/example_test.go
+++ b/pkg/doc/presexch/example_test.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
+
 	jld "github.com/hyperledger/aries-framework-go/pkg/doc/jsonld"
 	. "github.com/hyperledger/aries-framework-go/pkg/doc/presexch"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
@@ -30,7 +32,7 @@ func ExamplePresentationDefinition_CreateVP() {
 			ID:      "age_descriptor",
 			Purpose: "Your age should be greater or equal to 18.",
 			Schema: []*Schema{{
-				URI: verifiable.ContextURI,
+				URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 			}},
 			Constraints: &Constraints{
 				LimitDisclosure: &required,
@@ -127,7 +129,7 @@ func ExamplePresentationDefinition_CreateVP_multipleMatches() {
 			ID:      "age_descriptor",
 			Purpose: "Your age should be greater or equal to 18.",
 			Schema: []*Schema{{
-				URI: verifiable.ContextURI,
+				URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 			}},
 			Constraints: &Constraints{
 				Fields: []*Field{{
@@ -142,7 +144,7 @@ func ExamplePresentationDefinition_CreateVP_multipleMatches() {
 			ID:      "first_name_descriptor",
 			Purpose: "First name must be either Andrew or Jesse",
 			Schema: []*Schema{{
-				URI: verifiable.ContextURI,
+				URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 			}},
 			Constraints: &Constraints{
 				Fields: []*Field{{
@@ -286,7 +288,7 @@ func ExamplePresentationDefinition_CreateVP_multipleMatchesDisclosure() {
 			ID:      "age_descriptor",
 			Purpose: "Your age should be greater or equal to 18.",
 			Schema: []*Schema{{
-				URI: verifiable.ContextURI,
+				URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 			}},
 			Constraints: &Constraints{
 				Fields: []*Field{{
@@ -301,7 +303,7 @@ func ExamplePresentationDefinition_CreateVP_multipleMatchesDisclosure() {
 			ID:      "first_name_descriptor",
 			Purpose: "First name must be either Andrew or Jesse",
 			Schema: []*Schema{{
-				URI: verifiable.ContextURI,
+				URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 			}},
 			Constraints: &Constraints{
 				LimitDisclosure: &required,
@@ -490,7 +492,7 @@ func ExamplePresentationDefinition_CreateVP_submissionRequirementsLimitDisclosur
 			Group:   []string{"A"},
 			Purpose: "Your age should be greater or equal to 18.",
 			Schema: []*Schema{{
-				URI: verifiable.ContextURI,
+				URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 			}},
 			Constraints: &Constraints{
 				Fields: []*Field{{
@@ -506,7 +508,7 @@ func ExamplePresentationDefinition_CreateVP_submissionRequirementsLimitDisclosur
 			Group:   []string{"drivers_license_image"},
 			Purpose: "We need your photo to identify you",
 			Schema: []*Schema{{
-				URI: verifiable.ContextURI,
+				URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 			}},
 			Constraints: &Constraints{
 				LimitDisclosure: &required,
@@ -523,7 +525,7 @@ func ExamplePresentationDefinition_CreateVP_submissionRequirementsLimitDisclosur
 			Group:   []string{"passport_image"},
 			Purpose: "We need your image to identify you",
 			Schema: []*Schema{{
-				URI: verifiable.ContextURI,
+				URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 			}},
 			Constraints: &Constraints{
 				LimitDisclosure: &required,
@@ -714,7 +716,7 @@ func ExamplePresentationDefinition_CreateVP_submissionRequirements() {
 			Group:   []string{"A"},
 			Purpose: "Your age should be greater or equal to 18.",
 			Schema: []*Schema{{
-				URI: verifiable.ContextURI,
+				URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 			}},
 			Constraints: &Constraints{
 				Fields: []*Field{{
@@ -730,7 +732,7 @@ func ExamplePresentationDefinition_CreateVP_submissionRequirements() {
 			Group:   []string{"drivers_license_image"},
 			Purpose: "We need your photo to identify you",
 			Schema: []*Schema{{
-				URI: verifiable.ContextURI,
+				URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 			}},
 			Constraints: &Constraints{
 				Fields: []*Field{{
@@ -746,7 +748,7 @@ func ExamplePresentationDefinition_CreateVP_submissionRequirements() {
 			Group:   []string{"passport_image"},
 			Purpose: "We need your image to identify you",
 			Schema: []*Schema{{
-				URI: verifiable.ContextURI,
+				URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 			}},
 			Constraints: &Constraints{
 				Fields: []*Field{{
@@ -892,21 +894,21 @@ func ExamplePresentationDefinition_Match() {
 			{
 				ID: "banking",
 				Schema: []*Schema{{
-					URI: "https://example.context.jsonld/account",
+					URI: "https://example.context.jsonld/account#Customer",
 				}},
 			},
 			{
 				ID: "residence",
 				Schema: []*Schema{{
-					URI: "https://example.context.jsonld/address",
+					URI: "https://example.context.jsonld/address#Street",
 				}},
 			},
 		},
 	}
 
 	// holder fetches their credentials
-	accountCredential := newVC([]string{"https://example.context.jsonld/account"})
-	addressCredential := newVC([]string{"https://example.context.jsonld/address"})
+	accountCredential := fetchVC([]string{"https://example.context.jsonld/account"}, []string{"Customer"})
+	addressCredential := fetchVC([]string{"https://example.context.jsonld/address"}, []string{"Street"})
 
 	// holder builds their presentation submission against the verifier's definitions
 	vp, err := newPresentationSubmission(
@@ -1021,3 +1023,20 @@ const exampleJSONLDContext = `{
       "xsd":"http://www.w3.org/2001/XMLSchema#"
    }
 }`
+
+func fetchVC(ctx, types []string) *verifiable.Credential {
+	vc := &verifiable.Credential{
+		Context: append([]string{verifiable.ContextURI}, ctx...),
+		Types:   append([]string{verifiable.VCType}, types...),
+		ID:      "http://test.credential.com/123",
+		Issuer:  verifiable.Issuer{ID: "http://test.issuer.com"},
+		Issued: &util.TimeWithTrailingZeroMsec{
+			Time: time.Now(),
+		},
+		Subject: map[string]interface{}{
+			"id": uuid.New().String(),
+		},
+	}
+
+	return vc
+}

--- a/pkg/wallet/query_test.go
+++ b/pkg/wallet/query_test.go
@@ -257,7 +257,7 @@ func TestQuery_PerformQuery(t *testing.T) {
 		InputDescriptors: []*presexch.InputDescriptor{{
 			ID: uuid.New().String(),
 			Schema: []*presexch.Schema{{
-				URI: verifiable.ContextURI,
+				URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 			}},
 			Constraints: &presexch.Constraints{
 				Fields: []*presexch.Field{{

--- a/pkg/wallet/wallet_test.go
+++ b/pkg/wallet/wallet_test.go
@@ -750,7 +750,7 @@ func TestWallet_Query(t *testing.T) {
 		InputDescriptors: []*presexch.InputDescriptor{{
 			ID: uuid.New().String(),
 			Schema: []*presexch.Schema{{
-				URI: verifiable.ContextURI,
+				URI: fmt.Sprintf("%s#%s", verifiable.ContextURI, verifiable.VCType),
 			}},
 			Constraints: &presexch.Constraints{
 				Fields: []*presexch.Field{{

--- a/test/aries-js-worker/test/presentproof/presentproof.js
+++ b/test/aries-js-worker/test/presentproof/presentproof.js
@@ -139,7 +139,7 @@ async function presentProofBBS(mode) {
                                                 "adcc44d9-1c0e-4e8f-9f21-6eda7dba9160",
                                             schema: [
                                                 {
-                                                    uri: "https://www.w3.org/2018/credentials/examples/v1"
+                                                    uri: "https://www.w3.org/2018/credentials/examples/v1#UniversityDegreeCredential"
                                                 },
                                             ],
                                             constraints: {

--- a/test/bdd/pkg/presentproof/presentproof_sdk_steps.go
+++ b/test/bdd/pkg/presentproof/presentproof_sdk_steps.go
@@ -249,7 +249,7 @@ func (a *SDKSteps) sendRequestPresentationDefinition(agent1, agent2 string) erro
 						ID: uuid.New().String(),
 						InputDescriptors: []*presexch.InputDescriptor{{
 							Schema: []*presexch.Schema{{
-								URI: "https://www.w3.org/2018/credentials/examples/v1",
+								URI: "https://www.w3.org/2018/credentials/examples/v1#UniversityDegreeCredential",
 							}},
 							ID: uuid.New().String(),
 							Constraints: &presexch.Constraints{

--- a/test/bdd/pkg/presentproof/testdata/request_presentation_bbs.json
+++ b/test/bdd/pkg/presentproof/testdata/request_presentation_bbs.json
@@ -20,7 +20,7 @@
                 "id":"f5a19811-06b1-42ae-b9ae-56e95ef67bee",
                 "schema":[
                   {
-                    "uri": "https://www.w3.org/2018/credentials/examples/v1"
+                    "uri": "https://www.w3.org/2018/credentials/examples/v1#UniversityDegreeCredential"
                   }
                 ],
                 "constraints":{


### PR DESCRIPTION
The `schema.uri` in presentation definitions should be the full URI to the type's definition (jsonschema or jsonld), not just the context. [Reference](https://github.com/decentralized-identity/presentation-exchange/issues/134#issuecomment-721624167).

TODO - #2756 

Signed-off-by: George Aristy <george.aristy@securekey.com>

