### PR TITLE
fix: presexch shouldn't use only the final schema match when checking for schema match

### DIFF
--- a/pkg/doc/presexch/definition.go
+++ b/pkg/doc/presexch/definition.go
@@ -883,10 +883,12 @@ func filterSchema(schemas []*Schema, credentials []*verifiable.Credential) []*ve
 		var applicable bool
 
 		for _, schema := range schemas {
-			applicable = schemaURIMatch(credential.Context, credential.Types, schema.URI)
-			if schema.Required && !applicable {
+			matches := schemaURIMatch(credential.Context, credential.Types, schema.URI)
+			if schema.Required && !matches {
 				break
 			}
+
+			applicable = applicable || matches
 		}
 
 		if applicable {


### PR DESCRIPTION
Also include context needed for test harness tests.

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>