### PR TITLE
DIDComm v2 Messaging without DIDExchange

### DIFF
--- a/pkg/client/messaging/client_test.go
+++ b/pkg/client/messaging/client_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -177,6 +178,15 @@ func TestCommand_Send(t *testing.T) { // nolint: gocognit, gocyclo
 			},
 		}
 
+		// Note: copied from store/connection/connection_lookup.go
+		mockDIDTagFunc := func(dids ...string) string {
+			for i, v := range dids {
+				dids[i] = strings.ReplaceAll(v, ":", "$")
+			}
+
+			return strings.Join(dids, "|")
+		}
+
 		t.Parallel()
 
 		for _, test := range tests {
@@ -192,7 +202,10 @@ func TestCommand_Send(t *testing.T) { // nolint: gocognit, gocyclo
 					require.NoError(t, errMarshal)
 					require.NoError(t,
 						memStore.Put(fmt.Sprintf("conn_%s", tc.testConnection.ConnectionID), connBytes,
-							spi.Tag{Name: "conn_"}))
+							spi.Tag{Name: "conn_"},
+							spi.Tag{Name: "bothDIDs", Value: mockDIDTagFunc(tc.testConnection.MyDID, tc.testConnection.TheirDID)},
+							spi.Tag{Name: "theirDID", Value: mockDIDTagFunc(tc.testConnection.TheirDID)},
+						))
 				}
 
 				cmd, err := New(&protocol.MockProvider{
@@ -262,6 +275,15 @@ func TestCommand_Send(t *testing.T) { // nolint: gocognit, gocyclo
 			},
 		}
 
+		// Note: copied from store/connection/connection_lookup.go
+		mockDIDTagFunc := func(dids ...string) string {
+			for i, v := range dids {
+				dids[i] = strings.ReplaceAll(v, ":", "$")
+			}
+
+			return strings.Join(dids, "|")
+		}
+
 		t.Parallel()
 
 		for _, test := range tests {
@@ -277,7 +299,10 @@ func TestCommand_Send(t *testing.T) { // nolint: gocognit, gocyclo
 					require.NoError(t, errMarshal)
 					require.NoError(t,
 						memStore.Put(fmt.Sprintf("conn_%s", tc.testConnection.ConnectionID), connBytes,
-							spi.Tag{Name: "conn_"}))
+							spi.Tag{Name: "conn_"},
+							spi.Tag{Name: "bothDIDs", Value: mockDIDTagFunc(tc.testConnection.MyDID, tc.testConnection.TheirDID)},
+							spi.Tag{Name: "theirDID", Value: mockDIDTagFunc(tc.testConnection.TheirDID)},
+						))
 				}
 
 				registrar := msghandler.NewMockMsgServiceProvider()

--- a/pkg/controller/rest/messaging/operation_test.go
+++ b/pkg/controller/rest/messaging/operation_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -469,6 +470,15 @@ func TestOperation_Send(t *testing.T) {
 			},
 		}
 
