### PR TITLE
feat: support different Accept header values for DIDcomm versions

### DIFF
--- a/pkg/client/outofband/client.go
+++ b/pkg/client/outofband/client.go
@@ -17,9 +17,11 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/outofband"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util/kmsdidkey"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
-	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
 )
 
 type (
@@ -36,23 +38,6 @@ const (
 	HandshakeReuseMsgType = outofband.HandshakeReuseMsgType
 	// HandshakeReuseAcceptedMsgType is the '@type' for the handshake reuse accepted message.
 	HandshakeReuseAcceptedMsgType = outofband.HandshakeReuseAcceptedMsgType
-)
-
-const (
-	// MediaTypeProfileDIDCommAIP1 is the encryption envelope, signing mechanism, plaintext conventions,
-	// and routing algorithms embodied in Aries AIP 1.0, circa 2020. Defined in RFC 0044.
-	MediaTypeProfileDIDCommAIP1 = outofband.MediaTypeProfileDIDCommAIP1
-	// MediaTypeProfileDIDCommAIP2RFC19 is the signing mechanism, plaintext conventions, and routing
-	// algorithms embodied in Aries AIP 2.0, circa 2021 -- with the old-style encryption envelope from
-	// Aries RFC 0019. Defined in RFC 0044.
-	MediaTypeProfileDIDCommAIP2RFC19 = outofband.MediaTypeProfileDIDCommAIP2RFC19
-	// MediaTypeProfileAIP2RFC587 is the signing mechanism, plaintext conventions, and routing algorithms
-	// embodied in Aries AIP 2.0, circa 2021 -- with the new-style encryption envelope from Aries RFC 0587.
-	// Defined in RFC 0044.
-	MediaTypeProfileAIP2RFC587 = outofband.MediaTypeProfileAIP2RFC587
-	// MediaTypeProfileDIDCommV2 is the encryption envelope, signing mechanism, plaintext conventions,
-	// and routing algorithms embodied in the DIDComm messaging spec. Defined in RFC 0044.
-	MediaTypeProfileDIDCommV2 = outofband.MediaTypeProfileDIDCommV2
 )
 
 // EventOptions are is a container of options that you can pass to an event's
@@ -134,13 +119,16 @@ type Provider interface {
 	ServiceEndpoint() string
 	Service(id string) (interface{}, error)
 	KMS() kms.KeyManager
+	KeyType() kms.KeyType
+	KeyAgreementType() kms.KeyType
+	MediaTypeProfiles() []string
 }
 
 // Client for the Out-Of-Band protocol:
 // https://github.com/hyperledger/aries-rfcs/blob/master/features/0434-outofband/README.md
 type Client struct {
 	service.Event
-	didDocSvcFunc func(routerConnID string) (*did.Service, error)
+	didDocSvcFunc func(routerConnID string, accept []string) (*did.Service, error)
 	oobService    OobService
 }
 
@@ -156,11 +144,14 @@ func New(p Provider) (*Client, error) {
 		return nil, fmt.Errorf("failed to cast service %s as a dependency", outofband.Name)
 	}
 
-	return &Client{
-		Event:         oobSvc,
-		didDocSvcFunc: didServiceBlockFunc(p),
-		oobService:    oobSvc,
-	}, nil
+	client := &Client{
+		Event:      oobSvc,
+		oobService: oobSvc,
+	}
+
+	client.didDocSvcFunc = client.didServiceBlockFunc(p)
+
+	return client, nil
 }
 
 // CreateInvitation creates and saves an out-of-band invitation.
@@ -186,8 +177,12 @@ func (c *Client) CreateInvitation(services []interface{}, opts ...MessageOption)
 		Requests:  msg.Attachments,
 	}
 
+	if len(inv.Accept) == 0 {
+		inv.Accept = []string{transport.MediaTypeAIP2RFC0019Profile}
+	}
+
 	if len(inv.Services) == 0 {
-		svc, err := c.didDocSvcFunc(msg.RouterConnection())
+		svc, err := c.didDocSvcFunc(msg.RouterConnection(), inv.Accept)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a new inlined did doc service block : %w", err)
 		}
