### PR TITLE
test: Updates and improvements to storage test suite

### DIFF
--- a/cmd/aries-agent-mobile/go.mod
+++ b/cmd/aries-agent-mobile/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/hyperledger/aries-framework-go v0.1.7-0.20210603210127-e57b8c94e3cf
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210708130136-17663938344d
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210708130136-17663938344d
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210806210220-65863dbe349a
 	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210603210127-e57b8c94e3cf
 	github.com/piprate/json-gold v0.4.0
 	github.com/stretchr/testify v1.7.0

--- a/cmd/aries-agent-rest/go.mod
+++ b/cmd/aries-agent-rest/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hyperledger/aries-framework-go v0.1.7-0.20210603210127-e57b8c94e3cf
 	github.com/hyperledger/aries-framework-go/component/storage/leveldb v0.0.0-20210603182844-353ecb34cf4d
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210708130136-17663938344d
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210708130136-17663938344d
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210806210220-65863dbe349a
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/cmd/aries-js-worker/go.mod
+++ b/cmd/aries-js-worker/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/hyperledger/aries-framework-go v0.1.7-0.20210603210127-e57b8c94e3cf
 	github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-00010101000000-000000000000
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210708130136-17663938344d
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210806210220-65863dbe349a
 	github.com/mitchellh/mapstructure v1.3.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/component/storage/indexeddb/indexeddb.go
+++ b/component/storage/indexeddb/indexeddb.go
@@ -387,6 +387,10 @@ func (s *store) Delete(k string) error {
 }
 
 func (s *store) Batch(operations []storage.Operation) error {
+	if len(operations) == 0 {
+		return errors.New("batch requires at least one operation")
+	}
+
 	for _, operation := range operations {
 		if operation.Value == nil {
 			err := s.Delete(operation.Key)

--- a/component/storageutil/mem/mem.go
+++ b/component/storageutil/mem/mem.go
@@ -309,6 +309,10 @@ func (m *memStore) Delete(k string) error {
 // Batch performs multiple Put and/or Delete operations in order.
 // If any of the given keys are empty, then an error will be returned.
 func (m *memStore) Batch(operations []spi.Operation) error {
+	if len(operations) == 0 {
+		return errors.New("batch requires at least one operation")
+	}
+
 	m.Lock()
 	defer m.Unlock()
 

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/hyperledger/aries-framework-go v0.1.7-0.20210603210127-e57b8c94e3cf
 	github.com/hyperledger/aries-framework-go/component/storage/leveldb v0.0.0-20210603182844-353ecb34cf4d
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210708130136-17663938344d
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210708130136-17663938344d
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210806210220-65863dbe349a
 	github.com/moby/sys/mount v0.2.0 // indirect
 	github.com/moby/term v0.0.0-20201110203204-bea5bbe245bf // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2

--- a/test/component/go.mod
+++ b/test/component/go.mod
@@ -8,6 +8,6 @@ go 1.16
 
 require (
 	github.com/google/uuid v1.1.2
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210603182844-353ecb34cf4d
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210806210220-65863dbe349a
 	github.com/stretchr/testify v1.6.1
 )

--- a/test/component/go.sum
+++ b/test/component/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210603182844-353ecb34cf4d h1:APHQQZy8S8KvLjj2sgjKZrrtJAMaQ0Ajg5l7a50Cbvw=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210603182844-353ecb34cf4d/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210806210220-65863dbe349a h1:fdvejEMjjwaPBawGl0gXOuQ1II7lYQyYZPIhq9iyeNA=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210806210220-65863dbe349a/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
- Added new tests to ensure correct behaviour for the Store.Batch and Store.Close methods per the recently updated interface documentation.
- Added close calls for all of the stores that get created in the tests. This is important for storage implementations that maintain connections to databases. By closing these stores after each test, those implementations should be able to safely call TestAll without exhausting the connection limit and causing test failures.
- Updated storage implementations (as needed) to pass the new tests.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>