### PR TITLE
fix: ECDH-1PU key derivation logic

### DIFF
--- a/pkg/crypto/tinkcrypto/testdata/alice_epk_ref.json
+++ b/pkg/crypto/tinkcrypto/testdata/alice_epk_ref.json
@@ -1,0 +1,7 @@
+{
+  "kty":"EC",
+  "crv":"P-256",
+  "x":"gI0GAILBdu7T53akrFmMyGcsF3n5dO7MmwNBHKW5SV0",
+  "y":"SLW_xSffzlPWrHEVI30DHM_4egVwt3NQqeUD7nMFpps",
+  "d":"0_NxaRPUMQoAJt50Gz8YiTr8gRTwyEaCumd-MToTmIo"
+}

--- a/pkg/crypto/tinkcrypto/testdata/alice_key_ref.json
+++ b/pkg/crypto/tinkcrypto/testdata/alice_key_ref.json
@@ -1,0 +1,7 @@
+{
+  "kty":"EC",
+  "crv":"P-256",
+  "x":"WKn-ZIGevcwGIyyrzFoZNBdaq9_TsqzGl96oc0CWuis",
+  "y":"y77t-RvAHRKTsSGdIYUfweuOvwrvDD-Q3Hv5J0fSKbE",
+  "d":"Hndv7ZZjs_ke8o9zXYo3iq-Yr8SewI5vrqd0pAvEPqg"
+}

--- a/pkg/crypto/tinkcrypto/testdata/bob_key_ref.json
+++ b/pkg/crypto/tinkcrypto/testdata/bob_key_ref.json
@@ -1,0 +1,7 @@
+{
+  "kty":"EC",
+  "crv":"P-256",
+  "x":"weNJy2HscCSM6AEDTDg04biOvhFhyyWvOHQfeF_PxMQ",
+  "y":"e8lnCO-AlStT-NJVX-crhB7QRYhiix03illJOVAOyck",
+  "d":"VEmDZpDXXK8p8N0Cndsxs924q6nS1RXFASRl6BfUqdw"
+}

--- a/pkg/crypto/tinkcrypto/testdata/ecdh_1pu.json
+++ b/pkg/crypto/tinkcrypto/testdata/ecdh_1pu.json
@@ -1,0 +1,7 @@
+{
+  "zeHex" : "9e56d91d817135d372834283bf84269cfb316ea3da806a48f6daa7798cfe90c4",
+  "zsHex": "e3ca3474384c9f62b30bfd4c688b3e7d4110a1b4badc3cc54ef7b81241efd50d",
+  "zHex": "9e56d91d817135d372834283bf84269cfb316ea3da806a48f6daa7798cfe90c4e3ca3474384c9f62b30bfd4c688b3e7d4110a1b4badc3cc54ef7b81241efd50d",
+  "sender1puHex": "6caf13723d14850ad4b42cd6dde935bffd2fff00a9ba70de05c203a5e1722ca7",
+  "sender1puB64": "bK8Tcj0UhQrUtCzW3ek1v_0v_wCpunDeBcIDpeFyLKc"
+}

--- a/pkg/crypto/tinkcrypto/testdata/recipient_ref.json
+++ b/pkg/crypto/tinkcrypto/testdata/recipient_ref.json
@@ -1,0 +1,12 @@
+{
+  "alg":"ECDH-1PU",
+  "enc":"A256GCM",
+  "apu":"QWxpY2U",
+  "apv":"Qm9i",
+  "epk":
+  {"kty":"EC",
+    "crv":"P-256",
+    "x":"gI0GAILBdu7T53akrFmMyGcsF3n5dO7MmwNBHKW5SV0",
+    "y":"SLW_xSffzlPWrHEVI30DHM_4egVwt3NQqeUD7nMFpps"
+  }
+}

--- a/pkg/crypto/tinkcrypto/wrap_support.go
+++ b/pkg/crypto/tinkcrypto/wrap_support.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package tinkcrypto
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/aes"
 	"crypto/cipher"
@@ -89,8 +90,8 @@ func (w *ecKWSupport) deriveSender1Pu(alg string, apu, apv []byte, ephemeralPriv
 		return nil, errors.New("deriveSender1Pu: recipient, sender and ephemeral key are not on the same curve")
 	}
 
