### PR TITLE
fix: rewrite util/time to save a time string instead of using zero-counting logic

### DIFF
--- a/pkg/client/vcwallet/client_test.go
+++ b/pkg/client/vcwallet/client_test.go
@@ -930,7 +930,7 @@ func TestClient_Query(t *testing.T) {
 		CustomFields: map[string]interface{}{
 			"first_name": "Jesse",
 		},
-		Issued: &util.TimeWithTrailingZeroMsec{
+		Issued: &util.TimeWrapper{
 			Time: time.Now(),
 		},
 		Issuer: verifiable.Issuer{

--- a/pkg/didcomm/protocol/middleware/presentproof/middlewares_test.go
+++ b/pkg/didcomm/protocol/middleware/presentproof/middlewares_test.go
@@ -436,7 +436,7 @@ func TestPresentationDefinition(t *testing.T) {
 						Context: []string{verifiable.ContextURI},
 						Types:   []string{verifiable.VCType},
 						Subject: "did:example:76e12ec712ebc6f1c221ebfeb1f",
-						Issued: &util.TimeWithTrailingZeroMsec{
+						Issued: &util.TimeWrapper{
 							Time: time.Now(),
 						},
 						Issuer: verifiable.Issuer{
@@ -507,7 +507,7 @@ func TestPresentationDefinition(t *testing.T) {
 						Context: []string{verifiable.ContextURI},
 						Types:   []string{verifiable.VCType},
 						Subject: "did:example:76e12ec712ebc6f1c221ebfeb1f",
-						Issued: &util.TimeWithTrailingZeroMsec{
+						Issued: &util.TimeWrapper{
 							Time: time.Now(),
 						},
 						Issuer: verifiable.Issuer{

--- a/pkg/doc/presexch/api_test.go
+++ b/pkg/doc/presexch/api_test.go
@@ -379,7 +379,7 @@ func newVC(ctx []string) *verifiable.Credential {
 		Types:   []string{verifiable.VCType},
 		ID:      "http://test.credential.com/123",
 		Issuer:  verifiable.Issuer{ID: "http://test.issuer.com"},
-		Issued: &util.TimeWithTrailingZeroMsec{
+		Issued: &util.TimeWrapper{
 			Time: time.Now(),
 		},
 		Subject: map[string]interface{}{

--- a/pkg/doc/presexch/definition_test.go
+++ b/pkg/doc/presexch/definition_test.go
@@ -303,7 +303,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 				Types:   []string{verifiable.VCType},
 				ID:      "http://example.edu/credentials/1872",
 				Subject: "did:example:76e12ec712ebc6f1c221ebfeb1f",
-				Issued: &util.TimeWithTrailingZeroMsec{
+				Issued: &util.TimeWrapper{
 					Time: time.Now(),
 				},
 				Issuer: verifiable.Issuer{
@@ -359,7 +359,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 				Types:   []string{verifiable.VCType},
 				ID:      "http://example.edu/credentials/1872",
 				Subject: "did:example:76e12ec712ebc6f1c221ebfeb1f",
-				Issued: &util.TimeWithTrailingZeroMsec{
+				Issued: &util.TimeWrapper{
 					Time: time.Now(),
 				},
 				Issuer: verifiable.Issuer{
@@ -433,10 +433,10 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 					},
 				},
 			},
-			Issued: &util.TimeWithTrailingZeroMsec{
+			Issued: &util.TimeWrapper{
 				Time: time.Now(),
 			},
-			Expired: &util.TimeWithTrailingZeroMsec{
+			Expired: &util.TimeWrapper{
 				Time: time.Now().AddDate(1, 0, 0),
 			},
 			Issuer: verifiable.Issuer{
@@ -550,10 +550,10 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 					"birthDate":              "1958-07-17",
 				},
 			},
-			Issued: &util.TimeWithTrailingZeroMsec{
+			Issued: &util.TimeWrapper{
 				Time: time.Now(),
 			},
-			Expired: &util.TimeWithTrailingZeroMsec{
+			Expired: &util.TimeWrapper{
 				Time: time.Now().AddDate(1, 0, 0),
 			},
 			Issuer: verifiable.Issuer{
@@ -811,7 +811,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 				Types:   []string{"VerifiableCredential"},
 				Subject: []map[string]interface{}{{"id": issuerID}},
 				Issuer:  verifiable.Issuer{ID: issuerID},
-				Issued: &util.TimeWithTrailingZeroMsec{
+				Issued: &util.TimeWrapper{
 					Time: time.Now(),
 				},
 				CustomFields: map[string]interface{}{

--- a/pkg/doc/presexch/example_test.go
+++ b/pkg/doc/presexch/example_test.go
@@ -61,7 +61,7 @@ func ExamplePresentationDefinition_CreateVP() {
 			Issuer: verifiable.Issuer{
 				ID: "did:example:76e12ec712ebc6f1c221ebfeb1f",
 			},
-			Issued: &util.TimeWithTrailingZeroMsec{
+			Issued: &util.TimeWrapper{
 				Time: time.Time{},
 			},
 			Subject: "did:example:76e12ec712ebc6f1c221ebfeb1f",
@@ -171,7 +171,7 @@ func ExamplePresentationDefinition_CreateVP_multipleMatches() {
 			Issuer: verifiable.Issuer{
 				ID: "did:example:777",
 			},
-			Issued: &util.TimeWithTrailingZeroMsec{
+			Issued: &util.TimeWrapper{
 				Time: time.Time{},
 			},
 			Subject: "did:example:777",
@@ -188,7 +188,7 @@ func ExamplePresentationDefinition_CreateVP_multipleMatches() {
 			Issuer: verifiable.Issuer{
 				ID: "did:example:888",
 			},
-			Issued: &util.TimeWithTrailingZeroMsec{
+			Issued: &util.TimeWrapper{
 				Time: time.Time{},
 			},
 			Subject: "did:example:888",
@@ -331,7 +331,7 @@ func ExamplePresentationDefinition_CreateVP_multipleMatchesDisclosure() {
 			Issuer: verifiable.Issuer{
 				ID: "did:example:777",
 			},
-			Issued: &util.TimeWithTrailingZeroMsec{
+			Issued: &util.TimeWrapper{
 				Time: time.Time{},
 			},
 			Subject: "did:example:777",
@@ -348,7 +348,7 @@ func ExamplePresentationDefinition_CreateVP_multipleMatchesDisclosure() {
 			Issuer: verifiable.Issuer{
 				ID: "did:example:888",
 			},
-			Issued: &util.TimeWithTrailingZeroMsec{
+			Issued: &util.TimeWrapper{
 				Time: time.Time{},
 			},
 			Subject: "did:example:888",
@@ -553,7 +553,7 @@ func ExamplePresentationDefinition_CreateVP_submissionRequirementsLimitDisclosur
 			Issuer: verifiable.Issuer{
 				ID: "did:example:777",
 			},
-			Issued: &util.TimeWithTrailingZeroMsec{
+			Issued: &util.TimeWrapper{
 				Time: time.Time{},
 			},
 			Subject: "did:example:777",
@@ -571,7 +571,7 @@ func ExamplePresentationDefinition_CreateVP_submissionRequirementsLimitDisclosur
 			Issuer: verifiable.Issuer{
 				ID: "did:example:888",
 			},
-			Issued: &util.TimeWithTrailingZeroMsec{
+			Issued: &util.TimeWrapper{
 				Time: time.Time{},
 			},
 			Subject: "did:example:888",
@@ -775,7 +775,7 @@ func ExamplePresentationDefinition_CreateVP_submissionRequirements() {
 			Issuer: verifiable.Issuer{
 				ID: "did:example:777",
 			},
-			Issued: &util.TimeWithTrailingZeroMsec{
+			Issued: &util.TimeWrapper{
 				Time: time.Time{},
 			},
 			Subject: "did:example:777",
@@ -793,7 +793,7 @@ func ExamplePresentationDefinition_CreateVP_submissionRequirements() {
 			Issuer: verifiable.Issuer{
 				ID: "did:example:888",
 			},
-			Issued: &util.TimeWithTrailingZeroMsec{
+			Issued: &util.TimeWrapper{
 				Time: time.Time{},
 			},
 			Subject: "did:example:888",
@@ -1032,7 +1032,7 @@ func fetchVC(ctx, types []string) *verifiable.Credential {
 		Types:   append([]string{verifiable.VCType}, types...),
 		ID:      "http://test.credential.com/123",
 		Issuer:  verifiable.Issuer{ID: "http://test.issuer.com"},
-		Issued: &util.TimeWithTrailingZeroMsec{
+		Issued: &util.TimeWrapper{
 			Time: time.Now(),
 		},
 		Subject: map[string]interface{}{

--- a/pkg/doc/signature/proof/proof.go
+++ b/pkg/doc/signature/proof/proof.go
@@ -41,7 +41,7 @@ const (
 // Proof is cryptographic proof of the integrity of the DID Document.
 type Proof struct {
 	Type                    string
-	Created                 *util.TimeWithTrailingZeroMsec
+	Created                 *util.TimeWrapper
 	Creator                 string
 	VerificationMethod      string
 	ProofValue              []byte
@@ -59,7 +59,7 @@ type Proof struct {
 func NewProof(emap map[string]interface{}) (*Proof, error) {
 	created := stringEntry(emap[jsonldCreated])
 
-	timeValue, err := util.ParseTimeWithTrailingZeroMsec(created)
+	timeValue, err := util.ParseTimeWrapper(created)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func (p *Proof) JSONLdObject() map[string]interface{} { // nolint:gocyclo
 	}
 
 	if p.Created != nil {
-		emap[jsonldCreated] = p.Created.Format(p.Created.GetFormat())
+		emap[jsonldCreated] = p.Created.FormatToString()
 	}
 
 	if len(p.ProofValue) > 0 {

--- a/pkg/doc/signature/proof/proof_test.go
+++ b/pkg/doc/signature/proof/proof_test.go
@@ -73,7 +73,7 @@ func TestProof(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, err)
-	require.Equal(t, "2018-03-15T00:00:00.00000Z", p.Created.Format(p.Created.GetFormat()))
+	require.Equal(t, "2018-03-15T00:00:00.00000Z", p.Created.FormatToString())
 
 	t.Run("capabilityChain", func(t *testing.T) {
 		t.Run("parses capabilityChain", func(t *testing.T) {
@@ -208,7 +208,9 @@ func TestProof_JSONLdObject(t *testing.T) {
 	created, err = time.Parse(time.RFC3339Nano, "2018-03-15T00:00:00.000Z")
 	require.NoError(t, err)
 
-	p.Created = util.NewTimeWithTrailingZeroMsec(created, 3)
+	p.Created, err = util.ParseTimeWrapper("2018-03-15T00:00:00.000Z")
+	require.NoError(t, err)
+
 	pJSONLd = p.JSONLdObject()
 	r.Equal("2018-03-15T00:00:00.000Z", pJSONLd["created"])
 

--- a/pkg/doc/signature/signer/signer.go
+++ b/pkg/doc/signature/signer/signer.go
@@ -105,7 +105,7 @@ func (signer *DocumentSigner) signObject(context *Context, jsonLdObject map[stri
 		Type:                    context.SignatureType,
 		SignatureRepresentation: context.SignatureRepresentation,
 		Creator:                 context.Creator,
-		Created:                 &util.TimeWithTrailingZeroMsec{Time: *created},
+		Created:                 &util.TimeWrapper{Time: *created},
 		Domain:                  context.Domain,
 		Nonce:                   context.Nonce,
 		VerificationMethod:      context.VerificationMethod,

--- a/pkg/doc/util/time.go
+++ b/pkg/doc/util/time.go
@@ -11,57 +11,60 @@ import (
 	"time"
 )
 
+// TimeWrapper overrides marshalling of time.Time. If a TimeWrapper is created from a time string, or
+// unmarshalled from JSON, it saves the string literal, which it uses when marshalling.
+// If a TimeWrapper is created using NewTime or a struct literal, it marshals with the default
+// time.RFC3339 format.
+type TimeWrapper struct {
+	time.Time
+	timeStr string
+}
+
 // TimeWithTrailingZeroMsec overrides marshalling of time.Time. It keeps a format of initial unmarshalling
 // in case when date has zero a fractional second (e.g. ".000").
 // For example, time.Time marshals 2018-03-15T00:00:00.000Z to 2018-03-15T00:00:00Z
 // while TimeWithTrailingZeroMsec marshals to the initial 2018-03-15T00:00:00.000Z value.
-type TimeWithTrailingZeroMsec struct {
-	time.Time
+//
+// Deprecated: use TimeWrapper instead.
+type TimeWithTrailingZeroMsec = TimeWrapper
 
-	trailingZerosMsecCount int
-	missingZ               bool
-}
-
-const (
-	rfc3339NanoWithoutZ = "2006-01-02T15:04:05.999999999"
-)
-
-// NewTime creates TimeWithTrailingZeroMsec without zero sub-second precision.
+// NewTime creates a TimeWrapper wrapped around the given time.Time.
 // It functions as a normal time.Time object.
-func NewTime(t time.Time) *TimeWithTrailingZeroMsec {
-	return &TimeWithTrailingZeroMsec{Time: t}
+func NewTime(t time.Time) *TimeWrapper {
+	return &TimeWrapper{Time: t}
 }
 
-// NewTimeWithTrailingZeroMsec creates TimeWithTrailingZeroMsec with certain zero sub-second precision.
-func NewTimeWithTrailingZeroMsec(t time.Time, trailingZerosMsecCount int) *TimeWithTrailingZeroMsec {
-	return &TimeWithTrailingZeroMsec{
-		Time:                   t,
-		trailingZerosMsecCount: trailingZerosMsecCount,
+// NewTimeWithTrailingZeroMsec creates a TimeWrapper wrapped around the given time.Time.
+//
+// Deprecated: use NewTime instead. For sub-zero precision,
+// use ParseTimeWrapper on a string with the desired precision.
+func NewTimeWithTrailingZeroMsec(t time.Time, _ int) *TimeWrapper {
+	return &TimeWrapper{
+		Time: t,
 	}
 }
 
 // MarshalJSON implements the json.Marshaler interface.
 // The time is a quoted string in RFC 3339 format, with sub-second precision added if present.
 // In case of zero sub-second precision presence, trailing zeros are included.
-func (tm TimeWithTrailingZeroMsec) MarshalJSON() ([]byte, error) {
-	if _, err := tm.Time.MarshalJSON(); err != nil {
+func (tm TimeWrapper) MarshalJSON() ([]byte, error) {
+	// catch time.Time marshaling errors
+	_, err := tm.Time.MarshalJSON()
+	if err != nil {
 		return nil, err
 	}
 
-	format := tm.GetFormat()
+	if tm.timeStr != "" {
+		return json.Marshal(tm.timeStr)
+	}
 
-	b := make([]byte, 0, len(format)+len(`""`))
-	b = append(b, '"')
-	b = tm.AppendFormat(b, format)
-	b = append(b, '"')
-
-	return b, nil
+	return json.Marshal(tm.FormatToString())
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 // The time is expected to be a quoted string in RFC 3339 format.
-// In case of zero sub-second precision, it's kept and applied when e.g. unmarshal the time to JSON.
-func (tm *TimeWithTrailingZeroMsec) UnmarshalJSON(data []byte) error {
+// The source string value is saved, and used if this is marshalled back to JSON.
+func (tm *TimeWrapper) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
 		return nil
 	}
@@ -81,42 +84,42 @@ func (tm *TimeWithTrailingZeroMsec) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (tm *TimeWithTrailingZeroMsec) parse(timeStr string) error {
-	missingZ := false
-
+func (tm *TimeWrapper) parse(timeStr string) error {
 	t, err := time.Parse(time.RFC3339, timeStr)
 	if err != nil {
 		t, err = time.Parse(time.RFC3339, timeStr+"Z")
 		if err != nil {
 			return err
 		}
-
-		missingZ = true
 	}
 
 	tm.Time = t
-	tm.missingZ = missingZ
-	tm.keepTrailingZerosMsecFormat(timeStr)
+	tm.timeStr = timeStr
 
 	return nil
 }
 
-// GetFormat returns customized time.RFC3339Nano with trailing zeros included in case of
-// zero sub-second precision presence. Otherwise it returns time.RFC3339Nano.
-func (tm TimeWithTrailingZeroMsec) GetFormat() string {
-	if tm.trailingZerosMsecCount > 0 {
-		return tm.getTrailingZeroIncludedFormat()
-	} else if tm.missingZ {
-		return rfc3339NanoWithoutZ
+// FormatToString returns the string representation of this TimeWrapper.
+// If it was unmarshalled from a JSON object, this returns the original string it was parsed from.
+// Otherwise, this returns the time in the time.RFC3339Nano format.
+func (tm *TimeWrapper) FormatToString() string {
+	if tm.timeStr != "" {
+		return tm.timeStr
 	}
 
-	return time.RFC3339Nano
+	return tm.Time.Format(time.RFC3339Nano)
 }
 
 // ParseTimeWithTrailingZeroMsec parses a formatted string and returns the time value it represents.
-// In case of zero sub-second precision, it's kept and applied when e.g. unmarshal the time to JSON.
-func ParseTimeWithTrailingZeroMsec(timeStr string) (*TimeWithTrailingZeroMsec, error) {
-	tm := TimeWithTrailingZeroMsec{}
+//
+// Deprecated: use ParseTimeWrapper instead.
+func ParseTimeWithTrailingZeroMsec(timeStr string) (*TimeWrapper, error) {
+	return ParseTimeWrapper(timeStr)
+}
+
+// ParseTimeWrapper parses a formatted string and returns the time value it represents.
+func ParseTimeWrapper(timeStr string) (*TimeWrapper, error) {
+	tm := TimeWrapper{}
 
 	err := tm.parse(timeStr)
 	if err != nil {
@@ -124,54 +127,4 @@ func ParseTimeWithTrailingZeroMsec(timeStr string) (*TimeWithTrailingZeroMsec, e
 	}
 
 	return &tm, nil
-}
-
-func (tm TimeWithTrailingZeroMsec) getTrailingZeroIncludedFormat() string {
-	format := "2006-01-02T15:04:05."
-
-	for i := 0; i < tm.trailingZerosMsecCount; i++ {
-		format += "0"
-	}
-
-	if !tm.missingZ {
-		format += "Z07:00"
-	}
-
-	return format
-}
-
-func (tm *TimeWithTrailingZeroMsec) keepTrailingZerosMsecFormat(timeStr string) {
-	msecFraction := false
-	zerosCount := 0
-
-	i := 0
-	for ; i < len(timeStr); i++ {
-		c := int(timeStr[i])
-		if !msecFraction {
-			if c == '.' {
-				msecFraction = true
-			}
-
-			continue
-		}
-
-		if c == 'Z' || c == 'z' {
-			if zerosCount > 0 {
-				tm.trailingZerosMsecCount = zerosCount
-			}
-
-			break
-		} else if c != '0' {
-			break
-		}
-
-		zerosCount++
-	}
-
-	// if we run off the end of the string, remember any trailing zeros
-	if i == len(timeStr) {
-		if zerosCount > 0 {
-			tm.trailingZerosMsecCount = zerosCount
-		}
-	}
 }

--- a/pkg/doc/util/time_test.go
+++ b/pkg/doc/util/time_test.go
@@ -23,18 +23,21 @@ func TestTimeWithTrailingZeroMsec(t *testing.T) {
 		{"2018-03-15T00:00:00.9724Z", "2018-03-15T00:00:00.9724Z"},
 		{"2018-03-15T00:00:00.000Z", "2018-03-15T00:00:00.000Z"},
 		{"2018-03-15T00:00:00.00000Z", "2018-03-15T00:00:00.00000Z"},
-		{"2018-03-15T00:00:00.0000100Z", "2018-03-15T00:00:00.00001Z"},
+		{"2018-03-15T00:00:00.0000100Z", "2018-03-15T00:00:00.0000100Z"},
+		{"2018-03-15T00:00:00.0000100+07:00", "2018-03-15T00:00:00.0000100+07:00"},
+		{"2018-03-15T00:00:00.0000100-07:00", "2018-03-15T00:00:00.0000100-07:00"},
 		{"2018-03-15T00:00:00", "2018-03-15T00:00:00"},
 		{"2018-03-15T00:00:00.9724", "2018-03-15T00:00:00.9724"},
 		{"2018-03-15T00:00:00.000", "2018-03-15T00:00:00.000"},
 		{"2018-03-15T00:00:00.00000", "2018-03-15T00:00:00.00000"},
-		{"2018-03-15T00:00:00.0000100", "2018-03-15T00:00:00.00001"},
+		{"2018-03-15T00:00:00.0000100", "2018-03-15T00:00:00.0000100"},
+		{"2021-08-24T22:18:06.333020", "2021-08-24T22:18:06.333020"}, // acapy interop corner case
 	}
 
 	for _, tt := range timeTests {
 		tt := tt
 		t.Run(tt.in, func(t *testing.T) {
-			var timeMsec TimeWithTrailingZeroMsec
+			var timeMsec TimeWrapper
 			err := json.Unmarshal([]byte(quote(tt.in)), &timeMsec)
 			require.NoError(t, err)
 
@@ -45,13 +48,23 @@ func TestTimeWithTrailingZeroMsec(t *testing.T) {
 	}
 
 	// Marshal corner cases.
-	timeMsec := TimeWithTrailingZeroMsec{Time: time.Date(10001, time.January, 1, 0, 0, 0, 0, time.UTC)}
+	timeMsec := &TimeWrapper{Time: time.Date(10001, time.January, 1, 0, 0, 0, 0, time.UTC)}
 	bytes, err := timeMsec.MarshalJSON()
 	require.Error(t, err)
 	require.Nil(t, bytes)
 
+	timeMsec = NewTime(time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC))
+	bytes, err = timeMsec.MarshalJSON()
+	require.NoError(t, err)
+	require.NotNil(t, bytes)
+
+	timeMsec = NewTimeWithTrailingZeroMsec(time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC), 0)
+	bytes, err = timeMsec.MarshalJSON()
+	require.NoError(t, err)
+	require.NotNil(t, bytes)
+
 	// Unmarshal corner cases.
-	newTimeMsec := &TimeWithTrailingZeroMsec{}
+	newTimeMsec := &TimeWrapper{}
 	err = newTimeMsec.UnmarshalJSON([]byte(quote("not_date")))
 	require.Error(t, err)
 
@@ -62,31 +75,21 @@ func TestTimeWithTrailingZeroMsec(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestTimeWithTrailingZeroMsec_GetFormat(t *testing.T) {
-	timeMsec, err := ParseTimeWithTrailingZeroMsec("2018-03-15T00:00:00Z")
-	require.NoError(t, err)
-	require.Equal(t, time.RFC3339Nano, timeMsec.GetFormat())
-
-	timeMsec, err = ParseTimeWithTrailingZeroMsec("2018-03-15T00:00:00.972Z")
-	require.NoError(t, err)
-	require.Equal(t, time.RFC3339Nano, timeMsec.GetFormat())
-
-	timeMsec, err = ParseTimeWithTrailingZeroMsec("2018-03-15T00:00:00.000Z")
-	require.NoError(t, err)
-	require.Equal(t, "2006-01-02T15:04:05.000Z07:00", timeMsec.GetFormat())
-}
-
 func TestParse(t *testing.T) {
-	timeMsec, err := ParseTimeWithTrailingZeroMsec("2018-03-15T00:00:00.000Z")
+	timeMsec, err := ParseTimeWrapper("2018-03-15T00:00:00.000Z")
 	require.NoError(t, err)
-	require.Equal(t, "2018-03-15T00:00:00.000Z", timeMsec.Format(timeMsec.GetFormat()))
+	require.Equal(t, "2018-03-15T00:00:00.000Z", timeMsec.FormatToString())
+
+	timeMsec, err = ParseTimeWrapper("2018-03-15T00:00:00.123Z")
+	require.NoError(t, err)
+	require.Equal(t, "2018-03-15T00:00:00.123Z", timeMsec.FormatToString())
 
 	timeMsec, err = ParseTimeWithTrailingZeroMsec("2018-03-15T00:00:00.123Z")
 	require.NoError(t, err)
-	require.Equal(t, "2018-03-15T00:00:00.123Z", timeMsec.Format(timeMsec.GetFormat()))
+	require.Equal(t, "2018-03-15T00:00:00.123Z", timeMsec.FormatToString())
 
 	// error case
-	timeMsec, err = ParseTimeWithTrailingZeroMsec("invalid")
+	timeMsec, err = ParseTimeWrapper("invalid")
 	require.Error(t, err)
 	require.Nil(t, timeMsec)
 }

--- a/pkg/doc/verifiable/credential.go
+++ b/pkg/doc/verifiable/credential.go
@@ -500,8 +500,8 @@ type Credential struct {
 	// Subject can be a string, map, slice of maps, struct (Subject or any custom), slice of structs.
 	Subject        interface{}
 	Issuer         Issuer
-	Issued         *util.TimeWithTrailingZeroMsec
-	Expired        *util.TimeWithTrailingZeroMsec
+	Issued         *util.TimeWrapper
+	Expired        *util.TimeWrapper
 	Proofs         []Proof
 	Status         *TypedID
 	Schemas        []TypedID
@@ -514,19 +514,19 @@ type Credential struct {
 
 // rawCredential is a basic verifiable credential.
 type rawCredential struct {
-	Context        interface{}                    `json:"@context,omitempty"`
-	ID             string                         `json:"id,omitempty"`
-	Type           interface{}                    `json:"type,omitempty"`
-	Subject        json.RawMessage                `json:"credentialSubject,omitempty"`
-	Issued         *util.TimeWithTrailingZeroMsec `json:"issuanceDate,omitempty"`
-	Expired        *util.TimeWithTrailingZeroMsec `json:"expirationDate,omitempty"`
-	Proof          json.RawMessage                `json:"proof,omitempty"`
-	Status         *TypedID                       `json:"credentialStatus,omitempty"`
-	Issuer         json.RawMessage                `json:"issuer,omitempty"`
-	Schema         interface{}                    `json:"credentialSchema,omitempty"`
-	Evidence       Evidence                       `json:"evidence,omitempty"`
-	TermsOfUse     json.RawMessage                `json:"termsOfUse,omitempty"`
-	RefreshService json.RawMessage                `json:"refreshService,omitempty"`
+	Context        interface{}       `json:"@context,omitempty"`
+	ID             string            `json:"id,omitempty"`
+	Type           interface{}       `json:"type,omitempty"`
+	Subject        json.RawMessage   `json:"credentialSubject,omitempty"`
+	Issued         *util.TimeWrapper `json:"issuanceDate,omitempty"`
+	Expired        *util.TimeWrapper `json:"expirationDate,omitempty"`
+	Proof          json.RawMessage   `json:"proof,omitempty"`
+	Status         *TypedID          `json:"credentialStatus,omitempty"`
+	Issuer         json.RawMessage   `json:"issuer,omitempty"`
+	Schema         interface{}       `json:"credentialSchema,omitempty"`
+	Evidence       Evidence          `json:"evidence,omitempty"`
+	TermsOfUse     json.RawMessage   `json:"termsOfUse,omitempty"`
+	RefreshService json.RawMessage   `json:"refreshService,omitempty"`
 
 	// All unmapped fields are put here.
 	CustomFields `json:"-"`

--- a/pkg/vdr/verifiable_compat_test.go
+++ b/pkg/vdr/verifiable_compat_test.go
@@ -241,7 +241,7 @@ func universityDegreeVC() *verifiable.Credential {
 				"name": "Transmute University",
 			},
 		},
-		Issued: &util.TimeWithTrailingZeroMsec{Time: time.Now()},
+		Issued: &util.TimeWrapper{Time: time.Now()},
 		Subject: &verifiable.Subject{
 			ID: "did:example:ebfeb1f712ebc6f1c276e12ec21",
 			CustomFields: map[string]interface{}{

--- a/pkg/wallet/query_test.go
+++ b/pkg/wallet/query_test.go
@@ -241,7 +241,7 @@ func TestQuery_PerformQuery(t *testing.T) {
 		CustomFields: map[string]interface{}{
 			"first_name": "Jesse",
 		},
-		Issued: &util.TimeWithTrailingZeroMsec{
+		Issued: &util.TimeWrapper{
 			Time: time.Now(),
 		},
 		Issuer: verifiable.Issuer{
@@ -800,7 +800,7 @@ func TestQueryByExample(t *testing.T) {
 		CustomFields: map[string]interface{}{
 			"first_name": "Jesse",
 		},
-		Issued: &util.TimeWithTrailingZeroMsec{
+		Issued: &util.TimeWrapper{
 			Time: time.Now(),
 		},
 		Issuer: verifiable.Issuer{

--- a/pkg/wallet/wallet_test.go
+++ b/pkg/wallet/wallet_test.go
@@ -1041,7 +1041,7 @@ func TestWallet_Query(t *testing.T) {
 		CustomFields: map[string]interface{}{
 			"first_name": "Jesse",
 		},
-		Issued: &util.TimeWithTrailingZeroMsec{
+		Issued: &util.TimeWrapper{
 			Time: time.Now(),
 		},
 		Issuer: verifiable.Issuer{

--- a/test/bdd/pkg/presentproof/presentproof_sdk_steps.go
+++ b/test/bdd/pkg/presentproof/presentproof_sdk_steps.go
@@ -380,10 +380,10 @@ func (a *SDKSteps) acceptRequestPresentationBBS(prover, _, proof string) error {
 				},
 			},
 		},
-		Issued: &util.TimeWithTrailingZeroMsec{
+		Issued: &util.TimeWrapper{
 			Time: time.Now(),
 		},
-		Expired: &util.TimeWithTrailingZeroMsec{
+		Expired: &util.TimeWrapper{
 			Time: time.Now().AddDate(1, 0, 0),
 		},
 		Issuer: verifiable.Issuer{


### PR DESCRIPTION
Fixes issues in parsing acapy time strings, generalizing the previous solution to allow any input document to be processed (eg, verify proof) without reformatting time values.

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>