### PR TITLE
refactor: use did:key in packagers (for didcomm v1)

### DIFF
--- a/pkg/controller/command/vdr/command.go
+++ b/pkg/controller/command/vdr/command.go
@@ -99,7 +99,7 @@ func (o *Command) GetHandlers() []command.Handler {
 	}
 }
 
-// CreateDID reate did.
+// CreateDID create did.
 func (o *Command) CreateDID(rw io.Writer, req io.Reader) command.Error {
 	var request CreateDIDRequest
 

--- a/pkg/didcomm/common/service/destination_default.go
+++ b/pkg/didcomm/common/service/destination_default.go
@@ -10,6 +10,7 @@ package service
 
 import (
 	"fmt"
+	"strings"
 
 	diddoc "github.com/hyperledger/aries-framework-go/pkg/doc/did"
 )
@@ -30,8 +31,12 @@ func CreateDestination(didDoc *diddoc.Doc) (*Destination, error) {
 		return nil, fmt.Errorf("create destination: no recipient keys on didcomm service block in diddoc: %+v", didDoc)
 	}
 
-	// TODO ensure recipient keys are did:key's
-	//  https://github.com/hyperledger/aries-framework-go/issues/1604
+	for i, k := range didCommService.RecipientKeys {
+		if !strings.HasPrefix(k, "did:") {
+			return nil, fmt.Errorf("create destination: recipient key %d:[%v] of didComm '%s' not a did:key", i+1,
+				k, didCommService.ID)
+		}
+	}
 
 	return &Destination{
 		RecipientKeys:     didCommService.RecipientKeys,

--- a/pkg/didcomm/common/service/destination_test.go
+++ b/pkg/didcomm/common/service/destination_test.go
@@ -90,6 +90,15 @@ func TestPrepareDestination(t *testing.T) {
 		require.Equal(t, doc.Service[0].RoutingKeys, dest.RoutingKeys)
 	})
 
+	t.Run("error with destination having recipientKeys not did:keys", func(t *testing.T) {
+		doc := mockdiddoc.GetMockDIDDoc(t)
+		doc.Service[0].RecipientKeys = []string{"badKey"}
+		dest, err := CreateDestination(doc)
+
+		require.EqualError(t, err, "create destination: recipient key 1:[badKey] of didComm '' not a did:key")
+		require.Nil(t, dest)
+	})
+
 	t.Run("error while getting service", func(t *testing.T) {
 		didDoc := mockdiddoc.GetMockDIDDoc(t)
 		didDoc.Service = nil

--- a/pkg/didcomm/dispatcher/outbound_test.go
+++ b/pkg/didcomm/dispatcher/outbound_test.go
@@ -39,6 +39,7 @@ func TestNewOutbound(t *testing.T) {
 			storageProvider: &mockstore.MockStoreProvider{
 				ErrOpenStoreHandle: expected,
 			},
+			mediaTypeProfiles: []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.ErrorIs(t, err, expected)
 	})
@@ -51,6 +52,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: true}},
 			storageProvider:         mockstore.NewMockStoreProvider(),
 			protoStorageProvider:    mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:       []string{transport.MediaTypeV1PlaintextPayload},
 		})
 		require.NoError(t, err)
 		require.NoError(t, o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"}))
@@ -62,6 +64,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: false}},
 			storageProvider:         mockstore.NewMockStoreProvider(),
 			protoStorageProvider:    mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:       []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 		err = o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"})
@@ -75,6 +78,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: true}},
 			storageProvider:         mockstore.NewMockStoreProvider(),
 			protoStorageProvider:    mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:       []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 		err = o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"})
@@ -90,6 +94,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			},
 			storageProvider:      mockstore.NewMockStoreProvider(),
 			protoStorageProvider: mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:    []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 		err = o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"})
@@ -103,6 +108,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: true}},
 			storageProvider:         mockstore.NewMockStoreProvider(),
 			protoStorageProvider:    mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:       []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 
@@ -122,6 +128,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			},
 			storageProvider:      mockstore.NewMockStoreProvider(),
 			protoStorageProvider: mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:    []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 
@@ -130,8 +137,8 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			RecipientKeys:   []string{"abc"},
 			RoutingKeys:     []string{"xyz"},
 		})
-		require.EqualError(t, err, "outboundDispatcher.Send: failed to create forward msg : failed Create "+
-			"and export SigningKey: create and export key error")
+		require.EqualError(t, err, "outboundDispatcher.Send: failed to create forward msg: failed Create "+
+			"and export Encryption Key: create and export key error")
 	})
 
 	t.Run("test send with forward message - packer error", func(t *testing.T) {
@@ -140,6 +147,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: true}},
 			storageProvider:         mockstore.NewMockStoreProvider(),
 			protoStorageProvider:    mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:       []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 
@@ -158,6 +166,7 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			outboundTransportsValue: []transport.OutboundTransport{},
 			storageProvider:         mockstore.NewMockStoreProvider(),
 			protoStorageProvider:    mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:       []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 
@@ -185,6 +194,7 @@ func TestOutboundDispatcher_SendToDID(t *testing.T) {
 			},
 			storageProvider:      mockstore.NewMockStoreProvider(),
 			protoStorageProvider: mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:    []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 
@@ -207,6 +217,7 @@ func TestOutboundDispatcher_SendToDID(t *testing.T) {
 			},
 			storageProvider:      mockstore.NewMockStoreProvider(),
 			protoStorageProvider: mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:    []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 