@@ -366,11 +361,30 @@ func validateServices(svcs ...interface{}) error {
 
 // DidDocServiceFunc returns a function that returns a DID doc `service` entry.
 // Used when no service entries are specified when creating messages.
-func didServiceBlockFunc(p Provider) func(routerConnID string) (*did.Service, error) {
-	return func(routerConnID string) (*did.Service, error) {
+//nolint:funlen
+func (c *Client) didServiceBlockFunc(p Provider) func(routerConnID string, accept []string) (*did.Service, error) {
+	return func(routerConnID string, accept []string) (*did.Service, error) {
+		var (
+			keyType            kms.KeyType
+			didCommServiceType string
+		)
+
+		useDIDCommV2 := isDIDCommV2(accept)
 		// TODO https://github.com/hyperledger/aries-framework-go/issues/623 'alias' should be passed as arg and persisted
 		//  with connection record
-		_, verKey, err := p.KMS().CreateAndExportPubKeyBytes(kms.ED25519Type)
+		if useDIDCommV2 {
+			keyType = p.KeyAgreementType()
+			didCommServiceType = vdr.DIDCommV2ServiceType
+		} else {
+			keyType = p.KeyType()
+			didCommServiceType = vdr.DIDCommServiceType
+		}
+
+		if string(keyType) == "" {
+			keyType = kms.ED25519Type
+		}
+
+		_, pubKey, err := p.KMS().CreateAndExportPubKeyBytes(keyType)
 		if err != nil {
 			return nil, fmt.Errorf("didServiceBlockFunc: failed to create and extract public SigningKey bytes: %w", err)
 		}
@@ -385,12 +399,15 @@ func didServiceBlockFunc(p Provider) func(routerConnID string) (*did.Service, er
 			return nil, errors.New("didServiceBlockFunc: cast service to Route Service failed")
 		}
 
-		didKey, _ := fingerprint.CreateDIDKey(verKey)
+		didKey, err := kmsdidkey.BuildDIDKeyByKeyType(pubKey, keyType)
+		if err != nil {
+			return nil, fmt.Errorf("didServiceBlockFunc: failed to build did:key for key type '%v': %w", keyType, err)
+		}
 
 		if routerConnID == "" {
 			return &did.Service{
 				ID:              uuid.New().String(),
-				Type:            "did-communication",
+				Type:            didCommServiceType,
 				RecipientKeys:   []string{didKey},
 				ServiceEndpoint: p.ServiceEndpoint(),
 			}, nil
@@ -408,10 +425,23 @@ func didServiceBlockFunc(p Provider) func(routerConnID string) (*did.Service, er
 
 		return &did.Service{
 			ID:              uuid.New().String(),
-			Type:            "did-communication",
+			Type:            didCommServiceType,
 			RecipientKeys:   []string{didKey},
 			RoutingKeys:     routingKeys,
 			ServiceEndpoint: serviceEndpoint,
 		}, nil
 	}
+}
+
+func isDIDCommV2(accept []string) bool {
+	for _, a := range accept {
+		switch a {
+		case transport.MediaTypeDIDCommV2Profile, transport.MediaTypeAIP2RFC0587Profile,
+			transport.MediaTypeV2EncryptedEnvelope, transport.MediaTypeV2EncryptedEnvelopeV1PlaintextPayload,
+			transport.MediaTypeV1EncryptedEnvelope:
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/controller/command/mediator/command.go
+++ b/pkg/controller/command/mediator/command.go
@@ -88,6 +88,9 @@ type provider interface {
 	Service(id string) (interface{}, error)
 	KMS() kms.KeyManager
 	ServiceEndpoint() string
+	KeyType() kms.KeyType
+	KeyAgreementType() kms.KeyType
+	MediaTypeProfiles() []string
 }
 
 // Command contains command operations provided by route controller.

--- a/pkg/controller/rest/mediator/operation.go
+++ b/pkg/controller/rest/mediator/operation.go
@@ -33,6 +33,9 @@ type provider interface {
 	Service(id string) (interface{}, error)
 	KMS() kms.KeyManager
 	ServiceEndpoint() string
+	KeyType() kms.KeyType
+	KeyAgreementType() kms.KeyType
+	MediaTypeProfiles() []string
 }
 
 // Operation contains basic common operations provided by controller REST API.

--- a/pkg/didcomm/common/service/destination.go
+++ b/pkg/didcomm/common/service/destination.go
@@ -24,8 +24,10 @@ type Destination struct {
 }
 
 const (
-	didCommServiceType   = "did-communication"
-	didCommV2ServiceType = "DIDCommMessaging"
+	didCommServiceType      = "did-communication"
+	didCommV2ServiceType    = "DIDCommMessaging"
+	defaultDIDCommProfile   = "didcomm/aip2;env=rfc19"
+	defaultDIDCommV2Profile = "didcomm/v2"
 )
 
 // GetDestination constructs a Destination struct based on the given DID and parameters

--- a/pkg/didcomm/common/service/destination_default.go
+++ b/pkg/didcomm/common/service/destination_default.go
@@ -17,6 +17,7 @@ import (
 
 // CreateDestination makes a DIDComm Destination object from a DID Doc as per the DIDComm service conventions:
 // https://github.com/hyperledger/aries-rfcs/blob/master/features/0067-didcomm-diddoc-conventions/README.md.
+//nolint:gocyclo
 func CreateDestination(didDoc *diddoc.Doc) (*Destination, error) {
 	// try DIDComm V2 and use it if found, else use default DIDComm v1 bloc.
 	didCommService, ok := diddoc.LookupService(didDoc, didCommV2ServiceType)
@@ -39,6 +40,11 @@ func CreateDestination(didDoc *diddoc.Doc) (*Destination, error) {
 
 		// use keyAgreements as recipientKeys
 		didCommService.RecipientKeys = recKeys
+
+		// if Accept is missing, ensure DIDCommV2 is at least added for packer selection based on MediaTypeProfile.
+		if len(didCommService.Accept) == 0 {
+			didCommService.Accept = []string{defaultDIDCommV2Profile}
+		}
 	} else {
 		didCommService, ok = diddoc.LookupService(didDoc, didCommServiceType)
 		if !ok {
@@ -58,6 +64,11 @@ func CreateDestination(didDoc *diddoc.Doc) (*Destination, error) {
 				return nil, fmt.Errorf("create destination: recipient key %d:[%v] of didComm '%s' not a did:key", i+1,
 					k, didCommService.ID)
 			}
+		}
+
+		// if Accept is missing, ensure DIDCommV1 is at least added for packer selection based on MediaTypeProfile.
+		if len(didCommService.Accept) == 0 {
+			didCommService.Accept = []string{defaultDIDCommProfile}
 		}
 	}
 

--- a/pkg/didcomm/dispatcher/outbound.go
+++ b/pkg/didcomm/dispatcher/outbound.go
@@ -330,7 +330,7 @@ func (o *OutboundDispatcher) mediaTypeProfile(des *service.Destination) string {
 		for _, mtp := range des.MediaTypeProfiles {
 			switch mtp {
 			case transport.MediaTypeV1PlaintextPayload, transport.MediaTypeRFC0019EncryptedEnvelope,
-				transport.MediaTypeAIP2RFC0019Profile:
+				transport.MediaTypeAIP2RFC0019Profile, transport.MediaTypeProfileDIDCommAIP1:
 				// overridable with higher priority media type.
 				if mt == "" {
 					mt = mtp

--- a/pkg/didcomm/dispatcher/outbound_test.go
+++ b/pkg/didcomm/dispatcher/outbound_test.go
@@ -139,6 +139,27 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 		}))
 	})
 
+	t.Run("test send with forward message with multiple media type profiles- success", func(t *testing.T) {
+		o, err := NewOutbound(&mockProvider{
+			packagerValue:           &mockpackager.Packager{PackValue: createPackedMsgForForward(t)},
+			outboundTransportsValue: []transport.OutboundTransport{&mockdidcomm.MockOutboundTransport{AcceptValue: true}},
+			storageProvider:         mockstore.NewMockStoreProvider(),
+			protoStorageProvider:    mockstore.NewMockStoreProvider(),
+			mediaTypeProfiles: []string{
+				transport.MediaTypeProfileDIDCommAIP1,
+				transport.MediaTypeAIP2RFC0019Profile,
+				transport.MediaTypeDIDCommV2Profile,
+			},
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{
+			ServiceEndpoint: "url",
+			RecipientKeys:   []string{"abc"},
+			RoutingKeys:     []string{"xyz"},
+		}))
+	})
+
 	t.Run("test send with forward message - create key failure", func(t *testing.T) {
 		o, err := NewOutbound(&mockProvider{
 			packagerValue:           &mockpackager.Packager{PackValue: createPackedMsgForForward(t)},

--- a/pkg/didcomm/packager/packager.go
+++ b/pkg/didcomm/packager/packager.go
@@ -235,7 +235,8 @@ func isMediaTypeForLegacyPacker(cty string) bool {
 	var isLegacy bool
 
 	switch cty {
-	case transport.MediaTypeRFC0019EncryptedEnvelope, transport.MediaTypeAIP2RFC0019Profile:
+	case transport.MediaTypeRFC0019EncryptedEnvelope, transport.MediaTypeAIP2RFC0019Profile,
+		transport.MediaTypeProfileDIDCommAIP1:
 		isLegacy = true
 	default:
 		isLegacy = false
@@ -329,7 +330,7 @@ func (bp *Packager) UnpackMessage(encMessage []byte) (*transport.Envelope, error
 
 func (bp *Packager) getCTYAndPacker(envelope *transport.Envelope) (string, packer.Packer, error) {
 	switch envelope.MediaTypeProfile {
-	case transport.MediaTypeAIP2RFC0019Profile:
+	case transport.MediaTypeAIP2RFC0019Profile, transport.MediaTypeProfileDIDCommAIP1:
 		return transport.MediaTypeRFC0019EncryptedEnvelope, bp.packers[transport.MediaTypeRFC0019EncryptedEnvelope], nil
 	case transport.MediaTypeRFC0019EncryptedEnvelope:
 		return envelope.MediaTypeProfile, bp.packers[transport.MediaTypeRFC0019EncryptedEnvelope], nil

--- a/pkg/didcomm/packager/packager_test.go
+++ b/pkg/didcomm/packager/packager_test.go
@@ -444,6 +444,10 @@ func packUnPackSuccess(keyType kms.KeyType, customKMS kms.KeyManager, cryptoSvc 
 			mediaType: transport.MediaTypeAIP2RFC0019Profile,
 		},
 		{
+			name:      fmt.Sprintf("success using mediaType %s", transport.MediaTypeProfileDIDCommAIP1),
+			mediaType: transport.MediaTypeProfileDIDCommAIP1,
+		},
+		{
 			name:      fmt.Sprintf("success using mediaType %s", transport.MediaTypeAIP2RFC0587Profile),
 			mediaType: transport.MediaTypeAIP2RFC0587Profile,
 		},
@@ -474,7 +478,8 @@ func packUnPackSuccess(keyType kms.KeyType, customKMS kms.KeyManager, cryptoSvc 
 			)
 
 			switch tc.mediaType {
-			case transport.MediaTypeRFC0019EncryptedEnvelope, transport.MediaTypeAIP2RFC0019Profile:
+			case transport.MediaTypeRFC0019EncryptedEnvelope, transport.MediaTypeAIP2RFC0019Profile,
+				transport.MediaTypeProfileDIDCommAIP1:
 				fromKIDPack = []byte(fromDIDKeyED25519)
 				toKIDsPack = []string{toLegacyDIDKey}
 			case transport.MediaTypeV1EncryptedEnvelope, transport.MediaTypeV1PlaintextPayload,

--- a/pkg/didcomm/transport/media_type.go
+++ b/pkg/didcomm/transport/media_type.go
@@ -28,6 +28,10 @@ const (
 	// below are pre-defined profiles supported by the framework as per
 	// https://github.com/hyperledger/aries-rfcs/tree/master/features/0044-didcomm-file-and-mime-types#defined-profiles.
 
+	// MediaTypeProfileDIDCommAIP1 is the encryption envelope, signing mechanism, plaintext conventions,
+	// and routing algorithms embodied in Aries AIP 1.0, circa 2020. Defined in RFC 0044.
+	MediaTypeProfileDIDCommAIP1 = "didcomm/aip1"
+
 	// MediaTypeAIP2RFC0019Profile for AIP 2.0, circa 2021 using RFC0019 encryption envelope.
 	MediaTypeAIP2RFC0019Profile = "didcomm/aip2;env=rfc19"
 

--- a/pkg/internal/gomocks/client/outofband/mocks.gen.go
+++ b/pkg/internal/gomocks/client/outofband/mocks.gen.go
@@ -50,6 +50,48 @@ func (mr *MockProviderMockRecorder) KMS() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KMS", reflect.TypeOf((*MockProvider)(nil).KMS))
 }
 
+// KeyAgreementType mocks base method.
+func (m *MockProvider) KeyAgreementType() kms.KeyType {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "KeyAgreementType")
+	ret0, _ := ret[0].(kms.KeyType)
+	return ret0
+}
+
+// KeyAgreementType indicates an expected call of KeyAgreementType.
+func (mr *MockProviderMockRecorder) KeyAgreementType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeyAgreementType", reflect.TypeOf((*MockProvider)(nil).KeyAgreementType))
+}
+
+// KeyType mocks base method.
+func (m *MockProvider) KeyType() kms.KeyType {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "KeyType")
+	ret0, _ := ret[0].(kms.KeyType)
+	return ret0
+}
+
+// KeyType indicates an expected call of KeyType.
+func (mr *MockProviderMockRecorder) KeyType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeyType", reflect.TypeOf((*MockProvider)(nil).KeyType))
+}
+
+// MediaTypeProfiles mocks base method.
+func (m *MockProvider) MediaTypeProfiles() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MediaTypeProfiles")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// MediaTypeProfiles indicates an expected call of MediaTypeProfiles.
+func (mr *MockProviderMockRecorder) MediaTypeProfiles() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MediaTypeProfiles", reflect.TypeOf((*MockProvider)(nil).MediaTypeProfiles))
+}
+
 // Service mocks base method.
 func (m *MockProvider) Service(arg0 string) (interface{}, error) {
 	m.ctrl.T.Helper()

--- a/test/bdd/features/outofband_e2e_sdk.feature
+++ b/test/bdd/features/outofband_e2e_sdk.feature
@@ -15,29 +15,51 @@ Feature: Out-Of-Band protocol (Go API)
     Given "Alice" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
       And "Bob" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
 
-  Scenario: handshake_protocols: yes | requests~attach: no | existing_conn: no
-    Given "Alice" creates an out-of-band invitation
+  Scenario Outline: handshake_protocols: yes | requests~attach: no | existing_conn: no
+    Given options "<accept>"
+      And "Alice" creates an out-of-band invitation
      When "Alice" sends the invitation to "Bob" through an out-of-band channel
       And "Bob" accepts the invitation and connects with "Alice"
      Then "Alice" and "Bob" confirm their connection is "completed"
+    Examples:
+      | accept                    |
+      | "didcomm/aip1"            |
+      | "didcomm/aip2;env=rfc19"  |
+      | "didcomm/aip2;env=rfc587" |
+      | "didcomm/v2"              |
 
-  Scenario: handshake_protocols: yes | requests~attach: yes | existing_conn: no
-    Given "Alice" creates an out-of-band invitation with an attached offer-credential message
+  Scenario Outline: handshake_protocols: yes | requests~attach: yes | existing_conn: no
+    Given options "<accept>"
+      And "Alice" creates an out-of-band invitation with an attached offer-credential message
       And "Alice" sends the invitation to "Bob" through an out-of-band channel
       And "Bob" accepts the invitation and connects with "Alice"
      When "Bob" accepts the offer-credential message from "Alice"
      Then "Bob" is issued the credential
+    Examples:
+      | accept                    |
+      | "didcomm/aip1"            |
+      | "didcomm/aip2;env=rfc19"  |
+      | "didcomm/aip2;env=rfc587" |
+      | "didcomm/v2"              |
 
-  Scenario: handshake_protocols: yes | requests~attach: no | existing_conn: yes
-    Given "Alice" creates an out-of-band invitation with a public DID
+  Scenario Outline: handshake_protocols: yes | requests~attach: no | existing_conn: yes
+    Given options "<accept>"
+      And "Alice" creates an out-of-band invitation with a public DID
       And "Bob" connects with "Alice" using the invitation
      When "Alice" creates another out-of-band invitation with the same public DID
       And "Alice" sends the invitation to "Bob" through an out-of-band channel
       And "Bob" accepts the invitation from "Alice" and both agents opt to reuse their connections
      Then "Alice" and "Bob" confirm they reused their connections
+    Examples:
+      | accept                    |
+      | "didcomm/aip1"            |
+      | "didcomm/aip2;env=rfc19"  |
+      | "didcomm/aip2;env=rfc587" |
+      | "didcomm/v2"              |
 
-  Scenario: handshake_protocols: yes | requests~attach: yes | existing_conn: yes
-    Given "Alice" creates an out-of-band invitation with a public DID
+  Scenario Outline: handshake_protocols: yes | requests~attach: yes | existing_conn: yes
+    Given options "<accept>"
+      And "Alice" creates an out-of-band invitation with a public DID
       And "Bob" connects with "Alice" using the invitation
      When "Alice" creates another out-of-band invitation with the same public DID and an attached offer-credential message
       And "Alice" sends the invitation to "Bob" through an out-of-band channel
@@ -45,3 +67,9 @@ Feature: Out-Of-Band protocol (Go API)
       And "Alice" and "Bob" confirm they reused their connections
       And "Bob" accepts the offer-credential message from "Alice"
      Then "Bob" is issued the credential
+    Examples:
+      | accept                    |
+      | "didcomm/aip1"            |
+      | "didcomm/aip2;env=rfc19"  |
+      | "didcomm/aip2;env=rfc587" |
+      | "didcomm/v2"              |


### PR DESCRIPTION
This change adds support for selection of the DIDComm service version based on
the OOB invitation's Accept header.

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