-	ze := josecipher.DeriveECDHES(alg, apu, apv, ephemeralPrivEC, recPubKeyEC, keySize)
-	zs := josecipher.DeriveECDHES(alg, apu, apv, senderPrivKeyEC, recPubKeyEC, keySize)
+	ze := deriveECDH(ephemeralPrivEC, recPubKeyEC, keySize)
+	zs := deriveECDH(senderPrivKeyEC, recPubKeyEC, keySize)
 
 	return derive1Pu(alg, ze, zs, apu, apv, keySize), nil
 }
@@ -117,10 +118,53 @@ func (w *ecKWSupport) deriveRecipient1Pu(alg string, apu, apv []byte, ephemeralP
 	}
 
 	// DeriveECDHES checks if keys are on the same curve
-	ze := josecipher.DeriveECDHES(alg, apu, apv, recPrivKeyEC, ephemeralPubEC, keySize)
-	zs := josecipher.DeriveECDHES(alg, apu, apv, recPrivKeyEC, senderPubKeyEC, keySize)
+	ze := deriveECDH(recPrivKeyEC, ephemeralPubEC, keySize)
+	zs := deriveECDH(recPrivKeyEC, senderPubKeyEC, keySize)
 
 	return derive1Pu(alg, ze, zs, apu, apv, keySize), nil
+}
+
+const byteSize = 8
+
+// deriveECDH does key derivation using ECDH only (without KDF).
+func deriveECDH(priv *ecdsa.PrivateKey, pub *ecdsa.PublicKey, size int) []byte {
+	if size > 1<<16 {
+		panic("ECDH-ES output size too large, must be less than or equal to 1<<16")
+	}
+
+	// suppPubInfo is the encoded length of the output size in bits
+	supPubInfo := make([]byte, 4)
+	binary.BigEndian.PutUint32(supPubInfo, uint32(size)*byteSize)
+
+	if !priv.PublicKey.Curve.IsOnCurve(pub.X, pub.Y) {
+		panic("public key not on same curve as private key")
+	}
+
+	z, _ := priv.Curve.ScalarMult(pub.X, pub.Y, priv.D.Bytes())
+	zBytes := z.Bytes()
+
+	// Note that calling z.Bytes() on a big.Int may strip leading zero bytes from
+	// the returned byte array. This can lead to a problem where zBytes will be
+	// shorter than expected which breaks the key derivation. Therefore we must pad
+	// to the full length of the expected coordinate here before calling the KDF.
+	octSize := dSize(priv.Curve)
+	if len(zBytes) != octSize {
+		zBytes = append(bytes.Repeat([]byte{0}, octSize-len(zBytes)), zBytes...)
+	}
+
+	return zBytes
+}
+
+func dSize(curve elliptic.Curve) int {
+	order := curve.Params().P
+	bitLen := order.BitLen()
+	size := bitLen / byteSize
+
+	if bitLen%byteSize != 0 {
+		size++
+	}
+
+	return size
 }
 
 type okpKWSupport struct{}