@@ -380,6 +391,7 @@ func TestOutboundDispatcherTransportReturnRoute(t *testing.T) {
 			transportReturnRoute: transportReturnRoute,
 			protoStorageProvider: mockstore.NewMockStoreProvider(),
 			storageProvider:      mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:    []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 
@@ -413,6 +425,7 @@ func TestOutboundDispatcherTransportReturnRoute(t *testing.T) {
 			transportReturnRoute: transportReturnRoute,
 			storageProvider:      mockstore.NewMockStoreProvider(),
 			protoStorageProvider: mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:    []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 
@@ -438,6 +451,7 @@ func TestOutboundDispatcherTransportReturnRoute(t *testing.T) {
 			transportReturnRoute: "",
 			storageProvider:      mockstore.NewMockStoreProvider(),
 			protoStorageProvider: mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:    []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 
@@ -451,6 +465,7 @@ func TestOutboundDispatcherTransportReturnRoute(t *testing.T) {
 			transportReturnRoute: transportReturnRoute,
 			storageProvider:      mockstore.NewMockStoreProvider(),
 			protoStorageProvider: mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:    []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 
@@ -469,6 +484,7 @@ func TestOutboundDispatcher_Forward(t *testing.T) {
 			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: true}},
 			storageProvider:         mockstore.NewMockStoreProvider(),
 			protoStorageProvider:    mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:       []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 		require.NoError(t, o.Forward("data", &service.Destination{ServiceEndpoint: "url"}))
@@ -480,6 +496,7 @@ func TestOutboundDispatcher_Forward(t *testing.T) {
 			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: false}},
 			storageProvider:         mockstore.NewMockStoreProvider(),
 			protoStorageProvider:    mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:       []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 		err = o.Forward("data", &service.Destination{ServiceEndpoint: "url"})
@@ -495,6 +512,7 @@ func TestOutboundDispatcher_Forward(t *testing.T) {
 			},
 			storageProvider:      mockstore.NewMockStoreProvider(),
 			protoStorageProvider: mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles:    []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
 		err = o.Forward("data", &service.Destination{ServiceEndpoint: "url"})
@@ -522,6 +540,7 @@ type mockProvider struct {
 	storageProvider         storage.Provider
 	protoStorageProvider    storage.Provider
 	mediaTypeProfiles       []string
+	keyAgreementType        kms.KeyType
 }
 
 func (p *mockProvider) Packager() transport.Packager {
@@ -558,6 +577,10 @@ func (p *mockProvider) ProtocolStateStorageProvider() storage.Provider {
 
 func (p *mockProvider) MediaTypeProfiles() []string {
 	return p.mediaTypeProfiles
+}
+
+func (p *mockProvider) KeyAgreementType() kms.KeyType {
+	return p.keyAgreementType
 }
 
 // mockOutboundTransport mock outbound transport.

--- a/pkg/didcomm/packer/anoncrypt/pack_test.go
+++ b/pkg/didcomm/packer/anoncrypt/pack_test.go
@@ -32,11 +32,13 @@ import (
 	ecdhpb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdh_aead_go_proto"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	afgjose "github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util/kmsdidkey"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
 	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
 	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
 	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	mockvdr "github.com/hyperledger/aries-framework-go/pkg/mock/vdr"
 	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
 	spilog "github.com/hyperledger/aries-framework-go/spi/log"
 )
@@ -130,7 +132,7 @@ func TestAnoncryptPackerSuccess(t *testing.T) {
 		tc := tt
 		t.Run(fmt.Sprintf("running %s", tc.name), func(t *testing.T) {
 			t.Logf("anoncrypt packing - creating recipient %s keys...", tc.keyType)
-			_, recipientsKeys, keyHandles := createRecipientsByKeyType(t, k, 3, tc.keyType)
+			kids, _, recipientsKeys, keyHandles := createRecipientsByKeyType(t, k, 3, tc.keyType)
 
 			log.SetLevel("aries-framework/pkg/didcomm/packer/anoncrypt", spilog.DEBUG)
 
@@ -151,7 +153,7 @@ func TestAnoncryptPackerSuccess(t *testing.T) {
 			msg, err := anonPacker.Unpack(ct)
 			require.NoError(t, err)
 
-			recKey, err := exportPubKeyBytes(keyHandles[0])
+			recKey, err := exportPubKeyBytes(keyHandles[0], kids[0])
 			require.NoError(t, err)
 
 			require.EqualValues(t, &transport.Envelope{Message: origMsg, ToKey: recKey}, msg)
@@ -200,10 +202,10 @@ func TestAnoncryptPackerSuccessWithDifferentCurvesSuccess(t *testing.T) {
 	log.SetLevel("aries-framework/pkg/didcomm/packer/anoncrypt", spilog.DEBUG)
 
 	k := createKMS(t)
-	_, recipientsKey1, keyHandles1 := createRecipients(t, k, 1)
-	_, recipientsKey2, _ := createRecipientsByKeyType(t, k, 1, kms.NISTP384ECDHKW)
-	_, recipientsKey3, _ := createRecipientsByKeyType(t, k, 1, kms.NISTP521ECDHKW)
-	_, recipientsKey4, _ := createRecipientsByKeyType(t, k, 1, kms.X25519ECDHKW)
+	kids, _, recipientsKey1, keyHandles1 := createRecipients(t, k, 1)
+	_, _, recipientsKey2, _ := createRecipientsByKeyType(t, k, 1, kms.NISTP384ECDHKW) //nolint:dogsled
+	_, _, recipientsKey3, _ := createRecipientsByKeyType(t, k, 1, kms.NISTP521ECDHKW) //nolint:dogsled
+	_, _, recipientsKey4, _ := createRecipientsByKeyType(t, k, 1, kms.X25519ECDHKW)   //nolint:dogsled
 
 	recipientsKeys := make([][]byte, 4)
 	recipientsKeys[0] = make([]byte, len(recipientsKey1[0]))
@@ -236,7 +238,7 @@ func TestAnoncryptPackerSuccessWithDifferentCurvesSuccess(t *testing.T) {
 	msg, err := anonPacker.Unpack(ct)
 	require.NoError(t, err)
 
-	recKey, err := exportPubKeyBytes(keyHandles1[0])
+	recKey, err := exportPubKeyBytes(keyHandles1[0], kids[0])
 	require.NoError(t, err)
 
 	require.EqualValues(t, &transport.Envelope{
@@ -260,6 +262,13 @@ func TestAnoncryptPackerSuccessWithDifferentCurvesSuccess(t *testing.T) {
 func TestAnoncryptPackerFail(t *testing.T) {
 	cty := transport.MediaTypeV1PlaintextPayload
 
+	t.Run("new Pack fail with nil crypto service", func(t *testing.T) {
+		k := createKMS(t)
+
+		_, err := New(newMockProvider(k, nil), afgjose.A128CBCHS256)
+		require.EqualError(t, err, "anoncrypt: failed to create packer because crypto service is empty")
+	})
+
 	cryptoSvc, err := tinkcrypto.New()
 	require.NoError(t, err)
 
@@ -269,7 +278,7 @@ func TestAnoncryptPackerFail(t *testing.T) {
 	})
 
 	k := createKMS(t)
-	_, recipientsKeys, _ := createRecipients(t, k, 10)
+	_, _, recipientsKeys, _ := createRecipients(t, k, 10) //nolint:dogsled
 	origMsg := []byte("secret message")
 	anonPacker, err := New(newMockProvider(k, cryptoSvc), afgjose.A256GCM)
 	require.NoError(t, err)
@@ -328,7 +337,7 @@ func TestAnoncryptPackerFail(t *testing.T) {
 	})
 
 	t.Run("pack success but unpack fails with missing kid in kms", func(t *testing.T) {
-		kids, newRecKeys, _ := createRecipients(t, k, 2)
+		kids, _, newRecKeys, _ := createRecipients(t, k, 2)
 		validAnonPacker, err := New(newMockProvider(k, cryptoSvc), afgjose.A256GCM)
 		require.NoError(t, err)
 
@@ -348,34 +357,38 @@ func TestAnoncryptPackerFail(t *testing.T) {
 }
 
 // createRecipients and return their public key and keyset.Handle.
-func createRecipients(t *testing.T, k *localkms.LocalKMS, recipientsCount int) ([]string, [][]byte, []*keyset.Handle) {
+func createRecipients(t *testing.T, k *localkms.LocalKMS,
+	recipientsCount int) ([]string, []string, [][]byte, []*keyset.Handle) {
 	return createRecipientsByKeyType(t, k, recipientsCount, kms.NISTP256ECDHKW)
 }
 
 func createRecipientsByKeyType(t *testing.T, k *localkms.LocalKMS, recipientsCount int,
-	kt kms.KeyType) ([]string, [][]byte, []*keyset.Handle) {
+	kt kms.KeyType) ([]string, []string, [][]byte, []*keyset.Handle) {
 	t.Helper()
 
 	var (
-		r    [][]byte
-		rKH  []*keyset.Handle
-		kids []string
+		r       [][]byte
+		rKH     []*keyset.Handle
+		kids    []string
+		didKeys []string
 	)
 
 	for i := 0; i < recipientsCount; i++ {
-		kid, marshalledPubKey, kh := createAndMarshalKeyByKeyType(t, k, kt)
+		kid, didKey, marshalledPubKey, kh := createAndMarshalKeyByKeyType(t, k, kt)
 
 		r = append(r, marshalledPubKey)
 		rKH = append(rKH, kh)
 		kids = append(kids, kid)
+		didKeys = append(didKeys, didKey)
 	}
 
-	return kids, r, rKH
+	return kids, didKeys, r, rKH
 }
 
 // createAndMarshalKeyByKeyType creates a new recipient keyset.Handle, extracts public key, marshals it and returns
-// both marshalled public key and original recipient keyset.Handle.
-func createAndMarshalKeyByKeyType(t *testing.T, k *localkms.LocalKMS, kt kms.KeyType) (string, []byte, *keyset.Handle) {
+// both marshalled public key, jwk kid, didKey and original recipient keyset.Handle.
+func createAndMarshalKeyByKeyType(t *testing.T, k *localkms.LocalKMS,
+	kt kms.KeyType) (string, string, []byte, *keyset.Handle) {
 	t.Helper()
 
 	kid, keyHandle, err := k.Create(kt)
@@ -384,23 +397,26 @@ func createAndMarshalKeyByKeyType(t *testing.T, k *localkms.LocalKMS, kt kms.Key
 	kh, ok := keyHandle.(*keyset.Handle)
 	require.True(t, ok)
 
-	pubKeyBytes, err := exportPubKeyBytes(kh)
+	pubKeyBytes, err := exportPubKeyBytes(kh, kid)
 	require.NoError(t, err)
 
 	key := &cryptoapi.PublicKey{}
 	err = json.Unmarshal(pubKeyBytes, key)
 	require.NoError(t, err)
 
-	key.KID = kid
+	didKey, err := kmsdidkey.BuildDIDKeyByKeyType(pubKeyBytes, kt)
+	require.NoError(t, err)
+
+	key.KID = didKey
 	mKey, err := json.Marshal(key)
 	require.NoError(t, err)
 
-	printKey(t, mKey, kh, kid)
+	printKey(t, mKey, kh, kid, didKey)
 
-	return kid, mKey, kh
+	return kid, didKey, mKey, kh
 }
 
-func printKey(t *testing.T, mPubKey []byte, kh *keyset.Handle, kid string) {
+func printKey(t *testing.T, mPubKey []byte, kh *keyset.Handle, kid, didKey string) {
 	t.Helper()
 
 	extractKey, err := extractPrivKey(kh)
@@ -408,14 +424,16 @@ func printKey(t *testing.T, mPubKey []byte, kh *keyset.Handle, kid string) {
 
 	switch keyType := extractKey.(type) {
 	case *hybrid.ECPrivateKey:
-		t.Logf("** EC key: %s, kid: %s", getPrintedECPrivKey(t, keyType), kid)
+		t.Logf("** EC key: %s, \n\t kms kid: %s, \n\t jwe kid (did:key):%s", getPrintedECPrivKey(t, keyType), kid,
+			didKey)
 	case []byte:
 		pubKey := new(cryptoapi.PublicKey)
 		err := json.Unmarshal(mPubKey, pubKey)
 		require.NoError(t, err)
 
 		fullKey := append(keyType, pubKey.X...)
-		t.Logf("** X25519 key: %s, kid: %s", getPrintedX25519PrivKey(t, fullKey), kid)
+		t.Logf("** X25519 key: %s, \n\t kms kid: %s, \n\t jwe kid (did:key):%s", getPrintedX25519PrivKey(t, fullKey), kid,
+			didKey)
 	default:
 		t.Errorf("not supported key type: %s", keyType)
 	}
@@ -529,11 +547,11 @@ func extractPrivKey(kh *keyset.Handle) (interface{}, error) {
 
 type noopAEAD struct{}
 
-func (n noopAEAD) Encrypt(plaintext, additionalData []byte) ([]byte, error) {
+func (n noopAEAD) Encrypt(plaintext, _ []byte) ([]byte, error) {
 	return plaintext, nil
 }
 
-func (n noopAEAD) Decrypt(ciphertext, additionalData []byte) ([]byte, error) {
+func (n noopAEAD) Decrypt(ciphertext, _ []byte) ([]byte, error) {
 	return ciphertext, nil
 }
 
@@ -570,7 +588,8 @@ func createKMS(t *testing.T) *localkms.LocalKMS {
 
 func newMockProvider(customKMS kms.KeyManager, customCrypto cryptoapi.Crypto) *mockprovider.Provider {
 	return &mockprovider.Provider{
-		KMSValue:    customKMS,
-		CryptoValue: customCrypto,
+		KMSValue:        customKMS,
+		CryptoValue:     customCrypto,
+		VDRegistryValue: &mockvdr.MockVDRegistry{},
 	}
 }

--- a/pkg/didcomm/packer/authcrypt/pack.go
+++ b/pkg/didcomm/packer/authcrypt/pack.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/tink/go/keyset"
 
@@ -20,8 +21,8 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/packer"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/kid/resolver"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
-	"github.com/hyperledger/aries-framework-go/pkg/store/wrapper/prefix"
 	"github.com/hyperledger/aries-framework-go/spi/storage"
 )
 
@@ -30,19 +31,14 @@ import (
 // authenticated) to the recipient(s). The assumption of using this package is that public keys exchange has previously
 // occurred between the sender and the recipient(s).
 
-const (
-	// ThirdPartyKeysDB is a store name containing keys of third party agents.
-	ThirdPartyKeysDB = "thirdpartykeysdb"
-)
-
 var logger = log.New("aries-framework/pkg/didcomm/packer/authcrypt")
 
 // Packer represents an Authcrypt Pack/Unpacker that outputs/reads Aries envelopes.
 type Packer struct {
 	kms           kms.KeyManager
 	encAlg        jose.EncAlg
-	thirdPartyKS  storage.Store
 	cryptoService cryptoapi.Crypto
+	kidResolvers  []resolver.KIDResolver
 }
 
 // New will create a Packer instance to 'AuthCrypt' payloads for a given sender and list of recipients keys using
@@ -67,26 +63,15 @@ func New(ctx packer.Provider, encAlg jose.EncAlg) (*Packer, error) {
 		return nil, errors.New("authcrypt: failed to create packer because crypto service is empty")
 	}
 
-	sp := ctx.StorageProvider()
-	if sp == nil {
-		return nil, errors.New("authcrypt: failed to create packer because StorageProvider is empty")
-	}
+	var kidResolvers []resolver.KIDResolver
 
-	store, err := sp.OpenStore(ThirdPartyKeysDB)
-	if err != nil {
-		return nil, fmt.Errorf("authcrypt: %w", err)
-	}
-
-	store, err = prefix.NewPrefixStoreWrapper(store, prefix.StorageKIDPrefix)
-	if err != nil {
-		return nil, fmt.Errorf("authcrypt: failed to wrap key store: %w", err)
-	}
+	kidResolvers = append(kidResolvers, &resolver.DIDKeyResolver{})
 
 	return &Packer{
 		kms:           k,
 		encAlg:        encAlg,
-		thirdPartyKS:  store,
 		cryptoService: c,
+		kidResolvers:  kidResolvers,
 	}, nil
 }
 
@@ -116,12 +101,20 @@ func (p *Packer) Pack(contentType string, payload, senderID []byte, recipientsPu
 		return nil, fmt.Errorf("authcrypt Pack: failed to convert recipient keys: %w", err)
 	}
 
-	kh, err := p.kms.Get(string(senderID))
-	if err != nil {
-		return nil, fmt.Errorf("authcrypt Pack: failed to get sender key from KMS: %w", err)
+	senderKID := string(senderID)
+	skid := senderKID
+
+	if idx := strings.Index(senderKID, "."); idx > 0 {
+		senderKID = senderKID[:idx] // senderKID is the kms kid
+		skid = skid[idx+1:]         // skid represented as did:key to be set as the `skid` header.
 	}
 
-	jweEncrypter, err := jose.NewJWEEncrypt(p.encAlg, p.EncodingType(), contentType, string(senderID),
+	kh, err := p.kms.Get(senderKID)
+	if err != nil {
+		return nil, fmt.Errorf("authcrypt Pack: failed to get kid key from KMS: %w", err)
+	}
+
+	jweEncrypter, err := jose.NewJWEEncrypt(p.encAlg, p.EncodingType(), contentType, skid,
 		kh.(*keyset.Handle), recECKeys, p.cryptoService)
 	if err != nil {
 		return nil, fmt.Errorf("authcrypt Pack: failed to new JWEEncrypt instance: %w", err)
@@ -174,7 +167,8 @@ func unmarshalRecipientKeys(keys [][]byte) ([]*cryptoapi.PublicKey, []byte, erro
 	return pubKeys, aad, nil
 }
 
-// Unpack will decode the envelope using a standard format.
+// Unpack will decode the envelope using a standard format. Using default did:key KID resolver. To use KeyAgreement.ID,
+// pass a resolver.DIDKeyResolver instance using packer.WithKIDResolver() option.
 func (p *Packer) Unpack(envelope []byte) (*transport.Envelope, error) {
 	// TODO validate `typ` and `cty` values
 	jwe, _, _, err := deserializeEnvelope(envelope)
@@ -189,7 +183,7 @@ func (p *Packer) Unpack(envelope []byte) (*transport.Envelope, error) {
 			pt, ecdh1puPubKeyByes []byte
 		)
 
-		kid, err = getKID(i, jwe)
+		kid, err = p.getKID(i, jwe)
 		if err != nil {
 			return nil, fmt.Errorf("authcrypt Unpack: %w", err)
 		}
@@ -216,14 +210,14 @@ func (p *Packer) Unpack(envelope []byte) (*transport.Envelope, error) {
 			return nil, fmt.Errorf("authcrypt Unpack: invalid keyset handle")
 		}
 
-		jweDecrypter := jose.NewJWEDecrypt(p.thirdPartyKS, p.cryptoService, p.kms)
+		jweDecrypter := jose.NewJWEDecrypt(p.kidResolvers, p.cryptoService, p.kms)
 
 		pt, err = jweDecrypter.Decrypt(jwe)
 		if err != nil {
 			return nil, fmt.Errorf("authcrypt Unpack: failed to decrypt JWE envelope: %w", err)
 		}
 
-		ecdh1puPubKeyByes, err = exportPubKeyBytes(keyHandle)
+		ecdh1puPubKeyByes, err = exportPubKeyBytes(keyHandle, kid)
 		if err != nil {
 			return nil, fmt.Errorf("authcrypt Unpack: failed to export public key bytes: %w", err)
 		}
@@ -249,8 +243,11 @@ func deserializeEnvelope(envelope []byte) (*jose.JSONWebEncryption, string, stri
 	return jwe, typ, cty, nil
 }
 
-func getKID(i int, jwe *jose.JSONWebEncryption) (string, error) {
-	var kid string
+func (p *Packer) getKID(i int, jwe *jose.JSONWebEncryption) (string, error) {
+	var (
+		kid         string
+		kidResolver resolver.KIDResolver
+	)
 
 	if i == 0 && len(jwe.Recipients) == 1 { // compact serialization, recipient headers are in jwe.ProtectedHeaders
 		var ok bool
@@ -263,10 +260,20 @@ func getKID(i int, jwe *jose.JSONWebEncryption) (string, error) {
 		kid = jwe.Recipients[i].Header.KID
 	}
 
-	return kid, nil
+	if strings.HasPrefix(kid, "did:key") {
+		kidResolver = p.kidResolvers[0]
+	}
+
+	// recipient kid header is the did:Key or KeyAgreement.ID, extract the public key and build a kms kid.
+	recKey, err := kidResolver.Resolve(kid)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve recipient key from did:key value: %w", err)
+	}
+
+	return recKey.KID, nil
 }
 
-func exportPubKeyBytes(keyHandle *keyset.Handle) ([]byte, error) {
+func exportPubKeyBytes(keyHandle *keyset.Handle, kid string) ([]byte, error) {
 	pubKH, err := keyHandle.Public()
 	if err != nil {
 		return nil, err
@@ -280,7 +287,16 @@ func exportPubKeyBytes(keyHandle *keyset.Handle) ([]byte, error) {
 		return nil, err
 	}
 
-	return buf.Bytes(), nil
+	pubKey := &cryptoapi.PublicKey{}
+
+	err = json.Unmarshal(buf.Bytes(), pubKey)
+	if err != nil {
+		return nil, err
+	}
+
+	pubKey.KID = kid
+
+	return json.Marshal(pubKey)
 }
 
 // EncodingType for didcomm.

--- a/pkg/didcomm/packer/authcrypt/pack_test.go
+++ b/pkg/didcomm/packer/authcrypt/pack_test.go
@@ -32,15 +32,15 @@ import (
 	ecdhpb "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/proto/ecdh_aead_go_proto"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	afgjose "github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util/kmsdidkey"
+	mockvdr "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/framework/aries/api/vdr"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
 	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
 	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
 	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
-	"github.com/hyperledger/aries-framework-go/pkg/store/wrapper/prefix"
 	spilog "github.com/hyperledger/aries-framework-go/spi/log"
-	"github.com/hyperledger/aries-framework-go/spi/storage"
 )
 
 func TestAuthcryptPackerSuccess(t *testing.T) {
@@ -131,28 +131,21 @@ func TestAuthcryptPackerSuccess(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(fmt.Sprintf("running %s", tc.name), func(t *testing.T) {
-			t.Logf("authcrypt packing - creating sender %s key...", tc.keyType)
-			skid, senderKey, _ := createAndMarshalKeyByKeyType(t, k, tc.keyType)
+			t.Logf("authcrypt packing - creating kid %s key...", tc.keyType)
+			skid, sDIDKey, _, _ := createAndMarshalKeyByKeyType(t, k, tc.keyType)
+
+			skid += "." + sDIDKey
 
 			t.Logf("authcrypt packing - creating recipient %s keys...", tc.keyType)
-			_, recipientsKeys, keyHandles := createRecipientsByKeyType(t, k, 3, tc.keyType)
-
-			thirdPartyKeyStore := make(map[string]mockstorage.DBEntry)
-			mockStoreProvider := &mockstorage.MockStoreProvider{Store: &mockstorage.MockStore{
-				Store: thirdPartyKeyStore,
-			}}
+			kids, _, recipientsKeys, keyHandles := createRecipientsByKeyType(t, k, 3, tc.keyType)
 
 			log.SetLevel("aries-framework/pkg/didcomm/packer/authcrypt", spilog.DEBUG)
 
 			cryptoSvc, err := tinkcrypto.New()
 			require.NoError(t, err)
 
-			authPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), tc.encAlg)
+			authPacker, err := New(newMockProvider(k, cryptoSvc), tc.encAlg)
 			require.NoError(t, err)
-
-			// add sender key in thirdPartyKS (prep step before Authcrypt.Pack()/Unpack())
-			fromWrappedKID := prefix.StorageKIDPrefix + skid
-			thirdPartyKeyStore[fromWrappedKID] = mockstorage.DBEntry{Value: senderKey}
 
 			origMsg := []byte("secret message")
 			ct, err := authPacker.Pack(tc.cty, origMsg, []byte(skid), recipientsKeys)
@@ -165,7 +158,7 @@ func TestAuthcryptPackerSuccess(t *testing.T) {
 			msg, err := authPacker.Unpack(ct)
 			require.NoError(t, err)
 
-			recKey, err := exportPubKeyBytes(keyHandles[0])
+			recKey, err := exportPubKeyBytes(keyHandles[0], kids[0])
 			require.NoError(t, err)
 
 			require.EqualValues(t, &transport.Envelope{Message: origMsg, ToKey: recKey}, msg)
@@ -212,12 +205,14 @@ func verifyJWETypes(t *testing.T, cty string, jweHeader afgjose.Headers) {
 
 func TestAuthcryptPackerUsingKeysWithDifferentCurvesSuccess(t *testing.T) {
 	k := createKMS(t)
-	_, recipientsKey1, keyHandles1 := createRecipients(t, k, 1)
+	kids, _, recipientsKey1, keyHandles1 := createRecipients(t, k, 1)
 	// since authcrypt does ECDH kw using the sender key, the recipient keys must be on the same curve (for NIST P keys)
 	// and the same key type (for NIST P / X25519 keys) as the sender's.
 	// this is why recipient keys with different curves/type are not supported for authcrypt.
-	_, recipientsKey2, _ := createRecipients(t, k, 1) // can't create key with kms.NISTP384ECDHKW
-	_, recipientsKey3, _ := createRecipients(t, k, 1) // can't create key with kms.NISTP521ECDHKW
+	//nolint:dogsled
+	_, _, recipientsKey2, _ := createRecipients(t, k, 1) // can't create key with kms.NISTP384ECDHKW
+	//nolint:dogsled
+	_, _, recipientsKey3, _ := createRecipients(t, k, 1) // can't create key with kms.NISTP521ECDHKW
 
 	recipientsKeys := make([][]byte, 3)
 	recipientsKeys[0] = make([]byte, len(recipientsKey1[0]))
@@ -230,22 +225,15 @@ func TestAuthcryptPackerUsingKeysWithDifferentCurvesSuccess(t *testing.T) {
 
 	cty := transport.MediaTypeV1PlaintextPayload
 
-	skid, senderKey, _ := createAndMarshalKey(t, k)
+	skid, didKey, _, _ := createAndMarshalKey(t, k)
 
-	thirdPartyKeyStore := make(map[string]mockstorage.DBEntry)
-	mockStoreProvider := &mockstorage.MockStoreProvider{Store: &mockstorage.MockStore{
-		Store: thirdPartyKeyStore,
-	}}
+	skid += "." + didKey
 
 	cryptoSvc, err := tinkcrypto.New()
 	require.NoError(t, err)
 
-	authPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), afgjose.A256CBCHS512)
+	authPacker, err := New(newMockProvider(k, cryptoSvc), afgjose.A256CBCHS512)
 	require.NoError(t, err)
-
-	// add sender key in thirdPartyKS (prep step before Authcrypt.Pack()/Unpack())
-	fromWrappedKID := prefix.StorageKIDPrefix + skid
-	thirdPartyKeyStore[fromWrappedKID] = mockstorage.DBEntry{Value: senderKey}
 
 	origMsg := []byte("secret message")
 	ct, err := authPacker.Pack(cty, origMsg, []byte(skid), recipientsKeys)
@@ -256,7 +244,7 @@ func TestAuthcryptPackerUsingKeysWithDifferentCurvesSuccess(t *testing.T) {
 	msg, err := authPacker.Unpack(ct)
 	require.NoError(t, err)
 
-	recKey, err := exportPubKeyBytes(keyHandles1[0])
+	recKey, err := exportPubKeyBytes(keyHandles1[0], kids[0])
 	require.NoError(t, err)
 
 	require.EqualValues(t, &transport.Envelope{
@@ -284,56 +272,33 @@ func TestAuthcryptPackerUsingKeysWithDifferentCurvesSuccess(t *testing.T) {
 
 func TestAuthcryptPackerFail(t *testing.T) {
 	cty := transport.MediaTypeV1PlaintextPayload
-
 	k := createKMS(t)
 
 	cryptoSvc, err := tinkcrypto.New()
 	require.NoError(t, err)
 
-	skid, senderKey, _ := createAndMarshalKey(t, k)
+	skid, sDIDKey, _, _ := createAndMarshalKey(t, k)
+	skidB := []byte(skid + "." + sDIDKey)
 
 	t.Run("new Pack fail with nil crypto service", func(t *testing.T) {
-		_, err = New(newMockProvider(nil, k, nil), afgjose.A128CBCHS256)
+		_, err = New(newMockProvider(k, nil), afgjose.A128CBCHS256)
 		require.EqualError(t, err, "authcrypt: failed to create packer because crypto service is empty")
 	})
 
-	t.Run("new Pack fail with nil thirdPartyKS provider", func(t *testing.T) {
-		_, err = New(newMockProvider(nil, k, cryptoSvc), afgjose.A128CBCHS256)
-		require.EqualError(t, err, "authcrypt: failed to create packer because StorageProvider is empty")
-	})
-
 	t.Run("new Pack fail with invalid encryption algorithm", func(t *testing.T) {
-		_, err = New(newMockProvider(nil, k, cryptoSvc), "invalidAlg")
+		_, err = New(newMockProvider(k, cryptoSvc), "invalidAlg")
 		require.EqualError(t, err, "authcrypt: unsupported content encrytpion algorithm: invalidAlg")
 	})
 
-	t.Run("new Pack fail with bad thirdPartyKS provider", func(t *testing.T) {
-		badStoreProvider := &mockstorage.MockStoreProvider{
-			ErrOpenStoreHandle: errors.New("failed to open thirdPartyKS"),
-			FailNamespace:      ThirdPartyKeysDB,
-		}
-
-		_, err = New(newMockProvider(badStoreProvider, k, cryptoSvc), afgjose.A192CBCHS384)
-		require.EqualError(t, err, "authcrypt: failed to open store for name space thirdpartykeysdb")
-	})
-
-	mockStoreMap := make(map[string]mockstorage.DBEntry)
-	mockStoreProvider := &mockstorage.MockStoreProvider{Store: &mockstorage.MockStore{
-		Store: mockStoreMap,
-	}}
-
 	t.Run("new Pack fail with nil kms", func(t *testing.T) {
-		_, err = New(newMockProvider(mockStoreProvider, nil, cryptoSvc), afgjose.A128CBCHS256)
+		_, err = New(newMockProvider(nil, cryptoSvc), afgjose.A128CBCHS256)
 		require.EqualError(t, err, "authcrypt: failed to create packer because KMS is empty")
 	})
 
-	_, recipientsKeys, _ := createRecipients(t, k, 10)
+	_, _, recipientsKeys, _ := createRecipients(t, k, 10) //nolint:dogsled
 	origMsg := []byte("secret message")
-	authPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), afgjose.A256CBCHS512)
+	authPacker, err := New(newMockProvider(k, cryptoSvc), afgjose.A256CBCHS512)
 	require.NoError(t, err)
-
-	mockStoreMap[skid] = mockstorage.DBEntry{Value: senderKey}
-	skidB := []byte(skid)
 
 	t.Run("pack fail with empty recipients keys", func(t *testing.T) {
 		_, err = authPacker.Pack(cty, origMsg, nil, nil)
@@ -348,7 +313,7 @@ func TestAuthcryptPackerFail(t *testing.T) {
 
 	t.Run("pack fail with invalid encAlg", func(t *testing.T) {
 		invalidAlg := "invalidAlg"
-		invalidAuthPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), afgjose.A256CBCHS512)
+		invalidAuthPacker, err := New(newMockProvider(k, cryptoSvc), afgjose.A256CBCHS512)
 		require.NoError(t, err)
 
 		invalidAuthPacker.encAlg = afgjose.EncAlg(invalidAlg)
@@ -357,7 +322,7 @@ func TestAuthcryptPackerFail(t *testing.T) {
 			" algorithm '%s' not supported", invalidAlg))
 	})
 
-	t.Run("pack fail with KMS can't get sender key", func(t *testing.T) {
+	t.Run("pack fail with KMS can't get kid key", func(t *testing.T) {
 		badKMSStoreProvider := mockstorage.NewCustomMockStoreProvider(
 			&mockstorage.MockStore{ErrGet: errors.New("bad fake key ID")})
 		p := mockkms.NewProviderForKMS(badKMSStoreProvider, &noop.NoLock{})
@@ -365,7 +330,7 @@ func TestAuthcryptPackerFail(t *testing.T) {
 		badKMS, err := localkms.New("local-lock://test/key/uri", p)
 		require.NoError(t, err)
 
-		badAuthPacker, err := New(newMockProvider(mockStoreProvider, badKMS, cryptoSvc), afgjose.A128CBCHS256)
+		badAuthPacker, err := New(newMockProvider(badKMS, cryptoSvc), afgjose.A128CBCHS256)
 		require.NoError(t, err)
 
 		_, err = badAuthPacker.Pack(cty, origMsg, skidB, recipientsKeys)
@@ -373,7 +338,7 @@ func TestAuthcryptPackerFail(t *testing.T) {
 	})
 
 	t.Run("pack success but unpack fails with invalid payload", func(t *testing.T) {
-		validAuthPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), afgjose.A192CBCHS384)
+		validAuthPacker, err := New(newMockProvider(k, cryptoSvc), afgjose.A192CBCHS384)
 		require.NoError(t, err)
 
 		_, err = validAuthPacker.Pack(cty, origMsg, skidB, recipientsKeys)
@@ -386,7 +351,7 @@ func TestAuthcryptPackerFail(t *testing.T) {
 	})
 
 	t.Run("pack success but unpack fails with missing keyID in protectedHeader", func(t *testing.T) {
-		validAuthPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), afgjose.A192CBCHS384)
+		validAuthPacker, err := New(newMockProvider(k, cryptoSvc), afgjose.A192CBCHS384)
 		require.NoError(t, err)
 
 		ct, err := validAuthPacker.Pack(cty, origMsg, skidB, [][]byte{recipientsKeys[0]})
@@ -405,8 +370,8 @@ func TestAuthcryptPackerFail(t *testing.T) {
 	})
 
 	t.Run("pack success but unpack fails with missing kid in kms", func(t *testing.T) {
-		kids, newRecKeys, _ := createRecipients(t, k, 2)
-		validAuthPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), afgjose.A128CBCHS256)
+		kids, _, newRecKeys, _ := createRecipients(t, k, 2)
+		validAuthPacker, err := New(newMockProvider(k, cryptoSvc), afgjose.A128CBCHS256)
 		require.NoError(t, err)
 
 		ct, err := validAuthPacker.Pack(cty, origMsg, skidB, newRecKeys)
@@ -424,8 +389,8 @@ func TestAuthcryptPackerFail(t *testing.T) {
 	})
 
 	t.Run("pack success but unpack fails with missing kms in packer", func(t *testing.T) {
-		kids, newRecKeys, _ := createRecipients(t, k, 2)
-		validAuthPacker, err := New(newMockProvider(mockStoreProvider, k, cryptoSvc), afgjose.A128CBCHS256)
+		kids, _, newRecKeys, _ := createRecipients(t, k, 2)
+		validAuthPacker, err := New(newMockProvider(k, cryptoSvc), afgjose.A128CBCHS256)
 		require.NoError(t, err)
 
 		ct, err := validAuthPacker.Pack(cty, origMsg, skidB, newRecKeys)
@@ -446,39 +411,43 @@ func TestAuthcryptPackerFail(t *testing.T) {
 	})
 }
 
-// createRecipients and return their public key and keyset.Handle.
-func createRecipients(t *testing.T, k *localkms.LocalKMS, recipientsCount int) ([]string, [][]byte, []*keyset.Handle) {
+// createRecipients and return their public key, jwk kid, didKey and keyset.Handle.
+func createRecipients(t *testing.T, k *localkms.LocalKMS,
+	recipientsCount int) ([]string, []string, [][]byte, []*keyset.Handle) {
 	return createRecipientsByKeyType(t, k, recipientsCount, kms.NISTP256ECDHKW)
 }
 
 func createRecipientsByKeyType(t *testing.T, k *localkms.LocalKMS, recipientsCount int,
-	kt kms.KeyType) ([]string, [][]byte, []*keyset.Handle) {
+	kt kms.KeyType) ([]string, []string, [][]byte, []*keyset.Handle) {
 	t.Helper()
 
 	var (
-		r    [][]byte
-		rKH  []*keyset.Handle
-		kids []string
+		r       [][]byte
+		rKH     []*keyset.Handle
+		kids    []string
+		didKeys []string
 	)
 
 	for i := 0; i < recipientsCount; i++ {
-		kid, marshalledPubKey, kh := createAndMarshalKeyByKeyType(t, k, kt)
+		kid, didKey, marshalledPubKey, kh := createAndMarshalKeyByKeyType(t, k, kt)
 
 		r = append(r, marshalledPubKey)
 		rKH = append(rKH, kh)
 		kids = append(kids, kid)
+		didKeys = append(didKeys, didKey)
 	}
 
-	return kids, r, rKH
+	return kids, didKeys, r, rKH
 }
 
 // createAndMarshalKey creates a new recipient keyset.Handle, extracts public key, marshals it and returns
 // both marshalled public key and original recipient keyset.Handle.
-func createAndMarshalKey(t *testing.T, k *localkms.LocalKMS) (string, []byte, *keyset.Handle) {
+func createAndMarshalKey(t *testing.T, k *localkms.LocalKMS) (string, string, []byte, *keyset.Handle) {
 	return createAndMarshalKeyByKeyType(t, k, kms.NISTP256ECDHKWType)
 }
 
-func createAndMarshalKeyByKeyType(t *testing.T, k *localkms.LocalKMS, kt kms.KeyType) (string, []byte, *keyset.Handle) {
+func createAndMarshalKeyByKeyType(t *testing.T, k *localkms.LocalKMS,
+	kt kms.KeyType) (string, string, []byte, *keyset.Handle) {
 	t.Helper()
 
 	kid, keyHandle, err := k.Create(kt)
@@ -487,23 +456,40 @@ func createAndMarshalKeyByKeyType(t *testing.T, k *localkms.LocalKMS, kt kms.Key
 	kh, ok := keyHandle.(*keyset.Handle)
 	require.True(t, ok)
 
-	pubKeyBytes, err := exportPubKeyBytes(kh)
+	pubKeyBytes, err := exportPubKeyBytes(kh, kid)
 	require.NoError(t, err)
 
 	key := &cryptoapi.PublicKey{}
 	err = json.Unmarshal(pubKeyBytes, key)
 	require.NoError(t, err)
 
-	key.KID = kid
+	/*
+		//keyTypeToMultiCodecMap := map[kms.KeyType]uint64{
+		//	kms.NISTP256ECDHKW: fingerprint.P256PubKeyMultiCodec,
+		//	kms.NISTP384ECDHKW: fingerprint.P384PubKeyMultiCodec,
+		//	kms.NISTP521ECDHKW: fingerprint.P521PubKeyMultiCodec,
+		//	kms.X25519ECDHKW:   fingerprint.X25519PubKeyMultiCodec,
+		//}
+
+		// used with raw key bytes for signing keys, it should not be used for encryption keys because it creates a
+		// did:key using 'pubKeyBytes' as is (without parsing 'pubKeyBytes').
+		// didKey, _ := fingerprint.CreateDIDKeyByCode(keyTypeToMultiCodecMap[kt], pubKeyBytes)
+	*/
+
+	// used with marshalled *crypto.PublicKey for encryption keys (it parses 'pubKeyBytes').
+	didKey, err := kmsdidkey.BuildDIDKeyByKeyType(pubKeyBytes, kt)
+	require.NoError(t, err)
+
+	key.KID = didKey
 	mKey, err := json.Marshal(key)
 	require.NoError(t, err)
 
-	printKey(t, mKey, kh, kid)
+	printKey(t, mKey, kh, kid, didKey)
 
-	return kid, mKey, kh
+	return kid, didKey, mKey, kh
 }
 
-func printKey(t *testing.T, mPubKey []byte, kh *keyset.Handle, kid string) {
+func printKey(t *testing.T, mPubKey []byte, kh *keyset.Handle, kid, didKey string) {
 	t.Helper()
 
 	extractKey, err := extractPrivKey(kh)
@@ -511,14 +497,16 @@ func printKey(t *testing.T, mPubKey []byte, kh *keyset.Handle, kid string) {
 
 	switch keyType := extractKey.(type) {
 	case *hybrid.ECPrivateKey:
-		t.Logf("** EC key: %s, kid: %s", getPrintedECPrivKey(t, keyType), kid)
+		t.Logf("** EC key: %s, \n\t kms kid: %s, \n\t jwe kid (did:key):%s", getPrintedECPrivKey(t, keyType), kid,
+			didKey)
 	case []byte:
 		pubKey := new(cryptoapi.PublicKey)
 		err := json.Unmarshal(mPubKey, pubKey)
 		require.NoError(t, err)
 
 		fullKey := append(keyType, pubKey.X...)
-		t.Logf("** X25519 key: %s, kid: %s", getPrintedX25519PrivKey(t, fullKey), kid)
+		t.Logf("** X25519 key: %s, \n\t kms kid: %s, \n\t jwe kid (did:key):%s", getPrintedX25519PrivKey(t, fullKey), kid,
+			didKey)
 	default:
 		t.Errorf("not supported key type: %s", keyType)
 	}
@@ -671,11 +659,11 @@ func createKMS(t *testing.T) *localkms.LocalKMS {
 	return k
 }
 
-func newMockProvider(customStoreProvider storage.Provider, customKMS kms.KeyManager,
+func newMockProvider(customKMS kms.KeyManager,
 	customCrypto cryptoapi.Crypto) *mockprovider.Provider {
 	return &mockprovider.Provider{
-		KMSValue:             customKMS,
-		StorageProviderValue: customStoreProvider,
-		CryptoValue:          customCrypto,
+		KMSValue:        customKMS,
+		CryptoValue:     customCrypto,
+		VDRegistryValue: &mockvdr.MockRegistry{},
 	}
 }

--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	vdrapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/logutil"
@@ -84,6 +85,7 @@ type provider interface {
 	Service(id string) (interface{}, error)
 	KeyType() kms.KeyType
 	KeyAgreementType() kms.KeyType
+	MediaTypeProfiles() []string
 }
 
 // stateMachineMsg is an internal struct used to pass data to state machine.
@@ -114,6 +116,7 @@ type context struct {
 	doACAPyInterop     bool
 	keyType            kms.KeyType
 	keyAgreementType   kms.KeyType
+	mediaTypeProfiles  []string
 }
 
 // opts are used to provide client properties to DID Exchange service.
@@ -157,6 +160,11 @@ func New(prov provider) (*Service, error) {
 		keyAgreementType = kms.X25519ECDHKWType
 	}
 
+	mediaTypeProfiles := prov.MediaTypeProfiles()
+	if len(mediaTypeProfiles) == 0 {
+		mediaTypeProfiles = []string{transport.MediaTypeRFC0019EncryptedEnvelope}
+	}
+
 	svc := &Service{
 		ctx: &context{
 			outboundDispatcher: prov.OutboundDispatcher(),
@@ -169,6 +177,7 @@ func New(prov provider) (*Service, error) {
 			doACAPyInterop:     doACAPyInterop,
 			keyType:            keyType,
 			keyAgreementType:   keyAgreementType,
+			mediaTypeProfiles:  mediaTypeProfiles,
 		},
 		// TODO channel size - https://github.com/hyperledger/aries-framework-go/issues/246
 		callbackChannel:    make(chan *message, callbackChannelSize),
@@ -348,7 +357,7 @@ func (s *Service) handle(msg *message, aEvent chan<- service.DIDCommAction) erro
 		logger.Debugf("finished execute state: %s", next.Name())
 
 		if err = s.update(msg.Msg.Type(), connectionRecord); err != nil {
-			return fmt.Errorf("failed to persist state %s %w", next.Name(), err)
+			return fmt.Errorf("failed to persist state '%s': %w", next.Name(), err)
 		}
 
 		if connectionRecord.State == StateIDCompleted {

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -273,13 +273,13 @@ func newSigningAndEncryptionDIDKeys(t *testing.T, ctx *context) (string, string)
 	_, pubKey, err := ctx.kms.CreateAndExportPubKeyBytes(ctx.keyType)
 	require.NoError(t, err)
 
-	didKey, err := kmsdidkey.BuildDIDKeyByKMSKeyType(pubKey, ctx.keyType)
+	didKey, err := kmsdidkey.BuildDIDKeyByKeyType(pubKey, ctx.keyType)
 	require.NoError(t, err)
 
 	_, encPubKey, err := ctx.kms.CreateAndExportPubKeyBytes(ctx.keyAgreementType)
 	require.NoError(t, err)
 
-	encDIDKey, err := kmsdidkey.BuildDIDKeyByKMSKeyType(encPubKey, ctx.keyAgreementType)
+	encDIDKey, err := kmsdidkey.BuildDIDKeyByKeyType(encPubKey, ctx.keyAgreementType)
 	require.NoError(t, err)
 
 	return didKey, encDIDKey

--- a/pkg/didcomm/protocol/didexchange/states.go
+++ b/pkg/didcomm/protocol/didexchange/states.go
@@ -586,9 +586,10 @@ func (ctx *context) getDestination(invitation *Invitation) (*service.Destination
 	}
 
 	return &service.Destination{
-		RecipientKeys:   invitation.RecipientKeys,
-		ServiceEndpoint: invitation.ServiceEndpoint,
-		RoutingKeys:     invitation.RoutingKeys,
+		RecipientKeys:     invitation.RecipientKeys,
+		ServiceEndpoint:   invitation.ServiceEndpoint,
+		RoutingKeys:       invitation.RoutingKeys,
+		MediaTypeProfiles: ctx.mediaTypeProfiles,
 	}, nil
 }
 
@@ -937,6 +938,7 @@ func (ctx *context) resolveVerKey(i *OOBInvitation) (string, error) {
 
 	logger.Debugf("extracted verkey=%s", svc.RecipientKeys[0])
 
+	// use RecipientKeys[0] (DIDComm V1)
 	return svc.RecipientKeys[0], nil
 }
 

--- a/pkg/didcomm/protocol/mediator/service.go
+++ b/pkg/didcomm/protocol/mediator/service.go
@@ -361,6 +361,8 @@ func (s *Service) handleInboundRequest(c *callback) error {
 		c.options,
 		s.endpoint,
 		func() (string, error) {
+			// TODO why use hard coded key type and key creation here? pass ctx.Keytype to s *service and use it instead
+			// TODO of hard coded ED25519 type if new key is still required.
 			_, pubKeyBytes, er := s.kms.CreateAndExportPubKeyBytes(kms.ED25519Type)
 			if er != nil {
 				return "", fmt.Errorf("outboundGrant from handleInboundRequest: kms failed to create and "+
@@ -554,7 +556,7 @@ func (s *Service) doRegistration(record *connection.Record, req *Request, timeou
 	// waits until the mediate-grant message is received or timeout was exceeded
 	grant, err := s.getGrant(req.ID, timeout)
 	if err != nil {
-		return fmt.Errorf("get grant: %w", err)
+		return fmt.Errorf("get grant for request ID '%s': %w", req.ID, err)
 	}
 
 	err = s.saveRouterConfig(record.ConnectionID, &config{

--- a/pkg/didcomm/protocol/mediator/service_test.go
+++ b/pkg/didcomm/protocol/mediator/service_test.go
@@ -988,7 +988,8 @@ func TestRegister(t *testing.T) {
 		})
 
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "get grant: store: data not found")
+		require.Contains(t, err.Error(), "get grant for request ID '")
+		require.Contains(t, err.Error(), "': store: data not found")
 	})
 
 	t.Run("test register route - router connection not found", func(t *testing.T) {

--- a/pkg/didcomm/transport/ws/pool.go
+++ b/pkg/didcomm/transport/ws/pool.go
@@ -99,6 +99,7 @@ func (d *connPool) listener(conn *websocket.Conn, outbound bool) {
 			logger.Errorf("unmarshal transport decorator : %v", err)
 		}
 
+		// TODO check for KeyAgreement.ID for DIDComm V2 instead of did:key
 		didKey, _ := fingerprint.CreateDIDKey(unpackMsg.FromKey)
 
 		if trans.ReturnRoute != nil && trans.ReturnRoute.Value == decorator.TransportReturnRouteAll {

--- a/pkg/doc/jose/kid/resolver/resolver.go
+++ b/pkg/doc/jose/kid/resolver/resolver.go
@@ -1,0 +1,60 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resolver
+
+import (
+	"encoding/json"
+	"fmt"
+
+	cryptoapi "github.com/hyperledger/aries-framework-go/pkg/crypto"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util/kmsdidkey"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+)
+
+// KIDResolver helps resolve the kid public key from a recipient 'kid' or a sender 'skid' during JWE decryption.
+// The JWEDecrypter should be able to load the public key using a resolution scheme for a key reference found in the
+// 'skid' JWE protected header/'kid' recipient header.
+type KIDResolver interface {
+	// Resolve a 'kid'/'skid' into a marshalled public key or error if key resolution fails.
+	Resolve(string) (*cryptoapi.PublicKey, error)
+}
+
+// DIDKeyResolver resolves a 'kid'/'skid' containing a did:key value.
+type DIDKeyResolver struct{}
+
+// Resolve a 'kid'/'skid' protected header with a did:key value into a marshalled public key or error if key
+// resolution fails.
+func (k *DIDKeyResolver) Resolve(kid string) (*cryptoapi.PublicKey, error) {
+	return kmsdidkey.EncryptionPubKeyFromDIDKey(kid)
+}
+
+// StoreResolver resolves a 'kid'/'skid' containing a kms ID value (JWK fingerprint) from a dedicated pre-loaded store.
+// Note: this is not a kms keystore. This StoreResolver is useful in cases where a thirdparty store is needed. This is
+// useful in unit tests and especially for test vectors using the ECDH-1PU Appendix B example to load the sender key
+// so that recipients can resolve a predefined 'skid'. Aries Framework Go is using the DIDKeyResolver by default (for
+// request without DID docs) and DIDDocResolver (for requests with existing DID connections).
+type StoreResolver struct {
+	// store where the kid key is potentially stored.
+	Store storage.Store
+}
+
+// Resolve a 'kid'/'skid' by loading kid's PublicKey from a store or return an error if it fails.
+func (s *StoreResolver) Resolve(kid string) (*cryptoapi.PublicKey, error) {
+	var pubKey *cryptoapi.PublicKey
+
+	mPubKey, err := s.Store.Get(kid)
+	if err != nil {
+		return nil, fmt.Errorf("storeResolver: failed to resolve kid from store: %w", err)
+	}
+
+	err = json.Unmarshal(mPubKey, &pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("storeResolver: failed to unmarshal public key from DB: %w", err)
+	}
+
+	return pubKey, nil
+}

--- a/pkg/doc/jose/kid/resolver/resolver_test.go
+++ b/pkg/doc/jose/kid/resolver/resolver_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resolver
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	commonpb "github.com/google/tink/go/proto/common_go_proto"
+	"github.com/stretchr/testify/require"
+
+	cryptoapi "github.com/hyperledger/aries-framework-go/pkg/crypto"
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+)
+
+func TestResolveDIDKey(t *testing.T) {
+	didKeyP256 := "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169"
+
+	didKeyResolver := &DIDKeyResolver{}
+
+	key, err := didKeyResolver.Resolve(didKeyP256)
+	require.NoError(t, err)
+	require.NotEmpty(t, key)
+	require.Equal(t, commonpb.EllipticCurveType_NIST_P256.String(), key.Curve)
+	require.Equal(t, "EC", key.Type)
+}
+
+func TestResolveStoreKey(t *testing.T) {
+	kid := "key-1"
+	expectedKey := &cryptoapi.PublicKey{
+		KID:   kid,
+		X:     []byte("x"),
+		Y:     []byte("y"),
+		Curve: "P-521",
+		Type:  "EC",
+	}
+
+	mKey, err := json.Marshal(expectedKey)
+	require.NoError(t, err)
+
+	store := &mockstorage.MockStore{Store: make(map[string]mockstorage.DBEntry)}
+
+	t.Run("resolve success", func(t *testing.T) {
+		err = store.Put(kid, mKey)
+		require.NoError(t, err)
+
+		storeKeyResolver := &StoreResolver{Store: store}
+
+		key, e := storeKeyResolver.Resolve(kid)
+		require.NoError(t, e)
+		require.EqualValues(t, expectedKey, key)
+	})
+
+	t.Run("resolve fail with Unmarshal error", func(t *testing.T) {
+		err = store.Put(kid, []byte("*"))
+		require.NoError(t, err)
+
+		storeKeyResolver := &StoreResolver{Store: store}
+
+		key, e := storeKeyResolver.Resolve(kid)
+		require.EqualError(t, e, "storeResolver: failed to unmarshal public key from DB: invalid character "+
+			"'*' looking for beginning of value")
+		require.Empty(t, key)
+	})
+
+	t.Run("resolve fail with Get error", func(t *testing.T) {
+		getFailErr := "get Fail"
+		failStore := &mockstorage.MockStore{ErrGet: errors.New(getFailErr)}
+		storeKeyResolver := &StoreResolver{Store: failStore}
+
+		key, e := storeKeyResolver.Resolve(kid)
+		require.EqualError(t, e, fmt.Sprintf("storeResolver: failed to resolve kid from store: %s", getFailErr))
+		require.Empty(t, key)
+	})
+}

--- a/pkg/doc/util/kmsdidkey/kmsdidkey_test.go
+++ b/pkg/doc/util/kmsdidkey/kmsdidkey_test.go
@@ -7,10 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package kmsdidkey
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
 	"github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol"
@@ -54,6 +56,15 @@ func TestBuildDIDKeyByKMSKeyType(t *testing.T) {
 	require.NoError(t, err)
 
 	_, p384KWKey, err := k.CreateAndExportPubKeyBytes(kms.NISTP384ECDHKWType)
+	require.NoError(t, err)
+
+	badP384KWKey := &crypto.PublicKey{}
+	err = json.Unmarshal(p384KWKey, badP384KWKey)
+	require.NoError(t, err)
+
+	badP384KWKey.Curve = "bad_curve"
+
+	badP384KWKeyBytes, err := json.Marshal(badP384KWKey)
 	require.NoError(t, err)
 
 	_, p521KWKey, err := k.CreateAndExportPubKeyBytes(kms.NISTP521ECDHKWType)
@@ -139,12 +150,17 @@ func TestBuildDIDKeyByKMSKeyType(t *testing.T) {
 			keyBytes: []byte("wrongKey."),
 			keyType:  kms.NISTP256ECDHKW,
 		},
+		{
+			name:     "test invalid NISTP384ECDHKW marshalled Key",
+			keyBytes: badP384KWKeyBytes,
+			keyType:  kms.NISTP384ECDHKWType,
+		},
 	}
 
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
-			didKey, err := BuildDIDKeyByKMSKeyType(tc.keyBytes, tc.keyType)
+			didKey, err := BuildDIDKeyByKeyType(tc.keyBytes, tc.keyType)
 			if tc.name == "test invalid key" {
 				require.EqualError(t, err, "keyType 'undefined' does not have a multi-base codec")
 
@@ -161,6 +177,13 @@ func TestBuildDIDKeyByKMSKeyType(t *testing.T) {
 			if tc.name == "test invalid NISTP256ECDHKW key" {
 				require.EqualError(t, err, "buildDIDkeyByKMSKeyType failed to unmarshal key type NISTP256ECDHKW:"+
 					" invalid character 'w' looking for beginning of value")
+
+				return
+			}
+
+			if tc.name == "test invalid NISTP384ECDHKW marshalled Key" {
+				require.EqualError(t, err, "buildDIDkeyByKMSKeyType failed to unmarshal key type NISTP384ECDHKW:"+
+					" invalid curve 'bad_curve'")
 
 				return
 			}
@@ -183,4 +206,84 @@ func newKMS(t *testing.T, store storage.Provider) kms.KeyManager {
 	require.NoError(t, err)
 
 	return customKMS
+}
+
+func TestEncryptionPubKeyFromDIDKey(t *testing.T) {
+	didKeyED25519 := "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+	didKeyX25519 := "did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQgQjQC23ZCit6F"
+	didKeyP256 := "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169"
+	didKeyP384 := "did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9"
+	didKeyP521 := "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7"                                                                                                     //nolint:lll
+	didKeyP256Uncompressed := "did:key:zrurwcJZss4ruepVNu1H3xmSirvNbzgBk9qrCktB6kaewXnJAhYWwtP3bxACqBpzjZdN7TyHNzzGGSSH5qvZsSDir9z"                                                                                              //nolint:lll
+	didKeyP384Uncompressed := "did:key:zFwfeyrSyWdksRYykTGGtagWazFB5zS4CjQcxDMQSNmCTQB5QMqokx2VJz4vBB2hN1nUrYDTuYq3kd1BM5cUCfFD4awiNuzEBuoy6rZZTMCsZsdvWkDXY6832qcAnzE7YGw43KU"                                                  //nolint:lll
+	didKeyP521Uncmopressed := "did:key:zWGhj2NTyCiehTPioanYSuSrfB7RJKwZj6bBUDNojfGEA21nr5NcBsHme7hcVSbptpWKarJpTcw814J3X8gVU9gZmeKM27JpGA5wNMzt8JZwjDyf8EzCJg5ve5GR2Xfm7d9Djp73V7s35KPeKe7VHMzmL8aPw4XBniNej5sXapPFoBs5R8m195HK" //nolint:lll
+
+	tests := []struct {
+		name   string
+		didKey string
+	}{
+		{
+			name:   "test ED25519 key",
+			didKey: didKeyED25519,
+		},
+		{
+			name:   "test P-256 key",
+			didKey: didKeyP256,
+		},
+		{
+			name:   "test P-384 key",
+			didKey: didKeyP384,
+		},
+		{
+			name:   "test P-521 key",
+			didKey: didKeyP521,
+		},
+		{
+			name:   "test P-256 uncompressed key",
+			didKey: didKeyP256Uncompressed,
+		},
+		{
+			name:   "test P-384 uncompressed key",
+			didKey: didKeyP384Uncompressed,
+		},
+		{
+			name:   "test P-521 uncompressed key",
+			didKey: didKeyP521Uncmopressed,
+		},
+		{
+			name:   "test X25519 key",
+			didKey: didKeyX25519,
+		},
+		{
+			name:   "invalid did:key code",
+			didKey: "did:key:zabcd",
+		},
+		{
+			name:   "invalid did:key method",
+			didKey: "did:key:invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			pubKey, err := EncryptionPubKeyFromDIDKey(tc.didKey)
+			switch tc.name {
+			case "invalid did:key code":
+				require.EqualError(t, err, "encryptionPubKeyFromDIDKey: unsupported key multicodec code [0x64]")
+				require.Empty(t, pubKey)
+
+				return
+			case "invalid did:key method":
+				require.EqualError(t, err, "encryptionPubKeyFromDIDKey: extractRawKey: MethodIDFromDIDKey "+
+					"failure: not a valid did:key identifier (not a base58btc multicodec): did:key:invalid")
+				require.Empty(t, pubKey)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotEmpty(t, pubKey)
+		})
+	}
 }

--- a/pkg/framework/aries/api/protocol.go
+++ b/pkg/framework/aries/api/protocol.go
@@ -47,6 +47,7 @@ type Provider interface {
 	JSONLDDocumentLoader() ld.DocumentLoader
 	KeyType() kms.KeyType
 	KeyAgreementType() kms.KeyType
+	MediaTypeProfiles() []string
 }
 
 // ProtocolSvcCreator method to create new protocol service.

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -503,6 +503,8 @@ func createOutboundDispatcher(frameworkOpts *Aries) error {
 		context.WithVDRegistry(frameworkOpts.vdrRegistry),
 		context.WithStorageProvider(frameworkOpts.storeProvider),
 		context.WithProtocolStateStorageProvider(frameworkOpts.protocolStateStoreProvider),
+		context.WithMediaTypeProfiles(frameworkOpts.mediaTypeProfiles),
+		context.WithKeyAgreementType(frameworkOpts.keyAgreementType),
 	)
 	if err != nil {
 		return fmt.Errorf("context creation failed: %w", err)
@@ -645,6 +647,9 @@ func loadServices(frameworkOpts *Aries) error {
 		context.WithDIDConnectionStore(frameworkOpts.didConnectionStore),
 		context.WithMessageServiceProvider(frameworkOpts.msgSvcProvider),
 		context.WithJSONLDDocumentLoader(frameworkOpts.documentLoader),
+		context.WithKeyType(frameworkOpts.keyType),
+		context.WithKeyAgreementType(frameworkOpts.keyAgreementType),
+		context.WithMediaTypeProfiles(frameworkOpts.mediaTypeProfiles),
 	)
 	if err != nil {
 		return fmt.Errorf("create context failed: %w", err)

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -114,7 +114,8 @@ func TestFramework(t *testing.T) {
 					return &didcomm.MockAuthCrypt{
 						EncryptValue: nil,
 					}, nil
-				}))
+				}),
+			WithMediaTypeProfiles([]string{"mockProfile"}))
 		require.NoError(t, err)
 
 		// context

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -37,6 +37,7 @@ import (
 	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 	mockvdr "github.com/hyperledger/aries-framework-go/pkg/mock/vdr"
 	"github.com/hyperledger/aries-framework-go/pkg/store/did"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
 )
 
 func TestNewProvider(t *testing.T) {
@@ -198,9 +199,14 @@ func TestNewProvider(t *testing.T) {
 
 		connectionStore := didStoreMocks.NewMockConnectionStore(ctrl)
 		connectionStore.EXPECT().GetDID(base58.Encode([]byte("toKey"))).Return("", did.ErrNotFound)
+		toDIDKey, _ := fingerprint.CreateDIDKey([]byte("toKey"))
+		connectionStore.EXPECT().GetDID(toDIDKey).Return("", did.ErrNotFound)
 		connectionStore.EXPECT().GetDID(base58.Encode([]byte("toKey"))).Return("", did.ErrNotFound)
+		connectionStore.EXPECT().GetDID(toDIDKey).Return("", did.ErrNotFound)
 		connectionStore.EXPECT().GetDID(base58.Encode([]byte("fromKey"))).Return("", errors.New("error"))
+		fromDIDKey, _ := fingerprint.CreateDIDKey([]byte("fromKey"))
 		connectionStore.EXPECT().GetDID(base58.Encode([]byte("fromKey"))).Return("", did.ErrNotFound)
+		connectionStore.EXPECT().GetDID(fromDIDKey).Return("", did.ErrNotFound)
 
 		ctx, err := New(WithProtocolServices(&mockdidexchange.MockDIDExchangeSvc{
 			ProtocolName: "mockProtocolSvc",

--- a/pkg/mock/didcomm/protocol/mock_protocol.go
+++ b/pkg/mock/didcomm/protocol/mock_protocol.go
@@ -42,6 +42,7 @@ type MockProvider struct {
 	InboundDIDCommMsgHandlerFunc func() service.InboundHandler
 	KeyTypeValue                 kms.KeyType
 	KeyAgreementTypeValue        kms.KeyType
+	mediaTypeProfilesValue       []string
 }
 
 // OutboundDispatcher is mock outbound dispatcher for DID exchange service.
@@ -144,6 +145,11 @@ func (p *MockProvider) KeyType() kms.KeyType {
 // KeyAgreementType returns a mocked keyType value for KeyAgreement.
 func (p *MockProvider) KeyAgreementType() kms.KeyType {
 	return p.KeyAgreementTypeValue
+}
+
+// MediaTypeProfiles returns the media type profiles.
+func (p *MockProvider) MediaTypeProfiles() []string {
+	return p.mediaTypeProfilesValue
 }
 
 type mockConnectionStore struct{}

--- a/pkg/mock/diddoc/mock_diddoc.go
+++ b/pkg/mock/diddoc/mock_diddoc.go
@@ -56,6 +56,32 @@ func GetMockDIDDoc(t *testing.T) *did.Doc {
 	}
 }
 
+// GetMockDIDDocWithKeyAgreements creates mock DID doc with KeyAgreements.
+func GetMockDIDDocWithKeyAgreements(t *testing.T) *did.Doc {
+	didDoc := GetMockDIDDoc(t)
+
+	didDoc.KeyAgreement = []did.Verification{
+		{
+			VerificationMethod: did.VerificationMethod{
+				ID:         "did:example:123456789abcdefghi#keys3",
+				Controller: "did:example:123456789abcdefghi",
+				Type:       "X25519KeyAgreementKey2019",
+				Value:      base58.Decode("JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr"),
+			},
+		},
+		{
+			VerificationMethod: did.VerificationMethod{
+				ID:         "#keys4",
+				Controller: "did:example:123456789abcdefghi",
+				Type:       "X25519KeyAgreementKey2019",
+				Value:      base58.Decode("JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr"),
+			},
+		},
+	}
+
+	return didDoc
+}
+
 // GetMockIndyDoc creates a mock DID Doc for testing.
 func GetMockIndyDoc(t *testing.T) *did.Doc {
 	t.Helper()

--- a/pkg/mock/provider/mock_provider.go
+++ b/pkg/mock/provider/mock_provider.go
@@ -38,6 +38,7 @@ type Provider struct {
 	DocumentLoaderValue               jsonld.DocumentLoader
 	KeyTypeValue                      kms.KeyType
 	KeyAgreementTypeValue             kms.KeyType
+	MediaTypeProfilesValue            []string
 }
 
 // Service return service.
@@ -116,6 +117,11 @@ func (p *Provider) JSONLDContextStore() ld.ContextStore {
 // JSONLDRemoteProviderStore returns remote JSON-LD context provider store.
 func (p *Provider) JSONLDRemoteProviderStore() ld.RemoteProviderStore {
 	return p.RemoteProviderStoreValue
+}
+
+// MediaTypeProfiles returns the media type profiles.
+func (p *Provider) MediaTypeProfiles() []string {
+	return p.MediaTypeProfilesValue
 }
 
 // JSONLDDocumentLoader returns JSON-LD document loader.

--- a/pkg/store/did/didconnection_test.go
+++ b/pkg/store/did/didconnection_test.go
@@ -101,7 +101,7 @@ func TestBaseConnectionStore(t *testing.T) {
 		connStore, err := NewConnectionStore(&prov)
 		require.NoError(t, err)
 
-		err = connStore.SaveDIDFromDoc(mockdiddoc.GetMockDIDDoc(t))
+		err = connStore.SaveDIDFromDoc(mockdiddoc.GetMockDIDDocWithKeyAgreements(t))
 		require.NoError(t, err)
 	})
 

--- a/pkg/vdr/fingerprint/didfp/parse.go
+++ b/pkg/vdr/fingerprint/didfp/parse.go
@@ -1,0 +1,30 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didfp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+)
+
+// MethodIDFromDIDKey parses the did:key DID and returns it's specific Method ID.
+func MethodIDFromDIDKey(didKey string) (string, error) {
+	id, err := did.Parse(didKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse did:key [%s]: %w", didKey, err)
+	}
+
+	// did:key is hard-coded to base58btc:
+	// - https://w3c-ccg.github.io/did-method-key/
+	// - https://github.com/multiformats/multibase#multibase-table
+	if !strings.HasPrefix(id.MethodSpecificID, "z") {
+		return "", fmt.Errorf("not a valid did:key identifier (not a base58btc multicodec): %s", didKey)
+	}
+
+	return id.MethodSpecificID, nil
+}

--- a/pkg/vdr/fingerprint/didfp/parse_test.go
+++ b/pkg/vdr/fingerprint/didfp/parse_test.go
@@ -1,25 +1,18 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
-
 SPDX-License-Identifier: Apache-2.0
 */
 
-package fingerprint
+package didfp_test
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"encoding/base64"
-	"math/big"
-	"strings"
 	"testing"
 
 	"github.com/btcsuite/btcutil/base58"
-	"github.com/square/go-jose/v3"
 	"github.com/stretchr/testify/require"
 
-	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/jwk"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/jwk/jwksupport"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint/didfp"
 )
 
 func TestCreateDIDKey(t *testing.T) {
@@ -44,7 +37,6 @@ func TestCreateDIDKey(t *testing.T) {
 		ecP521ExpectedDIDKey   = "did:key:zWGhj2NTyCiehTPioanYSuSrfB7RJKwZj6bBUDNojfGEA21nr5NcBsHme7hcVSbptpWKarJpTcw814J3X8gVU9gZmeKM27JpGA5wNMzt8JZwjDyf8EzCJg5ve5GR2Xfm7d9Djp73V7s35KPeKe7VHMzmL8aPw4XBniNej5sXapPFoBs5R8m195HK"                                                                                                                                                                                          //nolint:lll
 		ecP521ExpectedDIDKeyID = "did:key:zWGhj2NTyCiehTPioanYSuSrfB7RJKwZj6bBUDNojfGEA21nr5NcBsHme7hcVSbptpWKarJpTcw814J3X8gVU9gZmeKM27JpGA5wNMzt8JZwjDyf8EzCJg5ve5GR2Xfm7d9Djp73V7s35KPeKe7VHMzmL8aPw4XBniNej5sXapPFoBs5R8m195HK#zWGhj2NTyCiehTPioanYSuSrfB7RJKwZj6bBUDNojfGEA21nr5NcBsHme7hcVSbptpWKarJpTcw814J3X8gVU9gZmeKM27JpGA5wNMzt8JZwjDyf8EzCJg5ve5GR2Xfm7d9Djp73V7s35KPeKe7VHMzmL8aPw4XBniNej5sXapPFoBs5R8m195HK" //nolint:lll
 
-		bbsPubKeyG1Base58       = "6TBZrWMsPSFrJ2u7xFNyNA6VZs3gWpCwLi4jk8gB9EQ1bgNYK2Zjsxhku68mypBHke"
 		bbsPubKeyG2Base58       = "26jjNXrWtHvbrVaiYBKcFRkCvzyTUfg1W4odspRJjfQRfoT33jr91dEn2wqzaWVVVw1WmFwpGxrioYvy3sbvgphfu2D4nJUvrmQ7ZtoykgXA4EuJhmmV3TnnfHnBkKKBWn5q"                                                                                                                                                                                                                                                                                        //nolint:lll
 		bbsExpectedG1G2DIDKey   = "did:key:z5TcDLDFhBEndYdwFKkQMgVTgtRHx2sniQisVxdiXZ96pcrRy2ehWvcHfhSrfDmozq8dQNxhu2u7y9FUKJ8R3VPZNPjEgsozTSx47WysNM9GESUMmyniFxbdbpxNdocx6SbRyf6nBTFzoXojbWjSsDN4LhNz1sAMzTXgh5HvLYtYzJXo1JtLZBwHgmvtWyEQqtxtjV2eo"                                                                                                                                                                                                           //nolint:lll
 		bbsExpectedG1G2DIDKeyID = "did:key:z5TcDLDFhBEndYdwFKkQMgVTgtRHx2sniQisVxdiXZ96pcrRy2ehWvcHfhSrfDmozq8dQNxhu2u7y9FUKJ8R3VPZNPjEgsozTSx47WysNM9GESUMmyniFxbdbpxNdocx6SbRyf6nBTFzoXojbWjSsDN4LhNz1sAMzTXgh5HvLYtYzJXo1JtLZBwHgmvtWyEQqtxtjV2eo#z5TcDLDFhBEndYdwFKkQMgVTgtRHx2sniQisVxdiXZ96pcrRy2ehWvcHfhSrfDmozq8dQNxhu2u7y9FUKJ8R3VPZNPjEgsozTSx47WysNM9GESUMmyniFxbdbpxNdocx6SbRyf6nBTFzoXojbWjSsDN4LhNz1sAMzTXgh5HvLYtYzJXo1JtLZBwHgmvtWyEQqtxtjV2eo" //nolint:lll
@@ -56,218 +48,53 @@ func TestCreateDIDKey(t *testing.T) {
 		DIDKey   string
 		DIDKeyID string
 		keyCode  uint64
-		crv      elliptic.Curve
 	}{
 		{
 			name:     "test ED25519",
 			keyB58:   edPubKeyBase58,
 			DIDKey:   edExpectedDIDKey,
 			DIDKeyID: edExpectedDIDKeyID,
-			keyCode:  ED25519PubKeyMultiCodec,
 		},
 		{
 			name:     "test BBS+",
 			keyB58:   bbsPubKeyBase58,
 			DIDKey:   bbsExpectedDIDKey,
 			DIDKeyID: bbsExpectedDIDKeyID,
-			keyCode:  BLS12381g2PubKeyMultiCodec,
 		},
 		{
 			name:     "test P-256",
 			keyB58:   ecP256PubKeyBase58,
 			DIDKey:   ecP256ExpectedDIDKey,
 			DIDKeyID: ecP256ExpectedDIDKeyID,
-			keyCode:  P256PubKeyMultiCodec,
-			crv:      elliptic.P256(),
 		},
 		{
 			name:     "test P-384",
 			keyB58:   ecP384PubKeyBase58,
 			DIDKey:   ecP384ExpectedDIDKey,
 			DIDKeyID: ecP384ExpectedDIDKeyID,
-			keyCode:  P384PubKeyMultiCodec,
-			crv:      elliptic.P384(),
 		},
 		{
 			name:     "test P-521",
 			keyB58:   ecP521PubKeyBase58,
 			DIDKey:   ecP521ExpectedDIDKey,
 			DIDKeyID: ecP521ExpectedDIDKeyID,
-			keyCode:  P521PubKeyMultiCodec,
-			crv:      elliptic.P521(),
 		},
 		{
 			name:     "test BBS+ with G1G2",
 			keyB58:   bbsPubKeyG2Base58,
 			DIDKey:   bbsExpectedG1G2DIDKey,
 			DIDKeyID: bbsExpectedG1G2DIDKeyID,
-			keyCode:  BLS12381g1g2PubKeyMultiCodec,
 		},
 	}
 
 	for _, test := range tests {
 		tc := test
-		t.Run(tc.name+" CreateDIDKey", func(t *testing.T) {
-			keyBytes := base58.Decode(tc.keyB58)
-			// append G1G2 public keys for Creation of DIDKey for BLS12381g1g2PubKeyMultiCodec
-			if tc.keyCode == BLS12381g1g2PubKeyMultiCodec {
-				g1Bytes := base58.Decode(bbsPubKeyG1Base58)
-				keyBytes = append(g1Bytes, keyBytes...)
-			}
-
-			didKey, keyID := CreateDIDKeyByCode(tc.keyCode, keyBytes)
-
-			require.Equal(t, tc.DIDKey, didKey)
-			require.Equal(t, tc.DIDKeyID, keyID)
-		})
-
-		t.Run(tc.name+" PubKeyFromFingerprint success", func(t *testing.T) {
-			pubKey, code, err := PubKeyFromFingerprint(strings.Split(tc.DIDKeyID, "#")[1])
-			require.Equal(t, tc.keyCode, code)
-			require.NoError(t, err)
-
-			require.Equal(t, base58.Encode(pubKey), tc.keyB58)
-		})
-
 		t.Run(tc.name+" PubKeyFromDIDKey", func(t *testing.T) {
-			pubKey, err := PubKeyFromDIDKey(tc.DIDKey)
-			if tc.crv != nil {
-				mKeyCompressed := append([]byte{4}, pubKey...)
-				x, y := elliptic.Unmarshal(tc.crv, mKeyCompressed)
-				mKey := elliptic.Marshal(tc.crv, x, y)
-				require.EqualValues(t, mKeyCompressed, mKey)
-			}
-
-			require.Equal(t, tc.keyB58, base58.Encode(pubKey))
+			methodID, err := didfp.MethodIDFromDIDKey(tc.DIDKey)
+			require.EqualValues(t, tc.DIDKey[8:], methodID)
 			require.NoError(t, err)
 		})
 	}
-
-	t.Run("test PubKeyFromFingerprint fail", func(t *testing.T) {
-		badDIDKeyID := "AB" + strings.Split(edExpectedDIDKeyID, "#")[1][2:]
-
-		_, _, err := PubKeyFromFingerprint(badDIDKeyID)
-		require.EqualError(t, err, "unknown key encoding")
-	})
-
-	t.Run("invalid fingerprint", func(t *testing.T) {
-		_, _, err := PubKeyFromFingerprint("")
-		require.Error(t, err)
-
-		_, _, err = PubKeyFromFingerprint("a6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH")
-		require.Error(t, err)
-	})
-}
-
-func readBigInt(t *testing.T, b64 string) *big.Int {
-	buf, err := base64.RawURLEncoding.DecodeString(b64)
-	require.Nil(t, err, "can't parse string as b64: %v\n%s", err, b64)
-
-	var x big.Int
-	x = *x.SetBytes(buf)
-
-	return &x
-}
-
-func TestCreateDIDKeyByJwk(t *testing.T) {
-	tests := []struct {
-		name     string
-		kty      string
-		curve    elliptic.Curve
-		x        string
-		y        string
-		DIDKey   string
-		DIDKeyID string
-	}{
-		{
-			name:     "test P-256",
-			kty:      "EC",
-			curve:    elliptic.P256(),
-			x:        "igrFmi0whuihKnj9R3Om1SoMph72wUGeFaBbzG2vzns",
-			y:        "efsX5b10x8yjyrj4ny3pGfLcY7Xby1KzgqOdqnsrJIM",
-			DIDKey:   "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv",
-			DIDKeyID: "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv", //nolint:lll
-		},
-		{
-			name:     "test P-384",
-			kty:      "EC",
-			curve:    elliptic.P384(),
-			x:        "lInTxl8fjLKp_UCrxI0WDklahi-7-_6JbtiHjiRvMvhedhKVdHBfi2HCY8t_QJyc",
-			y:        "y6N1IC-2mXxHreETBW7K3mBcw0qGr3CWHCs-yl09yCQRLcyfGv7XhqAngHOu51Zv",
-			DIDKey:   "did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9",
-			DIDKeyID: "did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9", //nolint:lll
-		},
-		{
-			name:     "test P-521",
-			kty:      "EC",
-			curve:    elliptic.P521(),
-			x:        "ASUHPMyichQ0QbHZ9ofNx_l4y7luncn5feKLo3OpJ2nSbZoC7mffolj5uy7s6KSKXFmnNWxGJ42IOrjZ47qqwqyS",
-			y:        "AW9ziIC4ZQQVSNmLlp59yYKrjRY0_VqO-GOIYQ9tYpPraBKUloEId6cI_vynCzlZWZtWpgOM3HPhYEgawQ703RjC",
-			DIDKey:   "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7",
-			DIDKeyID: "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7", //nolint:lll
-		},
-		{
-			name:     "test EC with invalid curve",
-			kty:      "EC",
-			curve:    &elliptic.CurveParams{},
-			x:        "ASUHPMyichQ0QbHZ9ofNx_l4y7luncn5feKLo3OpJ2nSbZoC7mffolj5uy7s6KSKXFmnNWxGJ42IOrjZ47qqwqyS",
-			y:        "AW9ziIC4ZQQVSNmLlp59yYKrjRY0_VqO-GOIYQ9tYpPraBKUloEId6cI_vynCzlZWZtWpgOM3HPhYEgawQ703RjC",
-			DIDKey:   "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7",
-			DIDKeyID: "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7", //nolint:lll
-		},
-	}
-
-	for _, test := range tests {
-		tc := test
-		t.Run(tc.name+" CreateDIDKeyByJwk", func(t *testing.T) {
-			x := readBigInt(t, tc.x)
-			y := readBigInt(t, tc.y)
-			publicKey := ecdsa.PublicKey{
-				Curve: tc.curve,
-				X:     x,
-				Y:     y,
-			}
-
-			jwkKey, err := jwksupport.JWKFromKey(&publicKey)
-			if tc.name == "test EC with invalid curve" {
-				require.EqualError(t, err, "create JWK: square/go-jose: unsupported/unknown elliptic curve")
-				jwkKey = &jwk.JWK{
-					JSONWebKey: jose.JSONWebKey{},
-					Kty:        "EC",
-					Crv:        "invalid",
-				}
-			} else {
-				require.NoError(t, err)
-			}
-
-			didKey, keyID, err := CreateDIDKeyByJwk(jwkKey)
-
-			if tc.name == "test EC with invalid curve" {
-				require.EqualError(t, err, "unsupported crv invalid")
-				return
-			}
-
-			require.NoError(t, err)
-			require.Equal(t, tc.DIDKey, didKey)
-			require.Equal(t, tc.DIDKeyID, keyID)
-		})
-	}
-
-	t.Run("nil input", func(t *testing.T) {
-		_, _, err := CreateDIDKeyByJwk(nil)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "jsonWebKey is required")
-	})
-
-	t.Run("test invalid type", func(t *testing.T) {
-		jwkKey := jwk.JWK{
-			Kty: "XX",
-			Crv: elliptic.P256().Params().Name,
-		}
-		_, _, err := CreateDIDKeyByJwk(&jwkKey)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "unsupported kty")
-	})
 }
 
 func TestDIDKeyEd25519(t *testing.T) {
@@ -277,19 +104,22 @@ func TestDIDKeyEd25519(t *testing.T) {
 		k1KeyID  = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH" //nolint:lll
 	)
 
-	didKey, keyID := CreateDIDKey(base58.Decode(k1Base58))
+	didKey, keyID := fingerprint.CreateDIDKey(base58.Decode(k1Base58))
 
 	require.Equal(t, didKey, k1)
 	require.Equal(t, keyID, k1KeyID)
 
-	pubKey, err := PubKeyFromDIDKey(k1)
-	require.Equal(t, k1Base58, base58.Encode(pubKey))
+	methodID, err := didfp.MethodIDFromDIDKey(k1)
+	require.EqualValues(t, k1[8:], methodID)
 	require.NoError(t, err)
 }
 
-func TestPubKeyFromDIDKeyFailure(t *testing.T) {
-	_, err := PubKeyFromDIDKey("did:key:****")
-	require.EqualError(t, err, "pubKeyFromDIDKey: MethodIDFromDIDKey: failed to parse did:key [did:key:****]:"+
-		" invalid did: did:key:****. Make sure it conforms to the DID syntax: "+
-		"https://w3c.github.io/did-core/#did-syntax")
+func TestMethodIDFromDIDKeyFailure(t *testing.T) {
+	_, err := didfp.MethodIDFromDIDKey("did:key:****")
+	require.EqualError(t, err, "failed to parse did:key [did:key:****]: invalid did: did:key:****. Make sure "+
+		"it conforms to the DID syntax: https://w3c.github.io/did-core/#did-syntax")
+
+	_, err = didfp.MethodIDFromDIDKey("did:key:x6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH")
+	require.EqualError(t, err, "not a valid did:key identifier (not a base58btc multicodec): "+
+		"did:key:x6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH")
 }

--- a/pkg/vdr/peer/creator.go
+++ b/pkg/vdr/peer/creator.go
@@ -111,26 +111,28 @@ func build(didDoc *did.Doc, docOpts *vdrapi.DIDMethodOpts) (*did.DocResolution, 
 	t := time.Now()
 
 	assertion := []did.Verification{{
-		VerificationMethod: *mainVM,
+		VerificationMethod: mainVM[0],
 		Relationship:       did.AssertionMethod,
 	}}
 
 	authentication := []did.Verification{{
-		VerificationMethod: *mainVM,
+		VerificationMethod: mainVM[0],
 		Relationship:       did.Authentication,
 	}}
 
 	var keyAgreement []did.Verification
 
-	verificationMethods := []did.VerificationMethod{*mainVM}
+	verificationMethods := mainVM
 
 	if keyAgreementVM != nil {
-		verificationMethods = append(verificationMethods, *keyAgreementVM)
+		verificationMethods = append(verificationMethods, keyAgreementVM...)
 
-		keyAgreement = []did.Verification{{
-			VerificationMethod: *keyAgreementVM,
-			Relationship:       did.KeyAgreement,
-		}}
+		for _, ka := range keyAgreementVM {
+			keyAgreement = append(keyAgreement, did.Verification{
+				VerificationMethod: ka,
+				Relationship:       did.KeyAgreement,
+			})
+		}
 	}
 
 	didDoc, err = NewDoc(
@@ -149,42 +151,44 @@ func build(didDoc *did.Doc, docOpts *vdrapi.DIDMethodOpts) (*did.DocResolution, 
 	return &did.DocResolution{DIDDocument: didDoc}, nil
 }
 
-func buildDIDVMs(didDoc *did.Doc) (*did.VerificationMethod, *did.VerificationMethod, error) {
-	var mainVM, keyAgreementVM *did.VerificationMethod
+func buildDIDVMs(didDoc *did.Doc) ([]did.VerificationMethod, []did.VerificationMethod, error) {
+	var mainVM, keyAgreementVM []did.VerificationMethod
 
-	if len(didDoc.VerificationMethod) != 0 {
-		switch didDoc.VerificationMethod[0].Type {
+	// add all VMs, not only the first one.
+	for _, vm := range didDoc.VerificationMethod {
+		switch vm.Type {
 		case ed25519VerificationKey2018:
-			mainVM = did.NewVerificationMethodFromBytes(didDoc.VerificationMethod[0].ID, ed25519VerificationKey2018,
-				"#id", didDoc.VerificationMethod[0].Value)
+			mainVM = append(mainVM, *did.NewVerificationMethodFromBytes(vm.ID, ed25519VerificationKey2018,
+				"#id", didDoc.VerificationMethod[0].Value))
 		case jsonWebKey2020:
-			publicKey1, err := did.NewVerificationMethodFromJWK(didDoc.VerificationMethod[0].ID, jsonWebKey2020, "#id",
+			publicKey1, err := did.NewVerificationMethodFromJWK(vm.ID, jsonWebKey2020, "#id",
 				didDoc.VerificationMethod[0].JSONWebKey())
 			if err != nil {
 				return nil, nil, err
 			}
 
-			mainVM = publicKey1
+			mainVM = append(mainVM, *publicKey1)
 		default:
 			return nil, nil, fmt.Errorf("not supported VerificationMethod public key type: %s",
 				didDoc.VerificationMethod[0].Type)
 		}
 	}
 
-	if len(didDoc.KeyAgreement) != 0 {
-		switch didDoc.KeyAgreement[0].VerificationMethod.Type {
+	for _, vm := range didDoc.KeyAgreement {
+		switch vm.VerificationMethod.Type {
 		case x25519KeyAgreementKey2019:
-			keyAgreementVM = did.NewVerificationMethodFromBytes(didDoc.KeyAgreement[0].VerificationMethod.ID,
-				x25519KeyAgreementKey2019, "", didDoc.KeyAgreement[0].VerificationMethod.Value)
+			keyAgreementVM = append(keyAgreementVM, *did.NewVerificationMethodFromBytes(
+				didDoc.KeyAgreement[0].VerificationMethod.ID, x25519KeyAgreementKey2019, "",
+				didDoc.KeyAgreement[0].VerificationMethod.Value))
 
 		case jsonWebKey2020:
-			ka, err := did.NewVerificationMethodFromJWK(didDoc.VerificationMethod[0].ID, jsonWebKey2020, "",
+			ka, err := did.NewVerificationMethodFromJWK(didDoc.KeyAgreement[0].VerificationMethod.ID, jsonWebKey2020, "",
 				didDoc.VerificationMethod[0].JSONWebKey())
 			if err != nil {
 				return nil, nil, err
 			}
 
-			keyAgreementVM = ka
+			keyAgreementVM = append(keyAgreementVM, *ka)
 		default:
 			return nil, nil, fmt.Errorf("not supported KeyAgreement public key type: %s", didDoc.VerificationMethod[0].Type)
 		}

--- a/pkg/vdr/verifiable_compat_test.go
+++ b/pkg/vdr/verifiable_compat_test.go
@@ -180,7 +180,7 @@ func newKeyAgreementVM(t *testing.T, p *context.Provider, controller string) did
 	_, encPubKey, err := p.KMS().CreateAndExportPubKeyBytes(p.KeyAgreementType())
 	require.NoError(t, err)
 
-	encDIDKey, err := kmsdidkey.BuildDIDKeyByKMSKeyType(encPubKey, p.KeyAgreementType())
+	encDIDKey, err := kmsdidkey.BuildDIDKeyByKeyType(encPubKey, p.KeyAgreementType())
 	require.NoError(t, err)
 
 	const didPKID = "%s#keys-%d"
@@ -204,7 +204,7 @@ func getSigningKey(t *testing.T, a *context.Provider) did.VerificationMethod {
 	keyID, pubBytes, err := a.KMS().CreateAndExportPubKeyBytes(a.KeyType())
 	require.NoError(t, err)
 
-	didKey, err := kmsdidkey.BuildDIDKeyByKMSKeyType(pubBytes, a.KeyType())
+	didKey, err := kmsdidkey.BuildDIDKeyByKeyType(pubBytes, a.KeyType())
 	require.NoError(t, err)
 
 	id := fmt.Sprintf(didFormat, method, didKey[:16])

--- a/test/bdd/features/aries_mediator_e2e_controller.feature
+++ b/test/bdd/features/aries_mediator_e2e_controller.feature
@@ -61,7 +61,7 @@ Feature: DIDComm Transport between two Agents through DIDComm Routers [REST Bind
     And   "Dave-Router,Dave" retrieves connection record through controller and validates that connection state is "completed"
     And   "Dave" saves the connectionID to variable "dave-second-router-connID"
 
-    # Carl registers her routers
+    # Carl registers his routers
     Then   "Carl" unregisters the router with connection "carl-router-connID,carl-second-router-connID"
     And   "Carl" sets connection "carl-router-connID,carl-second-router-connID" as the router
     And   "Carl" verifies that the router connection is set to "carl-router-connID,carl-second-router-connID"


### PR DESCRIPTION
This change removes Base58 key encoding for recipients and sender for did:key (execept for legacy packer which will remain using bsae58 encoding).
It also includes vdr peer did creation with all VM and KeyAgreement keys, not only the first key.
This change adds key resolvers for the packers, one for did:key resolution and another one used for the 1PU test vector verification purposes using a thirdparty store resolution.
Finally, this change also moves did:key fingerprint code referencing did.Doc into a separate subpackage (pkg/vdr/fingerprint/didfp) to avoid cyclic dependency with jwk fingerprint.

closes #1604
closes #1207
closes #1659
closes #1847

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
