### PR TITLE
feat: OOB create/accept invitation commands use accept/mediatypeprofile

### DIFF
--- a/pkg/client/outofband/client.go
+++ b/pkg/client/outofband/client.go
@@ -130,6 +130,7 @@ type Client struct {
 	service.Event
 	didDocSvcFunc func(routerConnID string, accept []string) (*did.Service, error)
 	oobService    OobService
+	defaultAccept string
 }
 
 // New returns a new Client for the Out-Of-Band protocol.
@@ -150,6 +151,13 @@ func New(p Provider) (*Client, error) {
 	}
 
 	client.didDocSvcFunc = client.didServiceBlockFunc(p)
+
+	profiles := p.MediaTypeProfiles()
+	if len(profiles) > 0 {
+		client.defaultAccept = profiles[0]
+	} else {
+		client.defaultAccept = transport.MediaTypeAIP2RFC0019Profile
+	}
 
 	return client, nil
 }
@@ -178,7 +186,7 @@ func (c *Client) CreateInvitation(services []interface{}, opts ...MessageOption)
 	}
 
 	if len(inv.Accept) == 0 {
-		inv.Accept = []string{transport.MediaTypeAIP2RFC0019Profile}
+		inv.Accept = []string{c.defaultAccept}
 	}
 
 	if len(inv.Services) == 0 {

--- a/pkg/controller/command/outofband/command.go
+++ b/pkg/controller/command/outofband/command.go
@@ -122,6 +122,7 @@ func (c *Command) CreateInvitation(rw io.Writer, req io.Reader) command.Error {
 		outofband.WithLabel(args.Label),
 		outofband.WithHandshakeProtocols(args.Protocols...),
 		outofband.WithRouterConnections(args.RouterConnectionID),
+		outofband.WithAccept(args.Accept...),
 	)
 	if err != nil {
 		logutil.LogError(logger, CommandName, CreateInvitation, err.Error())

--- a/pkg/controller/command/outofband/command_test.go
+++ b/pkg/controller/command/outofband/command_test.go
@@ -40,6 +40,7 @@ func TestNew(t *testing.T) {
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+		provider.EXPECT().MediaTypeProfiles().AnyTimes()
 
 		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
 		require.NoError(t, err)
@@ -62,6 +63,7 @@ func TestNew(t *testing.T) {
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+		provider.EXPECT().MediaTypeProfiles().AnyTimes()
 
 		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
 		require.EqualError(t, err, "register action event: error")
@@ -75,6 +77,7 @@ func TestNew(t *testing.T) {
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+		provider.EXPECT().MediaTypeProfiles().AnyTimes()
 
 		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
 		require.EqualError(t, err, "register msg event: error")
@@ -92,6 +95,7 @@ func TestCommand_CreateInvitation(t *testing.T) {
 
 	provider := mocks.NewMockProvider(ctrl)
 	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+	provider.EXPECT().MediaTypeProfiles().AnyTimes()
 
 	t.Run("Decode error", func(t *testing.T) {
 		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
@@ -114,6 +118,8 @@ func TestCommand_CreateInvitation(t *testing.T) {
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+		provider.EXPECT().MediaTypeProfiles().AnyTimes()
+
 		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
@@ -135,6 +141,8 @@ func TestCommand_CreateInvitation(t *testing.T) {
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+		provider.EXPECT().MediaTypeProfiles().AnyTimes()
+
 		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
@@ -172,6 +180,7 @@ func TestCommand_AcceptInvitation(t *testing.T) {
 
 	provider := mocks.NewMockProvider(ctrl)
 	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+	provider.EXPECT().MediaTypeProfiles().AnyTimes()
 
 	t.Run("Decode error", func(t *testing.T) {
 		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
@@ -223,6 +232,8 @@ func TestCommand_AcceptInvitation(t *testing.T) {
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+		provider.EXPECT().MediaTypeProfiles().AnyTimes()
+
 		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
@@ -245,6 +256,8 @@ func TestCommand_AcceptInvitation(t *testing.T) {
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+		provider.EXPECT().MediaTypeProfiles().AnyTimes()
+
 		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
@@ -267,6 +280,7 @@ func TestCommand_Actions(t *testing.T) {
 
 	provider := mocks.NewMockProvider(ctrl)
 	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+	provider.EXPECT().MediaTypeProfiles().AnyTimes()
 
 	t.Run("Success", func(t *testing.T) {
 		expected := ActionsResponse{Actions: []outofband.Action{{
@@ -314,6 +328,7 @@ func TestCommand_ActionStop(t *testing.T) {
 
 	provider := mocks.NewMockProvider(ctrl)
 	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+	provider.EXPECT().MediaTypeProfiles().AnyTimes()
 
 	t.Run("Decode error", func(t *testing.T) {
 		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
@@ -350,6 +365,7 @@ func TestCommand_ActionStop(t *testing.T) {
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+		provider.EXPECT().MediaTypeProfiles().AnyTimes()
 
 		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
 		require.NoError(t, err)
@@ -372,6 +388,7 @@ func TestCommand_ActionStop(t *testing.T) {
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+		provider.EXPECT().MediaTypeProfiles().AnyTimes()
 
 		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
 		require.NoError(t, err)
@@ -392,6 +409,7 @@ func TestCommand_ActionContinue(t *testing.T) {
 
 	provider := mocks.NewMockProvider(ctrl)
 	provider.EXPECT().Service(gomock.Any()).Return(service, nil).AnyTimes()
+	provider.EXPECT().MediaTypeProfiles().AnyTimes()
 
 	t.Run("Decode error", func(t *testing.T) {
 		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
@@ -430,6 +448,7 @@ func TestCommand_ActionContinue(t *testing.T) {
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+		provider.EXPECT().MediaTypeProfiles().AnyTimes()
 
 		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
 		require.NoError(t, err)
@@ -454,6 +473,7 @@ func TestCommand_ActionContinue(t *testing.T) {
 
 		provider := mocks.NewMockProvider(ctrl)
 		provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+		provider.EXPECT().MediaTypeProfiles().AnyTimes()
 
 		cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
 		require.NoError(t, err)
@@ -474,6 +494,7 @@ func TestCommand_GetHandlers(t *testing.T) {
 
 	provider := mocks.NewMockProvider(ctrl)
 	provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+	provider.EXPECT().MediaTypeProfiles().AnyTimes()
 	cmd, err := New(provider, mocknotifier.NewMockNotifier(nil))
 	require.NoError(t, err)
 	require.Equal(t, 5, len(cmd.GetHandlers()))

--- a/pkg/controller/command/outofband/models.go
+++ b/pkg/controller/command/outofband/models.go
@@ -21,6 +21,7 @@ type CreateInvitationArgs struct {
 	GoalCode           string        `json:"goal_code"`
 	Service            []interface{} `json:"service"`
 	Protocols          []string      `json:"protocols"`
+	Accept             []string      `json:"accept"`
 	RouterConnectionID string        `json:"router_connection_id"`
 	// Attachments is intended to provide the possibility to include files, links or even JSON payload to the message.
 	Attachments []*decorator.Attachment `json:"attachments"`

--- a/pkg/controller/rest/outofband/operation_test.go
+++ b/pkg/controller/rest/outofband/operation_test.go
@@ -44,6 +44,7 @@ func provider(ctrl *gomock.Controller) client.Provider {
 
 	provider := mocks.NewMockProvider(ctrl)
 	provider.EXPECT().Service(gomock.Any()).Return(service, nil)
+	provider.EXPECT().MediaTypeProfiles().AnyTimes()
 
 	return provider
 }

--- a/pkg/didcomm/protocol/outofband/service_test.go
+++ b/pkg/didcomm/protocol/outofband/service_test.go
@@ -854,7 +854,7 @@ func TestAcceptInvitation(t *testing.T) {
 		inv.Accept = []string{"INVALID"}
 		_, err := s.AcceptInvitation(inv, &userOptions{})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid media type profile")
+		require.Contains(t, err.Error(), "no acceptable media type profile found in invitation")
 	})
 }
 

--- a/test/bdd/agent/agent_sdk_steps.go
+++ b/test/bdd/agent/agent_sdk_steps.go
@@ -77,6 +77,12 @@ func (a *SDKSteps) scenario(keyType, keyAgreementType, mediaTypeProfile string) 
 	return nil
 }
 
+func (a *SDKSteps) useMediaTypeProfiles(mediaTypeProfiles string) error {
+	a.newMediaTypeProfiles = strings.Split(mediaTypeProfiles, ",")
+
+	return nil
+}
+
 // CreateAgent with the given parameters.
 func (a *SDKSteps) CreateAgent(agentID, inboundHost, inboundPort, scheme string) error {
 	return a.createAgentByDIDCommVer(agentID, inboundHost, inboundPort, scheme, false)
@@ -258,6 +264,8 @@ func (a *SDKSteps) CreateAgentWithHTTPDIDResolver(
 	var opts []aries.Option
 
 	for _, agentID := range strings.Split(agents, ",") {
+		opts = nil
+
 		url := a.bddContext.Args[endpointURL]
 		if endpointURL == sideTreeURL {
 			url += "identifiers"
@@ -515,6 +523,7 @@ func (a *SDKSteps) RegisterSteps(s *godog.Suite) {
 		`as the transport provider and http-binding did resolver url "([^"]*)" which accepts did method "([^"]*)"$`,
 		a.createAgentWithRegistrarAndHTTPDIDResolver)
 	s.Step(`^options ""([^"]*)"" ""([^"]*)"" ""([^"]*)""$`, a.scenario)
+	s.Step(`^all agents are using Media Type Profiles "([^"]*)"$`, a.useMediaTypeProfiles)
 }
 
 func mustGetRandomPort(n int) int {

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -119,7 +119,7 @@ func runBddTests(tags, format string) int {
 		s.AfterSuite(func() {
 			for _, c := range composition {
 				if c != nil {
-					if err := c.GenerateLogs(c.Dir, c.ProjectName+".log"); err != nil {
+					if err := c.GenerateLogs(c.Dir, c.Dir+"-"+c.ProjectName+".log"); err != nil {
 						panic(err)
 					}
 					if _, err := c.Decompose(c.Dir); err != nil {

--- a/test/bdd/features/outofband_e2e_sdk.feature
+++ b/test/bdd/features/outofband_e2e_sdk.feature
@@ -12,6 +12,7 @@
 Feature: Out-Of-Band protocol (Go API)
 
   Background:
+    Given all agents are using Media Type Profiles "didcomm/aip1,didcomm/aip2;env=rfc19,didcomm/aip2;env=rfc587,didcomm/v2"
     Given "Alice" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
       And "Bob" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
 

--- a/test/bdd/pkg/introduce/introduce_sdk_steps.go
+++ b/test/bdd/pkg/introduce/introduce_sdk_steps.go
@@ -596,7 +596,7 @@ func (a *SDKSteps) newOOBInvitation(agentID string, requests ...interface{}) (*o
 		}
 	}
 
-	if !didCommV2 {
+	if !didCommV2 && len(mtps) == 0 {
 		mtps = []string{transport.MediaTypeAIP2RFC0019Profile}
 	}
 

--- a/test/bdd/pkg/outofband/outofband_sdk_steps.go
+++ b/test/bdd/pkg/outofband/outofband_sdk_steps.go
@@ -593,7 +593,7 @@ func (sdk *SDKSteps) CreateInvitationWithDID(agent string) error {
 		}
 	}
 
-	if !didCommV2 {
+	if !didCommV2 && len(mtps) == 0 {
 		mtps = []string{transport.MediaTypeAIP2RFC0019Profile}
 	}
 


### PR DESCRIPTION
CreateInvitation:
- Add accept parameter to command
- If accept parameter not present, use agent's first MediaTypeProfile.
  If agent doesn't have any MediaTypeProfile set, default to the aip2 rfc19
  profile, as before.

AcceptInvitation:
- use agent's media type profiles to validate oob accept handshake

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>