### PR TITLE
wip: fixes for implicit invitation interop with acapy

### DIFF
--- a/pkg/didcomm/packer/legacy/authcrypt/unpack.go
+++ b/pkg/didcomm/packer/legacy/authcrypt/unpack.go
@@ -36,6 +36,8 @@ func (p *Packer) Unpack(envelope []byte) (*transport.Envelope, error) {
 		return nil, err
 	}
 
+	fmt.Printf("protected: %s\n", string(protectedBytes))
+
 	var protectedData protected
 
 	err = json.Unmarshal(protectedBytes, &protectedData)
@@ -47,14 +49,21 @@ func (p *Packer) Unpack(envelope []byte) (*transport.Envelope, error) {
 		return nil, fmt.Errorf("message type %s not supported", protectedData.Typ)
 	}
 
-	if protectedData.Alg != "Authcrypt" {
-		// TODO https://github.com/hyperledger/aries-framework-go/issues/41 change this when anoncrypt is introduced
-		return nil, fmt.Errorf("message format %s not supported", protectedData.Alg)
-	}
+	var keys *keys
 
-	keys, err := getCEK(protectedData.Recipients, p.kms)
-	if err != nil {
-		return nil, err
+	switch protectedData.Alg {
+	case "Authcrypt":
+		keys, err = getCEK(protectedData.Recipients, p.kms)
+		if err != nil {
+			return nil, err
+		}
+	case "Anoncrypt":
+		keys, err = getCEKAnon(protectedData.Recipients, p.kms)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("message format %s not supported", protectedData.Alg)
 	}
 
 	cek, senderKey, recKey := keys.cek, keys.theirKey, keys.myKey
@@ -121,6 +130,47 @@ func getCEK(recipients []recipient, km kms.KeyManager) (*keys, error) {
 	return &keys{
 		cek:      &cek,
 		theirKey: senderPub,
+		myKey:    recKey,
+	}, nil
+}
+
+func getCEKAnon(recipients []recipient, km kms.KeyManager) (*keys, error) {
+	var candidateKeys []string
+
+	for _, candidate := range recipients {
+		candidateKeys = append(candidateKeys, candidate.Header.KID)
+	}
+
+	recKeyIdx, err := findVerKey(km, candidateKeys)
+	if err != nil {
+		return nil, fmt.Errorf("getCEKAnon: no key accessible %w", err)
+	}
+
+	recip := recipients[recKeyIdx]
+	recKey := base58.Decode(recip.Header.KID)
+
+	encCEK, err := base64.URLEncoding.DecodeString(recip.EncryptedKey)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := newCryptoBox(km)
+	if err != nil {
+		return nil, err
+	}
+
+	cekSlice, err := b.SealOpen(encCEK, recKey)
+	if err != nil {
+		return nil, fmt.Errorf("getCEKANon: failed to decrypt CEK: %w", err)
+	}
+
+	var cek [chacha.KeySize]byte
+
+	copy(cek[:], cekSlice)
+
+	return &keys{
+		cek:      &cek,
+		theirKey: nil,
 		myKey:    recKey,
 	}, nil
 }


### PR DESCRIPTION
N.B.:
- The first commit here is an implementation of legacy anoncrypt, since it looked (at first) like it was needed - I'll take another look.
- resolving key references is something we should push up to another layer, I implemented it in didexchange behind the interop flag for expediency only.