### PR TITLE
feat: enable ecdh-1pu draft4 JWE decryption test

### DIFF
--- a/pkg/crypto/tinkcrypto/primitive/composite/keyio/composite_key_export.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/keyio/composite_key_export.go
@@ -310,7 +310,7 @@ func PublicKeyToKeysetHandle(pubKey *cryptoapi.PublicKey, aeadAlg ecdh.AEADAlg) 
 // function serves as a helper to get a senderKH to be used as an option for ECDH execution (for ECDH-1PU/authcrypt).
 // The keyset handle will be set with either AES256-GCM, AES128CBC+SHA256, AES192CBC+SHA384, AES256CBC+SHA384 or
 // AES256CBC+SHA512 AEAD key template for content encryption. With:
-// - pubKey the public key to convert.
+// - privKey the private key to convert.
 // - aeadAlg the content encryption algorithm to use along the ECDH primitive.
 func PrivateKeyToKeysetHandle(privKey *cryptoapi.PrivateKey, aeadAlg ecdh.AEADAlg) (*keyset.Handle, error) {
 	// validate curve
@@ -330,6 +330,7 @@ func PrivateKeyToKeysetHandle(privKey *cryptoapi.PrivateKey, aeadAlg ecdh.AEADAl
 	}
 
 	protoKey := &ecdhpb.EcdhAeadPrivateKey{
+		Version: 0,
 		PublicKey: &ecdhpb.EcdhAeadPublicKey{
 			Version: 0,
 			Params: &ecdhpb.EcdhAeadParams{
@@ -346,6 +347,7 @@ func PrivateKeyToKeysetHandle(privKey *cryptoapi.PrivateKey, aeadAlg ecdh.AEADAl
 			X:   privKey.PublicKey.X,
 			Y:   privKey.PublicKey.Y,
 		},
+		KeyValue: privKey.D,
 	}
 
 	marshalledKey, err := proto.Marshal(protoKey)
@@ -353,7 +355,7 @@ func PrivateKeyToKeysetHandle(privKey *cryptoapi.PrivateKey, aeadAlg ecdh.AEADAl
 		return nil, fmt.Errorf("privateKeyToKeysetHandle: failed to marshal proto: %w", err)
 	}
 
-	ks := newKeySet(keyURL, marshalledKey, tinkpb.KeyData_ASYMMETRIC_PUBLIC)
+	ks := newKeySet(keyURL, marshalledKey, tinkpb.KeyData_ASYMMETRIC_PRIVATE)
 
 	memReader := &keyset.MemReaderWriter{Keyset: ks}
 

--- a/pkg/crypto/tinkcrypto/primitive/composite/register_ecdh_aead_enc_helper.go
+++ b/pkg/crypto/tinkcrypto/primitive/composite/register_ecdh_aead_enc_helper.go
@@ -294,8 +294,8 @@ func (r *RegisterCompositeAEADEncHelper) getSerializedAESCBCHMACKey(symmetricKey
 		return nil, errors.New("AES-CBC+HMAC-SHA key must be either 32, 48, 56 or 64 bytes")
 	}
 
-	cbcHMACKey.AesCbcKey.KeyValue = symmetricKeyValue[:keySize]
-	cbcHMACKey.HmacKey.KeyValue = symmetricKeyValue[keySize:]
+	cbcHMACKey.HmacKey.KeyValue = symmetricKeyValue[:keySize]
+	cbcHMACKey.AesCbcKey.KeyValue = symmetricKeyValue[keySize:]
 
 	return proto.Marshal(cbcHMACKey)
 }

--- a/pkg/didcomm/packer/anoncrypt/pack.go
+++ b/pkg/didcomm/packer/anoncrypt/pack.go
@@ -8,13 +8,9 @@ package anoncrypt
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
-	"strings"
 
 	"github.com/google/tink/go/keyset"
 
@@ -110,7 +106,6 @@ func (p *Packer) Pack(contentType string, payload, _ []byte, recipientsPubKeys [
 func unmarshalRecipientKeys(keys [][]byte) ([]*cryptoapi.PublicKey, []byte, error) {
 	var (
 		pubKeys []*cryptoapi.PublicKey
-		kids    []string
 		aad     []byte
 	)
 
@@ -122,20 +117,7 @@ func unmarshalRecipientKeys(keys [][]byte) ([]*cryptoapi.PublicKey, []byte, erro
 			return nil, nil, err
 		}
 
-		kids = append(kids, ecKey.KID)
 		pubKeys = append(pubKeys, ecKey)
-	}
-
-	if len(keys) > 1 {
-		sort.Strings(kids)
-
-		kidsStr := strings.Join(kids, ".")
-		logger.Debugf("Anoncrypt Pack KIDs for AAD: %s", kidsStr)
-
-		aad32 := sha256.Sum256([]byte(kidsStr))
-		aad = make([]byte, 32)
-		copy(aad, aad32[:])
-		logger.Debugf("Anoncrypt Pack AAD: %s", base64.RawURLEncoding.EncodeToString(aad))
 	}
 
 	return pubKeys, aad, nil

--- a/pkg/didcomm/packer/authcrypt/pack.go
+++ b/pkg/didcomm/packer/authcrypt/pack.go
@@ -8,13 +8,9 @@ package authcrypt
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
-	"strings"
 
 	"github.com/google/tink/go/keyset"
 
@@ -161,7 +157,6 @@ func (p *Packer) Pack(contentType string, payload, senderID []byte, recipientsPu
 func unmarshalRecipientKeys(keys [][]byte) ([]*cryptoapi.PublicKey, []byte, error) {
 	var (
 		pubKeys []*cryptoapi.PublicKey
-		kids    []string
 		aad     []byte
 	)
 
@@ -173,20 +168,7 @@ func unmarshalRecipientKeys(keys [][]byte) ([]*cryptoapi.PublicKey, []byte, erro
 			return nil, nil, err
 		}
 
-		kids = append(kids, ecKey.KID)
 		pubKeys = append(pubKeys, ecKey)
-	}
-
-	if len(keys) > 1 {
-		sort.Strings(kids)
-
-		kidsStr := strings.Join(kids, ".")
-		logger.Infof("Authcrypt Pack KIDs for AAD: %s", kidsStr)
-
-		aad32 := sha256.Sum256([]byte(kidsStr))
-		aad = make([]byte, 32)
-		copy(aad, aad32[:])
-		logger.Infof("Authcrypt Pack AAD: %s", base64.RawURLEncoding.EncodeToString(aad))
 	}
 
 	return pubKeys, aad, nil

--- a/pkg/doc/jose/encrypt_test.go
+++ b/pkg/doc/jose/encrypt_test.go
@@ -154,7 +154,7 @@ func TestMergeSingleRecipientsHeadersFailureWithUnsetCurve(t *testing.T) {
 func TestEmptyComputeAuthData(t *testing.T) {
 	protecteHeaders := new(map[string]interface{})
 	aad := []byte("")
-	_, err := computeAuthData(*protecteHeaders, aad)
+	_, err := computeAuthData(*protecteHeaders, "", aad)
 	require.NoError(t, err, "computeAuthData with empty protectedHeaders and empty aad should not fail")
 }
 


### PR DESCRIPTION
This change enables the commented out test for full compatibility with ECDH-1PU draft4 Appendix B example.

It also includes the following changes:
* fixes CBC+HMAC keys extracted from the ECDH cek. The keys were inversed.
* moved recipients' kids list from AAD to APV (recipients) protectedHeader
* use originalProtectedHeaders if populated instead of protectedHeader when building authData. To avoid marshal/unmarshal calls from changing the json order.
* ECDH-1PU messages with multi-recipients can now read the sender kid (skid) from APU if skid wass empty since it's an optional header.

closes #2850

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
