### PR TITLE
feat: extend support cases for VC BBS derivation

### DIFF
--- a/pkg/doc/presexch/definition.go
+++ b/pkg/doc/presexch/definition.go
@@ -556,11 +556,19 @@ func filterConstraints(constraints *Constraints, creds []*verifiable.Credential,
 		if constraints.LimitDisclosure.isRequired() || predicate {
 			template := credentialSrc
 
+			var contexts []interface{}
+
+			for _, ctx := range credential.Context {
+				contexts = append(contexts, ctx)
+			}
+
+			contexts = append(contexts, credential.CustomContext...)
+
 			if constraints.LimitDisclosure.isRequired() {
 				template, err = json.Marshal(map[string]interface{}{
 					"id":                credential.ID,
 					"type":              credential.Types,
-					"@context":          credential.Context,
+					"@context":          contexts,
 					"issuer":            credential.Issuer,
 					"credentialSubject": toSubject(credential.Subject),
 					"issuanceDate":      credential.Issued,

--- a/pkg/doc/signature/jsonld/processor.go
+++ b/pkg/doc/signature/jsonld/processor.go
@@ -190,6 +190,13 @@ func (p *Processor) Frame(inputDoc map[string]interface{}, frameDoc map[string]i
 
 	proc := ld.NewJsonLdProcessor()
 
+	hasBlankBaseID := false
+	if checkID, ok := inputDoc["id"]; !ok || checkID == "" {
+		hasBlankBaseID = true
+		inputDoc["id"] = fmt.Sprintf("urn:uuid:%s", uuid.New().String())
+		frameDoc["id"] = inputDoc["id"]
+	}
+
 	// TODO Drop replacing duplicated IDs as soon as https://github.com/piprate/json-gold/issues/44 will be fixed.
 	inputDocCopy, randomIds, err := removeDuplicateIDs(inputDoc, proc, ldOptions)
 	if err != nil {
@@ -207,6 +214,11 @@ func (p *Processor) Frame(inputDoc map[string]interface{}, frameDoc map[string]i
 	}
 
 	framedInputDoc["@context"] = frameDoc["@context"]
+
+	if hasBlankBaseID {
+		delete(framedInputDoc, "id")
+		delete(frameDoc, "id")
+	}
 
 	// TODO Drop replacing duplicated IDs as soon as https://github.com/piprate/json-gold/issues/44 will be fixed.
 	if len(randomIds) == 0 {

--- a/pkg/doc/signature/jsonld/processor_test.go
+++ b/pkg/doc/signature/jsonld/processor_test.go
@@ -288,6 +288,10 @@ func TestProcessor_Frame(t *testing.T) {
 			"spouse": "did:example:c276e12ec21ebfeb1f712ebc6f2",
 		},
 	}
+
+	// clear the ID, to test empty-ID handling
+	doc["id"] = ""
+
 	framedView, err = processor.Frame(doc, frameDoc, ldtestutil.WithDocumentLoader(t))
 	require.NoError(t, err)
 

--- a/pkg/doc/verifiable/credential.go
+++ b/pkg/doc/verifiable/credential.go
@@ -37,7 +37,7 @@ const DefaultSchema = `{
   ],
   "properties": {
     "@context": {
-      "oneOf": [
+      "anyOf": [
         {
           "type": "string",
           "const": "https://www.w3.org/2018/credentials/v1"
@@ -52,7 +52,7 @@ const DefaultSchema = `{
           ],
           "uniqueItems": true,
           "additionalItems": {
-            "oneOf": [
+            "anyOf": [
               {
                 "type": "object"
               },

--- a/test/bdd/features/presentproof_controller.feature
+++ b/test/bdd/features/presentproof_controller.feature
@@ -45,6 +45,18 @@ Feature: Present Proof using controller API
     Then  "Jennifer" successfully accepts a presentation with "bbs-passport" name through PresentProof controller
     And "Jennifer" checks that presentation is being stored under the "bbs-passport" name
 
+  @present_proof_controller_bbs_dl
+  Scenario: The Verifier begins with a presentation request (BBS+ with embedded context and no ID)
+    Given "Jennifer" agent is running on "localhost" port "8081" with controller "https://localhost:8082"
+    And "Julia" agent is running on "localhost" port "9081" with controller "https://localhost:9082"
+    And "Jennifer" has established connection with "Julia" through PresentProof controller
+
+    When  "Jennifer" sends "request_presentation_bbs_dl.json" to "Julia" through PresentProof controller
+    When  "Julia" sends "presentation_bbs_dl.json" to "Jennifer" through PresentProof controller
+
+    Then  "Jennifer" successfully accepts a presentation with "bbs-drivers-license" name through PresentProof controller
+    And "Jennifer" checks that presentation is being stored under the "bbs-drivers-license" name
+
   @present_proof_controller_bbs_v3
   Scenario: The Verifier begins with a presentation request v3 (BBS+)
     Given "Harold" agent is running on "localhost" port "8081" with controller "https://localhost:8082"

--- a/test/bdd/pkg/presentproof/testdata/presentation_bbs_dl.json
+++ b/test/bdd/pkg/presentproof/testdata/presentation_bbs_dl.json
@@ -1,0 +1,37 @@
+{
+  "@type":"https://didcomm.org/present-proof/2.0/presentation",
+  "presentations~attach":[
+    {
+      "@id":"e78bbb0a-124e-11ec-8950-0242ac110003",
+      "mime-type":"application/ld+json",
+      "data":{
+        "json":{
+          "@context":[
+            "https://www.w3.org/2018/credentials/v1",
+            "https://w3id.org/security/bbs/v1",
+            {
+              "AATHDriversLicense":"dl:AATHDriversLicense",
+              "DL_number":"dl:DL_number",
+              "address":"dl:address",
+              "age":"dl:age",
+              "dl":"http://example.com/drivers-license#",
+              "expiry":"dl:expiry"
+            }
+          ],
+          "credentialSubject":{
+            "DL_number":"09385029529385",
+            "address":"947 this street, Kingston Ontario Canada, K9O 3R5",
+            "age":"30",
+            "expiry":"10/12/2022"
+          },
+          "issuanceDate":"2021-09-10T15:51:04Z",
+          "issuer":"did:example:489398593",
+          "type":[
+            "VerifiableCredential",
+            "AATHDriversLicense"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/bdd/pkg/presentproof/testdata/request_presentation_bbs_dl.json
+++ b/test/bdd/pkg/presentproof/testdata/request_presentation_bbs_dl.json
@@ -1,0 +1,46 @@
+{
+  "@type":"https://didcomm.org/present-proof/2.0/request-presentation",
+  "will_confirm":true,
+  "formats":[
+    {
+      "attach_id":"01a500ee-124f-11ec-9768-0242ac110004",
+      "format":"dif/presentation-exchange/definitions@v1.0"
+    }
+  ],
+  "request_presentations~attach":[
+    {
+      "@id":"01a500ee-124f-11ec-9768-0242ac110004",
+      "mime-type":"application/ld+json",
+      "data":{
+        "json":{
+          "presentation_definition": {
+            "id": "5ab84299-c066-4b34-bcc6-d356aa44c826",
+            "input_descriptors": [
+              {
+                "id": "drivers_license_input_1",
+                "name": "American Driver's License",
+                "schema": [
+                  {
+                    "uri": "https://www.w3.org/2018/credentials#VerifiableCredential"
+                  },
+                  {
+                    "uri": "http://example.com/drivers-license#AATHDriversLicense"
+                  }
+                ],
+                "constraints": {
+                  "limit_disclosure": "required",
+                  "fields": [
+                    {
+                      "path": ["$.credentialSubject.address"],
+                      "purpose": "Please share your address"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- support embedded contexts: include custom contexts in bbs limited credential template
- support ID being optional: allow json-ld Processor to Frame docs with blank ID

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>