### PR TITLE
docs: Updates to storage interface documentation

### DIFF
--- a/pkg/mock/storage/mock_store.go
+++ b/pkg/mock/storage/mock_store.go
@@ -30,6 +30,7 @@ type MockStoreProvider struct {
 	Store              *MockStore
 	Custom             storage.Store
 	ErrOpenStoreHandle error
+	ErrSetStoreConfig  error
 	ErrClose           error
 	ErrCloseStore      error
 	FailNamespace      string
@@ -63,7 +64,7 @@ func (s *MockStoreProvider) OpenStore(name string) (storage.Store, error) {
 
 // SetStoreConfig always return a nil error.
 func (s *MockStoreProvider) SetStoreConfig(name string, config storage.StoreConfiguration) error {
-	return nil
+	return s.ErrSetStoreConfig
 }
 
 // GetStoreConfig is not implemented.

--- a/pkg/store/ld/context_store.go
+++ b/pkg/store/ld/context_store.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	jsonld "github.com/piprate/json-gold/ld"
@@ -48,6 +47,12 @@ func NewContextStore(storageProvider storage.Provider) (*ContextStoreImpl, error
 	store, err := storageProvider.OpenStore(ContextStoreName)
 	if err != nil {
 		return nil, fmt.Errorf("open store: %w", err)
+	}
+
+	err = storageProvider.SetStoreConfig(ContextStoreName,
+		storage.StoreConfiguration{TagNames: []string{ContextRecordTag}})
+	if err != nil {
+		return nil, fmt.Errorf("set store config: %w", err)
 	}
 
 	return &ContextStoreImpl{store: store}, nil
@@ -142,10 +147,6 @@ func (s *ContextStoreImpl) Delete(documents []ldcontext.Document) error {
 func computeContextHashes(store storage.Store) (map[string]string, error) {
 	iter, err := store.Query(ContextRecordTag)
 	if err != nil {
-		if errors.Is(err, storage.ErrDataNotFound) {
-			return map[string]string{}, nil
-		}
-
 		return nil, fmt.Errorf("query store: %w", err)
 	}
 

--- a/pkg/store/ld/context_store_test.go
+++ b/pkg/store/ld/context_store_test.go
@@ -49,12 +49,24 @@ func TestNewContextStore(t *testing.T) {
 	t.Run("Fail to open store", func(t *testing.T) {
 		storageProvider := mockstorage.NewMockStoreProvider()
 		storageProvider.ErrOpenStoreHandle = errors.New("open store error")
+		storageProvider.ErrSetStoreConfig = errors.New("set store config error")
 
 		store, err := ld.NewContextStore(storageProvider)
 
 		require.Nil(t, store)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "open store")
+	})
+
+	t.Run("Fail to set store config", func(t *testing.T) {
+		storageProvider := mockstorage.NewMockStoreProvider()
+		storageProvider.ErrSetStoreConfig = errors.New("set store config error")
+
+		store, err := ld.NewContextStore(storageProvider)
+
+		require.Nil(t, store)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "set store config")
 	})
 }
 
@@ -176,17 +188,6 @@ func TestContextStoreImpl_Import(t *testing.T) {
 
 		require.Equal(t, 1, store.BatchSize)
 		assertContextInStore(t, store, sampleContextURL, "updated-context")
-	})
-
-	t.Run("Import successfully when querying store for computing hashes returns ErrDataNotFound", func(t *testing.T) {
-		storageProvider := mockstorage.NewMockStoreProvider()
-		storageProvider.Store.ErrQuery = storage.ErrDataNotFound
-
-		contextStore, err := ld.NewContextStore(storageProvider)
-		require.NoError(t, err)
-
-		err = contextStore.Import(embed.Contexts)
-		require.NoError(t, err)
 	})
 
 	t.Run("Fail to query store for contexts", func(t *testing.T) {


### PR DESCRIPTION
- Clarified expected behaviour of storage interface implementations
- Added missing call to Provider.SetStoreConfig for the context store.
- Removed the workaround for MySQL, which is no longer needed.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>