### PR TITLE
feat: support present proof v2 interop with acapy

### DIFF
--- a/pkg/client/presentproof/client.go
+++ b/pkg/client/presentproof/client.go
@@ -102,7 +102,7 @@ func (c *Client) SendRequestPresentation(msg *RequestPresentation, myDID, theirD
 
 	msg.Type = presentproof.RequestPresentationMsgTypeV2
 
-	return c.service.HandleInbound(service.NewDIDCommMsgMap(msg), service.NewDIDCommContext(myDID, theirDID, nil))
+	return c.service.HandleOutbound(service.NewDIDCommMsgMap(msg), myDID, theirDID)
 }
 
 // SendRequestPresentationV3 is used by the Verifier to send a request presentation.
@@ -114,7 +114,7 @@ func (c *Client) SendRequestPresentationV3(msg *RequestPresentationV3, myDID, th
 
 	msg.Type = presentproof.RequestPresentationMsgTypeV3
 
-	return c.service.HandleInbound(service.NewDIDCommMsgMap(msg), service.NewDIDCommContext(myDID, theirDID, nil))
+	return c.service.HandleOutbound(service.NewDIDCommMsgMap(msg), myDID, theirDID)
 }
 
 type addProof func(presentation *verifiable.Presentation) error
@@ -153,7 +153,7 @@ func (c *Client) SendProposePresentation(msg *ProposePresentation, myDID, theirD
 
 	msg.Type = presentproof.ProposePresentationMsgTypeV2
 
-	return c.service.HandleInbound(service.NewDIDCommMsgMap(msg), service.NewDIDCommContext(myDID, theirDID, nil))
+	return c.service.HandleOutbound(service.NewDIDCommMsgMap(msg), myDID, theirDID)
 }
 
 // SendProposePresentationV3 is used by the Prover to send a propose presentation.
@@ -165,7 +165,7 @@ func (c *Client) SendProposePresentationV3(msg *ProposePresentationV3, myDID, th
 
 	msg.Type = presentproof.ProposePresentationMsgTypeV3
 
-	return c.service.HandleInbound(service.NewDIDCommMsgMap(msg), service.NewDIDCommContext(myDID, theirDID, nil))
+	return c.service.HandleOutbound(service.NewDIDCommMsgMap(msg), myDID, theirDID)
 }
 
 // AcceptProposePresentation is used when the Verifier is willing to accept the propose presentation.