@@ -214,14 +258,14 @@ func (o *okpKWSupport) deriveSender1Pu(kwAlg string, apu, apv []byte, ephemeralP
 	recPubKeyOKPChacha := new([chacha20poly1305.KeySize]byte)
 	copy(recPubKeyOKPChacha[:], recPubKeyOKP)
 
-	ze, err := cryptoutil.Derive25519KEK([]byte(kwAlg), apu, apv, ephemeralPrivOKPChacha, recPubKeyOKPChacha)
+	ze, err := cryptoutil.DeriveECDHX25519(ephemeralPrivOKPChacha, recPubKeyOKPChacha)
 	if err != nil {
-		return nil, fmt.Errorf("deriveSender1Pu: derive25519KEK with ephemeral key failed: %w", err)
+		return nil, fmt.Errorf("deriveSender1Pu: %w", err)
 	}
 
-	zs, err := cryptoutil.Derive25519KEK([]byte(kwAlg), apu, apv, senderPrivKeyOKPChacha, recPubKeyOKPChacha)
+	zs, err := cryptoutil.DeriveECDHX25519(senderPrivKeyOKPChacha, recPubKeyOKPChacha)
 	if err != nil {
-		return nil, fmt.Errorf("deriveSender1Pu: derive25519KEK with sender key failed: %w", err)
+		return nil, fmt.Errorf("deriveSender1Pu: %w", err)
 	}
 
 	return derive1Pu(kwAlg, ze, zs, apu, apv, chacha20poly1305.KeySize), nil
@@ -253,27 +297,27 @@ func (o *okpKWSupport) deriveRecipient1Pu(kwAlg string, apu, apv []byte, ephemer
 	recPrivKeyOKPChacha := new([chacha20poly1305.KeySize]byte)
 	copy(recPrivKeyOKPChacha[:], recPrivKeyOKP)
 
-	ze, err := cryptoutil.Derive25519KEK([]byte(kwAlg), apu, apv, recPrivKeyOKPChacha, ephemeralPubOKPChacha)
+	ze, err := cryptoutil.DeriveECDHX25519(recPrivKeyOKPChacha, ephemeralPubOKPChacha)
 	if err != nil {
-		return nil, fmt.Errorf("deriveRecipient1Pu: derive25519KEK with ephemeral key failed: %w", err)
+		return nil, fmt.Errorf("deriveRecipient1Pu: %w", err)
 	}
 
-	zs, err := cryptoutil.Derive25519KEK([]byte(kwAlg), apu, apv, recPrivKeyOKPChacha, senderPubKeyOKPChacha)
+	zs, err := cryptoutil.DeriveECDHX25519(recPrivKeyOKPChacha, senderPubKeyOKPChacha)
 	if err != nil {
-		return nil, fmt.Errorf("deriveRecipient1Pu: derive25519KEK with sender key failed: %w", err)
+		return nil, fmt.Errorf("deriveRecipient1Pu: %w", err)
 	}
 
 	return derive1Pu(kwAlg, ze, zs, apu, apv, chacha20poly1305.KeySize), nil
 }
 
 func derive1Pu(kwAlg string, ze, zs, apu, apv []byte, keySize int) []byte {
-	round1 := make([]byte, 4)
-	binary.BigEndian.PutUint32(round1, uint32(1))
-
-	// 1PU requires round one number (0001) to be prefixed to the Z concatenation
-	z := append(round1, ze...)
+	z := append([]byte{}, ze...)
 	z = append(z, zs...)
 
+	return kdf(kwAlg, z, apu, apv, keySize)
+}
+
+func kdf(kwAlg string, z, apu, apv []byte, keySize int) []byte {
 	algID := cryptoutil.LengthPrefix([]byte(kwAlg))
 	ptyUInfo := cryptoutil.LengthPrefix(apu)
 	ptyVInfo := cryptoutil.LengthPrefix(apv)

--- a/pkg/crypto/tinkcrypto/wrap_support_test.go
+++ b/pkg/crypto/tinkcrypto/wrap_support_test.go
@@ -9,6 +9,11 @@ package tinkcrypto
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	_ "embed"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -105,8 +110,7 @@ func Test_okpKWSupportFailures(t *testing.T) {
 	require.EqualError(t, err, "deriveSender1Pu: recipient key not OKP type")
 
 	_, err = okpKW.deriveSender1Pu("", nil, nil, []byte{}, []byte{}, []byte{}, 0)
-	require.EqualError(t, err, "deriveSender1Pu: derive25519KEK with ephemeral key failed: bad input point: "+
-		"low order point")
+	require.EqualError(t, err, "deriveSender1Pu: deriveECDHX25519: bad input point: low order point")
 
 	derivedKEK, err := curve25519.X25519(kekBytes, curve25519.Basepoint)
 	require.NoError(t, err)
@@ -119,8 +123,7 @@ func Test_okpKWSupportFailures(t *testing.T) {
 	}
 
 	_, err = okpKW.deriveSender1Pu("", nil, nil, derivedKEK, kekBytes, lowOrderPoint, 0)
-	require.EqualError(t, err, "deriveSender1Pu: derive25519KEK with ephemeral key failed: bad input point: "+
-		"low order point")
+	require.EqualError(t, err, "deriveSender1Pu: deriveECDHX25519: bad input point: low order point")
 	// can't reproduce key derivation error with sender key because recipient public key as lowOrderPoint fails for
 	// ephemeral key derivation. ie sender key derivation failure only fails if ephemeral key derivation fails.
 
@@ -134,6 +137,134 @@ func Test_okpKWSupportFailures(t *testing.T) {
 	require.EqualError(t, err, "deriveRecipient1Pu: recipient key not OKP type")
 
 	_, err = okpKW.deriveRecipient1Pu("", nil, nil, []byte{}, []byte{}, []byte{}, 0)
-	require.EqualError(t, err, "deriveRecipient1Pu: derive25519KEK with ephemeral key failed: bad input point:"+
-		" low order point")
+	require.EqualError(t, err, "deriveRecipient1Pu: deriveECDHX25519: bad input point: low order point")
+}
+
+type mockKey struct {
+	Kty string `json:"kty,omitempty"`
+	Crv string `json:"crv,omitempty"`
+	X   string `json:"x,omitempty"`
+	Y   string `json:"y,omitempty"`
+	D   string `json:"d,omitempty"`
+}
+
+type mockRecipient struct {
+	Alg string  `json:"alg,omitempty"`
+	Enc string  `json:"enc,omitempty"`
+	Apu string  `json:"apu,omitempty"`
+	Apv string  `json:"apv,omitempty"`
+	Epk mockKey `json:"epk,omitempty"`
+}
+
+type ref1PU struct {
+	ZeHex        string `json:"zeHex,omitempty"`
+	ZsHex        string `json:"zsHex,omitempty"`
+	ZHex         string `json:"zHex,omitempty"`
+	Sender1PUHex string `json:"sender1puHex,omitempty"`
+	Sender1PUB64 string `json:"sender1puB64,omitempty"`
+}
+
+func refJWKtoECKey(t *testing.T, jwkMarshalled string) *ecdsa.PrivateKey {
+	t.Helper()
+
+	jwk := &mockKey{}
+	err := json.Unmarshal([]byte(jwkMarshalled), jwk)
+	require.NoError(t, err)
+
+	x, err := base64.RawURLEncoding.DecodeString(jwk.X)
+	require.NoError(t, err)
+
+	y, err := base64.RawURLEncoding.DecodeString(jwk.Y)
+	require.NoError(t, err)
+
+	d, err := base64.RawURLEncoding.DecodeString(jwk.D)
+	require.NoError(t, err)
+
+	return &ecdsa.PrivateKey{
+		PublicKey: ecdsa.PublicKey{
+			Curve: elliptic.P256(),
+			X:     new(big.Int).SetBytes(x),
+			Y:     new(big.Int).SetBytes(y),
+		},
+		D: new(big.Int).SetBytes(d),
+	}
+}
+
+// nolint:gochecknoglobals // embedded test data
+var (
+	// test vector retrieved from:
+	// (github: https://github.com/NeilMadden/jose-ecdh-1pu/blob/master/draft-madden-jose-ecdh-1pu-03.txt#L459)
+	// (ietf draft: https://tools.ietf.org/html/draft-madden-jose-ecdh-1pu-03#appendix-A)
+	//go:embed testdata/alice_key_ref.json
+	aliceKeyRef string
+	//go:embed testdata/bob_key_ref.json
+	bobKeyRef string
+	//go:embed testdata/alice_epk_ref.json
+	aliceEPKRef string
+	//go:embed testdata/recipient_ref.json
+	recipientRef string
+	//go:embed testdata/ecdh_1pu.json
+	ecdh1puRef string
+)
+
+// TestDeriveReferenceKey uses the test vector in the 1PU draft found at:
+// (github: https://github.com/NeilMadden/jose-ecdh-1pu/blob/master/draft-madden-jose-ecdh-1pu-03.txt#L459)
+// (ietf draft: https://tools.ietf.org/html/draft-madden-jose-ecdh-1pu-03#appendix-A)
+// to validate the ECDH-1PU key derivation.
+func TestDeriveReferenceKey(t *testing.T) {
+	ref1PUData := &ref1PU{}
+	err := json.Unmarshal([]byte(ecdh1puRef), ref1PUData)
+	require.NoError(t, err)
+
+	alicePrivKeyRefEC := refJWKtoECKey(t, aliceKeyRef)
+	bobPrivKeyEPKRefEC := refJWKtoECKey(t, bobKeyRef)
+	alicePrivKeyEPKRefEC := refJWKtoECKey(t, aliceEPKRef)
+
+	recipientRefJWK := &mockRecipient{}
+	err = json.Unmarshal([]byte(recipientRef), recipientRefJWK)
+	require.NoError(t, err)
+
+	apuRef, err := base64.RawURLEncoding.DecodeString(recipientRefJWK.Apu) // "Alice"
+	require.NoError(t, err)
+
+	apvRef, err := base64.RawURLEncoding.DecodeString(recipientRefJWK.Apv) // "Bob"
+	require.NoError(t, err)
+
+	zeRef, err := hex.DecodeString(ref1PUData.ZeHex)
+	require.NoError(t, err)
+
+	t.Run("test derive Ze", func(t *testing.T) {
+		ze := deriveECDH(alicePrivKeyEPKRefEC, &bobPrivKeyEPKRefEC.PublicKey, 32)
+		zeHEX := hex.EncodeToString(ze)
+		require.EqualValues(t, ref1PUData.ZeHex, zeHEX)
+		require.EqualValues(t, zeRef, ze)
+	})
+
+	zsRef, err := hex.DecodeString(ref1PUData.ZsHex)
+	require.NoError(t, err)
+
+	t.Run("test derive Zs", func(t *testing.T) {
+		zs := deriveECDH(alicePrivKeyRefEC, &bobPrivKeyEPKRefEC.PublicKey, 32)
+		zsHEX := hex.EncodeToString(zs)
+		require.EqualValues(t, ref1PUData.ZsHex, zsHEX)
+		require.EqualValues(t, zsRef, zs)
+	})
+
+	z, err := hex.DecodeString(ref1PUData.ZHex)
+	require.NoError(t, err)
+	require.EqualValues(t, append(zeRef, zsRef...), z)
+
+	ecWrapper := ecKWSupport{}
+
+	sender1PU, err := ecWrapper.deriveSender1Pu(recipientRefJWK.Enc, apuRef, apvRef, alicePrivKeyEPKRefEC,
+		alicePrivKeyRefEC, &bobPrivKeyEPKRefEC.PublicKey, 32)
+	require.NoError(t, err)
+
+	onePUFromHex, err := hex.DecodeString(ref1PUData.Sender1PUHex)
+	require.NoError(t, err)
+
+	onePUFromB64, err := base64.RawURLEncoding.DecodeString(ref1PUData.Sender1PUB64)
+	require.NoError(t, err)
+	require.EqualValues(t, onePUFromHex, onePUFromB64)
+	require.EqualValues(t, onePUFromB64, sender1PU)
 }

--- a/pkg/internal/cryptoutil/utils_test.go
+++ b/pkg/internal/cryptoutil/utils_test.go
@@ -16,27 +16,27 @@ import (
 )
 
 func TestDeriveKEK_Util(t *testing.T) {
-	kek, err := Derive25519KEK(nil, nil, nil, nil, nil)
-	require.EqualError(t, err, "invalid key")
-	require.Empty(t, kek)
+	z, err := DeriveECDHX25519(nil, nil)
+	require.EqualError(t, err, "deriveECDHX25519: invalid key")
+	require.Empty(t, z)
 
 	validChachaKey, err := base64.RawURLEncoding.DecodeString("c8CSJr_27PN9xWCpzXNmepRndD6neQcnO9DS0YWjhNs")
 	require.NoError(t, err)
 
 	chachaKey := new([chacha.KeySize]byte)
 	copy(chachaKey[:], validChachaKey)
-	kek, err = Derive25519KEK(nil, nil, nil, chachaKey, nil)
-	require.EqualError(t, err, "invalid key")
-	require.Empty(t, kek)
+	z, err = DeriveECDHX25519(chachaKey, nil)
+	require.EqualError(t, err, "deriveECDHX25519: invalid key")
+	require.Empty(t, z)
 
 	validChachaKey2, err := base64.RawURLEncoding.DecodeString("AAjrHjiFLw6kf6CZ5zqH1ooG3y2aQhuqxmUvqJnIvDI")
 	require.NoError(t, err)
 
 	chachaKey2 := new([chacha.KeySize]byte)
 	copy(chachaKey2[:], validChachaKey2)
-	kek, err = Derive25519KEK(nil, nil, nil, chachaKey, chachaKey2)
+	z, err = DeriveECDHX25519(chachaKey, chachaKey2)
 	require.NoError(t, err)
-	require.NotEmpty(t, kek)
+	require.NotEmpty(t, z)
 
 	// lowOrderPoint from golang.org/x/crypto/curve25519.
 	// https://github.com/golang/crypto/blob/f4817d981/curve25519/vectors_test.go#L10
@@ -46,9 +46,9 @@ func TestDeriveKEK_Util(t *testing.T) {
 	}
 	chachaKey2 = new([chacha.KeySize]byte)
 	copy(chachaKey2[:], lowOrderPoint)
-	// test error from curve25519.X25519() call in Derive25519KEK()
-	_, err = Derive25519KEK(nil, nil, nil, chachaKey, chachaKey2)
-	require.Error(t, err)
+	// test error from curve25519.X25519() call in DeriveECDHX25519()
+	_, err = DeriveECDHX25519(chachaKey, chachaKey2)
+	require.EqualError(t, err, "deriveECDHX25519: bad input point: low order point")
 }
 
 func TestNonceGeneration(t *testing.T) {


### PR DESCRIPTION
and add ECDH-1PU test against the draft's test vector

closes #2766

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>

