### PR TITLE
fix: wallet present proof fix

### DIFF
--- a/pkg/client/vcwallet/client_test.go
+++ b/pkg/client/vcwallet/client_test.go
@@ -1859,3 +1859,7 @@ type mockMsg struct {
 func (m *mockMsg) ParentThreadID() string {
 	return m.thID
 }
+
+func (m *mockMsg) ThreadID() (string, error) {
+	return m.thID, nil
+}

--- a/pkg/controller/command/vcwallet/command_test.go
+++ b/pkg/controller/command/vcwallet/command_test.go
@@ -2388,3 +2388,7 @@ type mockMsg struct {
 func (m *mockMsg) ParentThreadID() string {
 	return m.thID
 }
+
+func (m *mockMsg) ThreadID() (string, error) {
+	return m.thID, nil
+}

--- a/pkg/controller/rest/vcwallet/operation_test.go
+++ b/pkg/controller/rest/vcwallet/operation_test.go
@@ -1835,3 +1835,7 @@ type mockMsg struct {
 func (m *mockMsg) ParentThreadID() string {
 	return m.thID
 }
+
+func (m *mockMsg) ThreadID() (string, error) {
+	return m.thID, nil
+}

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -1079,7 +1079,7 @@ func waitForConnect(ctx context.Context, didStateMsgs chan service.StateMsg, con
 }
 
 // wait for present proof status to be completed (done or abandoned) from prover side.
-func waitForPresentProof(ctx context.Context, didStateMsgs chan service.StateMsg, thID string) (*PresentProofStatus, error) { // nolint:gocognit,gocyclo,lll
+func waitForPresentProof(ctx context.Context, didStateMsgs chan service.StateMsg, thID string) (*PresentProofStatus, error) { // nolint:gocognit,gocyclo,lll,funlen
 	done := make(chan *PresentProofStatus)
 
 	go func() {
@@ -1094,8 +1094,13 @@ func waitForPresentProof(ctx context.Context, didStateMsgs chan service.StateMsg
 				continue
 			}
 
+			msgThID, err := msg.Msg.ThreadID()
+			if err != nil {
+				continue
+			}
+
 			// match parent thread ID.
-			if msg.Msg.ParentThreadID() != thID {
+			if msg.Msg.ParentThreadID() != thID && msgThID != thID {
 				continue
 			}
 

--- a/pkg/wallet/wallet_test.go
+++ b/pkg/wallet/wallet_test.go
@@ -3272,6 +3272,12 @@ func TestWallet_PresentProof(t *testing.T) {
 				ch <- service.StateMsg{
 					Type:    service.PostState,
 					StateID: "invalid",
+					Msg:     &mockMsg{thID: thID, fail: errors.New(sampleWalletErr)},
+				}
+
+				ch <- service.StateMsg{
+					Type:    service.PostState,
+					StateID: "invalid",
 					Msg:     &mockMsg{thID: thID},
 				}
 
@@ -3353,8 +3359,13 @@ func addCredentialsToWallet(t *testing.T, walletInstance *Wallet, auth string, v
 type mockMsg struct {
 	*service.DIDCommMsgMap
 	thID string
+	fail error
 }
 
 func (m *mockMsg) ParentThreadID() string {
 	return m.thID
+}
+
+func (m *mockMsg) ThreadID() (string, error) {
+	return m.thID, m.fail
 }


### PR DESCRIPTION
- fixed issue where wallet is only relying parent thread id of present
proof V2

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>