### PR TITLE
fix: verifiable command building KID from didDoc.VM

### DIFF
--- a/pkg/controller/command/verifiable/command.go
+++ b/pkg/controller/command/verifiable/command.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
 	"github.com/hyperledger/aries-framework-go/pkg/internal/logutil"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
 	didstore "github.com/hyperledger/aries-framework-go/pkg/store/did"
 	verifiablestore "github.com/hyperledger/aries-framework-go/pkg/store/verifiable"
 	"github.com/hyperledger/aries-framework-go/spi/storage"
@@ -129,14 +130,23 @@ const (
 	// BbsBlsSignature2020 BBS signature suite.
 	BbsBlsSignature2020 = "BbsBlsSignature2020"
 
-	// Ed25519KeyType ed25519 key type.
-	Ed25519KeyType = "Ed25519"
+	// Ed25519Curve ed25519 curve.
+	Ed25519Curve = "ed25519"
 
-	// P256KeyType EC P-256 key type.
-	P256KeyType = "P256"
+	// P256KeyCurve EC P-256 curve.
+	P256KeyCurve = "p-256"
+
+	// P384KeyCurve EC P-384 curve.
+	P384KeyCurve = "p-384"
+
+	// P521KeyCurve EC P-521 curve.
+	P521KeyCurve = "p-521"
 
 	// Ed25519VerificationKey ED25519 verification key type.
 	Ed25519VerificationKey = "Ed25519VerificationKey"
+
+	// JSONWebKey2020 verification key type.
+	JSONWebKey2020 = "JsonWebKey2020"
 )
 
 type provable interface {
@@ -1044,7 +1054,9 @@ func prepareOpts(opts *ProofOptions, didDoc *did.Doc, method did.VerificationRel
 	if opts.VerificationMethod == "" {
 		logger.Warnf("Could not find matching verification method for '%s' proof purpose", opts.proofPurpose)
 
-		defaultVM, err := getDefaultVerificationMethod(didDoc)
+		var defaultVM string
+
+		defaultVM, err = getDefaultVerificationMethod(didDoc)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get default verification method: %w", err)
 		}
@@ -1052,7 +1064,56 @@ func prepareOpts(opts *ProofOptions, didDoc *did.Doc, method did.VerificationRel
 		opts.VerificationMethod = defaultVM
 	}
 
+	// if the VM key has #key-X, then extract key from Value/JWK value and build KID accordingly.
+	if strings.Index(opts.VerificationMethod, "#key-") > 0 {
+		err = buildKIDOption(opts, didDoc.VerificationMethod)
+		if err != nil {
+			return nil, fmt.Errorf("build KMS KID error: %w", err)
+		}
+	}
+
 	return opts, nil
+}
+
+func buildKIDOption(opts *ProofOptions, vms []did.VerificationMethod) error {
+	for _, vm := range vms {
+		if opts.VerificationMethod == vm.ID {
+			if len(vm.Value) > 0 {
+				kt := kms.ED25519Type
+
+				switch vm.Type {
+				case Ed25519VerificationKey:
+				case JSONWebKey2020:
+					kt = kmsKeyTypeByJWKCurve(vm.JSONWebKey().Crv)
+				}
+
+				kid, err := localkms.CreateKID(vm.Value, kt)
+				if err != nil {
+					return fmt.Errorf("failed to get default verification method: %w", err)
+				}
+
+				opts.KID = kid
+			}
+		}
+	}
+
+	return nil
+}
+
+func kmsKeyTypeByJWKCurve(crv string) kms.KeyType {
+	kt := kms.ED25519Type
+
+	switch crv {
+	case Ed25519Curve:
+	case P256KeyCurve:
+		kt = kms.ECDSAP256TypeIEEEP1363
+	case P384KeyCurve:
+		kt = kms.ECDSAP384TypeIEEEP1363
+	case P521KeyCurve:
+		kt = kms.ECDSAP521IEEEP1363
+	}
+
+	return kt
 }
 
 // TODO default verification method logic needs to be revisited, [Issue #1693].

--- a/pkg/controller/command/verifiable/command_test.go
+++ b/pkg/controller/command/verifiable/command_test.go
@@ -101,6 +101,107 @@ const bbsVc = `{
    ]
 }`
 
+const authVC = `{
+	"@context": [
+		"https://www.w3.org/2018/credentials/v1", 
+		"https://trustbloc.github.io/context/vc/authorization-credential-v1.jsonld"
+	],
+	"credentialSubject": {
+		"id": "did:peer:1zQmXJMfYLECQagWsw57tTDtudqp8eT2FTFd4Wiy1YUxQvMw",
+		"issuerDIDDoc": {
+			"doc": {
+				"@context": ["https://www.w3.org/ns/did/v1"],
+				"assertionMethod": ["#key-1"],
+				"authentication": ["#key-1"],
+				"created": "2021-09-16T01:44:39.7337939Z",
+				"id": "did:peer:1zQmYEVm9usSN4UdR3bRH2GLzbbcdrzSMEXvgLweekn3yr66",
+				"keyAgreement": ["#key-2"],
+				"service": [{
+					"id": "038ecea0-06bd-495c-a2bd-df32f9a68aec",
+					"priority": 0,
+					"recipientKeys": ["did:key:z6Mkg3kFC6kLTZ9pqwzJrTpztq3FV7RsVVyXPrpJ8ZyAtYZJ"],
+					"routingKeys": [],
+					"serviceEndpoint": "http://mock-issuer-adapter.com:10010",
+					"type": "did-communication"
+				}],
+				"updated": "2021-09-16T01:44:39.7337939Z",
+				"verificationMethod": [{
+					"controller": "",
+					"id": "#key-1",
+					"publicKeyBase58": "2bVCbrVu81fMjT9cAtsA3jVFfYA25cjAhquNJJ19yKmv",
+					"type": "Ed25519VerificationKey2018"
+				}, {
+					"controller": "",
+					"id": "#key-2",
+					"publicKeyBase58": "4gj2K8KWyCQAxQyefUubHDSdakSNuLWatkHfcNtWuXa1",
+					"type": "X25519KeyAgreementKey2019"
+				}]
+			},
+			"id": "did:peer:1zQmYEVm9usSN4UdR3bRH2GLzbbcdrzSMEXvgLweekn3yr66"
+		},
+		"requestingPartyDIDDoc": {
+			"doc": {
+				"@context": ["https://www.w3.org/ns/did/v1"],
+				"assertionMethod": ["#oBCLqpUt8SaReCcRyTJVlBAEVQTTaOT7H1QfdFBKoDI"],
+				"authentication": ["#oBCLqpUt8SaReCcRyTJVlBAEVQTTaOT7H1QfdFBKoDI"],
+				"created": "2021-09-16T01:45:23.4119263Z",
+				"id": "did:peer:1zQmeiHBZ2ymS7S43X43hGhJth5Fxc3uSaRcQ3ECwz7MFQvD",
+				"service": [{
+					"id": "57c0c1e7-8171-43e4-8b2a-60a695cd452c",
+					"priority": 0,
+					"recipientKeys": ["did:key:z6Mkmjb9tNbRnL3vpR5Pt6qEtYE8MeL8BvSBAd7iD2p2wYDh"],
+					"routingKeys": [],
+					"serviceEndpoint": "http://rp.adapter.rest.example.com:8071",
+					"type": "did-communication"
+				}],
+				"updated": "2021-09-16T01:45:23.4119263Z",
+				"verificationMethod": [{
+					"controller": "",
+					"id": "#oBCLqpUt8SaReCcRyTJVlBAEVQTTaOT7H1QfdFBKoDI",
+					"publicKeyBase58": "8HL7J8LzSnZThvEhCXsQ3Sg8Y54Gn3BpUcCnNkr22KSK",
+					"type": "Ed25519VerificationKey2018"
+				}]
+			},
+			"id": "did:peer:1zQmeiHBZ2ymS7S43X43hGhJth5Fxc3uSaRcQ3ECwz7MFQvD"
+		},
+		"subjectDIDDoc": {
+			"doc": {
+				"@context": ["https://www.w3.org/ns/did/v1"],
+				"assertionMethod": ["#key-1"],
+				"authentication": ["#key-1"],
+				"created": "2021-09-16T01:44:39.7286951Z",
+				"id": "did:peer:1zQmXJMfYLECQagWsw57tTDtudqp8eT2FTFd4Wiy1YUxQvMw",
+				"keyAgreement": ["#key-2"],
+				"service": [{
+					"id": "ec900fc4-29c2-43a4-91df-3098d617a981",
+					"priority": 0,
+					"recipientKeys": ["did:key:z6MkibZkEZAGr3HZfbWNiSBR8dvNnpZmSXm5A9weBMrTKjk3"],
+					"routingKeys": [],
+					"serviceEndpoint": "http://mock-wallet.com:9081",
+					"type": "did-communication"
+				}],
+				"updated": "2021-09-16T01:44:39.7286951Z",
+				"verificationMethod": [{
+					"controller": "",
+					"id": "#key-1",
+					"publicKeyBase58": "59JheJuqWVo6Z6fg2sDaHYNNyFHv2eWiU92iM5tSQWxf",
+					"type": "Ed25519VerificationKey2018"
+				}, {
+					"controller": "",
+					"id": "#key-2",
+					"publicKeyBase58": "9MFKK9MeTCCD1irEWcLv4hYwM9v5APovXNzzLoZdFQ3L",
+					"type": "X25519KeyAgreementKey2019"
+				}]
+			},
+			"id": "did:peer:1zQmXJMfYLECQagWsw57tTDtudqp8eT2FTFd4Wiy1YUxQvMw"
+		}
+	},
+	"id": "http://example.gov/credentials/ff98f978-588f-4eb0-b17b-60c18e1dac2c",
+	"issuanceDate": "2020-03-16T22:37:26.544Z",
+	"issuer": "did:peer:1zQmXJMfYLECQagWsw57tTDtudqp8eT2FTFd4Wiy1YUxQvMw",
+	"type": ["VerifiableCredential", "AuthorizationCredential"]
+}`
+
 //nolint:lll
 const vcWithDIDNotAvailble = `{ 
    "@context":[ 
@@ -176,6 +277,35 @@ const doc = `{
     }
 
   ]
