### PR TITLE
docs: update WACI universal wallet interface reference

### DIFF
--- a/cmd/aries-js-worker/src/aries.js
+++ b/cmd/aries-js-worker/src/aries.js
@@ -536,6 +536,7 @@ const Aries = function (opts) {
             },
             /**
              * Sends a propose presentation.
+             * https://w3c-ccg.github.io/universal-wallet-interop-spec/#proposepresentation
              *
              * @param req - json document
              * @returns {Promise<Object>}
@@ -545,6 +546,7 @@ const Aries = function (opts) {
             },
             /**
              * Accepts a problem report.
+             * https://w3c-ccg.github.io/universal-wallet-interop-spec/#presentproof
              *
              * @param req - json document
              * @returns {Promise<Object>}

--- a/docs/vc_wallet.md
+++ b/docs/vc_wallet.md
@@ -580,7 +580,7 @@ Returns,
   
  ``` 
 
-#### [ProposePresentation](https://identity.foundation/waci-presentation-exchange/#step-2-send-message-proposing-presentation)
+#### [ProposePresentation](https://w3c-ccg.github.io/universal-wallet-interop-spec/#proposepresentation)
 Proposing presentation from wallet to initiate WACI share flow.
 
 Params,
@@ -610,7 +610,7 @@ Returns,
   
  ``` 
  
- #### [PresentProof](https://identity.foundation/waci-presentation-exchange/#step-4-present-proof)
+ #### [PresentProof](https://w3c-ccg.github.io/universal-wallet-interop-spec/#presentproof)
  Presenting proof to relying party from wallet for WACI share flow.
  
  Params,

--- a/pkg/client/vcwallet/client.go
+++ b/pkg/client/vcwallet/client.go
@@ -374,6 +374,8 @@ func (c *Client) Connect(invitation *outofband.Invitation, options ...wallet.Con
 // ProposePresentation accepts out-of-band invitation and sends message proposing presentation
 // from wallet to relying party.
 //
+// https://w3c-ccg.github.io/universal-wallet-interop-spec/#proposepresentation
+//
 // Currently Supporting
 // [0454-present-proof-v2](https://github.com/hyperledger/aries-rfcs/tree/master/features/0454-present-proof-v2)
 //
@@ -395,6 +397,7 @@ func (c *Client) ProposePresentation(invitation *outofband.Invitation, options .
 }
 
 // PresentProof sends message present proof message from wallet to relying party.
+// https://w3c-ccg.github.io/universal-wallet-interop-spec/#presentproof
 //
 // Currently Supporting
 // [0454-present-proof-v2](https://github.com/hyperledger/aries-rfcs/tree/master/features/0454-present-proof-v2)

--- a/pkg/controller/command/vcwallet/command.go
+++ b/pkg/controller/command/vcwallet/command.go
@@ -758,6 +758,7 @@ func (o *Command) Connect(rw io.Writer, req io.Reader) command.Error {
 
 // ProposePresentation accepts out-of-band invitation and sends message proposing presentation
 // from wallet to relying party.
+// https://w3c-ccg.github.io/universal-wallet-interop-spec/#proposepresentation
 //
 // Currently Supporting
 // [0454-present-proof-v2](https://github.com/hyperledger/aries-rfcs/tree/master/features/0454-present-proof-v2)
@@ -800,6 +801,7 @@ func (o *Command) ProposePresentation(rw io.Writer, req io.Reader) command.Error
 }
 
 // PresentProof sends present proof message from wallet to relying party.
+// https://w3c-ccg.github.io/universal-wallet-interop-spec/#presentproof
 //
 // Currently Supporting
 // [0454-present-proof-v2](https://github.com/hyperledger/aries-rfcs/tree/master/features/0454-present-proof-v2)

--- a/pkg/controller/rest/vcwallet/operation.go
+++ b/pkg/controller/rest/vcwallet/operation.go
@@ -356,6 +356,7 @@ func (o *Operation) Connect(rw http.ResponseWriter, req *http.Request) {
 //
 // accepts out-of-band invitation and sends message proposing presentation
 // from wallet to relying party.
+// https://w3c-ccg.github.io/universal-wallet-interop-spec/#proposepresentation
 //
 // Currently Supporting
 // [0454-present-proof-v2](https://github.com/hyperledger/aries-rfcs/tree/master/features/0454-present-proof-v2)
@@ -370,6 +371,7 @@ func (o *Operation) ProposePresentation(rw http.ResponseWriter, req *http.Reques
 // PresentProof swagger:route POST /vcwallet/present-proof vcwallet presentProofReq
 //
 // sends message present proof message from wallet to relying party.
+// https://w3c-ccg.github.io/universal-wallet-interop-spec/#presentproof
 //
 // Currently Supporting
 // [0454-present-proof-v2](https://github.com/hyperledger/aries-rfcs/tree/master/features/0454-present-proof-v2)

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -662,6 +662,7 @@ func (c *Wallet) Connect(authToken string, invitation *outofband.Invitation, opt
 
 // ProposePresentation accepts out-of-band invitation and sends message proposing presentation
 // from wallet to relying party.
+// https://w3c-ccg.github.io/universal-wallet-interop-spec/#proposepresentation
 //
 // Currently Supporting
 // [0454-present-proof-v2](https://github.com/hyperledger/aries-rfcs/tree/master/features/0454-present-proof-v2)
@@ -706,6 +707,7 @@ func (c *Wallet) ProposePresentation(authToken string, invitation *outofband.Inv
 }
 
 // PresentProof sends message present proof message from wallet to relying party.
+// https://w3c-ccg.github.io/universal-wallet-interop-spec/#presentproof
 //
 // Currently Supporting
 // [0454-present-proof-v2](https://github.com/hyperledger/aries-rfcs/tree/master/features/0454-present-proof-v2)


### PR DESCRIPTION
Since WACI interfaces are now updated in universal wallet spec, aries
vcwallet documentations are updated to refer WACI interfaces.

Part of #2433

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
