### PR TITLE
fix: Race condition in IndexedDB and LevelDB storage providers

### DIFF
--- a/component/storage/indexeddb/indexeddb.go
+++ b/component/storage/indexeddb/indexeddb.go
@@ -209,6 +209,7 @@ func (p *Provider) openDB(db string, names ...string) error {
 type store struct {
 	name string
 	db   *js.Value
+	lock sync.RWMutex
 }
 
 func (s *store) Put(key string, value []byte, tags ...storage.Tag) error {
@@ -414,6 +415,9 @@ func (s *store) Close() error {
 }
 
 func (s *store) updateTagMap(key string, tags []storage.Tag) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	tagMapBytes, err := s.Get(tagMapKey)
 	if err != nil {
 		return fmt.Errorf("failed to get tag map: %w", err)
@@ -448,6 +452,9 @@ func (s *store) updateTagMap(key string, tags []storage.Tag) error {
 }
 
 func (s *store) removeFromTagMap(keyToRemove string) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	tagMapBytes, err := s.Get(tagMapKey)
 	if err != nil {
 		// If there's no tag map, then this means that no store configuration was set.

--- a/component/storage/leveldb/leveldb.go
+++ b/component/storage/leveldb/leveldb.go
@@ -214,6 +214,7 @@ type store struct {
 	db    *leveldb.DB
 	name  string
 	close closer
+	lock  sync.RWMutex
 }
 
 // Put stores the key and the record.
@@ -397,6 +398,9 @@ func (s *store) Close() error {
 }
 
 func (s *store) updateTagMap(key string, tags []storage.Tag) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	tagMap, err := s.getTagMap()
 	if err != nil {
 		return fmt.Errorf("failed to get tag map: %w", err)
@@ -464,6 +468,9 @@ func (s *store) getDBEntry(key string) (dbEntry, error) {
 }
 
 func (s *store) removeFromTagMap(keyToRemove string) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	tagMap, err := s.getTagMap()
 	if err != nil {
 		return fmt.Errorf("failed to get tag map: %w", err)


### PR DESCRIPTION
Fixes a race condition in the IndexedDB and LevelDB storage providers that causes tags to be lost when storing data in parallel.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>