+}`
+
+const authDoc = `{
+	"@context": ["https://www.w3.org/ns/did/v1"],
+	"assertionMethod": ["#key-1"],
+	"authentication": ["#key-1"],
+	"created": "2021-09-16T01:44:39.7337939Z",
+	"id": "did:peer:1zQmYEVm9usSN4UdR3bRH2GLzbbcdrzSMEXvgLweekn3yr66",
+	"keyAgreement": ["#key-2"],
+	"service": [{
+		"id": "038ecea0-06bd-495c-a2bd-df32f9a68aec",
+		"priority": 0,
+		"recipientKeys": ["did:key:z6Mkg3kFC6kLTZ9pqwzJrTpztq3FV7RsVVyXPrpJ8ZyAtYZJ"],
+		"routingKeys": [],
+		"serviceEndpoint": "http://mock-issuer-adapter.com:10010",
+		"type": "did-communication"
+	}],
+	"updated": "2021-09-16T01:44:39.7337939Z",
+	"verificationMethod": [{
+		"controller": "",
+		"id": "#key-1",
+		"publicKeyBase58": "2bVCbrVu81fMjT9cAtsA3jVFfYA25cjAhquNJJ19yKmv",
+		"type": "Ed25519VerificationKey2018"
+	}, {
+		"controller": "",
+		"id": "#key-2",
+		"publicKeyBase58": "4gj2K8KWyCQAxQyefUubHDSdakSNuLWatkHfcNtWuXa1",
+		"type": "X25519KeyAgreementKey2019"
+	}]
 }`
 
 const invalidDoc = `{
@@ -411,6 +541,7 @@ const sampleFrame = `
 const (
 	invalidDID = "did:error:123"
 	jwsDID     = "did:trustbloc:testnet.trustbloc.local:EiBug_0h2oNJj4Vhk7yrC36HvskhngqTJC46VKS-FDM5fA"
+	authDID    = "did:peer:1zQmYEVm9usSN4UdR3bRH2GLzbbcdrzSMEXvgLweekn3yr66"
 )
 
 func TestNew(t *testing.T) {
@@ -1989,6 +2120,14 @@ func TestCommand_SignCredential(t *testing.T) {
 					return &did.DocResolution{DIDDocument: jwsDoc}, nil
 				}
 
+				if didID == authDID {
+					authDoc, err := did.ParseDocument([]byte(authDoc))
+					if err != nil {
+						return nil, errors.New("unmarshal failed ")
+					}
+					return &did.DocResolution{DIDDocument: authDoc}, nil
+				}
+
 				didDoc, err := did.ParseDocument([]byte(doc))
 				if err != nil {
 					return nil, errors.New("unmarshal failed ")
@@ -2008,6 +2147,27 @@ func TestCommand_SignCredential(t *testing.T) {
 		req := SignCredentialRequest{
 			Credential:   []byte(vc),
 			DID:          "did:peer:123456789abcdefghi#inbox",
+			ProofOptions: &ProofOptions{SignatureType: Ed25519Signature2018},
+		}
+		reqBytes, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var b bytes.Buffer
+		err = cmd.SignCredential(&b, bytes.NewBuffer(reqBytes))
+		require.NoError(t, err)
+
+		// verify response
+		var response SignCredentialResponse
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, response)
+	})
+
+	t.Run("test sign auth credential - success", func(t *testing.T) {
+		req := SignCredentialRequest{
+			Credential:   []byte(authVC),
+			DID:          "did:peer:1zQmYEVm9usSN4UdR3bRH2GLzbbcdrzSMEXvgLweekn3yr66",
 			ProofOptions: &ProofOptions{SignatureType: Ed25519Signature2018},
 		}
 		reqBytes, err := json.Marshal(req)

--- a/pkg/internal/ldtestutil/contexts/third_party/trustbloc.github.io/trustbloc-authorization-credential_v1.jsonld
+++ b/pkg/internal/ldtestutil/contexts/third_party/trustbloc.github.io/trustbloc-authorization-credential_v1.jsonld
@@ -1,0 +1,40 @@
+{
+   "@context":{
+      "@version":1.1,
+      "@protected":true,
+      "name":"http://schema.org/name",
+      "ex":"https://example.org/examples#",
+      "xsd":"http://www.w3.org/2001/XMLSchema#",
+
+      "AuthorizationCredential":"ex:AuthorizationCredential",
+      "DIDDoc":{
+         "@id":"ex:DIDDoc",
+         "@context":{
+            "@version":1.1,
+            "@protected":true,
+            "id":"@id",
+            "type":"@type",
+            "doc":{
+               "@id":"ex:doc",
+               "@type":"@json"
+            }
+         }
+      },
+      "subjectDIDDoc":{
+         "@id":"ex:subjectDIDDoc",
+         "@type":"DIDDoc"
+      },
+      "issuerDIDDoc":{
+         "@id":"ex:issuerDIDDoc",
+         "@type":"DIDDoc"
+      },
+      "requestingPartyDIDDoc":{
+         "@id":"ex:requestingPartyDIDDoc",
+         "@type":"DIDDoc"
+      },
+      "subjectDID":{
+         "@id":"ex:subjectDID",
+         "@type":"xsd:string"
+      }
+   }
+}

--- a/pkg/internal/ldtestutil/document_loader.go
+++ b/pkg/internal/ldtestutil/document_loader.go
@@ -30,6 +30,8 @@ var (
 	credentialExamples []byte
 	//go:embed contexts/third_party/trustbloc.github.io/trustbloc-examples_v1.jsonld
 	vcExamples []byte
+	//go:embed contexts/third_party/trustbloc.github.io/trustbloc-authorization-credential_v1.jsonld
+	authCred []byte
 )
 
 var testContexts = []ldcontext.Document{ //nolint:gochecknoglobals // embedded test contexts
@@ -49,6 +51,10 @@ var testContexts = []ldcontext.Document{ //nolint:gochecknoglobals // embedded t
 	{
 		URL:     "https://trustbloc.github.io/context/vc/examples-v1.jsonld",
 		Content: vcExamples,
+	},
+	{
+		URL:     "https://trustbloc.github.io/context/vc/authorization-credential-v1.jsonld",
+		Content: authCred,
 	},
 }
 


### PR DESCRIPTION
when didDoc.VM.ID has a #key-X suffix, the kms KID must be built from the VM.Value or VM.JWK() instead of being extracted from VM.ID

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>

