### PR TITLE
test: Added tests to ensure that store config is optional for queries

### DIFF
--- a/cmd/aries-agent-mobile/go.mod
+++ b/cmd/aries-agent-mobile/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/hyperledger/aries-framework-go v0.1.7-0.20210603210127-e57b8c94e3cf
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210807121559-b41545a4f1e8
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210807121559-b41545a4f1e8
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210818133831-4e22573c126d
 	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210807121559-b41545a4f1e8
 	github.com/piprate/json-gold v0.4.1-0.20210813112359-33b90c4ca86c
 	github.com/stretchr/testify v1.7.0

--- a/cmd/aries-agent-rest/go.mod
+++ b/cmd/aries-agent-rest/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hyperledger/aries-framework-go v0.1.7-0.20210603210127-e57b8c94e3cf
 	github.com/hyperledger/aries-framework-go/component/storage/leveldb v0.0.0-20210603182844-353ecb34cf4d
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210807121559-b41545a4f1e8
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210807121559-b41545a4f1e8
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210818133831-4e22573c126d
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/cmd/aries-agent-rest/go.sum
+++ b/cmd/aries-agent-rest/go.sum
@@ -285,8 +285,6 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
-github.com/piprate/json-gold v0.4.0 h1:XQ6ZMLCjuXhtvqr60IrGl2uNYojl64B/dIUmI2iqThs=
-github.com/piprate/json-gold v0.4.0/go.mod h1:OK1z7UgtBZk06n2cDE2OSq1kffmjFFp5/2yhLLCz9UM=
 github.com/piprate/json-gold v0.4.1-0.20210813112359-33b90c4ca86c h1:F4YQvOA7UTccz06y59KLw4C0iXD28hnKUP9R9zeSe8U=
 github.com/piprate/json-gold v0.4.1-0.20210813112359-33b90c4ca86c/go.mod h1:OK1z7UgtBZk06n2cDE2OSq1kffmjFFp5/2yhLLCz9UM=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/cmd/aries-js-worker/go.mod
+++ b/cmd/aries-js-worker/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/hyperledger/aries-framework-go v0.1.7-0.20210603210127-e57b8c94e3cf
 	github.com/hyperledger/aries-framework-go/component/storage/indexeddb v0.0.0-00010101000000-000000000000
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210807121559-b41545a4f1e8
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210818133831-4e22573c126d
 	github.com/mitchellh/mapstructure v1.3.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/cmd/aries-js-worker/go.sum
+++ b/cmd/aries-js-worker/go.sum
@@ -240,8 +240,6 @@ github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
-github.com/piprate/json-gold v0.4.0 h1:XQ6ZMLCjuXhtvqr60IrGl2uNYojl64B/dIUmI2iqThs=
-github.com/piprate/json-gold v0.4.0/go.mod h1:OK1z7UgtBZk06n2cDE2OSq1kffmjFFp5/2yhLLCz9UM=
 github.com/piprate/json-gold v0.4.1-0.20210813112359-33b90c4ca86c h1:F4YQvOA7UTccz06y59KLw4C0iXD28hnKUP9R9zeSe8U=
 github.com/piprate/json-gold v0.4.1-0.20210813112359-33b90c4ca86c/go.mod h1:OK1z7UgtBZk06n2cDE2OSq1kffmjFFp5/2yhLLCz9UM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/hyperledger/aries-framework-go v0.1.7-0.20210603210127-e57b8c94e3cf
 	github.com/hyperledger/aries-framework-go/component/storage/leveldb v0.0.0-20210807121559-b41545a4f1e8
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210807121559-b41545a4f1e8
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210807121559-b41545a4f1e8
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210818133831-4e22573c126d
 	github.com/moby/sys/mount v0.2.0 // indirect
 	github.com/moby/term v0.0.0-20201110203204-bea5bbe245bf // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2

--- a/test/component/go.mod
+++ b/test/component/go.mod
@@ -8,6 +8,6 @@ go 1.16
 
 require (
 	github.com/google/uuid v1.1.2
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210806210220-65863dbe349a
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210818133831-4e22573c126d
 	github.com/stretchr/testify v1.6.1
 )

--- a/test/component/go.sum
+++ b/test/component/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210806210220-65863dbe349a h1:fdvejEMjjwaPBawGl0gXOuQ1II7lYQyYZPIhq9iyeNA=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210806210220-65863dbe349a/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210818133831-4e22573c126d h1:9GtIFD6Ih6xvFgEg91GsDV8Fp8HKwF/batx37uhH5lg=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210818133831-4e22573c126d/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/test/component/storage/storage.go
+++ b/test/component/storage/storage.go
@@ -987,1855 +987,20 @@ func TestStoreDelete(t *testing.T, provider spi.Provider) {
 }
 
 // TestStoreQuery tests common Store Query functionality.