+		// Note: copied from store/connection/connection_lookup.go
+		mockDIDTagFunc := func(dids ...string) string {
+			for i, v := range dids {
+				dids[i] = strings.ReplaceAll(v, ":", "$")
+			}
+
+			return strings.Join(dids, "|")
+		}
+
 		t.Parallel()
 
 		for _, test := range tests {
@@ -479,7 +489,11 @@ func TestOperation_Send(t *testing.T) {
 					connBytes, err := json.Marshal(tc.testConnection)
 					require.NoError(t, err)
 					require.NoError(t, mockStore.Put(fmt.Sprintf("conn_%s", tc.testConnection.ConnectionID),
-						connBytes, spi.Tag{Name: "conn_"}))
+						connBytes,
+						spi.Tag{Name: "conn_"},
+						spi.Tag{Name: "bothDIDs", Value: mockDIDTagFunc(tc.testConnection.MyDID, tc.testConnection.TheirDID)},
+						spi.Tag{Name: "theirDID", Value: mockDIDTagFunc(tc.testConnection.TheirDID)},
+					))
 				}
 
 				svc, err := New(&protocol.MockProvider{StoreProvider: storage.NewCustomMockStoreProvider(mockStore)},

--- a/pkg/didcomm/protocol/didexchange/states_test.go
+++ b/pkg/didcomm/protocol/didexchange/states_test.go
@@ -882,11 +882,9 @@ func TestRespondedState_Execute(t *testing.T) {
 						State:        (&responded{}).Name(),
 						ThreadID:     request.ID,
 						ConnectionID: "123",
+						Namespace:    findNamespace(ResponseMsgType),
 					}
-					err = tc.ctx.connectionRecorder.SaveConnectionRecord(connRec)
-					require.NoError(t, err)
-					err = tc.ctx.connectionRecorder.SaveNamespaceThreadID(request.ID, findNamespace(ResponseMsgType),
-						connRec.ConnectionID)
+					err = tc.ctx.connectionRecorder.SaveConnectionRecordWithMappings(connRec)
 					require.NoError(t, err)
 					connRec, followup, _, e := (&responded{}).ExecuteInbound(
 						&stateMachineMsg{
@@ -1008,12 +1006,10 @@ func TestCompletedState_Execute(t *testing.T) {
 			State:         (&responded{}).Name(),
 			ThreadID:      response.Thread.ID,
 			ConnectionID:  "123",
+			Namespace:     findNamespace(AckMsgType),
 			RecipientKeys: []string{pubKey},
 		}
-		err = ctx.connectionRecorder.SaveConnectionRecord(connRec)
-		require.NoError(t, err)
-		err = ctx.connectionRecorder.SaveNamespaceThreadID(response.Thread.ID, findNamespace(AckMsgType),
-			connRec.ConnectionID)
+		err = ctx.connectionRecorder.SaveConnectionRecordWithMappings(connRec)
 		require.NoError(t, err)
 		ack := &model.Ack{
 			Type:   AckMsgType,
@@ -1036,12 +1032,10 @@ func TestCompletedState_Execute(t *testing.T) {
 			State:         (&responded{}).Name(),
 			ThreadID:      response.Thread.ID,
 			ConnectionID:  "123",
+			Namespace:     findNamespace(AckMsgType),
 			RecipientKeys: []string{pubKey},
 		}
-		err = ctx.connectionRecorder.SaveConnectionRecord(connRec)
-		require.NoError(t, err)
-		err = ctx.connectionRecorder.SaveNamespaceThreadID(response.Thread.ID, findNamespace(AckMsgType),
-			connRec.ConnectionID)
+		err = ctx.connectionRecorder.SaveConnectionRecordWithMappings(connRec)
 		require.NoError(t, err)
 		complete := &Complete{
 			Type: CompleteMsgType,

--- a/pkg/didcomm/protocol/mediator/service.go
+++ b/pkg/didcomm/protocol/mediator/service.go
@@ -129,6 +129,7 @@ type callback struct {
 type connections interface {
 	GetConnectionIDByDIDs(string, string) (string, error)
 	GetConnectionRecord(string) (*connection.Record, error)
+	GetConnectionRecordByDIDs(myDID string, theirDID string) (*connection.Record, error)
 }
 
 // Service for Route Coordination protocol.
@@ -841,14 +842,10 @@ func (s *Service) handleOutboundRequest(msg service.DIDCommMsg, myDID, theirDID 
 		return fmt.Errorf("failed to decode request : %w", err)
 	}
 
-	connID, err := s.connectionLookup.GetConnectionIDByDIDs(myDID, theirDID)
+	record, err := s.connectionLookup.GetConnectionRecordByDIDs(myDID, theirDID)
 	if err != nil {
-		return fmt.Errorf("failed to lookup connection ID for myDID=%s theirDID=%s : %w", myDID, theirDID, err)
-	}
-
-	record, err := s.connectionLookup.GetConnectionRecord(connID)
-	if err != nil {
-		return fmt.Errorf("failed to lookup connection record with id=%s : %w", connID, err)
+		return fmt.Errorf("failed to lookup connection record with myDID=%s theirDID=%s : %w",
+			myDID, theirDID, err)
 	}
 
 	return s.doRegistration(record, req, updateTimeout)

--- a/pkg/didcomm/protocol/mediator/service_test.go
+++ b/pkg/didcomm/protocol/mediator/service_test.go
@@ -1509,6 +1509,15 @@ type connectionsStub struct {
 	getConnRecord   func(string) (*connection.Record, error)
 }
 
+func (c *connectionsStub) GetConnectionRecordByDIDs(myDID, theirDID string) (*connection.Record, error) {
+	connID, err := c.GetConnectionIDByDIDs(myDID, theirDID)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetConnectionRecord(connID)
+}
+
 func (c *connectionsStub) GetConnectionIDByDIDs(myDID, theirDID string) (string, error) {
 	if c.getConnIDByDIDs != nil {
 		return c.getConnIDByDIDs(myDID, theirDID)

--- a/pkg/store/connection/connection_recorder.go
+++ b/pkg/store/connection/connection_recorder.go
@@ -83,14 +83,16 @@ func (c *Recorder) SaveConnectionRecord(record *Record) error {
 			record, c.store, storage.Tag{
 				Name:  getConnectionKeyPrefix()(""),
 				Value: getConnectionKeyPrefix()(record.ConnectionID),
+			},
+			storage.Tag{
+				Name:  bothDIDsTagName,
+				Value: tagValueFromDIDs(record.MyDID, record.TheirDID),
+			},
+			storage.Tag{
+				Name:  theirDIDTagName,
+				Value: tagValueFromDIDs(record.TheirDID),
 			}); err != nil {
 			return fmt.Errorf("save connection record in permanent store: %w", err)
-		}
-
-		// create map between DIDs and ConnectionID
-		if err := c.store.Put(getDIDConnMapKeyPrefix()(record.MyDID, record.TheirDID),
-			[]byte(record.ConnectionID)); err != nil {
-			return fmt.Errorf("save did and connection map in store: %w", err)
 		}
 	}
 
@@ -164,12 +166,6 @@ func (c *Recorder) RemoveConnection(connectionID string) error {
 	err = c.store.Delete(getConnectionKeyPrefix()(connectionID))
 	if err != nil {
 		return fmt.Errorf("unable to delete connection record from the store: connectionid=%s err=%w", connectionID, err)
-	}
-
-	err = c.store.Delete(getDIDConnMapKeyPrefix()(record.MyDID, record.TheirDID))
-	if err != nil {
-		return fmt.Errorf("unable to delete did mapping connection record from the store: connectionid=%s err=%w",
-			connectionID, err)
 	}
 
 	// remove namespace, threadID and connection ID mapping from protocol state store

--- a/pkg/store/connection/connection_recorder_test.go
+++ b/pkg/store/connection/connection_recorder_test.go
@@ -503,8 +503,7 @@ func TestConnectionRecorder_RemoveConnection(t *testing.T) {
 			t.Errorf("protocol state store still has connection state records: key=%s", key)
 		}
 
-		var r3 Record
-		err = getAndUnmarshal(getDIDConnMapKeyPrefix()(record.MyDID, record.TheirDID), &r3, recorder.store)
+		_, err = recorder.GetConnectionRecordByDIDs(record.MyDID, record.TheirDID)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "data not found")
 	})

--- a/test/bdd/features/presentproof.feature
+++ b/test/bdd/features/presentproof.feature
@@ -187,3 +187,16 @@ Feature: Present Proof protocol
     And "Tiana" declines a propose presentation and requests redirect to "http://example.com/error"
     Then "Gracia" receives problem report message (Present Proof)
     Then "Gracia" receives present proof event "abandoned" with status "FAIL" and redirect "http://example.com/error"
+  @ppv3_no_didex
+  Scenario: The Verifier begins with a request presentation v3 without didexchange
+    Given "Clarence" agent is running on "localhost" port "random" with "http" as the transport provider and "sidetree=${SIDETREE_URL},DIDCommV2" flags
+     And "Florence" agent is running on "localhost" port "random" with "http" as the transport provider and "sidetree=${SIDETREE_URL},DIDCommV2" flags
+    Given "Clarence" creates public DID for did method "sidetree"
+     And "Florence" creates public DID for did method "sidetree"
+    Then "Clarence" waits for public did to become available in sidetree for up to 10 seconds
+    And "Florence" waits for public did to become available in sidetree for up to 10 seconds
+    Then "Clarence" sends a request presentation v3 to the "Florence"
+    And "Florence" accepts a request and sends a presentation v3 to the "Clarence"
+    And "Clarence" accepts a presentation with name "license"
+    And "Clarence" checks that presentation is being stored under "license" name
+    Then "Florence" checks the history of events "request-received,request-received,presentation-sent,presentation-sent,done,done"


### PR DESCRIPTION
Outbound Dispatcher SendToDID can now create a default connection, if a connection doesn't yet exist, allowing didcomm V2 protocols to operate without DIDExchange, as long as the recipient DID can be resolved (ie, public or otherwise previously provided to the agent).

Also fixes connection Recorder/Lookup so it makes only one database read instead of two, when fetching a record by DIDs.