### PR TITLE
chore: disable dependabot PRs on gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "npm"
     directory: "/cmd/aries-js-worker"


### PR DESCRIPTION
- the other gomod in the repo need to be updated in sync.

Signed-off-by: Troy Ronda <troy@troyronda.com>
