### PR TITLE
test: BDD tests for context API js bindings

### DIFF
--- a/cmd/aries-js-worker/src/agent-rest-client.js
+++ b/cmd/aries-js-worker/src/agent-rest-client.js
@@ -449,8 +449,8 @@ const pkgs = {
         },
     },
     context: {
-        AddContext: {
-            path: "/jsonld/context/add",
+        Add: {
+            path: "/context/add",
             method: "POST",
         },
     },

--- a/cmd/aries-js-worker/src/aries.js
+++ b/cmd/aries-js-worker/src/aries.js
@@ -1267,7 +1267,7 @@ const Aries = function (opts) {
              * @returns {Promise<Object>}
              */
             add: async function (req) {
-                return invoke(aw, pending, this.pkgname, "AddContext", req, "timeout while adding contexts")
+                return invoke(aw, pending, this.pkgname, "Add", req, "timeout while adding contexts")
             },
         },
     }

--- a/pkg/controller/command/jsonld/context/command.go
+++ b/pkg/controller/command/jsonld/context/command.go
@@ -35,7 +35,7 @@ const (
 	// CommandName is a base command name for JSON-LD context operations.
 	CommandName = "context"
 	// AddContextCommandMethod is a command method for adding context.
-	AddContextCommandMethod = "AddContext"
+	AddContextCommandMethod = "Add"
 )
 
 var logger = log.New("aries-framework/command/jsonld/context")

--- a/pkg/controller/command/jsonld/context/command_test.go
+++ b/pkg/controller/command/jsonld/context/command_test.go
@@ -103,25 +103,6 @@ func TestCommand_Add(t *testing.T) {
 		require.Contains(t, err.Error(), "content is mandatory")
 	})
 
