### PR TITLE
feat: support packer selection based on destination MediaType

### DIFF
--- a/pkg/didcomm/packer/anoncrypt/pack.go
+++ b/pkg/didcomm/packer/anoncrypt/pack.go
@@ -166,7 +166,6 @@ func (p *Packer) Unpack(envelope []byte) (*transport.Envelope, error) {
 			return nil, fmt.Errorf("anoncrypt Unpack: failed to decrypt JWE envelope: %w", err)
 		}
 
-		// TODO get mapped verKey for the recipient encryption key (kid)
 		ecdhesPubKeyByes, err := exportPubKeyBytes(keyHandle)
 		if err != nil {
 			return nil, fmt.Errorf("anoncrypt Unpack: failed to export public key bytes: %w", err)

--- a/pkg/didcomm/packer/api.go
+++ b/pkg/didcomm/packer/api.go
@@ -47,7 +47,6 @@ type Packer interface {
 	// returns:
 	// 		[]byte containing the encrypted envelope
 	//		error if encryption failed
-	// TODO add key type of recipients and sender keys to be validated by the implementation - Issue #272
 	Pack(contentType string, payload []byte, senderKey []byte, recipients [][]byte) ([]byte, error)
 	// Unpack an envelope in an Aries compliant format.
 	// 		The recipient's key will be the one found in KMS that matches one of the list of recipients in the envelope
@@ -55,7 +54,6 @@ type Packer interface {
 	// returns:
 	// 		Envelope containing the message, decryption key, and sender key
 	//		error if decryption failed
-	// TODO add key type of recipients keys to be validated by the implementation - Issue #272
 	Unpack(envelope []byte) (*transport.Envelope, error)
 
 	// Encoding returns the type of the encoding, as found in the protected header 'typ' field

--- a/pkg/didcomm/packer/authcrypt/pack.go
+++ b/pkg/didcomm/packer/authcrypt/pack.go
@@ -223,7 +223,6 @@ func (p *Packer) Unpack(envelope []byte) (*transport.Envelope, error) {
 			return nil, fmt.Errorf("authcrypt Unpack: failed to decrypt JWE envelope: %w", err)
 		}
 
-		// TODO get mapped verKey for the recipient encryption key (kid)
 		ecdh1puPubKeyByes, err = exportPubKeyBytes(keyHandle)
 		if err != nil {
 			return nil, fmt.Errorf("authcrypt Unpack: failed to export public key bytes: %w", err)

--- a/pkg/didcomm/transport/media_type.go
+++ b/pkg/didcomm/transport/media_type.go
@@ -10,7 +10,9 @@ const (
 	// MediaTypeRFC0019EncryptedEnvelope is the original media type for DIDComm V1 encrypted envelopes as per
 	// Aries RFC 0019.
 	MediaTypeRFC0019EncryptedEnvelope = "JWM/1.0"
-	// MediaTypeV1EncryptedEnvelope is the media type for DIDComm V1 encrypted envelopes as per Aries RFC 0044.
+	// MediaTypeV1EncryptedEnvelope is the media type for DIDComm V1 encrypted envelopes as per Aries RFC 0044. This
+	// media type never materialized as it was in-between state of DIDComm V1 and V2 and the intent was to build the new
+	// JWE format which has now become V2. It's treated as V2 in the framework for the sake of JWE compatibility.
 	MediaTypeV1EncryptedEnvelope = "application/didcomm-enc-env"
 	// MediaTypeV1PlaintextPayload is the media type for DIDComm V1 JWE payloads as per Aries RFC 0044.
 	MediaTypeV1PlaintextPayload = "application/json;flavor=didcomm-msg"
@@ -20,4 +22,18 @@ const (
 	// MediaTypeV2EncryptedEnvelopeV1PlaintextPayload is the media type for DIDComm V2 encrypted envelopes with a
 	// V1 plaintext payload as per Aries RFC 0587.
 	MediaTypeV2EncryptedEnvelopeV1PlaintextPayload = MediaTypeV2EncryptedEnvelope + ";cty=" + MediaTypeV1PlaintextPayload
+	// MediaTypeV2PlaintextPayload is the media type for DIDComm V1 JWE payloads as per Aries 044.
+	MediaTypeV2PlaintextPayload = "application/didcomm-plain+json"
+
+	// below are pre-defined profiles supported by the framework as per
+	// https://github.com/hyperledger/aries-rfcs/tree/master/features/0044-didcomm-file-and-mime-types#defined-profiles.
+
+	// MediaTypeAIP2RFC0019Profile for AIP 2.0, circa 2021 using RFC0019 encryption envelope.
+	MediaTypeAIP2RFC0019Profile = "didcomm/aip2;env=rfc19"
+
+	// MediaTypeAIP2RFC0587Profile for AIP 2.0, circa 2021 using the new JWE encryption envelope (DIDComm V2 style).
+	MediaTypeAIP2RFC0587Profile = "didcomm/aip2;env=rfc587"
+
+	// MediaTypeDIDCommV2Profile is the official DIDComm V2 profile.
+	MediaTypeDIDCommV2Profile = "didcomm/v2"
 )

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -196,7 +196,7 @@ func setAdditionalDefaultOpts(frameworkOpts *Aries) error {
 				return legacy.New(provider), nil
 			},
 			func(provider packer.Provider) (packer.Packer, error) {
-				return authcrypt.New(provider, jose.A128CBCHS256)
+				return authcrypt.New(provider, jose.A256CBCHS512)
 			},
 			func(provider packer.Provider) (packer.Packer, error) {
 				return anoncrypt.New(provider, jose.A256GCM)
@@ -216,6 +216,13 @@ func setAdditionalDefaultOpts(frameworkOpts *Aries) error {
 
 	if frameworkOpts.msgSvcProvider == nil {
 		frameworkOpts.msgSvcProvider = &noOpMessageServiceProvider{}
+	}
+
+	if frameworkOpts.mediaTypeProfiles == nil {
+		// for now only set legacy media type profile to match default key type and primary packer above.
+		// TODO once keyAgreement is added in the packers, this can be switched to DIDcomm V2 media type as well as
+		// 		switching legacyPacker with authcrtypt as primary packer and using an ECDH-1PU key as default key above.
+		frameworkOpts.mediaTypeProfiles = []string{transport.MediaTypeRFC0019EncryptedEnvelope}
 	}
 
 	return nil

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -70,6 +70,7 @@ type Aries struct {
 	id                         string
 	keyType                    kms.KeyType
 	keyAgreementType           kms.KeyType
+	mediaTypeProfiles          []string
 }
 
 // Option configures the framework.
@@ -311,6 +312,16 @@ func WithKeyAgreementType(keyAgreementType kms.KeyType) Option {
 	}
 }
 
+// WithMediaTypeProfiles injects a default media types profile.
+func WithMediaTypeProfiles(mediaTypeProfiles []string) Option {
+	return func(opts *Aries) error {
+		opts.mediaTypeProfiles = make([]string, len(mediaTypeProfiles))
+		copy(opts.mediaTypeProfiles, mediaTypeProfiles)
+
+		return nil
+	}
+}
+
 // Context provides a handle to the framework context.
 func (a *Aries) Context() (*context.Provider, error) {
 	return context.New(
@@ -336,6 +347,7 @@ func (a *Aries) Context() (*context.Provider, error) {
 		context.WithJSONLDDocumentLoader(a.jsonldDocumentLoader),
 		context.WithKeyType(a.keyType),
 		context.WithKeyAgreementType(a.keyAgreementType),
+		context.WithMediaTypeProfiles(a.mediaTypeProfiles),
 	)
 }
 
@@ -515,6 +527,9 @@ func startTransports(frameworkOpts *Aries) error {
 		context.WithMessageServiceProvider(frameworkOpts.msgSvcProvider),
 		context.WithMessengerHandler(frameworkOpts.messenger),
 		context.WithDIDConnectionStore(frameworkOpts.didConnectionStore),
+		context.WithKeyType(frameworkOpts.keyType),
+		context.WithKeyAgreementType(frameworkOpts.keyAgreementType),
+		context.WithMediaTypeProfiles(frameworkOpts.mediaTypeProfiles),
 	)
 	if err != nil {
 		return fmt.Errorf("context creation failed: %w", err)

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -637,6 +637,17 @@ func TestFramework(t *testing.T) {
 		require.Equal(t, kms.BLS12381G2Type, aries.keyType)
 		require.Equal(t, kms.NISTP384ECDHKWType, aries.keyAgreementType)
 	})
+
+	t.Run("test new with mediaTypeProfiles", func(t *testing.T) {
+		aries, err := New(WithMediaTypeProfiles([]string{
+			transport.MediaTypeV2EncryptedEnvelope,
+			transport.MediaTypeV1EncryptedEnvelope,
+		}))
+		require.NoError(t, err)
+		require.Equal(t, 2, len(aries.mediaTypeProfiles))
+		require.Equal(t, transport.MediaTypeV2EncryptedEnvelope, aries.mediaTypeProfiles[0])
+		require.Equal(t, transport.MediaTypeV1EncryptedEnvelope, aries.mediaTypeProfiles[1])
+	})
 }
 
 func Test_Packager(t *testing.T) {

--- a/pkg/framework/context/context.go
+++ b/pkg/framework/context/context.go
@@ -56,6 +56,7 @@ type Provider struct {
 	frameworkID                string
 	keyType                    kms.KeyType
 	keyAgreementType           kms.KeyType
+	mediaTypeProfiles          []string
 }
 
 type inboundHandler struct {
@@ -298,6 +299,11 @@ func (p *Provider) KeyAgreementType() kms.KeyType {
 	return p.keyAgreementType
 }
 
+// MediaTypeProfiles returns the default media types profile.
+func (p *Provider) MediaTypeProfiles() []string {
+	return p.mediaTypeProfiles
+}
+
 // ProviderOption configures the framework.
 type ProviderOption func(opts *Provider) error
 
@@ -491,5 +497,15 @@ func WithKeyAgreementType(keyAgreementType kms.KeyType) ProviderOption {
 		default:
 			return fmt.Errorf("invalid KeyAgreement key type: %s", keyAgreementType)
 		}
+	}
+}
+
+// WithMediaTypeProfiles injects a media type profile into the context.
+func WithMediaTypeProfiles(mediaTypeProfiles []string) ProviderOption {
+	return func(opts *Provider) error {
+		opts.mediaTypeProfiles = make([]string, len(mediaTypeProfiles))
+		copy(opts.mediaTypeProfiles, mediaTypeProfiles)
+
+		return nil
 	}
 }

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -620,4 +620,17 @@ func TestNewProvider(t *testing.T) {
 		_, err = New(WithKeyAgreementType(kms.XChaCha20Poly1305Type))
 		require.EqualError(t, err, "option failed: invalid KeyAgreement key type: XChaCha20Poly1305")
 	})
+
+	t.Run("test new with mediaTypeProfiles", func(t *testing.T) {
+		prov, err := New(WithMediaTypeProfiles([]string{
+			transport.MediaTypeV2EncryptedEnvelope,
+			transport.MediaTypeV1EncryptedEnvelope,
+			transport.MediaTypeRFC0019EncryptedEnvelope,
+		}))
+		require.NoError(t, err)
+		require.Equal(t, 3, len(prov.MediaTypeProfiles()))
+		require.Equal(t, transport.MediaTypeV2EncryptedEnvelope, prov.MediaTypeProfiles()[0])
+		require.Equal(t, transport.MediaTypeV1EncryptedEnvelope, prov.MediaTypeProfiles()[1])
+		require.Equal(t, transport.MediaTypeRFC0019EncryptedEnvelope, prov.MediaTypeProfiles()[2])
+	})
 }


### PR DESCRIPTION
This change sets the media type priority based on the destination according to Aries RFCs 19, 44 and 587.
It sets the JWE message's CTY header based on the received media type.
It also updates the default authcrypt packing sender key type to be AES256CBCHS512.

closes #1112 (packer is selected based on mediaTypeProfile)
closes #272 (key type is managed by the kms)
closes #749 (diffrent keys are supported by the packers, except LegacyPacker that supports ED25519 keys only)
closes #2858 (SendToDID now can be used without a DID connection, as it was before)

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
