### PR TITLE
feat: wallet open options for webkms & EDV

### DIFF
--- a/pkg/wallet/contents.go
+++ b/pkg/wallet/contents.go
@@ -112,8 +112,8 @@ func newContentStore(p storage.Provider, pr *profile) *contentStore {
 	return &contentStore{open: storeLocked, close: noOp, provider: newWalletStorageProvider(pr, p)}
 }
 
-func (cs *contentStore) Open(auth string) error {
-	store, err := cs.provider.OpenStore(auth, storage.StoreConfiguration{TagNames: []string{
+func (cs *contentStore) Open(auth string, opts *unlockOpts) error {
+	store, err := cs.provider.OpenStore(auth, opts, storage.StoreConfiguration{TagNames: []string{
 		Collection.Name(), Credential.Name(), Connection.Name(), DIDResolutionResponse.Name(), Connection.Name(), Key.Name(),
 	}})
 	if err != nil {

--- a/pkg/wallet/options.go
+++ b/pkg/wallet/options.go
@@ -10,7 +10,9 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/hyperledger/aries-framework-go/component/storage/edv"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/webkms"
 	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
 )
 
@@ -73,10 +75,14 @@ type unlockOpts struct {
 	secretLockSvc secretlock.Service
 
 	// remote(web) kms options
-	authToken string
+	authToken  string
+	webkmsOpts []webkms.Opt
 
 	// expiry
 	tokenExpiry time.Duration
+
+	// edv opts
+	edvOpts []edv.RESTProviderOption
 }
 
 // UnlockOptions is option for unlocking verifiable credential wallet key manager.
@@ -114,6 +120,22 @@ func WithUnlockByAuthorizationToken(url string) UnlockOptions {
 func WithUnlockExpiry(tokenExpiry time.Duration) UnlockOptions {
 	return func(opts *unlockOpts) {
 		opts.tokenExpiry = tokenExpiry
+	}
+}
+
+// WithUnlockWebKMSOptions can be used to provide custom aries web kms options for unlocking wallet.
+// This option can be used to set web kms client http header function instead of using WithUnlockByAuthorizationToken.
+func WithUnlockWebKMSOptions(webkmsOpts ...webkms.Opt) UnlockOptions {
+	return func(opts *unlockOpts) {
+		opts.webkmsOpts = webkmsOpts
+	}
+}
+
+// WithUnlockEDVOptions can be used to provide custom aries edv options for unlocking wallet.
+// Provided options will be considered only if given wallet profile is using EDV configurations.
+func WithUnlockEDVOptions(edvOpts ...edv.RESTProviderOption) UnlockOptions {
+	return func(opts *unlockOpts) {
+		opts.edvOpts = edvOpts
 	}
 }
 

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -201,7 +201,7 @@ func (c *Wallet) Open(options ...UnlockOptions) (string, error) {
 	}
 
 	// open content store using token
-	err = c.contents.Open(token)
+	err = c.contents.Open(token, opts)
 	if err != nil {
 		// close wallet if it fails to open store
 		c.Close()


### PR DESCRIPTION
- added more unlock wallet options to use all aries webkms & EDV
customization opts.
- can be used to pass auth & authz based http headers for EDV & web kms
- closes #2763

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
