### PR TITLE
feat: apis to create keys in wallet kms

### DIFF
--- a/pkg/controller/command/errors.go
+++ b/pkg/controller/command/errors.go
@@ -64,6 +64,9 @@ const (
 
 	// Outofband error group for outofband command errors.
 	Outofband = 11000
+
+	// VCWallet error group for verifiable Credential wallet command errors.
+	VCWallet = 12000
 )
 
 // Error is the  interface for representing an command error condition, with the nil value representing no error.

--- a/pkg/mock/kms/mock_kms.go
+++ b/pkg/mock/kms/mock_kms.go
@@ -24,6 +24,7 @@ type KeyManager struct {
 	CreateKeyID              string
 	CreateKeyValue           *keyset.Handle
 	CreateKeyErr             error
+	CreateKeyFn              func(kt kmsservice.KeyType) (string, interface{}, error)
 	GetKeyValue              *keyset.Handle
 	GetKeyErr                error
 	RotateKeyID              string
@@ -45,6 +46,10 @@ type KeyManager struct {
 func (k *KeyManager) Create(kt kmsservice.KeyType) (string, interface{}, error) {
 	if k.CreateKeyErr != nil {
 		return "", nil, k.CreateKeyErr
+	}
+
+	if k.CreateKeyFn != nil {
+		return k.CreateKeyFn(kt)
 	}
 
 	return k.CreateKeyID, k.CreateKeyValue, nil

--- a/pkg/wallet/contents_test.go
+++ b/pkg/wallet/contents_test.go
@@ -231,9 +231,15 @@ func TestContentStores(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, tkn)
 
-		ok, err := profileInfo.setupEDVKeys(tkn, "", "")
+		kmgr, err := keyManager().getKeyManger(tkn)
 		require.NoError(t, err)
-		require.True(t, ok)
+		require.NotEmpty(t, kmgr)
+
+		err = profileInfo.setupEDVEncryptionKey(kmgr)
+		require.NoError(t, err)
+
+		err = profileInfo.setupEDVMacKey(kmgr)
+		require.NoError(t, err)
 
 		// create new store
 		contentStore := newContentStore(sp, profileInfo)

--- a/pkg/wallet/storage.go
+++ b/pkg/wallet/storage.go
@@ -71,6 +71,10 @@ func (s *storageProvider) OpenStore(auth string, opts *unlockOpts, config storag
 }
 
 func createEDVStorageProvider(auth string, conf *edvConf, opts *unlockOpts) (storage.Provider, error) {
+	if conf.EncryptionKeyID == "" || conf.MACKeyID == "" {
+		return nil, errors.New("invalid EDV configuration found in wallet profile, key IDs for encryption and MAC operations are missing") //nolint: lll
+	}
+
 	// get key manager
 	keyMgr, err := keyManager().getKeyManger(auth)
 	if err != nil {


### PR DESCRIPTION
-EDV encryption & MAC key IDs cannot be passed as profile settings for
localkms users since wallet creates local kms internally based on user's
secret lock service. So wallet has to expose an API to generate EDV keys
in wallet kms.
- Closes #2768

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
