### PR TITLE
feat: use CBC+HMAC in ECDH Tink key and Crypto service

### DIFF
--- a/pkg/crypto/tinkcrypto/crypto.go
+++ b/pkg/crypto/tinkcrypto/crypto.go
@@ -23,13 +23,18 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 
 	cryptoapi "github.com/hyperledger/aries-framework-go/pkg/crypto"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/aead/subtle"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/bbs"
 )
 
 const (
 	// ECDHESA256KWAlg is the ECDH-ES with AES-GCM 256 key wrapping algorithm.
 	ECDHESA256KWAlg = "ECDH-ES+A256KW"
-	// ECDH1PUA256KWAlg is the ECDH-1PU with AES-GCM 256 key wrapping algorithm.
+	// ECDH1PUA128KWAlg is the ECDH-1PU with AES-CBC 128+HMAC-SHA 256 key wrapping algorithm.
+	ECDH1PUA128KWAlg = "ECDH-1PU+A128KW"
+	// ECDH1PUA192KWAlg is the ECDH-1PU with AES-CBC 192+HMAC-SHA 384 key wrapping algorithm.
+	ECDH1PUA192KWAlg = "ECDH-1PU+A192KW"
+	// ECDH1PUA256KWAlg is the ECDH-1PU with AES-CBC 256+HMAC-SHA 512 key wrapping algorithm.
 	ECDH1PUA256KWAlg = "ECDH-1PU+A256KW"
 	// ECDHESXC20PKWAlg is the ECDH-ES with XChacha20Poly1305 key wrapping algorithm.
 	ECDHESXC20PKWAlg = "ECDH-ES+XC20PKW"
@@ -97,6 +102,10 @@ func nonceSize(ps *primitiveset.PrimitiveSet) int {
 		ivSize = chacha20poly1305.NonceSizeX
 	case *aeadsubtle.AESGCM:
 		ivSize = aeadsubtle.AESGCMIVSize
+	case *aeadsubtle.EncryptThenAuthenticate:
+		// AESCBC+HMACSHA Tink keys use Tink's EncryptThenAuthenticate AEAD primitive as per the CBC hmac key manager's
+		// Primitive() call.
+		ivSize = subtle.AES128Size
 	default:
 		ivSize = aeadsubtle.AESGCMIVSize
 	}

--- a/pkg/crypto/tinkcrypto/primitive/aead/aead_key_templates.go
+++ b/pkg/crypto/tinkcrypto/primitive/aead/aead_key_templates.go
@@ -59,7 +59,7 @@ func AES256CBCHMACSHA384KeyTemplate() *tinkpb.KeyTemplate {
 //  - AES key size: 32 bytes
 //  - HMAC key size: 32 bytes
 //  - HMAC tag size: 32 bytes
-//  - HMAC hash function: SHA384
+//  - HMAC hash function: SHA512
 func AES256CBCHMACSHA512KeyTemplate() *tinkpb.KeyTemplate {
 	return createAESCBCHMACAEADKeyTemplate(subtle.AES256Size, subtle.AES256Size, subtle.AES256Size,
 		commonpb.HashType_SHA512)

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh.go
@@ -53,7 +53,8 @@ SPDX-License-Identifier: Apache-2.0
 //		// see pkg/crypto/tinkcrypto to see how you can wrap a shared secret (cek)
 //
 //		// once a cek is created create an ECDH KH that can be used to encrypt plaintext as follows
-//		kt := ecdh.NISTPECDHAES256GCMKeyTemplateWithCEK(cek)
+//		// for AES256GCM content encryption using a NIST P key for cek wrapping as an example
+//		kt := ecdh.KeyTemplateForECDHPrimitiveWithCEK(cek, true, ecdh.AES256GCM)
 //
 //		kh, err := keyset.NewHandle(kt)
 //		if err != nil {
@@ -75,7 +76,8 @@ SPDX-License-Identifier: Apache-2.0
 //      }
 //
 //      // to decrypt, recreate kh for the cek (once unwrapped from pkg/crypto)
-//		kt = ecdh.NISTPECDHAES256GCMKeyTemplateWithCEK(cek)
+//		// for AES256GCM content encryption using a NIST P key for cek wrapping to match the encryption template above
+//		kt = ecdh.KeyTemplateForECDHPrimitiveWithCEK(cek, true, ecdh.AES256GCM)
 //
 //		kh, err = keyset.NewHandle(kt)
 //		if err != nil {

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh_key_template.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh_key_template.go
@@ -17,13 +17,33 @@ import (
 	ecdhpb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdh_aead_go_proto"
 )
 
-type aeadAlg int
+// AEADAlg represents the AEAD implementation algorithm used by ECDH.
+type AEADAlg int
 
 const (
-	aesGCM = iota
-	xc20p
-	aesCBC
+	// AES256GCM AEAD.
+	AES256GCM = iota + 1
+	// XC20P AEAD.
+	XC20P
+	// AES128CBCHMACSHA256 AEAD.
+	AES128CBCHMACSHA256
+	// AES192CBCHMACSHA384 AEAD.
+	AES192CBCHMACSHA384
+	// AES256CBCHMACSHA384 AEAD.
+	AES256CBCHMACSHA384
+	// AES256CBCHMACSHA512 AEAD.
+	AES256CBCHMACSHA512
 )
+
+// EncryptionAlgLabel maps AEADAlg to its label.
+var EncryptionAlgLabel = map[AEADAlg]string{ //nolint:gochecknoglobals
+	AES256GCM:           "AES256GCM",
+	XC20P:               "XC20P",
+	AES128CBCHMACSHA256: "AES128CBCHMACSHA256",
+	AES192CBCHMACSHA384: "AES192CBCHMACSHA384",
+	AES256CBCHMACSHA384: "AES256CBCHMACSHA384",
+	AES256CBCHMACSHA512: "AES256CBCHMACSHA512",
+}
 
 // NISTP256ECDHKWKeyTemplate is a KeyTemplate that generates a key that accepts a CEK for JWE content
 // encryption. CEK wrapping is done outside of this Tink key (in the tinkcrypto service).
@@ -34,7 +54,7 @@ const (
 // encryption algorithm.
 func NISTP256ECDHKWKeyTemplate() *tinkpb.KeyTemplate {
 	// aesGCM is set to pass key generation in the key manager, it's irrelevant to the key or its intended use.
-	return createKeyTemplate(true, aesGCM, commonpb.EllipticCurveType_NIST_P256, nil)
+	return createKeyTemplate(true, AES256GCM, commonpb.EllipticCurveType_NIST_P256, nil)
 }
 
 // NISTP384ECDHKWKeyTemplate is a KeyTemplate that generates a key that accepts a CEK for JWE content
@@ -46,7 +66,7 @@ func NISTP256ECDHKWKeyTemplate() *tinkpb.KeyTemplate {
 // encryption algorithm.
 func NISTP384ECDHKWKeyTemplate() *tinkpb.KeyTemplate {
 	// aesGCM is set to pass key generation in the key manager, it's irrelevant to the key or its intended use.
-	return createKeyTemplate(true, aesGCM, commonpb.EllipticCurveType_NIST_P384, nil)
+	return createKeyTemplate(true, AES256GCM, commonpb.EllipticCurveType_NIST_P384, nil)
 }
 
 // NISTP521ECDHKWKeyTemplate is a KeyTemplate that generates a key that accepts a CEK for JWE content
@@ -58,7 +78,7 @@ func NISTP384ECDHKWKeyTemplate() *tinkpb.KeyTemplate {
 // encryption algorithm.
 func NISTP521ECDHKWKeyTemplate() *tinkpb.KeyTemplate {
 	// aesGCM is set to pass key generation in the key manager, it's irrelevant to the key or its intended use.
-	return createKeyTemplate(true, aesGCM, commonpb.EllipticCurveType_NIST_P521, nil)
+	return createKeyTemplate(true, AES256GCM, commonpb.EllipticCurveType_NIST_P521, nil)
 }
 
 // X25519ECDHKWKeyTemplate is a KeyTemplate that generates a key that accepts a CEK for JWE content
@@ -70,70 +90,34 @@ func NISTP521ECDHKWKeyTemplate() *tinkpb.KeyTemplate {
 // encryption algorithm.
 func X25519ECDHKWKeyTemplate() *tinkpb.KeyTemplate {
 	// xc20p is set to pass key generation in the key manager, it's irrelevant to the key or its intended use.
-	return createKeyTemplate(false, xc20p, commonpb.EllipticCurveType_CURVE25519, nil)
+	return createKeyTemplate(false, XC20P, commonpb.EllipticCurveType_CURVE25519, nil)
 }
 
-// NISTPECDHAES256GCMKeyTemplateWithCEK is similar to NISTP256ECDHKWKeyTemplate but adding the cek to execute the
+// KeyTemplateForECDHPrimitiveWithCEK is similar to NISTP256ECDHKWKeyTemplate but adding the cek to execute the
 // CompositeEncrypt primitive for encrypting a message targeted to one ore more recipients. KW is not executed by this
 // template, so it is ignored and set to NIST P Curved key by default.
 // Keys from this template offer valid CompositeEncrypt primitive execution only and should not be stored in the KMS.
 // The key created from this template has no recipient key info linked to it. It is exclusively used for primitive
-// execution using content encryption algorithm:
-//  - AES256-GCM
-func NISTPECDHAES256GCMKeyTemplateWithCEK(cek []byte) *tinkpb.KeyTemplate {
+// execution using content encryption. Available content encryption algorithms:
+//  - AES256GCM, XChacaha20Poly1305, AES128CBC+HMAC256, AES192CBC+HMAC384, AES256CBC+HMAC384, AES256CBC+HMAC512
+// It works with both key wrapping modes (executed outside of the key primitive created by this template):
+// NIST P kw or XC20P kw
+// cek should be of size:
+// - 32 bytes for AES256GCM, XChacaha20Poly1305, AES128CBC+HMAC256.
+// - 48 bytes for AES192CBC+HMAC384.
+// - 56 bytes for AES256CBC+HMAC384.
+// - 64 bytes for AES256CBC+HMAC512.
+func KeyTemplateForECDHPrimitiveWithCEK(cek []byte, nistpKW bool, encAlg AEADAlg) *tinkpb.KeyTemplate {
 	// the curve passed in the template below is ignored when executing the primitive, it's hardcoded to pass key
 	// key format validation only.
-	return createKeyTemplate(true, aesGCM, 0, cek)
-}
-
-// X25519ECDHXChachaKeyTemplateWithCEK is similar to X25519ECDHKWKeyTemplate but adding the cek to execute the
-// CompositeEncrypt primitive for encrypting a message targeted to one ore more recipients.
-// Keys from this template offer valid CompositeEncrypt primitive execution only and should not be stored in the KMS.
-// The key created from this template has no recipient key info linked to it. It is exclusively used for primitive
-// execution using content encryption algorithm:
-//  - XChacha20Poly1305
-func X25519ECDHXChachaKeyTemplateWithCEK(cek []byte) *tinkpb.KeyTemplate {
-	return createKeyTemplate(false, xc20p, 0, cek)
-}
-
-// NISTPECDHAESCBCHMACKeyTemplateWithCEK is similar to NISTPECDHAES256GCMKeyTemplateWithCEK but using AES_CBC+HMAC aead.
-// KW is not executed by this template, so it is ignored and set to NIST P Curved key by default.
-// Keys from this template offer valid CompositeEncrypt primitive execution only and should not be stored in the KMS.
-// The key created from this template has no recipient key info linked to it. It is exclusively used for primitive
-// execution using content encryption algorithm:
-//  - CBC+HMAC aead
-//  - cek size determines the cipher block and HMAC function to use, with valid size:
-// 		* 32: AES_CBC 16 bytes key size (128 bits) and SHA128 HMAC
-//		* 48: AES_CBC 24 bytes key size (192 bits) and SHA192 HMAC
-//		* 64: AES_CBC 32 bytes key size (256 bits) and SHA256 HMAC
-//		* and other size of cek will return a template with an empty AEAD embedded template which will fail encryption.
-func NISTPECDHAESCBCHMACKeyTemplateWithCEK(cek []byte) *tinkpb.KeyTemplate {
-	// the curve passed in the template below is ignored when executing the primitive, it's hardcoded to pass key
-	// key format validation only.
-	return createKeyTemplate(true, aesCBC, 0, cek)
-}
-
-// X25519ECDHAESCBCHMACKeyTemplateWithCEK is similar to X25519ECDHXChachaKeyTemplateWithCEK but using AES_CBC+HMAC aead.
-// KW is not executed by this template, so it is ignored and set to NIST P Curved key by default.
-// Keys from this template offer valid CompositeEncrypt primitive execution only and should not be stored in the KMS.
-// The key created from this template has no recipient key info linked to it. It is exclusively used for primitive
-// execution using content encryption algorithm:
-//  - CBC+HMAC aead
-//  - cek size determines the cipher block and HMAC function to use, with valid size:
-// 		* 32: AES_CBC 16 bytes key size (128 bits) and SHA128 HMAC
-//		* 48: AES_CBC 24 bytes key size (192 bits) and SHA192 HMAC
-//		* 64: AES_CBC 32 bytes key size (256 bits) and SHA256 HMAC
-//		* and other size of cek will return a template with an empty AEAD embedded template which will fail encryption.
-func X25519ECDHAESCBCHMACKeyTemplateWithCEK(cek []byte) *tinkpb.KeyTemplate {
-	// the curve passed in the template below is ignored when executing the primitive, it's hardcoded to pass key
-	// key format validation only.
-	return createKeyTemplate(false, aesCBC, 0, cek)
+	return createKeyTemplate(nistpKW, encAlg, 0, cek)
 }
 
 // createKeyTemplate creates a new ECDH-AEAD key template with the set cek for primitive execution. Boolean flag used:
 //  - nistpKW flag to state if kw is either NIST P curves (true) or Curve25519 (false)
 //  - encAlg + cek to determine the the nested AEAD key template to use
-func createKeyTemplate(nistpKW bool, encAlg aeadAlg, c commonpb.EllipticCurveType, cek []byte) *tinkpb.KeyTemplate {
+func createKeyTemplate(nistpKW bool, encAlg AEADAlg, c commonpb.EllipticCurveType,
+	cek []byte) *tinkpb.KeyTemplate {
 	typeURL, keyType, encTemplate := getTypeParams(nistpKW, encAlg, cek)
 
 	format := &ecdhpb.EcdhAeadKeyFormat{
@@ -162,25 +146,27 @@ func createKeyTemplate(nistpKW bool, encAlg aeadAlg, c commonpb.EllipticCurveTyp
 	}
 }
 
-func getTypeParams(nistpKW bool, encAlg aeadAlg, cek []byte) (string, ecdhpb.KeyType, *tinkpb.KeyTemplate) {
+func getTypeParams(nistpKW bool, encAlg AEADAlg, cek []byte) (string, ecdhpb.KeyType, *tinkpb.KeyTemplate) {
 	var (
 		keyTemplate *tinkpb.KeyTemplate
 		twoKeys     = 2
 	)
 
 	switch encAlg {
-	case aesGCM:
+	case AES256GCM:
 		keyTemplate = aead.AES256GCMKeyTemplate()
-	case aesCBC:
+	case AES128CBCHMACSHA256, AES192CBCHMACSHA384, AES256CBCHMACSHA384, AES256CBCHMACSHA512:
 		switch len(cek) {
 		case subtle.AES128Size * twoKeys:
 			keyTemplate = cbcaead.AES128CBCHMACSHA256KeyTemplate()
 		case subtle.AES192Size * twoKeys:
 			keyTemplate = cbcaead.AES192CBCHMACSHA384KeyTemplate()
+		case subtle.AES256Size + subtle.AES192Size:
+			keyTemplate = cbcaead.AES256CBCHMACSHA384KeyTemplate()
 		case subtle.AES256Size * twoKeys:
 			keyTemplate = cbcaead.AES256CBCHMACSHA512KeyTemplate()
 		}
-	case xc20p:
+	case XC20P:
 		keyTemplate = aead.XChaCha20Poly1305KeyTemplate()
 	}
 

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh_key_template_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh_key_template_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package ecdh
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -23,51 +22,153 @@ func TestECDHESKeyTemplateSuccess(t *testing.T) {
 	flagTests := []struct {
 		tcName   string
 		tmplFunc func() *tinkpb.KeyTemplate
-		forCBC   bool
+		nistpKW  bool
+		encAlg   AEADAlg
 	}{
 		{
 			tcName:   "create ECDH NIST P-256 KW with AES256-GCM key templates test",
 			tmplFunc: NISTP256ECDHKWKeyTemplate,
+			nistpKW:  true,
+			encAlg:   AES256GCM,
 		},
 		{
 			tcName:   "create ECDH NIST P-384 KW AES256-GCM key templates test",
 			tmplFunc: NISTP384ECDHKWKeyTemplate,
+			nistpKW:  true,
+			encAlg:   AES256GCM,
 		},
 		{
 			tcName:   "create ECDH NIST P-521 KW AES256-GCM key templates test",
 			tmplFunc: NISTP521ECDHKWKeyTemplate,
+			nistpKW:  true,
+			encAlg:   AES256GCM,
+		},
+		{
+			tcName:   "creat ECDH X25519 KW with AES256-GCM key templates test",
+			tmplFunc: X25519ECDHKWKeyTemplate,
+			encAlg:   AES256GCM,
+		},
+		{
+			tcName:   "create ECDH NIST P-256 KW with XChacha20Poly1305 key templates test",
+			tmplFunc: NISTP256ECDHKWKeyTemplate,
+			nistpKW:  true,
+			encAlg:   XC20P,
+		},
+		{
+			tcName:   "create ECDH NIST P-384 KW XChacha20Poly1305 key templates test",
+			tmplFunc: NISTP384ECDHKWKeyTemplate,
+			nistpKW:  true,
+			encAlg:   XC20P,
+		},
+		{
+			tcName:   "create ECDH NIST P-521 KW XChacha20Poly1305 key templates test",
+			tmplFunc: NISTP521ECDHKWKeyTemplate,
+			nistpKW:  true,
+			encAlg:   XC20P,
 		},
 		{
 			tcName:   "creat ECDH X25519 KW with XChacha20Poly1305 key templates test",
 			tmplFunc: X25519ECDHKWKeyTemplate,
+			encAlg:   XC20P,
 		},
 		{
-			tcName:   "create ECDH NIST P-256 KW with AESCBC+HMAC key templates test",
+			tcName:   "create ECDH NIST P-256 KW with AES128-CBC+HMAC-SHA256 key templates test",
 			tmplFunc: NISTP256ECDHKWKeyTemplate,
-			forCBC:   true,
+			nistpKW:  true,
+			encAlg:   AES128CBCHMACSHA256,
 		},
 		{
-			tcName:   "create ECDH NIST P-384 KW AESCBC+HMAC key templates test",
+			tcName:   "create ECDH NIST P-384 KW AES128-CBC+HMAC-SHA256 key templates test",
 			tmplFunc: NISTP384ECDHKWKeyTemplate,
-			forCBC:   true,
+			nistpKW:  true,
+			encAlg:   AES128CBCHMACSHA256,
 		},
 		{
-			tcName:   "create ECDH NIST P-521 KW AESCBC+HMAC key templates test",
+			tcName:   "create ECDH NIST P-521 KW AES128-CBC+HMAC-SHA256 key templates test",
 			tmplFunc: NISTP521ECDHKWKeyTemplate,
-			forCBC:   true,
+			nistpKW:  true,
+			encAlg:   AES128CBCHMACSHA256,
 		},
 		{
-			tcName:   "creat ECDH X25519 KW with AESCBC+HMAC key templates test",
+			tcName:   "creat ECDH X25519 KW with AES128-CBC+HMAC-SHA256 key templates test",
 			tmplFunc: X25519ECDHKWKeyTemplate,
-			forCBC:   true,
+			encAlg:   AES128CBCHMACSHA256,
+		},
+		{
+			tcName:   "create ECDH NIST P-256 KW with AES192-CBC+HMAC-SHA384 key templates test",
+			tmplFunc: NISTP256ECDHKWKeyTemplate,
+			nistpKW:  true,
+			encAlg:   AES192CBCHMACSHA384,
+		},
+		{
+			tcName:   "create ECDH NIST P-384 KW AES192-CBC+HMAC-SHA384 key templates test",
+			tmplFunc: NISTP384ECDHKWKeyTemplate,
+			nistpKW:  true,
+			encAlg:   AES192CBCHMACSHA384,
+		},
+		{
+			tcName:   "create ECDH NIST P-521 KW AES192-CBC+HMAC-SHA384 key templates test",
+			tmplFunc: NISTP521ECDHKWKeyTemplate,
+			nistpKW:  true,
+			encAlg:   AES192CBCHMACSHA384,
+		},
+		{
+			tcName:   "creat ECDH X25519 KW with AES192-CBC+HMAC-SHA384 key templates test",
+			tmplFunc: X25519ECDHKWKeyTemplate,
+			encAlg:   AES192CBCHMACSHA384,
+		},
+		{
+			tcName:   "create ECDH NIST P-256 KW with AES256-CBC+HMAC-SHA384 key templates test",
+			tmplFunc: NISTP256ECDHKWKeyTemplate,
+			nistpKW:  true,
+			encAlg:   AES256CBCHMACSHA384,
+		},
+		{
+			tcName:   "create ECDH NIST P-384 KW AES256-CBC+HMAC-SHA384 key templates test",
+			tmplFunc: NISTP384ECDHKWKeyTemplate,
+			nistpKW:  true,
+			encAlg:   AES256CBCHMACSHA384,
+		},
+		{
+			tcName:   "create ECDH NIST P-521 KW AES256-CBC+HMAC-SHA384 key templates test",
+			tmplFunc: NISTP521ECDHKWKeyTemplate,
+			nistpKW:  true,
+			encAlg:   AES256CBCHMACSHA384,
+		},
+		{
+			tcName:   "creat ECDH X25519 KW with AES256-CBC+HMAC-SHA384 key templates test",
+			tmplFunc: X25519ECDHKWKeyTemplate,
+			encAlg:   AES256CBCHMACSHA384,
+		},
+		{
+			tcName:   "create ECDH NIST P-256 KW with AES256-CBC+HMAC-SHA512 key templates test",
+			tmplFunc: NISTP256ECDHKWKeyTemplate,
+			nistpKW:  true,
+			encAlg:   AES256CBCHMACSHA512,
+		},
+		{
+			tcName:   "create ECDH NIST P-384 KW AES256-CBC+HMAC-SHA512 key templates test",
+			tmplFunc: NISTP384ECDHKWKeyTemplate,
+			nistpKW:  true,
+			encAlg:   AES256CBCHMACSHA512,
+		},
+		{
+			tcName:   "create ECDH NIST P-521 KW AES256-CBC+HMAC-SHA512 key templates test",
+			tmplFunc: NISTP521ECDHKWKeyTemplate,
+			nistpKW:  true,
+			encAlg:   AES256CBCHMACSHA512,
+		},
+		{
+			tcName:   "creat ECDH X25519 KW with AES256-CBC+HMAC-SHA512 key templates test",
+			tmplFunc: X25519ECDHKWKeyTemplate,
+			encAlg:   AES256CBCHMACSHA512,
 		},
 	}
 
 	for _, tt := range flagTests {
 		tc := tt
 		t.Run("Test "+tc.tcName, func(t *testing.T) {
-			cek := random.GetRandomBytes(uint32(32)) // default cek is 32 bytes.
-
+			cek := createCEK(tc.encAlg)
 			kt := tc.tmplFunc()
 
 			kh, err := keyset.NewHandle(kt)
@@ -90,21 +191,7 @@ func TestECDHESKeyTemplateSuccess(t *testing.T) {
 			elapsed := time.Now()
 
 			// now try to create a new KH for primitive execution and try to encrypt
-			if strings.Contains(tc.tcName, "XChacha") { //nolint:nestif
-				if tc.forCBC {
-					cek = createCBCHMACCEK(tc.tcName)
-					kt = X25519ECDHAESCBCHMACKeyTemplateWithCEK(cek)
-				} else {
-					kt = X25519ECDHXChachaKeyTemplateWithCEK(cek)
-				}
-			} else {
-				if tc.forCBC {
-					cek = createCBCHMACCEK(tc.tcName)
-					kt = NISTPECDHAESCBCHMACKeyTemplateWithCEK(cek)
-				} else {
-					kt = NISTPECDHAES256GCMKeyTemplateWithCEK(cek)
-				}
-			}
+			kt = KeyTemplateForECDHPrimitiveWithCEK(cek, tc.nistpKW, tc.encAlg)
 
 			t.Logf("time spent in ECDH keyTemplateWithCEK: %s", time.Since(elapsed))
 
@@ -134,12 +221,17 @@ func TestECDHESKeyTemplateSuccess(t *testing.T) {
 	}
 }
 
-func createCBCHMACCEK(tcName string) []byte {
-	if strings.Contains(tcName, "P-384") {
+func createCEK(cbcAlg AEADAlg) []byte {
+	switch cbcAlg {
+	case AES128CBCHMACSHA256:
+		return random.GetRandomBytes(uint32(subtle.AES128Size * 2)) // cek: 32 bytes.
+	case AES192CBCHMACSHA384:
 		return random.GetRandomBytes(uint32(subtle.AES192Size * 2)) // cek: 48 bytes.
-	} else if strings.Contains(tcName, "P-521") {
+	case AES256CBCHMACSHA384:
+		return random.GetRandomBytes(uint32(subtle.AES256Size + subtle.AES192Size)) // cek: 56 bytes.
+	case AES256CBCHMACSHA512:
 		return random.GetRandomBytes(uint32(subtle.AES256Size * 2)) // cek: 64 bytes.
+	default:
+		return random.GetRandomBytes(uint32(32)) // default cek: 32 bytes.
 	}
-
-	return random.GetRandomBytes(uint32(subtle.AES128Size * 2))
 }

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh_nistpkw_private_key_manager_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh_nistpkw_private_key_manager_test.go
@@ -21,6 +21,7 @@ import (
 	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
 	"github.com/stretchr/testify/require"
 
+	cbcaead "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/aead"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite"
 	ecdhpb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdh_aead_go_proto"
 )
@@ -273,6 +274,13 @@ func TestEcdhNISTPAESPrivateKeyManager_NewKey(t *testing.T) {
 				Value:            badSerializedFormat,
 				OutputPrefixType: tinkpb.OutputPrefixType_RAW,
 			},
+		},
+		{
+			tcName:    "success private key manager NewKey() and NewKeyData() with AES-CBC+HMAC encTmp",
+			curveType: commonpb.EllipticCurveType_NIST_P256,
+			keyType:   ecdhpb.KeyType_EC,
+			ecPtFmt:   commonpb.EcPointFormat_COMPRESSED,
+			encTmp:    cbcaead.AES128CBCHMACSHA256KeyTemplate(),
 		},
 	}
 

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh_nistpkw_public_key_manager_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh_nistpkw_public_key_manager_test.go
@@ -20,6 +20,7 @@ import (
 	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
 	"github.com/stretchr/testify/require"
 
+	cbcaead "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/aead"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite"
 	ecdhpb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdh_aead_go_proto"
 )
@@ -103,6 +104,13 @@ func TestECDHNISTPAESPublicKeyManager_Primitive(t *testing.T) {
 				Value:            badSerializedFormat,
 				OutputPrefixType: tinkpb.OutputPrefixType_RAW,
 			},
+		},
+		{
+			tcName:    "success public key manager Primitive() with AES-CBC+HMAC encTmp",
+			version:   0,
+			curveType: commonpb.EllipticCurveType_NIST_P256,
+			ecPtFmt:   commonpb.EcPointFormat_UNCOMPRESSED,
+			encTmp:    cbcaead.AES128CBCHMACSHA256KeyTemplate(),
 		},
 	}
 

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh_x25519kw_private_key_manager_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh_x25519kw_private_key_manager_test.go
@@ -18,6 +18,7 @@ import (
 	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
 	"github.com/stretchr/testify/require"
 
+	cbcaead "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/aead"
 	ecdhpb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdh_aead_go_proto"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/cryptoutil"
 )
@@ -83,6 +84,13 @@ func TestECDHX25519XChachaPrivateKeyManager_Primitive(t *testing.T) {
 				TypeUrl:          "bad.type/url/value",
 				OutputPrefixType: tinkpb.OutputPrefixType_RAW,
 			},
+		},
+		{
+			tcName:    "success private key manager Primitive() with AES-CBC+HMAC encTmp",
+			version:   0,
+			curveType: commonpb.EllipticCurveType_CURVE25519,
+			keyType:   ecdhpb.KeyType_OKP,
+			encTmp:    cbcaead.AES128CBCHMACSHA256KeyTemplate(),
 		},
 	}
 

--- a/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh_x25519kw_public_key_manager_test.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/ecdh/ecdh_x25519kw_public_key_manager_test.go
@@ -18,6 +18,7 @@ import (
 	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
 	"github.com/stretchr/testify/require"
 
+	cbcaead "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/aead"
 	ecdhpb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdh_aead_go_proto"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/cryptoutil"
 )
@@ -83,6 +84,13 @@ func TestECDHX25519XChachaPublicKeyManager_Primitive(t *testing.T) {
 				TypeUrl:          "bad.type/url/value",
 				OutputPrefixType: tinkpb.OutputPrefixType_RAW,
 			},
+		},
+		{
+			tcName:    "success public key manager Primitive() with AES-CBC+HMAC encTmp",
+			version:   0,
+			curveType: commonpb.EllipticCurveType_CURVE25519,
+			keyType:   ecdhpb.KeyType_OKP,
+			encTmp:    cbcaead.AES128CBCHMACSHA256KeyTemplate(),
 		},
 	}
 

--- a/pkg/crypto/tinkcrypto/primitive/composite/register_ecdh_aead_enc_helper.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/register_ecdh_aead_enc_helper.go
@@ -286,10 +286,12 @@ func (r *RegisterCompositeAEADEncHelper) getSerializedAESCBCHMACKey(symmetricKey
 		keySize = subtle.AES128Size
 	case subtle.AES192Size * twoKeys:
 		keySize = subtle.AES192Size
+	case subtle.AES256Size + subtle.AES192Size:
+		keySize = subtle.AES256Size
 	case subtle.AES256Size * twoKeys:
 		keySize = subtle.AES256Size
 	default:
-		return nil, errors.New("symmetric key must be either 32, 48 or 64 bytes")
+		return nil, errors.New("AES-CBC+HMAC-SHA key must be either 32, 48, 56 or 64 bytes")
 	}
 
 	cbcHMACKey.AesCbcKey.KeyValue = symmetricKeyValue[:keySize]

--- a/pkg/crypto/webkms/remotecrypto_test.go
+++ b/pkg/crypto/webkms/remotecrypto_test.go
@@ -1417,7 +1417,7 @@ func TestCloseResponseBody(t *testing.T) {
 
 func nonceSize(ps *primitiveset.PrimitiveSet) int {
 	var ivSize int
-	// AESGCM and XChacha20Poly1305 nonce sizes supported only for now
+	// AES256GCM and XChacha20Poly1305 nonce sizes supported only for now
 	switch ps.Primary.Primitive.(type) {
 	case *aeadsubtle.XChaCha20Poly1305:
 		ivSize = chacha20poly1305.NonceSizeX

--- a/pkg/doc/jose/common.go
+++ b/pkg/doc/jose/common.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package jose
 
+import "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/composite/ecdh"
+
 // IANA registered JOSE headers (https://tools.ietf.org/html/rfc7515#section-4.1)
 const (
 	// HeaderAlgorithm identifies:
@@ -85,9 +87,26 @@ const (
 	// A256GCMALG is the default content encryption algorithm value as per
 	// the JWA specification: https://tools.ietf.org/html/rfc7518#section-5.1
 	A256GCMALG = "A256GCM"
-	// XC20PALG represented XChacha20Poly1305 content encryption algorithm value.
+	// XC20PALG represents XChacha20Poly1305 content encryption algorithm value.
 	XC20PALG = "XC20P"
+	// A128CBCHS256ALG represents AES_128_CBC_HMAC_SHA_256 encryption algorithm value.
+	A128CBCHS256ALG = "A128CBC-HS256"
+	// A192CBCHS384ALG represents AES_192_CBC_HMAC_SHA_384 encryption algorithm value.
+	A192CBCHS384ALG = "A192CBC-HS384"
+	// A256CBCHS384ALG represents AES_256_CBC_HMAC_SHA_384 encryption algorithm value (not defined in JWA spec above).
+	A256CBCHS384ALG = "A256CBC-HS384"
+	// A256CBCHS512ALG represents AES_256_CBC_HMAC_SHA_512 encryption algorithm value.
+	A256CBCHS512ALG = "A256CBC-HS512"
 )
+
+var aeadAlg = map[EncAlg]ecdh.AEADAlg{ //nolint:gochecknoglobals
+	A256GCM:      ecdh.AES256GCM,
+	XC20P:        ecdh.XC20P,
+	A128CBCHS256: ecdh.AES128CBCHMACSHA256,
+	A192CBCHS384: ecdh.AES192CBCHMACSHA384,
+	A256CBCHS384: ecdh.AES256CBCHMACSHA384,
+	A256CBCHS512: ecdh.AES256CBCHMACSHA512,
+}
 
 // Headers represents JOSE headers.
 type Headers map[string]interface{}

--- a/pkg/doc/jose/encrypter_decrypter_test.go
+++ b/pkg/doc/jose/encrypter_decrypter_test.go
@@ -233,6 +233,182 @@ func TestJWEEncryptRoundTrip(t *testing.T) {
 			nbRec:      1,
 			useCompact: true,
 		},
+		{
+			name:    "P-256 ECDH KW and A128CBCHS256 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A128CBCHS256,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "P-256 ECDH KW and A128CBCHS256 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A128CBCHS256,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "P-256 ECDH KW and A128CBCHS256 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:        ariesjose.A128CBCHS256,
+			keyType:    kms.NISTP256ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
+		{
+			name:    "X25519 ECDH KW and A128CBCHS256 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A128CBCHS256,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "X25519 ECDH KW and A128CBCHS256 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A128CBCHS256,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "X25519 ECDH KW and A128CBCHS256 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.X25519ECDHKWKeyTemplate(),
+			enc:        ariesjose.A128CBCHS256,
+			keyType:    kms.X25519ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
+		{
+			name:    "P-256 ECDH KW and A192CBCHS384 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A192CBCHS384,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "P-256 ECDH KW and A192CBCHS384 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A192CBCHS384,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "P-256 ECDH KW and A192CBCHS384 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:        ariesjose.A192CBCHS384,
+			keyType:    kms.NISTP256ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
+		{
+			name:    "X25519 ECDH KW and A192CBCHS384 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A192CBCHS384,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "X25519 ECDH KW and A192CBCHS384 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A192CBCHS384,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "X25519 ECDH KW and A192CBCHS384 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.X25519ECDHKWKeyTemplate(),
+			enc:        ariesjose.A192CBCHS384,
+			keyType:    kms.X25519ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
+		{
+			name:    "P-256 ECDH KW and A256CBCHS384 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS384,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "P-256 ECDH KW and A256CBCHS384 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS384,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "P-256 ECDH KW and A256CBCHS384 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:        ariesjose.A256CBCHS384,
+			keyType:    kms.NISTP256ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
+		{
+			name:    "X25519 ECDH KW and A256CBCHS384 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS384,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "X25519 ECDH KW and A256CBCHS384 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS384,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "X25519 ECDH KW and A256CBCHS384 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.X25519ECDHKWKeyTemplate(),
+			enc:        ariesjose.A256CBCHS384,
+			keyType:    kms.X25519ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
+		{
+			name:    "P-256 ECDH KW and A256CBCHS512 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS512,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "P-256 ECDH KW and A256CBCHS512 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS512,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "P-256 ECDH KW and A256CBCHS512 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:        ariesjose.A256CBCHS512,
+			keyType:    kms.NISTP256ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
+		{
+			name:    "X25519 ECDH KW and A256CBCHS512 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS512,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "X25519 ECDH KW and A256CBCHS512 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS512,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "X25519 ECDH KW and A256CBCHS512 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.X25519ECDHKWKeyTemplate(),
+			enc:        ariesjose.A256CBCHS512,
+			keyType:    kms.X25519ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -263,6 +439,30 @@ func TestJWEEncryptRoundTrip(t *testing.T) {
 			t.Logf("ECDH-ES KW in EncryptWithAuthData took %v", time.Since(testEncTime))
 			require.NoError(t, err)
 			require.Equal(t, len(recECKeys), len(jwe.Recipients))
+
+			cty, ok := jwe.ProtectedHeaders.ContentType()
+			require.True(t, ok)
+			require.Equal(t, DIDCommContentEncodingType, cty)
+
+			typ, ok := jwe.ProtectedHeaders.Type()
+			require.True(t, ok)
+			require.Equal(t, EnvelopeEncodingType, typ)
+
+			alg, ok := jwe.ProtectedHeaders.Algorithm()
+			if alg != "" {
+				require.True(t, ok)
+				require.Contains(t, []string{"ECDH-ES+A256KW", "ECDH-ES+XC20PKW"}, alg)
+			} else {
+				require.False(t, ok)
+			}
+
+			kid, ok := jwe.ProtectedHeaders.KeyID()
+			if kid != "" {
+				require.True(t, ok)
+				require.NotEmpty(t, kid)
+			} else {
+				require.False(t, ok)
+			}
 
 			var serializedJWE, jweStr string
 			serialization := "Full"
@@ -719,9 +919,17 @@ func TestFailNewJWEEncrypt(t *testing.T) {
 
 	recipients, recsKH, kids := createRecipients(t, 2)
 
-	_, err = ariesjose.NewJWEEncrypt(ariesjose.A256GCM, EnvelopeEncodingType, DIDCommContentEncodingType,
-		"", recsKH[kids[0]], recipients, c)
-	require.EqualError(t, err, "senderKID is required with senderKH")
+	t.Run("test with missing skid", func(t *testing.T) {
+		_, err = ariesjose.NewJWEEncrypt(ariesjose.A256GCM, EnvelopeEncodingType, DIDCommContentEncodingType,
+			"", recsKH[kids[0]], recipients, c)
+		require.EqualError(t, err, "senderKID is required with senderKH")
+	})
+
+	t.Run("test with missing crypto", func(t *testing.T) {
+		_, err = ariesjose.NewJWEEncrypt(ariesjose.A256GCM, EnvelopeEncodingType, DIDCommContentEncodingType,
+			kids[0], recsKH[kids[0]], recipients, nil)
+		require.EqualError(t, err, "crypto service is required to create a JWEEncrypt instance")
+	})
 }
 
 func TestECDH1PU(t *testing.T) {
@@ -909,6 +1117,182 @@ func TestECDH1PU(t *testing.T) {
 			nbRec:      1,
 			useCompact: true,
 		},
+		{
+			name:    "P-256 ECDH KW and A128CBCHS256 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A128CBCHS256,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "P-256 ECDH KW and A128CBCHS256 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A128CBCHS256,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "P-256 ECDH KW and A128CBCHS256 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:        ariesjose.A128CBCHS256,
+			keyType:    kms.NISTP256ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
+		{
+			name:    "X25519 ECDH KW and A128CBCHS256 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A128CBCHS256,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "X25519 ECDH KW and A128CBCHS256 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A128CBCHS256,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "X25519 ECDH KW and A128CBCHS256 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.X25519ECDHKWKeyTemplate(),
+			enc:        ariesjose.A128CBCHS256,
+			keyType:    kms.X25519ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
+		{
+			name:    "P-256 ECDH KW and A192CBCHS384 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A192CBCHS384,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "P-256 ECDH KW and A192CBCHS384 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A192CBCHS384,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "P-256 ECDH KW and A192CBCHS384 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:        ariesjose.A192CBCHS384,
+			keyType:    kms.NISTP256ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
+		{
+			name:    "X25519 ECDH KW and A192CBCHS384 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A192CBCHS384,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "X25519 ECDH KW and A192CBCHS384 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A192CBCHS384,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "X25519 ECDH KW and A192CBCHS384 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.X25519ECDHKWKeyTemplate(),
+			enc:        ariesjose.A192CBCHS384,
+			keyType:    kms.X25519ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
+		{
+			name:    "P-256 ECDH KW and A256CBCHS384 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS384,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "P-256 ECDH KW and A256CBCHS384 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS384,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "P-256 ECDH KW and A256CBCHS384 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:        ariesjose.A256CBCHS384,
+			keyType:    kms.NISTP256ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
+		{
+			name:    "X25519 ECDH KW and A256CBCHS384 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS384,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "X25519 ECDH KW and A256CBCHS384 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS384,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "X25519 ECDH KW and A256CBCHS384 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.X25519ECDHKWKeyTemplate(),
+			enc:        ariesjose.A256CBCHS384,
+			keyType:    kms.X25519ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
+		{
+			name:    "P-256 ECDH KW and A256CBCHS512 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS512,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "P-256 ECDH KW and A256CBCHS512 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS512,
+			keyType: kms.NISTP256ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "P-256 ECDH KW and A256CBCHS512 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.NISTP256ECDHKWKeyTemplate(),
+			enc:        ariesjose.A256CBCHS512,
+			keyType:    kms.NISTP256ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
+		{
+			name:    "X25519 ECDH KW and A256CBCHS512 encryption with 2 recipients (Full serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS512,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   2,
+		},
+		{
+			name:    "X25519 ECDH KW and A256CBCHS512 encryption with 1 recipient (Flattened serialization)",
+			kt:      ecdh.X25519ECDHKWKeyTemplate(),
+			enc:     ariesjose.A256CBCHS512,
+			keyType: kms.X25519ECDHKWType,
+			nbRec:   1,
+		},
+		{
+			name:       "X25519 ECDH KW and A256CBCHS512 encryption with 1 recipient (Compact serialization)",
+			kt:         ecdh.X25519ECDHKWKeyTemplate(),
+			enc:        ariesjose.A256CBCHS512,
+			keyType:    kms.X25519ECDHKWType,
+			nbRec:      1,
+			useCompact: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -946,6 +1330,35 @@ func TestECDH1PU(t *testing.T) {
 			jwe, err := jweEnc.EncryptWithAuthData(pt, aad)
 			t.Logf("ECDH-1PU KW in EncryptWithAuthData took %v", time.Since(testEncTime))
 			require.NoError(t, err)
+
+			cty, ok := jwe.ProtectedHeaders.ContentType()
+			require.True(t, ok)
+			require.Equal(t, DIDCommContentEncodingType, cty)
+
+			typ, ok := jwe.ProtectedHeaders.Type()
+			require.True(t, ok)
+			require.Equal(t, EnvelopeEncodingType, typ)
+
+			alg, ok := jwe.ProtectedHeaders.Algorithm()
+			if alg != "" {
+				cbcHMACAlgs := []string{
+					tinkcrypto.ECDH1PUA128KWAlg, tinkcrypto.ECDH1PUA192KWAlg,
+					tinkcrypto.ECDH1PUA256KWAlg, tinkcrypto.ECDH1PUXC20PKWAlg,
+				}
+
+				require.True(t, ok)
+				require.Contains(t, cbcHMACAlgs, alg)
+			} else {
+				require.False(t, ok)
+			}
+
+			kid, ok := jwe.ProtectedHeaders.KeyID()
+			if kid != "" {
+				require.True(t, ok)
+				require.NotEmpty(t, kid)
+			} else {
+				require.False(t, ok)
+			}
 
 			var serializedJWE, jweStr string
 			serialization := "Full"
@@ -993,8 +1406,8 @@ func TestECDH1PU(t *testing.T) {
 				require.NotEmpty(t, jd)
 
 				_, err = jd.Decrypt(localJWE)
-				require.EqualError(t, err, "jwedecrypt: failed to add sender public key for skid: failed to get sender"+
-					" key from DB: data not found")
+				require.EqualError(t, err, "jwedecrypt: failed to add sender public key for skid: fetchSenderPubKey: "+
+					"failed to get sender key from DB: data not found")
 			})
 
 			// add sender pubkey into the recipient's mock store to prepare for a successful JWEDecrypt() for each recipient


### PR DESCRIPTION
And also support converting an EC public key into an ECDH Tink key using CBC+HMAC AEAD.

closes #2832

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