-func TestStoreQuery(t *testing.T, provider spi.Provider, opts ...TestOption) { // nolint: funlen // Test file
+func TestStoreQuery(t *testing.T, provider spi.Provider, opts ...TestOption) {
 	options := getOptions(opts)
 
-	t.Run("Tag name only query - 2 values found", func(t *testing.T) {
-		keysToPut := []string{"key1", "key2", "key3"}
-		valuesToPut := [][]byte{[]byte("value1"), []byte("value2"), []byte("value3")}
-		tagsToPut := [][]spi.Tag{
-			{{Name: "tagName1", Value: "tagValue1"}, {Name: "tagName2", Value: "tagValue2"}},
-			{{Name: "tagName3", Value: "tagValue"}, {Name: "tagName4"}},
-			{{Name: "tagName3", Value: "tagValue2"}},
-		}
-
-		expectedKeys := []string{keysToPut[1], keysToPut[2]}
-		expectedValues := [][]byte{valuesToPut[1], valuesToPut[2]}
-		expectedTags := [][]spi.Tag{tagsToPut[1], tagsToPut[2]}
-		expectedTotalItemsCount := 2
-
-		queryExpression := "tagName3"
-
-		t.Run("Default page setting", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName,
-				spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
-			require.NoError(t, err)
-
-			putData(t, store, keysToPut, valuesToPut, tagsToPut)
-
-			iterator, err := store.Query(queryExpression)
-			require.NoError(t, err)
-
-			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
-				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-		})
-		t.Run("Page size 2", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName,
-				spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
-			require.NoError(t, err)
-
-			putData(t, store, keysToPut, valuesToPut, tagsToPut)
-
-			//nolint:gomnd // Test file
-			iterator, err := store.Query(queryExpression, spi.WithPageSize(2))
-			require.NoError(t, err)
-
-			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
-				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-		})
-		t.Run("Page size 1", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName,
-				spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
-			require.NoError(t, err)
-
-			putData(t, store, keysToPut, valuesToPut, tagsToPut)
-
-			iterator, err := store.Query(queryExpression, spi.WithPageSize(1))
-			require.NoError(t, err)
-
-			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
-				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-		})
-		t.Run("Page size 100", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName,
-				spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
-			require.NoError(t, err)
-
-			putData(t, store, keysToPut, valuesToPut, tagsToPut)
-
-			//nolint:gomnd // Test file
-			iterator, err := store.Query(queryExpression, spi.WithPageSize(100))
-			require.NoError(t, err)
-
-			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
-				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-		})
-	})
-	t.Run("Tag name only query - 0 values found", func(t *testing.T) {
-		keysToPut := []string{"key1", "key2", "key3"}
-		valuesToPut := [][]byte{[]byte("value1"), []byte("value2"), []byte("value3")}
-		tagsToPut := [][]spi.Tag{
-			{{Name: "tagName1", Value: "tagValue1"}, {Name: "tagName2", Value: "tagValue2"}},
-			{{Name: "tagName3", Value: "tagValue"}, {Name: "tagName4"}},
-			{{Name: "tagName3", Value: "tagValue2"}},
-		}
-
-		expectedTotalItemsCount := 0
-
-		queryExpression := "tagName5"
-
-		t.Run("Default page setting", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName,
-				spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4", "tagName5"}})
-			require.NoError(t, err)
-
-			putData(t, store, keysToPut, valuesToPut, tagsToPut)
-
-			iterator, err := store.Query(queryExpression)
-			require.NoError(t, err)
-
-			verifyExpectedIterator(t, iterator, nil, nil, nil, false,
-				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-		})
-		t.Run("Page size 2", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName,
-				spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4", "tagName5"}})
-			require.NoError(t, err)
-
-			putData(t, store, keysToPut, valuesToPut, tagsToPut)
-
-			//nolint:gomnd // Test file
-			iterator, err := store.Query(queryExpression, spi.WithPageSize(2))
-			require.NoError(t, err)
-
-			verifyExpectedIterator(t, iterator, nil, nil, nil,
-				false, options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-		})
-		t.Run("Page size 1", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName,
-				spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4", "tagName5"}})
-			require.NoError(t, err)
-
-			putData(t, store, keysToPut, valuesToPut, tagsToPut)
-
-			iterator, err := store.Query(queryExpression, spi.WithPageSize(1))
-			require.NoError(t, err)
-
-			verifyExpectedIterator(t, iterator, nil, nil, nil, false,
-				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-		})
-		t.Run("Page size 100", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName,
-				spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4", "tagName5"}})
-			require.NoError(t, err)
-
-			putData(t, store, keysToPut, valuesToPut, tagsToPut)
-
-			//nolint:gomnd // Test file
-			iterator, err := store.Query(queryExpression, spi.WithPageSize(100))
-			require.NoError(t, err)
-
-			verifyExpectedIterator(t, iterator, nil, nil, nil, false,
-				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-		})
-	})
-	t.Run("Tag name and value query - 2 values found", func(t *testing.T) {
-		keysToPut := []string{"key1", "key2", "key3", "key4"}
-		valuesToPut := [][]byte{[]byte("value1"), []byte("value2"), []byte("value3"), []byte("value4")}
-		tagsToPut := [][]spi.Tag{
-			{{Name: "tagName1", Value: "tagValue1"}, {Name: "tagName2", Value: "tagValue2"}},
-			{{Name: "tagName3", Value: "tagValue1"}, {Name: "tagName4"}},
-			{{Name: "tagName3", Value: "tagValue2"}},
-			{{Name: "tagName3", Value: "tagValue1"}},
-		}
-
-		expectedKeys := []string{keysToPut[1], keysToPut[3]}
-		expectedValues := [][]byte{valuesToPut[1], valuesToPut[3]}
-		expectedTags := [][]spi.Tag{tagsToPut[1], tagsToPut[3]}
-		expectedTotalItemsCount := 2
-
-		queryExpression := "tagName3:tagValue1"
-
-		t.Run("Default page setting", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName,
-				spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
-			require.NoError(t, err)
-
-			putData(t, store, keysToPut, valuesToPut, tagsToPut)
-
-			iterator, err := store.Query(queryExpression)
-			require.NoError(t, err)
-
-			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
-				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-		})
-		t.Run("Page size 2", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName,
-				spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
-			require.NoError(t, err)
-
-			putData(t, store, keysToPut, valuesToPut, tagsToPut)
-
-			//nolint:gomnd // Test file
-			iterator, err := store.Query(queryExpression, spi.WithPageSize(2))
-			require.NoError(t, err)
-
-			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
-				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-		})
-		t.Run("Page size 1", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName,
-				spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
-			require.NoError(t, err)
-
-			putData(t, store, keysToPut, valuesToPut, tagsToPut)
-
-			iterator, err := store.Query(queryExpression, spi.WithPageSize(1))
-			require.NoError(t, err)
-
-			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
-				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-		})
-		t.Run("Page size 100", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName,
-				spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
-			require.NoError(t, err)
-
-			putData(t, store, keysToPut, valuesToPut, tagsToPut)
-
-			//nolint:gomnd // Test file
-			iterator, err := store.Query(queryExpression, spi.WithPageSize(100))
-			require.NoError(t, err)
-
-			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
-				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-		})
-	})
-	t.Run("Tag name and value query - only 1 value found "+
-		"(would have been two, but the other was deleted before the query was executed)", func(t *testing.T) {
-		keysToPut := []string{"key1", "key2", "key3", "key4"}
-		valuesToPut := [][]byte{[]byte("value1"), []byte("value2"), []byte("value3"), []byte("value4")}
-		tagsToPut := [][]spi.Tag{
-			{{Name: "tagName1", Value: "tagValue1"}, {Name: "tagName2", Value: "tagValue2"}},
-			{{Name: "tagName3", Value: "tagValue1"}, {Name: "tagName4"}},
-			{{Name: "tagName3", Value: "tagValue2"}},
-			{{Name: "tagName3", Value: "tagValue1"}},
-		}
-
-		expectedKeys := []string{keysToPut[3]}
-		expectedValues := [][]byte{valuesToPut[3]}
-		expectedTags := [][]spi.Tag{tagsToPut[3]}
-		expectedTotalItemsCount := 1
-
-		storeName := randomStoreName()
-
-		store, err := provider.OpenStore(storeName)
-		require.NoError(t, err)
-		require.NotNil(t, store)
-
-		defer func() {
-			require.NoError(t, store.Close())
-		}()
-
-		err = provider.SetStoreConfig(storeName,
-			spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
-		require.NoError(t, err)
-
-		putData(t, store, keysToPut, valuesToPut, tagsToPut)
-
-		err = store.Delete("key2")
-		require.NoError(t, err)
-
-		iterator, err := store.Query("tagName3:tagValue1")
-		require.NoError(t, err)
-
-		verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
-			options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-	})
-	t.Run("Tag name and value query - 0 values found since the store is empty", func(t *testing.T) {
-		storeName := randomStoreName()
-
-		store, err := provider.OpenStore(storeName)
-		require.NoError(t, err)
-		require.NotNil(t, store)
-
-		defer func() {
-			require.NoError(t, store.Close())
-		}()
-
-		err = provider.SetStoreConfig(storeName,
-			spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
-		require.NoError(t, err)
-
-		iterator, err := store.Query("tagName3:tagValue1")
-		require.NoError(t, err)
-
-		verifyExpectedIterator(t, iterator, nil, nil, nil, false,
-			options.checkIteratorTotalItemCounts, 0)
-	})
-	t.Run("Invalid expression formats", func(t *testing.T) {
-		storeName := randomStoreName()
-
-		store, err := provider.OpenStore(storeName)
-		require.NoError(t, err)
-		require.NotNil(t, store)
-
-		defer func() {
-			require.NoError(t, store.Close())
-		}()
-
-		err = provider.SetStoreConfig(storeName, spi.StoreConfiguration{})
-		require.NoError(t, err)
-
-		t.Run("Empty expression", func(t *testing.T) {
-			iterator, err := store.Query("")
-			require.Error(t, err)
-			require.Empty(t, iterator)
-		})
-		t.Run("Too many colon-separated parts", func(t *testing.T) {
-			iterator, err := store.Query("name:value:somethingElse")
-			require.Error(t, err)
-			require.Empty(t, iterator)
-		})
-	})
+	doStoreQueryTests(t, provider, false, options)
+	doStoreQueryTests(t, provider, true, options)
 }
 
 // TestStoreQueryWithSortingAndInitialPageOptions tests common Store Query functionality when the sorting and initial
 // page options are used.
-func TestStoreQueryWithSortingAndInitialPageOptions(t *testing.T, //nolint: funlen // Test file
-	provider spi.Provider, opts ...TestOption) {
+func TestStoreQueryWithSortingAndInitialPageOptions(t *testing.T, provider spi.Provider, opts ...TestOption) {
 	options := getOptions(opts)
 
-	t.Run("Sorting by a small numerical tag", func(t *testing.T) { //nolint: dupl // Test file
-		keysToPutAscendingOrder := []string{
-			"key1", "key2", "key3", "key4", "key5", "key6",
-			"key7", "key8", "key9", "key10",
-		}
-		valuesToPutAscendingOrder := [][]byte{
-			[]byte("value1"), []byte("value2"), []byte("value3"), []byte("value4"), []byte("value5"), []byte("value6"),
-			[]byte("value7"), []byte("value8"), []byte("value9"), []byte("value10"),
-		}
-
-		// The tag value associated with "numberTag" will determine the sort order.
-		tagsToPutAscendingOrder := [][]spi.Tag{
-			{
-				{Name: "tagName1", Value: "tagValue1"},
-				{Name: "tagName2", Value: "tagValue2"},
-				{Name: "numberTag", Value: "1"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue2"},
-				{Name: "tagName2"},
-				{Name: "numberTag", Value: "2"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue3"},
-				{Name: "numberTag", Value: "4"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue4"},
-				{Name: "numberTag", Value: "8"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue5"},
-				{Name: "numberTag", Value: "10"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue6"},
-				{Name: "numberTag", Value: "11"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue7"},
-				{Name: "numberTag", Value: "12"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue8"},
-				{Name: "numberTag", Value: "20"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue9"},
-				{Name: "numberTag", Value: "21"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue10"},
-				{Name: "numberTag", Value: "22"},
-			},
-		}
-
-		storeConfig := spi.StoreConfiguration{TagNames: []string{
-			"tagName1", "tagName2", "tagName3", "tagName4",
-			"numberTag",
-		}}
-
-		queryExpression := "tagName1"
-
-		expectedTotalItemsCount := 10
-
-		t.Run("Data inserted in ascending order", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName, storeConfig)
-			require.NoError(t, err)
-
-			putData(t, store, keysToPutAscendingOrder, valuesToPutAscendingOrder, tagsToPutAscendingOrder)
-
-			t.Run("Ascending order", func(t *testing.T) { //nolint: dupl // Test file
-				// The results should be sorted numerically (and not lexicographically) on the tag values associated
-				// with "numberTag". The order should go from the smallest number to the biggest.
-				t.Run("Default page size setting", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}))
-						require.NoError(t, err)
-
-						expectedKeys := keysToPutAscendingOrder
-						expectedValues := valuesToPutAscendingOrder
-						expectedTags := tagsToPutAscendingOrder
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-				t.Run("Page size 3", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := keysToPutAscendingOrder
-						expectedValues := valuesToPutAscendingOrder
-						expectedTags := tagsToPutAscendingOrder
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(0))
-						require.NoError(t, err)
-
-						expectedKeys := keysToPutAscendingOrder
-						expectedValues := valuesToPutAscendingOrder
-						expectedTags := tagsToPutAscendingOrder
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at second page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(1))
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[4], keysToPutAscendingOrder[5],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
-							keysToPutAscendingOrder[9],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[4], valuesToPutAscendingOrder[5],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
-							valuesToPutAscendingOrder[9],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[4], tagsToPutAscendingOrder[5],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
-							tagsToPutAscendingOrder[9],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at third page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
-							keysToPutAscendingOrder[9],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
-							valuesToPutAscendingOrder[9],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
-							tagsToPutAscendingOrder[9],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at fifth page (but there should only be four pages max, "+
-						"so iterator should have no results)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-			})
-			t.Run("Descending order", func(t *testing.T) {
-				// The results should be sorted numerically (and not lexicographically) on the tag values associated
-				// with "numberTag". The order should go from the biggest number to the smallest.
-				t.Run("Default page size setting", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						querySortOption := spi.WithSortOrder(&spi.SortOptions{
-							Order:   spi.SortDescending,
-							TagName: "numberTag",
-						})
-
-						iterator, err := store.Query(queryExpression, querySortOption)
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-				t.Run("Page size 3", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}), spi.WithPageSize(3)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(0))
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at second page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(1))
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at third page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at fifth page(but there should only be four pages max, "+
-						"so iterator should have no results)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-			})
-		})
-		t.Run("Data inserted in arbitrary order", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName, storeConfig)
-			require.NoError(t, err)
-
-			keysToPutArbitraryOrder := []string{
-				keysToPutAscendingOrder[5], keysToPutAscendingOrder[1], keysToPutAscendingOrder[9],
-				keysToPutAscendingOrder[0], keysToPutAscendingOrder[4], keysToPutAscendingOrder[7],
-				keysToPutAscendingOrder[2], keysToPutAscendingOrder[8], keysToPutAscendingOrder[6],
-				keysToPutAscendingOrder[3],
-			}
-			valuesToPutArbitraryOrder := [][]byte{
-				valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[1], valuesToPutAscendingOrder[9],
-				valuesToPutAscendingOrder[0], valuesToPutAscendingOrder[4], valuesToPutAscendingOrder[7],
-				valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[6],
-				valuesToPutAscendingOrder[3],
-			}
-			tagsToPutArbitraryOrder := [][]spi.Tag{
-				tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[1], tagsToPutAscendingOrder[9],
-				tagsToPutAscendingOrder[0], tagsToPutAscendingOrder[4], tagsToPutAscendingOrder[7],
-				tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[6],
-				tagsToPutAscendingOrder[3],
-			}
-
-			putData(t, store, keysToPutArbitraryOrder, valuesToPutArbitraryOrder, tagsToPutArbitraryOrder)
-
-			t.Run("Ascending order", func(t *testing.T) { //nolint: dupl // Test file
-				// The results should be sorted numerically (and not lexicographically) on the tag values associated
-				// with "numberTag". The order should go from the smallest number to the biggest.
-				t.Run("Default page size setting", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}))
-						require.NoError(t, err)
-
-						expectedKeys := keysToPutAscendingOrder
-						expectedValues := valuesToPutAscendingOrder
-						expectedTags := tagsToPutAscendingOrder
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-				t.Run("Page size 3", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := keysToPutAscendingOrder
-						expectedValues := valuesToPutAscendingOrder
-						expectedTags := tagsToPutAscendingOrder
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(0))
-						require.NoError(t, err)
-
-						expectedKeys := keysToPutAscendingOrder
-						expectedValues := valuesToPutAscendingOrder
-						expectedTags := tagsToPutAscendingOrder
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at second page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(1))
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[4], keysToPutAscendingOrder[5],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
-							keysToPutAscendingOrder[9],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[4], valuesToPutAscendingOrder[5],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
-							valuesToPutAscendingOrder[9],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[4], tagsToPutAscendingOrder[5],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
-							tagsToPutAscendingOrder[9],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at third page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
-							keysToPutAscendingOrder[9],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
-							valuesToPutAscendingOrder[9],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
-							tagsToPutAscendingOrder[9],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at fifth page(but there should only be four pages max, "+
-						"so iterator should have no results)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-			})
-			t.Run("Descending order", func(t *testing.T) {
-				// The results should be sorted numerically (and not lexicographically) on the tag values associated with
-				// "numberTag". The order should go from the biggest number to the smallest.
-				t.Run("Default page size setting", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						querySortOption := spi.WithSortOrder(&spi.SortOptions{
-							Order:   spi.SortDescending,
-							TagName: "numberTag",
-						})
-
-						iterator, err := store.Query(queryExpression, querySortOption)
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-				t.Run("Page size 3", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(0))
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at second page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(1))
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at third page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at fifth page"+
-						"(but there should only be four pages max, so iterator should have no results)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-			})
-		})
-	})
-	t.Run("Sorting by a large numerical tag (Unix timestamps)", func(t *testing.T) { //nolint: dupl // Test file
-		keysToPutAscendingOrder := []string{
-			"key1", "key2", "key3", "key4", "key5", "key6",
-			"key7", "key8", "key9", "key10",
-		}
-		valuesToPutAscendingOrder := [][]byte{
-			[]byte("value1"), []byte("value2"), []byte("value3"), []byte("value4"), []byte("value5"), []byte("value6"),
-			[]byte("value7"), []byte("value8"), []byte("value9"), []byte("value10"),
-		}
-
-		// The tag value associated with "numberTag" will determine the sort order.
-		tagsToPutAscendingOrder := [][]spi.Tag{
-			{
-				{Name: "tagName1", Value: "tagValue1"},
-				{Name: "tagName2", Value: "tagValue2"},
-				{Name: "numberTag", Value: "0"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue2"},
-				{Name: "tagName2"},
-				{Name: "numberTag", Value: "1234"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue3"},
-				{Name: "numberTag", Value: "140000"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue4"},
-				{Name: "numberTag", Value: "1000000000"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue5"},
-				{Name: "numberTag", Value: "1619022042"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue6"},
-				{Name: "numberTag", Value: "1619022043"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue7"},
-				{Name: "numberTag", Value: "1619022044"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue8"},
-				{Name: "numberTag", Value: "1619122040"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue9"},
-				{Name: "numberTag", Value: "1619122041"},
-			},
-			{
-				{Name: "tagName1", Value: "tagValue10"},
-				{Name: "numberTag", Value: "92147483647"},
-			},
-		}
-
-		storeConfig := spi.StoreConfiguration{TagNames: []string{
-			"tagName1", "tagName2", "tagName3", "tagName4", "numberTag",
-		}}
-
-		queryExpression := "tagName1"
-
-		expectedTotalItemsCount := 10
-
-		t.Run("Data inserted in ascending order", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName, storeConfig)
-			require.NoError(t, err)
-
-			putData(t, store, keysToPutAscendingOrder, valuesToPutAscendingOrder, tagsToPutAscendingOrder)
-
-			t.Run("Ascending order", func(t *testing.T) { //nolint: dupl // Test file
-				// The results should be sorted numerically (and not lexicographically) on the tag values associated
-				// with "numberTag". The order should go from the smallest number to the biggest.
-				t.Run("Default page size setting", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}))
-						require.NoError(t, err)
-
-						expectedKeys := keysToPutAscendingOrder
-						expectedValues := valuesToPutAscendingOrder
-						expectedTags := tagsToPutAscendingOrder
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-				t.Run("Page size 3", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := keysToPutAscendingOrder
-						expectedValues := valuesToPutAscendingOrder
-						expectedTags := tagsToPutAscendingOrder
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(0))
-						require.NoError(t, err)
-
-						expectedKeys := keysToPutAscendingOrder
-						expectedValues := valuesToPutAscendingOrder
-						expectedTags := tagsToPutAscendingOrder
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at second page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(1))
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[4], keysToPutAscendingOrder[5],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
-							keysToPutAscendingOrder[9],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[4], valuesToPutAscendingOrder[5],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
-							valuesToPutAscendingOrder[9],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[4], tagsToPutAscendingOrder[5],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
-							tagsToPutAscendingOrder[9],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at third page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
-							keysToPutAscendingOrder[9],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
-							valuesToPutAscendingOrder[9],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
-							tagsToPutAscendingOrder[9],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at fifth page(but there should only be four pages max, "+
-						"so iterator should have no results)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-			})
-			t.Run("Descending order", func(t *testing.T) {
-				// The results should be sorted numerically (and not lexicographically) on the tag values associated with
-				// "numberTag". The order should go from the biggest number to the smallest.
-				t.Run("Default page size setting", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						querySortOption := spi.WithSortOrder(&spi.SortOptions{
-							Order:   spi.SortDescending,
-							TagName: "numberTag",
-						})
-
-						iterator, err := store.Query(queryExpression, querySortOption)
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-				t.Run("Page size 3", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(0))
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at second page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(1))
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at third page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at fifth page(but there should only be four pages max, "+
-						"so iterator should have no results)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-			})
-		})
-		t.Run("Data inserted in arbitrary order", func(t *testing.T) {
-			storeName := randomStoreName()
-
-			store, err := provider.OpenStore(storeName)
-			require.NoError(t, err)
-			require.NotNil(t, store)
-
-			defer func() {
-				require.NoError(t, store.Close())
-			}()
-
-			err = provider.SetStoreConfig(storeName, storeConfig)
-			require.NoError(t, err)
-
-			keysToPutArbitraryOrder := []string{
-				keysToPutAscendingOrder[5], keysToPutAscendingOrder[1], keysToPutAscendingOrder[9],
-				keysToPutAscendingOrder[0], keysToPutAscendingOrder[4], keysToPutAscendingOrder[7],
-				keysToPutAscendingOrder[2], keysToPutAscendingOrder[8], keysToPutAscendingOrder[6],
-				keysToPutAscendingOrder[3],
-			}
-			valuesToPutArbitraryOrder := [][]byte{
-				valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[1], valuesToPutAscendingOrder[9],
-				valuesToPutAscendingOrder[0], valuesToPutAscendingOrder[4], valuesToPutAscendingOrder[7],
-				valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[6],
-				valuesToPutAscendingOrder[3],
-			}
-			tagsToPutArbitraryOrder := [][]spi.Tag{
-				tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[1], tagsToPutAscendingOrder[9],
-				tagsToPutAscendingOrder[0], tagsToPutAscendingOrder[4], tagsToPutAscendingOrder[7],
-				tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[6],
-				tagsToPutAscendingOrder[3],
-			}
-
-			putData(t, store, keysToPutArbitraryOrder, valuesToPutArbitraryOrder, tagsToPutArbitraryOrder)
-
-			t.Run("Ascending order", func(t *testing.T) { //nolint: dupl // Test file
-				// The results should be sorted numerically (and not lexicographically) on the tag values associated
-				// with "numberTag". The order should go from the smallest number to the biggest.
-				t.Run("Default page size setting", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}))
-						require.NoError(t, err)
-
-						expectedKeys := keysToPutAscendingOrder
-						expectedValues := valuesToPutAscendingOrder
-						expectedTags := tagsToPutAscendingOrder
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-				t.Run("Page size 3", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := keysToPutAscendingOrder
-						expectedValues := valuesToPutAscendingOrder
-						expectedTags := tagsToPutAscendingOrder
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(0))
-						require.NoError(t, err)
-
-						expectedKeys := keysToPutAscendingOrder
-						expectedValues := valuesToPutAscendingOrder
-						expectedTags := tagsToPutAscendingOrder
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at second page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(1))
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[4], keysToPutAscendingOrder[5],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
-							keysToPutAscendingOrder[9],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[4], valuesToPutAscendingOrder[5],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
-							valuesToPutAscendingOrder[9],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[4], tagsToPutAscendingOrder[5],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
-							tagsToPutAscendingOrder[9],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at third page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
-							keysToPutAscendingOrder[9],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
-							valuesToPutAscendingOrder[9],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
-							tagsToPutAscendingOrder[9],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at fifth page(but there should only be four pages max, "+
-						"so iterator should have no results)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortAscending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-			})
-			t.Run("Descending order", func(t *testing.T) {
-				// The results should be sorted numerically (and not lexicographically) on the tag values associated
-				// with "numberTag". The order should go from the biggest number to the smallest.
-				t.Run("Default page size setting", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						querySortOption := spi.WithSortOrder(&spi.SortOptions{
-							Order:   spi.SortDescending,
-							TagName: "numberTag",
-						})
-
-						iterator, err := store.Query(queryExpression, querySortOption)
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-				t.Run("Page size 3", func(t *testing.T) {
-					t.Run("Start at the default (first) page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(0))
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at second page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3), // nolint: gomnd // Test file
-							spi.WithInitialPageNum(1))
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at third page", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						expectedKeys := []string{
-							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
-							keysToPutAscendingOrder[0],
-						}
-						expectedValues := [][]byte{
-							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
-							valuesToPutAscendingOrder[0],
-						}
-						expectedTags := [][]spi.Tag{
-							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
-							tagsToPutAscendingOrder[0],
-						}
-
-						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-					t.Run("Start at fifth page(but there should only be four pages max, "+
-						"so iterator should have no results)", func(t *testing.T) {
-						iterator, err := store.Query(queryExpression,
-							spi.WithSortOrder(&spi.SortOptions{
-								Order:   spi.SortDescending,
-								TagName: "numberTag",
-							}),
-							spi.WithPageSize(3),       // nolint: gomnd // Test file
-							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
-						require.NoError(t, err)
-
-						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
-							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
-					})
-				})
-			})
-		})
-	})
+	doStoreQueryWithSortingAndInitialPageOptionsTests(t, provider, false, options)
+	doStoreQueryWithSortingAndInitialPageOptionsTests(t, provider, true, options)
 }
 
 // TestStoreBatch tests common Store Batch functionality.
@@ -3464,6 +1629,1890 @@ func doPutThenUpdateThenGetTest(t *testing.T, provider spi.Provider, key string,
 	retrievedValue, err := store.Get(key)
 	require.NoError(t, err)
 	require.Equal(t, updatedValue, retrievedValue)
+}
+
+func doStoreQueryTests(t *testing.T, // nolint: funlen,gocognit,gocyclo // Test file
+	provider spi.Provider, setStoreConfig bool, options testOptions) {
+	t.Run("Tag name only query - 2 values found", func(t *testing.T) {
+		keysToPut := []string{"key1", "key2", "key3"}
+		valuesToPut := [][]byte{[]byte("value1"), []byte("value2"), []byte("value3")}
+		tagsToPut := [][]spi.Tag{
+			{{Name: "tagName1", Value: "tagValue1"}, {Name: "tagName2", Value: "tagValue2"}},
+			{{Name: "tagName3", Value: "tagValue"}, {Name: "tagName4"}},
+			{{Name: "tagName3", Value: "tagValue2"}},
+		}
+
+		expectedKeys := []string{keysToPut[1], keysToPut[2]}
+		expectedValues := [][]byte{valuesToPut[1], valuesToPut[2]}
+		expectedTags := [][]spi.Tag{tagsToPut[1], tagsToPut[2]}
+		expectedTotalItemsCount := 2
+
+		queryExpression := "tagName3"
+
+		t.Run("Default page setting", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName,
+					spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
+				require.NoError(t, err)
+			}
+
+			putData(t, store, keysToPut, valuesToPut, tagsToPut)
+
+			iterator, err := store.Query(queryExpression)
+			require.NoError(t, err)
+
+			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
+				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+		})
+		t.Run("Page size 2", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName,
+					spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
+				require.NoError(t, err)
+			}
+
+			putData(t, store, keysToPut, valuesToPut, tagsToPut)
+
+			//nolint:gomnd // Test file
+			iterator, err := store.Query(queryExpression, spi.WithPageSize(2))
+			require.NoError(t, err)
+
+			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
+				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+		})
+		t.Run("Page size 1", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName,
+					spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
+				require.NoError(t, err)
+			}
+
+			putData(t, store, keysToPut, valuesToPut, tagsToPut)
+
+			iterator, err := store.Query(queryExpression, spi.WithPageSize(1))
+			require.NoError(t, err)
+
+			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
+				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+		})
+		t.Run("Page size 100", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName,
+					spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
+				require.NoError(t, err)
+			}
+
+			putData(t, store, keysToPut, valuesToPut, tagsToPut)
+
+			//nolint:gomnd // Test file
+			iterator, err := store.Query(queryExpression, spi.WithPageSize(100))
+			require.NoError(t, err)
+
+			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
+				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+		})
+	})
+	t.Run("Tag name only query - 0 values found", func(t *testing.T) {
+		keysToPut := []string{"key1", "key2", "key3"}
+		valuesToPut := [][]byte{[]byte("value1"), []byte("value2"), []byte("value3")}
+		tagsToPut := [][]spi.Tag{
+			{{Name: "tagName1", Value: "tagValue1"}, {Name: "tagName2", Value: "tagValue2"}},
+			{{Name: "tagName3", Value: "tagValue"}, {Name: "tagName4"}},
+			{{Name: "tagName3", Value: "tagValue2"}},
+		}
+
+		expectedTotalItemsCount := 0
+
+		queryExpression := "tagName5"
+
+		t.Run("Default page setting", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName,
+					spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4", "tagName5"}})
+				require.NoError(t, err)
+			}
+
+			putData(t, store, keysToPut, valuesToPut, tagsToPut)
+
+			iterator, err := store.Query(queryExpression)
+			require.NoError(t, err)
+
+			verifyExpectedIterator(t, iterator, nil, nil, nil, false,
+				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+		})
+		t.Run("Page size 2", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName,
+					spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4", "tagName5"}})
+				require.NoError(t, err)
+			}
+
+			putData(t, store, keysToPut, valuesToPut, tagsToPut)
+
+			//nolint:gomnd // Test file
+			iterator, err := store.Query(queryExpression, spi.WithPageSize(2))
+			require.NoError(t, err)
+
+			verifyExpectedIterator(t, iterator, nil, nil, nil,
+				false, options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+		})
+		t.Run("Page size 1", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName,
+					spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4", "tagName5"}})
+				require.NoError(t, err)
+			}
+
+			putData(t, store, keysToPut, valuesToPut, tagsToPut)
+
+			iterator, err := store.Query(queryExpression, spi.WithPageSize(1))
+			require.NoError(t, err)
+
+			verifyExpectedIterator(t, iterator, nil, nil, nil, false,
+				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+		})
+		t.Run("Page size 100", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName,
+					spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4", "tagName5"}})
+				require.NoError(t, err)
+			}
+
+			putData(t, store, keysToPut, valuesToPut, tagsToPut)
+
+			//nolint:gomnd // Test file
+			iterator, err := store.Query(queryExpression, spi.WithPageSize(100))
+			require.NoError(t, err)
+
+			verifyExpectedIterator(t, iterator, nil, nil, nil, false,
+				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+		})
+	})
+	t.Run("Tag name and value query - 2 values found", func(t *testing.T) {
+		keysToPut := []string{"key1", "key2", "key3", "key4"}
+		valuesToPut := [][]byte{[]byte("value1"), []byte("value2"), []byte("value3"), []byte("value4")}
+		tagsToPut := [][]spi.Tag{
+			{{Name: "tagName1", Value: "tagValue1"}, {Name: "tagName2", Value: "tagValue2"}},
+			{{Name: "tagName3", Value: "tagValue1"}, {Name: "tagName4"}},
+			{{Name: "tagName3", Value: "tagValue2"}},
+			{{Name: "tagName3", Value: "tagValue1"}},
+		}
+
+		expectedKeys := []string{keysToPut[1], keysToPut[3]}
+		expectedValues := [][]byte{valuesToPut[1], valuesToPut[3]}
+		expectedTags := [][]spi.Tag{tagsToPut[1], tagsToPut[3]}
+		expectedTotalItemsCount := 2
+
+		queryExpression := "tagName3:tagValue1"
+
+		t.Run("Default page setting", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName,
+					spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
+				require.NoError(t, err)
+			}
+
+			putData(t, store, keysToPut, valuesToPut, tagsToPut)
+
+			iterator, err := store.Query(queryExpression)
+			require.NoError(t, err)
+
+			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
+				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+		})
+		t.Run("Page size 2", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName,
+					spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
+				require.NoError(t, err)
+			}
+
+			putData(t, store, keysToPut, valuesToPut, tagsToPut)
+
+			//nolint:gomnd // Test file
+			iterator, err := store.Query(queryExpression, spi.WithPageSize(2))
+			require.NoError(t, err)
+
+			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
+				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+		})
+		t.Run("Page size 1", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName,
+					spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
+				require.NoError(t, err)
+			}
+
+			putData(t, store, keysToPut, valuesToPut, tagsToPut)
+
+			iterator, err := store.Query(queryExpression, spi.WithPageSize(1))
+			require.NoError(t, err)
+
+			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
+				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+		})
+		t.Run("Page size 100", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName,
+					spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
+				require.NoError(t, err)
+			}
+
+			putData(t, store, keysToPut, valuesToPut, tagsToPut)
+
+			//nolint:gomnd // Test file
+			iterator, err := store.Query(queryExpression, spi.WithPageSize(100))
+			require.NoError(t, err)
+
+			verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
+				options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+		})
+	})
+	t.Run("Tag name and value query - only 1 value found "+
+		"(would have been two, but the other was deleted before the query was executed)", func(t *testing.T) {
+		keysToPut := []string{"key1", "key2", "key3", "key4"}
+		valuesToPut := [][]byte{[]byte("value1"), []byte("value2"), []byte("value3"), []byte("value4")}
+		tagsToPut := [][]spi.Tag{
+			{{Name: "tagName1", Value: "tagValue1"}, {Name: "tagName2", Value: "tagValue2"}},
+			{{Name: "tagName3", Value: "tagValue1"}, {Name: "tagName4"}},
+			{{Name: "tagName3", Value: "tagValue2"}},
+			{{Name: "tagName3", Value: "tagValue1"}},
+		}
+
+		expectedKeys := []string{keysToPut[3]}
+		expectedValues := [][]byte{valuesToPut[3]}
+		expectedTags := [][]spi.Tag{tagsToPut[3]}
+		expectedTotalItemsCount := 1
+
+		storeName := randomStoreName()
+
+		store, err := provider.OpenStore(storeName)
+		require.NoError(t, err)
+		require.NotNil(t, store)
+
+		defer func() {
+			require.NoError(t, store.Close())
+		}()
+
+		if setStoreConfig {
+			err = provider.SetStoreConfig(storeName,
+				spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
+			require.NoError(t, err)
+		}
+
+		putData(t, store, keysToPut, valuesToPut, tagsToPut)
+
+		err = store.Delete("key2")
+		require.NoError(t, err)
+
+		iterator, err := store.Query("tagName3:tagValue1")
+		require.NoError(t, err)
+
+		verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, false,
+			options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+	})
+	t.Run("Tag name and value query - 0 values found since the store is empty", func(t *testing.T) {
+		storeName := randomStoreName()
+
+		store, err := provider.OpenStore(storeName)
+		require.NoError(t, err)
+		require.NotNil(t, store)
+
+		defer func() {
+			require.NoError(t, store.Close())
+		}()
+
+		if setStoreConfig {
+			err = provider.SetStoreConfig(storeName,
+				spi.StoreConfiguration{TagNames: []string{"tagName1", "tagName2", "tagName3", "tagName4"}})
+			require.NoError(t, err)
+		}
+
+		iterator, err := store.Query("tagName3:tagValue1")
+		require.NoError(t, err)
+
+		verifyExpectedIterator(t, iterator, nil, nil, nil, false,
+			options.checkIteratorTotalItemCounts, 0)
+	})
+	t.Run("Invalid expression formats", func(t *testing.T) {
+		storeName := randomStoreName()
+
+		store, err := provider.OpenStore(storeName)
+		require.NoError(t, err)
+		require.NotNil(t, store)
+
+		defer func() {
+			require.NoError(t, store.Close())
+		}()
+
+		if setStoreConfig {
+			err = provider.SetStoreConfig(storeName, spi.StoreConfiguration{})
+			require.NoError(t, err)
+		}
+
+		t.Run("Empty expression", func(t *testing.T) {
+			iterator, err := store.Query("")
+			require.Error(t, err)
+			require.Empty(t, iterator)
+		})
+		t.Run("Too many colon-separated parts", func(t *testing.T) {
+			iterator, err := store.Query("name:value:somethingElse")
+			require.Error(t, err)
+			require.Empty(t, iterator)
+		})
+	})
+}
+
+func doStoreQueryWithSortingAndInitialPageOptionsTests(t *testing.T, // nolint: funlen // Test file
+	provider spi.Provider, setStoreConfig bool, options testOptions) {
+	t.Run("Sorting by a small numerical tag", func(t *testing.T) { //nolint: dupl // Test file
+		keysToPutAscendingOrder := []string{
+			"key1", "key2", "key3", "key4", "key5", "key6",
+			"key7", "key8", "key9", "key10",
+		}
+		valuesToPutAscendingOrder := [][]byte{
+			[]byte("value1"), []byte("value2"), []byte("value3"), []byte("value4"), []byte("value5"), []byte("value6"),
+			[]byte("value7"), []byte("value8"), []byte("value9"), []byte("value10"),
+		}
+
+		// The tag value associated with "numberTag" will determine the sort order.
+		tagsToPutAscendingOrder := [][]spi.Tag{
+			{
+				{Name: "tagName1", Value: "tagValue1"},
+				{Name: "tagName2", Value: "tagValue2"},
+				{Name: "numberTag", Value: "1"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue2"},
+				{Name: "tagName2"},
+				{Name: "numberTag", Value: "2"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue3"},
+				{Name: "numberTag", Value: "4"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue4"},
+				{Name: "numberTag", Value: "8"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue5"},
+				{Name: "numberTag", Value: "10"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue6"},
+				{Name: "numberTag", Value: "11"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue7"},
+				{Name: "numberTag", Value: "12"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue8"},
+				{Name: "numberTag", Value: "20"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue9"},
+				{Name: "numberTag", Value: "21"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue10"},
+				{Name: "numberTag", Value: "22"},
+			},
+		}
+
+		storeConfig := spi.StoreConfiguration{TagNames: []string{
+			"tagName1", "tagName2", "tagName3", "tagName4",
+			"numberTag",
+		}}
+
+		queryExpression := "tagName1"
+
+		expectedTotalItemsCount := 10
+
+		t.Run("Data inserted in ascending order", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName, storeConfig)
+				require.NoError(t, err)
+			}
+
+			putData(t, store, keysToPutAscendingOrder, valuesToPutAscendingOrder, tagsToPutAscendingOrder)
+
+			t.Run("Ascending order", func(t *testing.T) { //nolint: dupl // Test file
+				// The results should be sorted numerically (and not lexicographically) on the tag values associated
+				// with "numberTag". The order should go from the smallest number to the biggest.
+				t.Run("Default page size setting", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}))
+						require.NoError(t, err)
+
+						expectedKeys := keysToPutAscendingOrder
+						expectedValues := valuesToPutAscendingOrder
+						expectedTags := tagsToPutAscendingOrder
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+				t.Run("Page size 3", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := keysToPutAscendingOrder
+						expectedValues := valuesToPutAscendingOrder
+						expectedTags := tagsToPutAscendingOrder
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(0))
+						require.NoError(t, err)
+
+						expectedKeys := keysToPutAscendingOrder
+						expectedValues := valuesToPutAscendingOrder
+						expectedTags := tagsToPutAscendingOrder
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at second page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(1))
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[4], keysToPutAscendingOrder[5],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
+							keysToPutAscendingOrder[9],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[4], valuesToPutAscendingOrder[5],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
+							valuesToPutAscendingOrder[9],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[4], tagsToPutAscendingOrder[5],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
+							tagsToPutAscendingOrder[9],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at third page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
+							keysToPutAscendingOrder[9],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
+							valuesToPutAscendingOrder[9],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
+							tagsToPutAscendingOrder[9],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at fifth page (but there should only be four pages max, "+
+						"so iterator should have no results)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+			})
+			t.Run("Descending order", func(t *testing.T) {
+				// The results should be sorted numerically (and not lexicographically) on the tag values associated
+				// with "numberTag". The order should go from the biggest number to the smallest.
+				t.Run("Default page size setting", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						querySortOption := spi.WithSortOrder(&spi.SortOptions{
+							Order:   spi.SortDescending,
+							TagName: "numberTag",
+						})
+
+						iterator, err := store.Query(queryExpression, querySortOption)
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+				t.Run("Page size 3", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}), spi.WithPageSize(3)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(0))
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at second page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(1))
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at third page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at fifth page(but there should only be four pages max, "+
+						"so iterator should have no results)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+			})
+		})
+		t.Run("Data inserted in arbitrary order", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName, storeConfig)
+				require.NoError(t, err)
+			}
+
+			keysToPutArbitraryOrder := []string{
+				keysToPutAscendingOrder[5], keysToPutAscendingOrder[1], keysToPutAscendingOrder[9],
+				keysToPutAscendingOrder[0], keysToPutAscendingOrder[4], keysToPutAscendingOrder[7],
+				keysToPutAscendingOrder[2], keysToPutAscendingOrder[8], keysToPutAscendingOrder[6],
+				keysToPutAscendingOrder[3],
+			}
+			valuesToPutArbitraryOrder := [][]byte{
+				valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[1], valuesToPutAscendingOrder[9],
+				valuesToPutAscendingOrder[0], valuesToPutAscendingOrder[4], valuesToPutAscendingOrder[7],
+				valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[6],
+				valuesToPutAscendingOrder[3],
+			}
+			tagsToPutArbitraryOrder := [][]spi.Tag{
+				tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[1], tagsToPutAscendingOrder[9],
+				tagsToPutAscendingOrder[0], tagsToPutAscendingOrder[4], tagsToPutAscendingOrder[7],
+				tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[6],
+				tagsToPutAscendingOrder[3],
+			}
+
+			putData(t, store, keysToPutArbitraryOrder, valuesToPutArbitraryOrder, tagsToPutArbitraryOrder)
+
+			t.Run("Ascending order", func(t *testing.T) { //nolint: dupl // Test file
+				// The results should be sorted numerically (and not lexicographically) on the tag values associated
+				// with "numberTag". The order should go from the smallest number to the biggest.
+				t.Run("Default page size setting", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}))
+						require.NoError(t, err)
+
+						expectedKeys := keysToPutAscendingOrder
+						expectedValues := valuesToPutAscendingOrder
+						expectedTags := tagsToPutAscendingOrder
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+				t.Run("Page size 3", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := keysToPutAscendingOrder
+						expectedValues := valuesToPutAscendingOrder
+						expectedTags := tagsToPutAscendingOrder
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(0))
+						require.NoError(t, err)
+
+						expectedKeys := keysToPutAscendingOrder
+						expectedValues := valuesToPutAscendingOrder
+						expectedTags := tagsToPutAscendingOrder
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at second page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(1))
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[4], keysToPutAscendingOrder[5],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
+							keysToPutAscendingOrder[9],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[4], valuesToPutAscendingOrder[5],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
+							valuesToPutAscendingOrder[9],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[4], tagsToPutAscendingOrder[5],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
+							tagsToPutAscendingOrder[9],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at third page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
+							keysToPutAscendingOrder[9],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
+							valuesToPutAscendingOrder[9],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
+							tagsToPutAscendingOrder[9],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at fifth page(but there should only be four pages max, "+
+						"so iterator should have no results)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+			})
+			t.Run("Descending order", func(t *testing.T) {
+				// The results should be sorted numerically (and not lexicographically) on the tag values associated with
+				// "numberTag". The order should go from the biggest number to the smallest.
+				t.Run("Default page size setting", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						querySortOption := spi.WithSortOrder(&spi.SortOptions{
+							Order:   spi.SortDescending,
+							TagName: "numberTag",
+						})
+
+						iterator, err := store.Query(queryExpression, querySortOption)
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+				t.Run("Page size 3", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(0))
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at second page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(1))
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at third page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at fifth page"+
+						"(but there should only be four pages max, so iterator should have no results)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+			})
+		})
+	})
+	t.Run("Sorting by a large numerical tag (Unix timestamps)", func(t *testing.T) { //nolint: dupl // Test file
+		keysToPutAscendingOrder := []string{
+			"key1", "key2", "key3", "key4", "key5", "key6",
+			"key7", "key8", "key9", "key10",
+		}
+		valuesToPutAscendingOrder := [][]byte{
+			[]byte("value1"), []byte("value2"), []byte("value3"), []byte("value4"), []byte("value5"), []byte("value6"),
+			[]byte("value7"), []byte("value8"), []byte("value9"), []byte("value10"),
+		}
+
+		// The tag value associated with "numberTag" will determine the sort order.
+		tagsToPutAscendingOrder := [][]spi.Tag{
+			{
+				{Name: "tagName1", Value: "tagValue1"},
+				{Name: "tagName2", Value: "tagValue2"},
+				{Name: "numberTag", Value: "0"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue2"},
+				{Name: "tagName2"},
+				{Name: "numberTag", Value: "1234"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue3"},
+				{Name: "numberTag", Value: "140000"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue4"},
+				{Name: "numberTag", Value: "1000000000"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue5"},
+				{Name: "numberTag", Value: "1619022042"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue6"},
+				{Name: "numberTag", Value: "1619022043"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue7"},
+				{Name: "numberTag", Value: "1619022044"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue8"},
+				{Name: "numberTag", Value: "1619122040"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue9"},
+				{Name: "numberTag", Value: "1619122041"},
+			},
+			{
+				{Name: "tagName1", Value: "tagValue10"},
+				{Name: "numberTag", Value: "92147483647"},
+			},
+		}
+
+		storeConfig := spi.StoreConfiguration{TagNames: []string{
+			"tagName1", "tagName2", "tagName3", "tagName4", "numberTag",
+		}}
+
+		queryExpression := "tagName1"
+
+		expectedTotalItemsCount := 10
+
+		t.Run("Data inserted in ascending order", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName, storeConfig)
+				require.NoError(t, err)
+			}
+
+			putData(t, store, keysToPutAscendingOrder, valuesToPutAscendingOrder, tagsToPutAscendingOrder)
+
+			t.Run("Ascending order", func(t *testing.T) { //nolint: dupl // Test file
+				// The results should be sorted numerically (and not lexicographically) on the tag values associated
+				// with "numberTag". The order should go from the smallest number to the biggest.
+				t.Run("Default page size setting", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}))
+						require.NoError(t, err)
+
+						expectedKeys := keysToPutAscendingOrder
+						expectedValues := valuesToPutAscendingOrder
+						expectedTags := tagsToPutAscendingOrder
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+				t.Run("Page size 3", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := keysToPutAscendingOrder
+						expectedValues := valuesToPutAscendingOrder
+						expectedTags := tagsToPutAscendingOrder
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(0))
+						require.NoError(t, err)
+
+						expectedKeys := keysToPutAscendingOrder
+						expectedValues := valuesToPutAscendingOrder
+						expectedTags := tagsToPutAscendingOrder
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at second page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(1))
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[4], keysToPutAscendingOrder[5],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
+							keysToPutAscendingOrder[9],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[4], valuesToPutAscendingOrder[5],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
+							valuesToPutAscendingOrder[9],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[4], tagsToPutAscendingOrder[5],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
+							tagsToPutAscendingOrder[9],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at third page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
+							keysToPutAscendingOrder[9],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
+							valuesToPutAscendingOrder[9],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
+							tagsToPutAscendingOrder[9],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at fifth page(but there should only be four pages max, "+
+						"so iterator should have no results)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+			})
+			t.Run("Descending order", func(t *testing.T) {
+				// The results should be sorted numerically (and not lexicographically) on the tag values associated with
+				// "numberTag". The order should go from the biggest number to the smallest.
+				t.Run("Default page size setting", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						querySortOption := spi.WithSortOrder(&spi.SortOptions{
+							Order:   spi.SortDescending,
+							TagName: "numberTag",
+						})
+
+						iterator, err := store.Query(queryExpression, querySortOption)
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+				t.Run("Page size 3", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(0))
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at second page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(1))
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at third page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at fifth page(but there should only be four pages max, "+
+						"so iterator should have no results)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+			})
+		})
+		t.Run("Data inserted in arbitrary order", func(t *testing.T) {
+			storeName := randomStoreName()
+
+			store, err := provider.OpenStore(storeName)
+			require.NoError(t, err)
+			require.NotNil(t, store)
+
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			if setStoreConfig {
+				err = provider.SetStoreConfig(storeName, storeConfig)
+				require.NoError(t, err)
+			}
+
+			keysToPutArbitraryOrder := []string{
+				keysToPutAscendingOrder[5], keysToPutAscendingOrder[1], keysToPutAscendingOrder[9],
+				keysToPutAscendingOrder[0], keysToPutAscendingOrder[4], keysToPutAscendingOrder[7],
+				keysToPutAscendingOrder[2], keysToPutAscendingOrder[8], keysToPutAscendingOrder[6],
+				keysToPutAscendingOrder[3],
+			}
+			valuesToPutArbitraryOrder := [][]byte{
+				valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[1], valuesToPutAscendingOrder[9],
+				valuesToPutAscendingOrder[0], valuesToPutAscendingOrder[4], valuesToPutAscendingOrder[7],
+				valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[6],
+				valuesToPutAscendingOrder[3],
+			}
+			tagsToPutArbitraryOrder := [][]spi.Tag{
+				tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[1], tagsToPutAscendingOrder[9],
+				tagsToPutAscendingOrder[0], tagsToPutAscendingOrder[4], tagsToPutAscendingOrder[7],
+				tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[6],
+				tagsToPutAscendingOrder[3],
+			}
+
+			putData(t, store, keysToPutArbitraryOrder, valuesToPutArbitraryOrder, tagsToPutArbitraryOrder)
+
+			t.Run("Ascending order", func(t *testing.T) { //nolint: dupl // Test file
+				// The results should be sorted numerically (and not lexicographically) on the tag values associated
+				// with "numberTag". The order should go from the smallest number to the biggest.
+				t.Run("Default page size setting", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}))
+						require.NoError(t, err)
+
+						expectedKeys := keysToPutAscendingOrder
+						expectedValues := valuesToPutAscendingOrder
+						expectedTags := tagsToPutAscendingOrder
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+				t.Run("Page size 3", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := keysToPutAscendingOrder
+						expectedValues := valuesToPutAscendingOrder
+						expectedTags := tagsToPutAscendingOrder
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(0))
+						require.NoError(t, err)
+
+						expectedKeys := keysToPutAscendingOrder
+						expectedValues := valuesToPutAscendingOrder
+						expectedTags := tagsToPutAscendingOrder
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at second page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(1))
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[4], keysToPutAscendingOrder[5],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
+							keysToPutAscendingOrder[9],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[4], valuesToPutAscendingOrder[5],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
+							valuesToPutAscendingOrder[9],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[4], tagsToPutAscendingOrder[5],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
+							tagsToPutAscendingOrder[9],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at third page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[7], keysToPutAscendingOrder[8],
+							keysToPutAscendingOrder[9],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[7], valuesToPutAscendingOrder[8],
+							valuesToPutAscendingOrder[9],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[7], tagsToPutAscendingOrder[8],
+							tagsToPutAscendingOrder[9],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at fifth page(but there should only be four pages max, "+
+						"so iterator should have no results)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortAscending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+			})
+			t.Run("Descending order", func(t *testing.T) {
+				// The results should be sorted numerically (and not lexicographically) on the tag values associated
+				// with "numberTag". The order should go from the biggest number to the smallest.
+				t.Run("Default page size setting", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						querySortOption := spi.WithSortOrder(&spi.SortOptions{
+							Order:   spi.SortDescending,
+							TagName: "numberTag",
+						})
+
+						iterator, err := store.Query(queryExpression, querySortOption)
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+				t.Run("Page size 3", func(t *testing.T) {
+					t.Run("Start at the default (first) page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at first page (explicitly set)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(0))
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[9], keysToPutAscendingOrder[8], keysToPutAscendingOrder[7],
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[9], valuesToPutAscendingOrder[8], valuesToPutAscendingOrder[7],
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[9], tagsToPutAscendingOrder[8], tagsToPutAscendingOrder[7],
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at second page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3), // nolint: gomnd // Test file
+							spi.WithInitialPageNum(1))
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[6], keysToPutAscendingOrder[5], keysToPutAscendingOrder[4],
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[6], valuesToPutAscendingOrder[5], valuesToPutAscendingOrder[4],
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[6], tagsToPutAscendingOrder[5], tagsToPutAscendingOrder[4],
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at third page", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(2)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						expectedKeys := []string{
+							keysToPutAscendingOrder[3], keysToPutAscendingOrder[2], keysToPutAscendingOrder[1],
+							keysToPutAscendingOrder[0],
+						}
+						expectedValues := [][]byte{
+							valuesToPutAscendingOrder[3], valuesToPutAscendingOrder[2], valuesToPutAscendingOrder[1],
+							valuesToPutAscendingOrder[0],
+						}
+						expectedTags := [][]spi.Tag{
+							tagsToPutAscendingOrder[3], tagsToPutAscendingOrder[2], tagsToPutAscendingOrder[1],
+							tagsToPutAscendingOrder[0],
+						}
+
+						verifyExpectedIterator(t, iterator, expectedKeys, expectedValues, expectedTags, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+					t.Run("Start at fifth page(but there should only be four pages max, "+
+						"so iterator should have no results)", func(t *testing.T) {
+						iterator, err := store.Query(queryExpression,
+							spi.WithSortOrder(&spi.SortOptions{
+								Order:   spi.SortDescending,
+								TagName: "numberTag",
+							}),
+							spi.WithPageSize(3),       // nolint: gomnd // Test file
+							spi.WithInitialPageNum(4)) // nolint: gomnd // Test file
+						require.NoError(t, err)
+
+						verifyExpectedIterator(t, iterator, nil, nil, nil, true,
+							options.checkIteratorTotalItemCounts, expectedTotalItemsCount)
+					})
+				})
+			})
+		})
+	})
 }
 
 func randomStoreName() string {


### PR DESCRIPTION
- Updated common storage tests to check and make sure that stores can query without requiring a store configuration (indexes). The interface says that indexes are recommended for large stores, but it doesn't say that they're always required, so storage providers should ensure that they can function without them.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>