### PR TITLE
feat: support DID Doc KeyAgreement.ID as kid/skid for DIDCommV2

### DIFF
--- a/pkg/client/vcwallet/client.go
+++ b/pkg/client/vcwallet/client.go
@@ -36,6 +36,7 @@ type provider interface {
 	VDRegistry() vdr.Registry
 	Crypto() crypto.Crypto
 	JSONLDDocumentLoader() ld.DocumentLoader
+	MediaTypeProfiles() []string
 	didCommProvider // to be used only if wallet needs to be participated in DIDComm.
 }
 

--- a/pkg/controller/command/didexchange/command.go
+++ b/pkg/controller/command/didexchange/command.go
@@ -93,6 +93,7 @@ type provider interface {
 	ProtocolStateStorageProvider() storage.Provider
 	KeyType() kms.KeyType
 	KeyAgreementType() kms.KeyType
+	MediaTypeProfiles() []string
 }
 
 // New returns new DID Exchange controller command instance.

--- a/pkg/controller/command/vcwallet/command.go
+++ b/pkg/controller/command/vcwallet/command.go
@@ -169,6 +169,7 @@ type provider interface {
 	VDRegistry() vdr.Registry
 	Crypto() crypto.Crypto
 	JSONLDDocumentLoader() ld.DocumentLoader
+	MediaTypeProfiles() []string
 	didCommProvider // to be used only if wallet needs to be participated in DIDComm.
 }
 

--- a/pkg/controller/rest/didexchange/operation.go
+++ b/pkg/controller/rest/didexchange/operation.go
@@ -46,6 +46,7 @@ type provider interface {
 	ProtocolStateStorageProvider() storage.Provider
 	KeyType() kms.KeyType
 	KeyAgreementType() kms.KeyType
+	MediaTypeProfiles() []string
 }
 
 // New returns new DID Exchange rest client protocol instance.

--- a/pkg/controller/rest/vcwallet/operation.go
+++ b/pkg/controller/rest/vcwallet/operation.go
@@ -55,6 +55,7 @@ type provider interface {
 	VDRegistry() vdr.Registry
 	Crypto() crypto.Crypto
 	JSONLDDocumentLoader() ld.DocumentLoader
+	MediaTypeProfiles() []string
 	didCommProvider // to be used only if wallet needs to be participated in DIDComm.
 }
 

--- a/pkg/didcomm/packager/packager.go
+++ b/pkg/didcomm/packager/packager.go
@@ -155,7 +155,9 @@ func (bp *Packager) prepareSenderAndRecipientKeys(cty string, envelope *transpor
 				"senderVerKey: %w", err)
 		}
 
-		senderKID = senderKey.X // for legacy, use the sender raw key (Ed25519 key)
+		if isLegacy {
+			senderKID = senderKey.X // for legacy, use the sender raw key (Ed25519 key)
+		}
 
 		if !isLegacy {
 			senderKID = buildSenderKID(senderKey, envelope)

--- a/pkg/didcomm/packer/authcrypt/pack.go
+++ b/pkg/didcomm/packer/authcrypt/pack.go
@@ -250,10 +250,12 @@ func (p *Packer) extractSenderKey(jwe *jose.JSONWebEncryption) ([]byte, error) {
 				senderKey, err = r.Resolve(skid)
 				if err != nil {
 					logger.Debugf("authcrypt Unpack: unpack successful, but resolving sender key failed [%v] "+
-						" using %T resolver, skipping it.", err.Error(), r)
+						"using %T resolver, skipping it.", err.Error(), r)
 				}
 
 				if senderKey != nil {
+					logger.Debugf("authcrypt Unpack: unpack successful with resolving sender key success "+
+						"using %T resolver, will be using resolved senderKey for skid: %v", r, skid)
 					break
 				}
 			}

