### PR TITLE
feat: More storage tests and options

### DIFF
--- a/cmd/aries-js-worker/go.mod
+++ b/cmd/aries-js-worker/go.mod
@@ -21,5 +21,4 @@ replace (
 	github.com/hyperledger/aries-framework-go/component/storage/indexeddb => ../../component/storage/indexeddb
 	github.com/hyperledger/aries-framework-go/component/storageutil => ../../component/storageutil
 	github.com/hyperledger/aries-framework-go/spi => ../../spi
-	github.com/hyperledger/aries-framework-go/test/component => ../../test/component
 )

--- a/cmd/aries-js-worker/go.sum
+++ b/cmd/aries-js-worker/go.sum
@@ -183,6 +183,8 @@ github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvh
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210807121559-b41545a4f1e8 h1:9nd+4NsvBSjH3zIaM0B3Zr5kpaQHMmFFqzgVAE2fG7o=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:3idbNcBl2wdRaETayzpY95KK5SfSzwXb5uqLW/Ldh0g=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=


### PR DESCRIPTION
- Added new storage tests to ensure that SetStoreConfig and GetStoreConfig are also case-insensitive with respect to the store name.
- Added an option to skip all query sorting tests, along with a parameter for only skipping query sorting tests that don't set a store configuration. This is needed for testing storage providers that don't support sorts on queries (or that can only do it when a store configuration is set).
- Reworked the Iterator TotalItems tests option to be an opt-out rather than an opt-in for consistency with the new option mentioned above. This option is now called SkipIteratorTotalItemTests as a result.
- With that newly reworked SkipIteratorTotalItemTests option, there's a new parameter to allow TotalItems checks to occur, but only if a store configuration is set this is needed for testing storage providers that require a store configuration to run TotalItems.
- Removed aries-framework-go/test/component replace directive from aries-js-worker since it causes checks to break when the common test method signatures are updated... and since the indexeddb module lacks a replace, it also can't be updated to have the new method signature in a single commit.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>