-	t.Run("Fail to read context document", func(t *testing.T) {
-		cmd, err := context.New(newMockProvider(t))
-		require.NoError(t, err)
-
-		b, err := json.Marshal(context.AddRequest{Documents: []jsonld.ContextDocument{
-			{
-				URL:     "https://www.w3.org/2018/credentials/examples/v1",
-				Content: []byte("invalid content"),
-			},
-		}})
-		require.NoError(t, err)
-
-		var rw bytes.Buffer
-		err = cmd.Add(&rw, bytes.NewReader(b))
-
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "document from reader: loading document failed")
-	})
-
 	t.Run("Fail to save contexts", func(t *testing.T) {
 		storage := mockstorage.NewMockStoreProvider()
 		storage.Store.ErrBatch = errors.New("batch error")

--- a/pkg/controller/rest/jsonld/context/operation.go
+++ b/pkg/controller/rest/jsonld/context/operation.go
@@ -18,7 +18,7 @@ import (
 
 // constants for the JSON-LD context operations.
 const (
-	OperationID    = "/jsonld/context"
+	OperationID    = "/context"
 	AddContextPath = OperationID + "/add"
 )
 
@@ -56,7 +56,7 @@ func (o *Operation) GetRESTHandlers() []rest.Handler {
 	return o.handlers
 }
 
-// Add swagger:route POST /jsonld/context/add context addContextReq
+// Add swagger:route POST /context/add context addContextReq
 //
 // Adds JSON-LD context documents to the underlying storage.
 //

--- a/pkg/doc/jsonld/document_loader.go
+++ b/pkg/doc/jsonld/document_loader.go
@@ -144,9 +144,9 @@ type DocumentLoaderOpts func(opts *documentLoaderOpts)
 
 // ContextDocument is a JSON-LD context document with associated metadata.
 type ContextDocument struct {
-	URL         string `json:"url"`                   // URL is a context URL that shows up in the documents.
-	DocumentURL string `json:"documentURL,omitempty"` // The final URL of the loaded context document.
-	Content     []byte `json:"content"`               // Content of the context document.
+	URL         string          `json:"url,omitempty"`         // URL is a context URL that shows up in the documents.
+	DocumentURL string          `json:"documentURL,omitempty"` // The final URL of the loaded context document.
+	Content     json.RawMessage `json:"content,omitempty"`     // Content of the context document.
 }
 
 // WithExtraContexts sets the extra contexts (in addition to embedded) for preloading into the underlying storage.

--- a/test/aries-js-worker/test/contexts.js
+++ b/test/aries-js-worker/test/contexts.js
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-const credentialExamplesVocab = JSON.parse(`{
+export const credentialExamplesVocab = JSON.parse(`{
   "@context": [{
     "@version": 1.1
   },"https://www.w3.org/ns/odrl.jsonld", {
@@ -52,7 +52,7 @@ const credentialExamplesVocab = JSON.parse(`{
   }]
 }`)
 
-const odrlVocab = JSON.parse(`{
+export const odrlVocab = JSON.parse(`{
  "@context": {
     "odrl":    "http://www.w3.org/ns/odrl/2/",
     "rdf":     "http://www.w3.org/1999/02/22-rdf-syntax-ns#",

--- a/test/aries-js-worker/test/issuecredential/issuecredential.js
+++ b/test/aries-js-worker/test/issuecredential/issuecredential.js
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 import {environment} from "../environment.js";
 import {newDIDExchangeClient, newDIDExchangeRESTClient} from "../didexchange/didexchange_e2e.js";
 import {watchForEvent} from "../common.js";
-import {addJSONLDContexts} from "../contexts";
+import {addJSONLDContexts} from "../contexts.js";
 
 const agent1ControllerApiUrl = `${environment.HTTP_SCHEME}://${environment.SECOND_USER_HOST}:${environment.SECOND_USER_API_PORT}`
 const agent2ControllerApiUrl = `${environment.HTTP_SCHEME}://${environment.USER_HOST}:${environment.USER_API_PORT}`

--- a/test/aries-js-worker/test/jsonld/context/jsonld_context.js
+++ b/test/aries-js-worker/test/jsonld/context/jsonld_context.js
@@ -1,0 +1,65 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import {newAries, newAriesREST} from "../../common.js"
+import {environment} from "../../environment.js";
+import {credentialExamplesVocab, odrlVocab} from "../../contexts.js"
+
+const agentControllerApiUrl = `${environment.HTTP_SCHEME}://${environment.USER_HOST}:${environment.USER_API_PORT}`
+
+const restMode = 'rest'
+const wasmMode = 'wasm'
+
+describe("JSON-LD Context API Test", function () {
+    describe(restMode, function () {
+        addContext(restMode)
+    })
+    describe(wasmMode, function () {
+        addContext(wasmMode)
+    })
+})
+
+async function addContext(mode) {
+    let aries
+    let modePrefix = '[' + mode + '] '
+
+    before(async () => {
+        if (mode === restMode) {
+            aries = await newAriesREST(agentControllerApiUrl)
+        } else {
+            aries = await newAries()
+        }
+    })
+
+    after(async () => {
+        await aries.destroy()
+    })
+
+    it(modePrefix + "Alice imports extra JSON-LD contexts", function (done) {
+        aries.context.add({
+            documents: [
+                {
+                    url: "https://www.w3.org/2018/credentials/examples/v1",
+                    content: credentialExamplesVocab
+                },
+                {
+                    url: "https://www.w3.org/ns/odrl.jsonld",
+                    content: odrlVocab
+                }
+            ]
+        }).then(
+            resp => {
+                try {
+                    console.log(resp);
+                } catch (err) {
+                    done(err)
+                }
+                done()
+            },
+            err => done(err)
+        )
+    })
+}

--- a/test/aries-js-worker/test/presentproof/presentproof.js
+++ b/test/aries-js-worker/test/presentproof/presentproof.js
@@ -10,7 +10,7 @@ import {
     newDIDExchangeRESTClient,
 } from "../didexchange/didexchange_e2e.js";
 import { watchForEvent } from "../common.js";
-import { addJSONLDContexts } from "../contexts";
+import { addJSONLDContexts } from "../contexts.js";
 import "/base/node_modules/base64-js/base64js.min.js";
 import "/base/node_modules/base-58/Base58.js";
 


### PR DESCRIPTION
* added BDD tests for js context API bindings
* removed `jsonld` section from URL path for adding context
* switched to `json.RawMessage` for `Content` field in `ContextDocument` type

Signed-off-by: Andriy Holovko <andriy.holovko@gmail.com>