--- a/pkg/didcomm/protocol/didexchange/keys_test.go
+++ b/pkg/didcomm/protocol/didexchange/keys_test.go
@@ -11,18 +11,33 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol"
+	mockroute "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/mediator"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
 	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 )
 
 func TestCreateNewKeyAndVM(t *testing.T) {
 	k := newKMS(t, mockstorage.NewMockStoreProvider())
 
+	p, err := New(&protocol.MockProvider{
+		ServiceMap: map[string]interface{}{
+			mediator.Coordination: &mockroute.MockMediatorSvc{},
+		},
+		CustomKMS: k,
+	})
+	require.NoError(t, err)
+
 	t.Run("createNewKeyAndVM success", func(t *testing.T) {
 		didDoc := &did.Doc{}
 
-		err := createNewKeyAndVM(didDoc, kms.ED25519, kms.X25519ECDHKWType, k)
+		p.ctx.keyType = kms.ED25519
+		p.ctx.keyAgreementType = kms.X25519ECDHKWType
+
+		err = p.ctx.createNewKeyAndVM(didDoc)
 		require.NoError(t, err)
 		require.Equal(t, ed25519VerificationKey2018, didDoc.VerificationMethod[0].Type)
 		require.Equal(t, x25519KeyAgreementKey2019, didDoc.KeyAgreement[0].VerificationMethod.Type)
@@ -31,7 +46,10 @@ func TestCreateNewKeyAndVM(t *testing.T) {
 	t.Run("createNewKeyAndVM invalid keyType export signing key", func(t *testing.T) {
 		didDoc := &did.Doc{}
 
-		err := createNewKeyAndVM(didDoc, kms.HMACSHA256Tag256Type, kms.X25519ECDHKWType, k)
+		p.ctx.keyType = kms.HMACSHA256Tag256Type // invalid signing key
+		p.ctx.keyAgreementType = kms.X25519ECDHKWType
+
+		err = p.ctx.createNewKeyAndVM(didDoc)
 		require.EqualError(t, err, "createSigningVM: createAndExportPubKeyBytes: failed to export new public key bytes: "+
 			"exportPubKeyBytes: failed to export marshalled key: exportPubKeyBytes: failed to get public keyset "+
 			"handle: keyset.Handle: keyset.Handle: keyset contains a non-private key")
@@ -43,15 +61,48 @@ func TestCreateNewKeyAndVM(t *testing.T) {
 func TestCreateSigningVM(t *testing.T) {
 	k := newKMS(t, mockstorage.NewMockStoreProvider())
 
+	p, err := New(&protocol.MockProvider{
+		ServiceMap: map[string]interface{}{
+			mediator.Coordination: &mockroute.MockMediatorSvc{},
+		},
+		CustomKMS: k,
+	})
+	require.NoError(t, err)
+
 	t.Run("createSigningVM success", func(t *testing.T) {
-		svm, err := createSigningVM(k, ed25519VerificationKey2018, kms.ED25519)
+		p.ctx.keyType = kms.ED25519
+
+		svm, err := p.ctx.createSigningVM()
 		require.NoError(t, err)
 		require.NotEmpty(t, svm)
 	})
 
 	t.Run("createSigningVM with empty vmType", func(t *testing.T) {
-		svm, err := createSigningVM(k, "", kms.ED25519)
-		require.EqualError(t, err, "unsupported verification method: ''")
+		p.ctx.keyType = ""
+
+		svm, err := p.ctx.createSigningVM()
+		require.EqualError(t, err, "createSigningVM: createAndExportPubKeyBytes: failed to create new key: "+
+			"failed to create new key, missing key type")
+		require.Empty(t, svm)
+	})
+
+	t.Run("createSigningVM with unsupported keyType", func(t *testing.T) {
+		p.ctx.keyType = kms.X25519ECDHKW
+
+		svm, err := p.ctx.createSigningVM()
+		require.EqualError(t, err, "createSigningVM: unsupported verification method: 'X25519KeyAgreementKey2019'")
+		require.Empty(t, svm)
+	})
+
+	t.Run("createSigningVM failed with invalid jsonWebkey2020 key value", func(t *testing.T) {
+		p.ctx.keyType = kms.ECDSAP256TypeDER
+		p.ctx.kms = &mockkms.KeyManager{
+			CrAndExportPubKeyValue: []byte("a"),
+		}
+
+		svm, err := p.ctx.createSigningVM()
+		require.EqualError(t, err, "createSigningVM: failed to convert public key to JWK for VM: asn1: syntax "+
+			"error: truncated tag or length")
 		require.Empty(t, svm)
 	})
 }
@@ -59,29 +110,54 @@ func TestCreateSigningVM(t *testing.T) {
 func TestCreateEncryptionVM(t *testing.T) {
 	k := newKMS(t, mockstorage.NewMockStoreProvider())
 
+	p, err := New(&protocol.MockProvider{
+		ServiceMap: map[string]interface{}{
+			mediator.Coordination: &mockroute.MockMediatorSvc{},
+		},
+		CustomKMS: k,
+	})
+	require.NoError(t, err)
+
 	t.Run("createEncryptionVM success", func(t *testing.T) {
-		evm, err := createEncryptionVM(k, x25519KeyAgreementKey2019, kms.X25519ECDHKW)
+		p.ctx.keyAgreementType = kms.X25519ECDHKW
+
+		evm, err := p.ctx.createEncryptionVM()
+		require.NoError(t, err)
+		require.NotEmpty(t, evm)
+
+		p.ctx.keyAgreementType = kms.NISTP521ECDHKWType
+
+		evm, err = p.ctx.createEncryptionVM()
 		require.NoError(t, err)
 		require.NotEmpty(t, evm)
 	})
 
-	t.Run("createEncryptionVM success with X25519 as jsonwebk2020", func(t *testing.T) {
-		evm, err := createEncryptionVM(k, jsonWebKey2020, kms.X25519ECDHKW)
-		require.NoError(t, err)
-		require.NotEmpty(t, evm)
-	})
+	t.Run("createEncryptionVM with empty keyAgreementType", func(t *testing.T) {
+		p.ctx.keyAgreementType = ""
 
-	t.Run("createEncryptionVM with empty vmType", func(t *testing.T) {
-		evm, err := createEncryptionVM(k, "", kms.X25519ECDHKWType)
-		require.EqualError(t, err, "unsupported verification method for KeyAgreement: ''")
+		evm, err := p.ctx.createEncryptionVM()
+		require.EqualError(t, err, "createEncryptionVM: createAndExportPubKeyBytes: failed to create new key: "+
+			"failed to create new key, missing key type")
 		require.Empty(t, evm)
 	})
 
 	t.Run("createEncryptionVM with unsupported keyType", func(t *testing.T) {
-		evm, err := createEncryptionVM(k, jsonWebKey2020, kms.HMACSHA256Tag256Type)
-		require.EqualError(t, err, "createEncryptionVM: createAndExportPubKeyBytes: failed to export new public key "+
-			"bytes: exportPubKeyBytes: failed to export marshalled key: exportPubKeyBytes: failed to get public "+
-			"keyset handle: keyset.Handle: keyset.Handle: keyset contains a non-private key")
+		p.ctx.keyAgreementType = kms.ED25519Type
+
+		evm, err := p.ctx.createEncryptionVM()
+		require.EqualError(t, err, "unsupported verification method for KeyAgreement: 'Ed25519VerificationKey2018'")
+		require.Empty(t, evm)
+	})
+
+	t.Run("createSigningVM failed with invalid jsonWebkey2020 key value", func(t *testing.T) {
+		p.ctx.keyAgreementType = kms.NISTP384ECDHKWType
+		p.ctx.kms = &mockkms.KeyManager{
+			CrAndExportPubKeyValue: []byte("a"),
+		}
+
+		evm, err := p.ctx.createEncryptionVM()
+		require.EqualError(t, err, "createEncryptionVM: failed to unmarshal JWK for KeyAgreement: invalid "+
+			"character 'a' looking for beginning of value")
 		require.Empty(t, evm)
 	})
 }

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/util/kmsdidkey"
 	vdrapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
@@ -125,8 +126,9 @@ func TestService_Handle_Inviter(t *testing.T) {
 	}
 
 	verPubKey, encPubKey := newSigningAndEncryptionDIDKeys(t, ctx)
+	mtp := transport.MediaTypeRFC0019EncryptedEnvelope
 
-	ctx.vdRegistry = &mockvdr.MockVDRegistry{CreateValue: createDIDDocWithKey(verPubKey, encPubKey)}
+	ctx.vdRegistry = &mockvdr.MockVDRegistry{CreateValue: createDIDDocWithKey(verPubKey, encPubKey, mtp)}
 
 	connRec, err := connection.NewRecorder(prov)
 	require.NoError(t, err)
@@ -301,17 +303,20 @@ func TestService_Handle_Invitee(t *testing.T) {
 		KeyAgreementTypeValue: kms.X25519ECDHKWType,
 	}
 
+	mtp := transport.MediaTypeRFC0019EncryptedEnvelope
+
 	ctx := &context{
 		outboundDispatcher: prov.OutboundDispatcher(),
 		crypto:             &tinkcrypto.Crypto{},
 		kms:                k,
 		keyType:            kms.ED25519Type,
 		keyAgreementType:   kms.X25519ECDHKWType,
+		mediaTypeProfiles:  []string{mtp},
 	}
 
 	verPubKey, encPubKey := newSigningAndEncryptionDIDKeys(t, ctx)
 
-	ctx.vdRegistry = &mockvdr.MockVDRegistry{CreateValue: createDIDDocWithKey(verPubKey, encPubKey)}
+	ctx.vdRegistry = &mockvdr.MockVDRegistry{CreateValue: createDIDDocWithKey(verPubKey, encPubKey, mtp)}
 
 	connRec, err := connection.NewRecorder(prov)
 	require.NoError(t, err)
@@ -2022,10 +2027,11 @@ func TestService_CreateImplicitInvitation(t *testing.T) {
 			routeSvc:           routeSvc,
 			keyType:            kms.ED25519Type,
 			keyAgreementType:   kms.X25519ECDHKWType,
+			mediaTypeProfiles:  []string{transport.MediaTypeRFC0019EncryptedEnvelope},
 		}
 
 		verPubKey, encPubKey := newSigningAndEncryptionDIDKeys(t, ctx)
-		newDIDDoc := createDIDDocWithKey(verPubKey, encPubKey)
+		newDIDDoc := createDIDDocWithKey(verPubKey, encPubKey, ctx.mediaTypeProfiles[0])
 
 		connRec, err := connection.NewRecorder(prov)
 		require.NoError(t, err)
@@ -2063,9 +2069,10 @@ func TestService_CreateImplicitInvitation(t *testing.T) {
 			routeSvc:           routeSvc,
 			keyType:            kms.ED25519Type,
 			keyAgreementType:   kms.X25519ECDHKWType,
+			mediaTypeProfiles:  []string{transport.MediaTypeRFC0019EncryptedEnvelope},
 		}
 		verPubKey, encPubKey := newSigningAndEncryptionDIDKeys(t, ctx)
-		newDIDDoc := createDIDDocWithKey(verPubKey, encPubKey)
+		newDIDDoc := createDIDDocWithKey(verPubKey, encPubKey, ctx.mediaTypeProfiles[0])
 
 		connRec, err := connection.NewRecorder(prov)
 		require.NoError(t, err)
@@ -2093,9 +2100,10 @@ func TestService_CreateImplicitInvitation(t *testing.T) {
 		sp := mockstorage.NewMockStoreProvider()
 		k := newKMS(t, sp)
 		ctx := &context{
-			kms:              k,
-			keyType:          kms.ED25519Type,
-			keyAgreementType: kms.X25519ECDHKWType,
+			kms:               k,
+			keyType:           kms.ED25519Type,
+			keyAgreementType:  kms.X25519ECDHKWType,
+			mediaTypeProfiles: []string{transport.MediaTypeRFC0019EncryptedEnvelope},
 		}
 		routeSvc := &mockroute.MockMediatorSvc{}
 		protocolStateStore := mockstorage.NewMockStoreProvider()
@@ -2113,7 +2121,7 @@ func TestService_CreateImplicitInvitation(t *testing.T) {
 		ctx.routeSvc = routeSvc
 
 		verPubKey, encPubKey := newSigningAndEncryptionDIDKeys(t, ctx)
-		newDIDDoc := createDIDDocWithKey(verPubKey, encPubKey)
+		newDIDDoc := createDIDDocWithKey(verPubKey, encPubKey, ctx.mediaTypeProfiles[0])
 
 		connRec, err := connection.NewRecorder(prov)
 		require.NoError(t, err)
@@ -2155,9 +2163,10 @@ func TestRespondTo(t *testing.T) {
 	})
 	t.Run("responds to an implicit invitation", func(t *testing.T) {
 		publicDID := createDIDDoc(t, &context{
-			kms:              k,
-			keyType:          kms.ED25519Type,
-			keyAgreementType: kms.X25519ECDHKWType,
+			kms:               k,
+			keyType:           kms.ED25519Type,
+			keyAgreementType:  kms.X25519ECDHKWType,
+			mediaTypeProfiles: []string{transport.MediaTypeRFC0019EncryptedEnvelope},
 		})
 		provider := testProvider()
 		provider.CustomVDR = &mockvdr.MockVDRegistry{ResolveValue: publicDID}

--- a/pkg/framework/aries/api/vdr/vdr.go
+++ b/pkg/framework/aries/api/vdr/vdr.go
@@ -15,8 +15,13 @@ import (
 // ErrNotFound is returned when a DID resolver does not find the DID.
 var ErrNotFound = errors.New("DID not found")
 
-// DIDCommServiceType default DID Communication service endpoint type.
-const DIDCommServiceType = "did-communication"
+const (
+	// DIDCommServiceType default DID Communication service endpoint type.
+	DIDCommServiceType = "did-communication"
+
+	// DIDCommV2ServiceType is the DID Communications V2 service type.
+	DIDCommV2ServiceType = "DIDCommMessaging"
+)
 
 // Registry vdr registry.
 type Registry interface {

--- a/pkg/framework/aries/framework.go
+++ b/pkg/framework/aries/framework.go
@@ -461,9 +461,18 @@ func createVDR(frameworkOpts *Aries) error {
 		return fmt.Errorf("create new vdr peer failed: %w", err)
 	}
 
+	dst := vdrapi.DIDCommServiceType
+
+	for _, mediaType := range frameworkOpts.mediaTypeProfiles {
+		if mediaType == transport.MediaTypeDIDCommV2Profile || mediaType == transport.MediaTypeAIP2RFC0587Profile {
+			dst = vdrapi.DIDCommV2ServiceType
+			break
+		}
+	}
+
 	opts = append(opts,
 		vdr.WithVDR(p),
-		vdr.WithDefaultServiceType(vdrapi.DIDCommServiceType),
+		vdr.WithDefaultServiceType(dst),
 		vdr.WithDefaultServiceEndpoint(ctx.ServiceEndpoint()),
 	)
 

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -131,6 +131,19 @@ func TestFramework(t *testing.T) {
 	})
 
 	// framework new - success
+	t.Run("test vdr - with DIDComm V2", func(t *testing.T) {
+		vdr := &mockvdr.MockVDR{}
+		aries, err := New(WithVDR(vdr), WithInboundTransport(&mockInboundTransport{}),
+			WithMediaTypeProfiles([]string{transport.MediaTypeDIDCommV2Profile}))
+		require.NoError(t, err)
+		require.NotEmpty(t, aries)
+
+		require.Equal(t, len(aries.vdr), 1)
+		require.Equal(t, vdr, aries.vdr[0])
+		err = aries.Close()
+		require.NoError(t, err)
+	})
+
 	t.Run("test vdr - with user provided", func(t *testing.T) {
 		vdr := &mockvdr.MockVDR{}
 		aries, err := New(WithVDR(vdr), WithInboundTransport(&mockInboundTransport{}))

--- a/pkg/store/did/didconnection_test.go
+++ b/pkg/store/did/didconnection_test.go
@@ -105,6 +105,20 @@ func TestBaseConnectionStore(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("SaveDIDFromDoc with invalid DIDCommService type does not link keys to the DID", func(t *testing.T) {
+		connStore, err := NewConnectionStore(&prov)
+		require.NoError(t, err)
+
+		mDIDDoc := mockdiddoc.GetMockDIDDocWithKeyAgreements(t)
+		mDIDDoc.Service[0].Type = "invalid"
+
+		err = connStore.SaveDIDFromDoc(mDIDDoc)
+		require.NoError(t, err)
+
+		_, err = connStore.GetDID(mDIDDoc.KeyAgreement[0].VerificationMethod.ID)
+		require.EqualError(t, err, "did not found under given key")
+	})
+
 	t.Run("SaveDIDByResolving success", func(t *testing.T) {
 		cs, err := NewConnectionStore(&prov)
 		require.NoError(t, err)

--- a/pkg/vdr/peer/creator.go
+++ b/pkg/vdr/peer/creator.go
@@ -98,11 +98,8 @@ func build(didDoc *did.Doc, docOpts *vdrapi.DIDMethodOpts) (*did.DocResolution, 
 			didDoc.Service[i].ServiceEndpoint = v
 		}
 
-		if didDoc.Service[i].Type == vdrapi.DIDCommServiceType {
-			didKey, _ := fingerprint.CreateDIDKey(didDoc.VerificationMethod[0].Value)
-			didDoc.Service[i].RecipientKeys = []string{didKey}
-			didDoc.Service[i].Priority = 0
-		}
+		applyDIDCommKeys(i, didDoc)
+		applyDIDCommV2Keys(i, didDoc)
 
 		service = append(service, didDoc.Service[i])
 	}
@@ -149,6 +146,27 @@ func build(didDoc *did.Doc, docOpts *vdrapi.DIDMethodOpts) (*did.DocResolution, 
 	}
 
 	return &did.DocResolution{DIDDocument: didDoc}, nil
+}
+
+func applyDIDCommKeys(i int, didDoc *did.Doc) {
+	if didDoc.Service[i].Type == vdrapi.DIDCommServiceType {
+		didKey, _ := fingerprint.CreateDIDKey(didDoc.VerificationMethod[0].Value)
+		didDoc.Service[i].RecipientKeys = []string{didKey}
+		didDoc.Service[i].Priority = 0
+	}
+}
+
+func applyDIDCommV2Keys(i int, didDoc *did.Doc) {
+	if didDoc.Service[i].Type == vdrapi.DIDCommV2ServiceType {
+		didDoc.Service[i].RecipientKeys = []string{}
+		didDoc.Service[i].Priority = 0
+
+		for _, ka := range didDoc.KeyAgreement {
+			kaID := ka.VerificationMethod.ID
+
+			didDoc.Service[i].RecipientKeys = append(didDoc.Service[i].RecipientKeys, kaID)
+		}
+	}
 }
 
 func buildDIDVMs(didDoc *did.Doc) ([]did.VerificationMethod, []did.VerificationMethod, error) {

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -82,6 +82,7 @@ type provider interface {
 	VDRegistry() vdr.Registry
 	Crypto() crypto.Crypto
 	JSONLDDocumentLoader() ld.DocumentLoader
+	MediaTypeProfiles() []string
 	didCommProvider // to be used only if wallet needs to be participated in DIDComm.
 }
 

--- a/test/bdd/features/didexchange_e2e_sdk.feature
+++ b/test/bdd/features/didexchange_e2e_sdk.feature
@@ -8,7 +8,7 @@
 @all
 @didexchange_e2e_sdk
 Feature: Decentralized Identifier(DID) exchange between the agents using SDK
-
+  @localkms_didexchange_e2e_sdk
   Scenario: did exchange e2e flow
     Given "Alice" agent is running on "localhost" port "random" with "http" as the transport provider
       And   "Alice" creates did exchange client

--- a/test/bdd/features/didexchange_e2e_sdk_didcommv2.feature
+++ b/test/bdd/features/didexchange_e2e_sdk_didcommv2.feature
@@ -1,0 +1,47 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Reference : https://github.com/hyperledger/aries-rfcs/tree/master/features/0023-did-exchange
+
+@all
+@didexchange_e2e_sdk_didcommv2
+Feature: Decentralized Identifier(DID) exchange between the agents using SDK with DIDComm V2 media type profile
+  @localkms_didexchange_e2e_sdk_didcommv2
+  Scenario: did exchange e2e flow with DIDComm V2 media type profile
+    Given "Alice" agent is running on "localhost" port "random" with "http" using DIDCommV2 as the transport provider
+      And   "Alice" creates did exchange client
+      And   "Alice" registers to receive notification for post state event "completed"
+
+    Given "Bob" agent is running on "localhost" port "random" with "http" using DIDCommV2 as the transport provider
+      And   "Bob" creates did exchange client
+
+    When   "Bob" registers to receive notification for post state event "completed"
+      And   "Alice" creates invitation
+      And   "Bob" receives invitation from "Alice"
+      And   "Bob" approves invitation request
+      And   "Alice" approves did exchange request
+      And   "Alice" waits for post state event "completed"
+      And   "Bob" waits for post state event "completed"
+
+    Then   "Alice" retrieves connection record and validates that connection state is "completed"
+      And   "Bob" retrieves connection record and validates that connection state is "completed"
+
+  Scenario: did exchange e2e flow using WebSocket as the DIDComm transport with DIDComm V2 media type profile
+    Given "Alice" agent is running on "localhost" port "random" with "websocket" using DIDCommV2 as the transport provider
+      And   "Alice" creates did exchange client
+      And   "Alice" registers to receive notification for post state event "completed"
+
+    When "Bob" agent is running on "localhost" port "random" with "websocket" using DIDCommV2 as the transport provider
+      And   "Bob" creates did exchange client
+      And   "Bob" registers to receive notification for post state event "completed"
+      And   "Alice" creates invitation
+      And   "Bob" receives invitation from "Alice"
+      And   "Bob" approves invitation request
+      And   "Alice" approves did exchange request
+      And   "Alice" waits for post state event "completed"
+      And   "Bob" waits for post state event "completed"
+
+    Then   "Alice" retrieves connection record and validates that connection state is "completed"
+      And   "Bob" retrieves connection record and validates that connection state is "completed"


### PR DESCRIPTION
This change adds DIDCommV2 support to use KeyAgreement.ID when a DID doc is available.
Default behaviour is to use did:key for pre DIDCommV2 or where DID doc is not available to the recipient.
The Peer VDR creator now uses DIDCommV2 service type matching the media porfile version: DIDCommMessaging (for V2).
Default is did-communication (for pre V2) if media profile is missing or is not DIDCommV2.

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