--- a/pkg/client/presentproof/client_test.go
+++ b/pkg/client/presentproof/client_test.go
@@ -54,8 +54,8 @@ func TestClient_SendRequestPresentation(t *testing.T) {
 		thid := uuid.New().String()
 
 		svc := mocks.NewMockProtocolService(ctrl)
-		svc.EXPECT().HandleInbound(gomock.Any(), service.NewDIDCommContext(Alice, Bob, nil)).
-			DoAndReturn(func(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) {
+		svc.EXPECT().HandleOutbound(gomock.Any(), Alice, Bob).
+			DoAndReturn(func(msg service.DIDCommMsg, _, _ string) (string, error) {
 				require.Equal(t, msg.Type(), presentproof.RequestPresentationMsgTypeV2)
 
 				return thid, nil
@@ -91,8 +91,8 @@ func TestClient_SendRequestPresentationV3(t *testing.T) {
 		thid := uuid.New().String()
 
 		svc := mocks.NewMockProtocolService(ctrl)
-		svc.EXPECT().HandleInbound(gomock.Any(), service.NewDIDCommContext(Alice, Bob, nil)).
-			DoAndReturn(func(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) {
+		svc.EXPECT().HandleOutbound(gomock.Any(), Alice, Bob).
+			DoAndReturn(func(msg service.DIDCommMsg, _, _ string) (string, error) {
 				require.Equal(t, msg.Type(), presentproof.RequestPresentationMsgTypeV3)
 
 				return thid, nil
@@ -128,8 +128,8 @@ func TestClient_SendProposePresentation(t *testing.T) {
 		thid := uuid.New().String()
 
 		svc := mocks.NewMockProtocolService(ctrl)
-		svc.EXPECT().HandleInbound(gomock.Any(), service.NewDIDCommContext(Alice, Bob, nil)).
-			DoAndReturn(func(msg service.DIDCommMsg, _ service.DIDCommContext) (string, error) {
+		svc.EXPECT().HandleOutbound(gomock.Any(), Alice, Bob).
+			DoAndReturn(func(msg service.DIDCommMsg, _, _ string) (string, error) {
 				require.Equal(t, msg.Type(), presentproof.ProposePresentationMsgTypeV2)
 
 				return thid, nil
@@ -165,8 +165,8 @@ func TestClient_SendProposePresentationV3(t *testing.T) {
 		thid := uuid.New().String()
 
 		svc := mocks.NewMockProtocolService(ctrl)
-		svc.EXPECT().HandleInbound(gomock.Any(), service.NewDIDCommContext(Alice, Bob, nil)).
-			DoAndReturn(func(msg service.DIDCommMsg, _ service.DIDCommContext) (string, error) {
+		svc.EXPECT().HandleOutbound(gomock.Any(), Alice, Bob).
+			DoAndReturn(func(msg service.DIDCommMsg, _, _ string) (string, error) {
 				require.Equal(t, msg.Type(), presentproof.ProposePresentationMsgTypeV3)
 
 				return thid, nil

--- a/pkg/controller/command/presentproof/command_test.go
+++ b/pkg/controller/command/presentproof/command_test.go
@@ -149,8 +149,8 @@ func TestCommand_SendRequestPresentation(t *testing.T) {
 		service := mocks.NewMockProtocolService(ctrl)
 		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
 		service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
-		service.EXPECT().HandleInbound(
-			gomock.Any(), gomock.Any(),
+		service.EXPECT().HandleOutbound(
+			gomock.Any(), gomock.Any(), gomock.Any(),
 		).Return("", errors.New("some error message"))
 
 		provider := mocks.NewMockProvider(ctrl)
@@ -174,7 +174,7 @@ func TestCommand_SendRequestPresentation(t *testing.T) {
 		service := mocks.NewMockProtocolService(ctrl)
 		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
 		service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
-		service.EXPECT().HandleInbound(gomock.Any(), gomock.Any())
+		service.EXPECT().HandleOutbound(gomock.Any(), gomock.Any(), gomock.Any())
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
@@ -259,8 +259,8 @@ func TestCommand_SendRequestPresentationV3(t *testing.T) {
 		service := mocks.NewMockProtocolService(ctrl)
 		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
 		service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
-		service.EXPECT().HandleInbound(
-			gomock.Any(), gomock.Any(),
+		service.EXPECT().HandleOutbound(
+			gomock.Any(), gomock.Any(), gomock.Any(),
 		).Return("", errors.New("some error message"))
 
 		provider := mocks.NewMockProvider(ctrl)
@@ -284,7 +284,7 @@ func TestCommand_SendRequestPresentationV3(t *testing.T) {
 		service := mocks.NewMockProtocolService(ctrl)
 		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
 		service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
-		service.EXPECT().HandleInbound(gomock.Any(), gomock.Any())
+		service.EXPECT().HandleOutbound(gomock.Any(), gomock.Any(), gomock.Any())
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
@@ -369,8 +369,8 @@ func TestCommand_SendProposePresentation(t *testing.T) {
 		service := mocks.NewMockProtocolService(ctrl)
 		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
 		service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
-		service.EXPECT().HandleInbound(
-			gomock.Any(), gomock.Any(),
+		service.EXPECT().HandleOutbound(
+			gomock.Any(), gomock.Any(), gomock.Any(),
 		).Return("", errors.New("some error message"))
 
 		provider := mocks.NewMockProvider(ctrl)
@@ -394,7 +394,7 @@ func TestCommand_SendProposePresentation(t *testing.T) {
 		service := mocks.NewMockProtocolService(ctrl)
 		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
 		service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
-		service.EXPECT().HandleInbound(gomock.Any(), gomock.Any())
+		service.EXPECT().HandleOutbound(gomock.Any(), gomock.Any(), gomock.Any())
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
@@ -479,8 +479,8 @@ func TestCommand_SendProposePresentationV3(t *testing.T) {
 		service := mocks.NewMockProtocolService(ctrl)
 		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
 		service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
-		service.EXPECT().HandleInbound(
-			gomock.Any(), gomock.Any(),
+		service.EXPECT().HandleOutbound(
+			gomock.Any(), gomock.Any(), gomock.Any(),
 		).Return("", errors.New("some error message"))
 
 		provider := mocks.NewMockProvider(ctrl)
@@ -504,7 +504,7 @@ func TestCommand_SendProposePresentationV3(t *testing.T) {
 		service := mocks.NewMockProtocolService(ctrl)
 		service.EXPECT().RegisterActionEvent(gomock.Any()).Return(nil)
 		service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
-		service.EXPECT().HandleInbound(gomock.Any(), gomock.Any())
+		service.EXPECT().HandleOutbound(gomock.Any(), gomock.Any(), gomock.Any())
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)

--- a/pkg/controller/rest/presentproof/operation_test.go
+++ b/pkg/controller/rest/presentproof/operation_test.go
@@ -30,7 +30,7 @@ func provider(ctrl *gomock.Controller) client.Provider {
 	service.EXPECT().RegisterMsgEvent(gomock.Any()).Return(nil)
 	service.EXPECT().ActionContinue(gomock.Any(), gomock.Any()).AnyTimes()
 	service.EXPECT().ActionStop(gomock.Any(), gomock.Any()).AnyTimes()
-	service.EXPECT().HandleInbound(gomock.Any(), gomock.Any()).AnyTimes()
+	service.EXPECT().HandleOutbound(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
 	provider := mocks.NewMockProvider(ctrl)
 	provider.EXPECT().Service(gomock.Any()).Return(service, nil)

--- a/pkg/didcomm/protocol/presentproof/states_test.go
+++ b/pkg/didcomm/protocol/presentproof/states_test.go
@@ -323,6 +323,7 @@ func TestRequestSent_Execute(t *testing.T) {
 			Action: Action{Msg: service.NewDIDCommMsgMap(struct {
 				WillConfirm bool `json:"will_confirm"`
 			}{WillConfirm: true})},
+			Direction: outboundMessage,
 		}})
 		require.NoError(t, err)
 		require.Equal(t, &noOp{}, followup)
@@ -502,7 +503,9 @@ func TestProposePresentationSent_Execute(t *testing.T) {
 	})
 
 	t.Run("Success (outbound)", func(t *testing.T) {
-		followup, action, err := (&proposalSent{}).Execute(&metaData{})
+		followup, action, err := (&proposalSent{}).Execute(&metaData{
+			transitionalPayload: transitionalPayload{Direction: outboundMessage},
+		})
 		require.NoError(t, err)
 		require.Equal(t, &noOp{}, followup)
 		require.NotNil(t, action)

--- a/pkg/doc/signature/signer/signer.go
+++ b/pkg/doc/signature/signer/signer.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/proof"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 )
 
 const defaultProofPurpose = "assertionMethod"
@@ -105,7 +104,7 @@ func (signer *DocumentSigner) signObject(context *Context, jsonLdObject map[stri
 		Type:                    context.SignatureType,
 		SignatureRepresentation: context.SignatureRepresentation,
 		Creator:                 context.Creator,
-		Created:                 &util.TimeWrapper{Time: *created},
+		Created:                 wrapTime(*created),
 		Domain:                  context.Domain,
 		Nonce:                   context.Nonce,
 		VerificationMethod:      context.VerificationMethod,

--- a/pkg/doc/signature/signer/signer_default.go
+++ b/pkg/doc/signature/signer/signer_default.go
@@ -1,0 +1,19 @@
+// +build !ACAPyInterop
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package signer
+
+import (
+	"time"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
+)
+
+func wrapTime(t time.Time) *util.TimeWrapper {
+	return &util.TimeWrapper{Time: t}
+}

--- a/pkg/doc/signature/signer/signer_interop.go
+++ b/pkg/doc/signature/signer/signer_interop.go
@@ -1,0 +1,20 @@
+// +build ACAPyInterop
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package signer
+
+import (
+	"time"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
+)
+
+func wrapTime(t time.Time) *util.TimeWrapper {
+	tw, _ := util.ParseTimeWrapper(t.Format(time.RFC3339))
+	return tw
+}

--- a/pkg/wallet/wallet_test.go
+++ b/pkg/wallet/wallet_test.go
@@ -2877,6 +2877,9 @@ func TestWallet_ProposePresentation(t *testing.T) {
 			HandleFunc: func(service.DIDCommMsg) (string, error) {
 				return "", fmt.Errorf(sampleWalletErr)
 			},
+			HandleOutboundFunc: func(service.DIDCommMsg, string, string) (string, error) {
+				return "", fmt.Errorf(sampleWalletErr)
+			},
 		}
 		mockctx.ServiceMap[presentproofSvc.Name] = ppSvc
 


### PR DESCRIPTION
- Add present proof ack status
- Separate inbound/outbound message handling in present proof
- Set presentation format attach_id when constructing presentation message
- Use interop-compatible time format for LD signing when in interop mode

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>