### PR TITLE
feat: acapy issue-credential v2 interop support

### DIFF
--- a/pkg/controller/command/kms/command.go
+++ b/pkg/controller/command/kms/command.go
@@ -137,6 +137,8 @@ func (o *Command) ImportKey(rw io.Writer, req io.Reader) command.Error {
 		keyType = kms.ED25519Type
 	case "P-256":
 		keyType = kms.ECDSAP256TypeIEEEP1363
+	case "BLS12381_G2":
+		keyType = kms.BLS12381G2Type
 	default:
 		return command.NewValidationError(InvalidRequestErrorCode,
 			fmt.Errorf("import key type not supported %s", j.Crv))

--- a/pkg/controller/command/verifiable/command_test.go
+++ b/pkg/controller/command/verifiable/command_test.go
@@ -987,8 +987,8 @@ func TestGeneratePresentation(t *testing.T) {
 		require.Equal(t, vp.Proofs[0]["domain"], presReq.Domain)
 		require.Equal(t, vp.Proofs[0]["proofPurpose"], "authentication")
 		require.Contains(t, vp.Proofs[0]["created"], strconv.Itoa(presReq.Created.Year()))
-		require.Equal(t, vp.Proofs[0]["verificationMethod"],
-			"did:peer:123456789abcdefghi#keys-1")
+		require.Equal(t, "did:sample:EiAiSE10ugVUHXsOp4pm86oN6LnjuCdrkt3s12rcVFkilQ#signing-key",
+			vp.Proofs[0]["verificationMethod"])
 	})
 
 	t.Run("test generate presentation with proof options - success (p256 jsonwebsignature)", func(t *testing.T) {
@@ -2125,8 +2125,8 @@ func TestCommand_SignCredential(t *testing.T) {
 		require.Equal(t, vp.Proofs[0]["domain"], req.Domain)
 		require.Equal(t, vp.Proofs[0]["proofPurpose"], "assertionMethod")
 		require.Contains(t, vp.Proofs[0]["created"], strconv.Itoa(req.Created.Year()))
-		require.Equal(t, vp.Proofs[0]["verificationMethod"],
-			"did:peer:123456789abcdefghi#keys-1")
+		require.Equal(t, "did:sample:EiAiSE10ugVUHXsOp4pm86oN6LnjuCdrkt3s12rcVFkilQ#signing-key",
+			vp.Proofs[0]["verificationMethod"])
 	})
 
 	t.Run("test sign credential with proof options - success (p256 jsonwebsignature)", func(t *testing.T) {

--- a/pkg/doc/signature/proof/proof.go
+++ b/pkg/doc/signature/proof/proof.go
@@ -130,7 +130,7 @@ func decodeCapabilityChain(proof map[string]interface{}) ([]interface{}, error) 
 
 func decodeBase64(s string) ([]byte, error) {
 	allEncodings := []*base64.Encoding{
-		base64.RawURLEncoding, base64.StdEncoding,
+		base64.RawURLEncoding, base64.StdEncoding, base64.RawStdEncoding,
 	}
 
 	for _, encoding := range allEncodings {

--- a/pkg/doc/signature/suite/bbsblssignature2020/public_key_verifier_test.go
+++ b/pkg/doc/signature/suite/bbsblssignature2020/public_key_verifier_test.go
@@ -46,14 +46,14 @@ message2
 	require.Error(t, err)
 	require.EqualError(t, err, "a type of public key is not 'Bls12381G2Key2020'")
 
-	// Failed as we do not support JWK for Bls12381G2Key2020.
+	// Success as we now support JWK for Bls12381G2Key2020.
 	err = verifier.Verify(&sigverifier.PublicKey{
 		Type: "Bls12381G2Key2020",
 		JWK: &jwk.JWK{
 			Kty: "EC",
 			Crv: "BLS12381_G2",
 		},
+		Value: pkBytes,
 	}, []byte(msg), sigBytes)
-	require.Error(t, err)
-	require.EqualError(t, err, "verifier does not match JSON Web Key")
+	require.NoError(t, err)
 }

--- a/pkg/doc/signature/verifier/public_key_verifier.go
+++ b/pkg/doc/signature/verifier/public_key_verifier.go
@@ -374,7 +374,13 @@ func NewECDSAES521SignatureVerifier() *ECDSASignatureVerifier {
 
 // NewBBSG2SignatureVerifier creates a new BBSG2SignatureVerifier.
 func NewBBSG2SignatureVerifier() *BBSG2SignatureVerifier {
-	return &BBSG2SignatureVerifier{}
+	return &BBSG2SignatureVerifier{
+		baseSignatureVerifier{
+			keyType:   "EC",
+			curve:     "BLS12381_G2",
+			algorithm: "",
+		},
+	}
 }
 
 // BBSG2SignatureVerifier is a signature verifier that verifies a BBS+ Signature

--- a/pkg/doc/util/time_test.go
+++ b/pkg/doc/util/time_test.go
@@ -24,6 +24,11 @@ func TestTimeWithTrailingZeroMsec(t *testing.T) {
 		{"2018-03-15T00:00:00.000Z", "2018-03-15T00:00:00.000Z"},
 		{"2018-03-15T00:00:00.00000Z", "2018-03-15T00:00:00.00000Z"},
 		{"2018-03-15T00:00:00.0000100Z", "2018-03-15T00:00:00.00001Z"},
+		{"2018-03-15T00:00:00", "2018-03-15T00:00:00"},
+		{"2018-03-15T00:00:00.9724", "2018-03-15T00:00:00.9724"},
+		{"2018-03-15T00:00:00.000", "2018-03-15T00:00:00.000"},
+		{"2018-03-15T00:00:00.00000", "2018-03-15T00:00:00.00000"},
+		{"2018-03-15T00:00:00.0000100", "2018-03-15T00:00:00.00001"},
 	}
 
 	for _, tt := range timeTests {
@@ -52,6 +57,9 @@ func TestTimeWithTrailingZeroMsec(t *testing.T) {
 
 	err = newTimeMsec.UnmarshalJSON([]byte("null"))
 	require.NoError(t, err)
+
+	err = newTimeMsec.UnmarshalJSON([]byte("not string"))
+	require.Error(t, err)
 }
 
 func TestTimeWithTrailingZeroMsec_GetFormat(t *testing.T) {


### PR DESCRIPTION
Fixes & improvements:
- `/kms/import` accepts BLS12381_G2 private keys.
- `/verifiable` commands try to pick verification methods that match
  the requested crypto suite for signing.
- Supports raw base64 fields in proof parsing.
- Supports bbs signature verification through public key verifier
  SignatureVerifier.
- time.Time wrapper handles timestrings without a timezone suffix,
  and will transparently marshal with/without the suffix, as its
  source string was.

Interop tweaks:
- Fixes for handling acapy "peer" DID docs.

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>
