### PR TITLE
fix: Crytpo signature verification using P384 key from JWK import 

### DIFF
--- a/pkg/crypto/tinkcrypto/crypto_test.go
+++ b/pkg/crypto/tinkcrypto/crypto_test.go
@@ -209,6 +209,35 @@ func TestCrypto_SignVerify(t *testing.T) {
 		err = c.Verify(s, msg, badKH)
 		require.Error(t, err)
 	})
+
+	t.Run("test with P-384 signature", func(t *testing.T) {
+		kh, err := keyset.NewHandle(signature.ECDSAP384KeyTemplate())
+		require.NoError(t, err)
+
+		badKH, err := keyset.NewHandle(tinkaead.KMSEnvelopeAEADKeyTemplate("babdUrl", nil))
+		require.NoError(t, err)
+
+		c := Crypto{}
+		msg := []byte(testMessage)
+		s, err := c.Sign(msg, kh)
+		require.NoError(t, err)
+
+		// get corresponding public key handle to verify
+		pubKH, err := kh.Public()
+		require.NoError(t, err)
+
+		err = c.Verify(s, msg, pubKH)
+		require.NoError(t, err)
+
+		// verify with nil key handle - should fail
+		err = c.Verify(s, msg, nil)
+		require.Error(t, err)
+		require.Equal(t, errBadKeyHandleFormat, err)
+
+		// verify with bad key handle - should fail
+		err = c.Verify(s, msg, badKH)
+		require.Error(t, err)
+	})
 }
 
 func TestCrypto_ComputeMAC(t *testing.T) {

--- a/pkg/crypto/tinkcrypto/withkms_test.go
+++ b/pkg/crypto/tinkcrypto/withkms_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package tinkcrypto_test
 
 import (

--- a/pkg/crypto/tinkcrypto/withkms_test.go
+++ b/pkg/crypto/tinkcrypto/withkms_test.go
@@ -1,0 +1,86 @@
+package tinkcrypto_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util/jwkkid"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+)
+
+func TestSignVerifyKeyTypes(t *testing.T) {
+	testCases := []struct {
+		name    string
+		keyType kms.KeyType
+	}{
+		{
+			"P-256",
+			kms.ECDSAP256TypeIEEEP1363,
+		},
+		{
+			"P-384",
+			kms.ECDSAP384TypeIEEEP1363,
+		},
+		{
+			"P-521",
+			kms.ECDSAP521TypeIEEEP1363,
+		},
+	}
+
+	data := []byte("abcdefg 1234567 1234567 1234567 1234567 1234567 AaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			kmsStorage, err := localkms.New("local-lock://test/master/key/", &mockProvider{
+				storeProvider: mockstorage.NewMockStoreProvider(),
+				secretLock:    &noop.NoLock{},
+			})
+			require.NoError(t, err)
+
+			cr, err := tinkcrypto.New()
+			require.NoError(t, err)
+
+			kid, pkb, err := kmsStorage.CreateAndExportPubKeyBytes(tc.keyType)
+			require.NoError(t, err)
+
+			kh, err := kmsStorage.Get(kid)
+			require.NoError(t, err)
+
+			pkJWK, err := jwkkid.BuildJWK(pkb, tc.keyType)
+			require.NoError(t, err)
+
+			jkBytes, err := pkJWK.PublicKeyBytes()
+			require.NoError(t, err)
+			require.Equal(t, pkb, jkBytes)
+
+			kh2, err := kmsStorage.PubKeyBytesToHandle(jkBytes, tc.keyType)
+			require.NoError(t, err)
+
+			sig, err := cr.Sign(data, kh)
+			require.NoError(t, err)
+
+			err = cr.Verify(sig, data, kh2)
+			require.NoError(t, err)
+		})
+	}
+}
+
+type mockProvider struct {
+	storeProvider storage.Provider
+	secretLock    secretlock.Service
+}
+
+func (m *mockProvider) StorageProvider() storage.Provider {
+	return m.storeProvider
+}
+
+func (m *mockProvider) SecretLock() secretlock.Service {
+	return m.secretLock
+}

--- a/pkg/kms/localkms/privkey_import.go
+++ b/pkg/kms/localkms/privkey_import.go
@@ -50,7 +50,7 @@ func (l *LocalKMS) importECDSAKey(privKey *ecdsa.PrivateKey, kt kms.KeyType,
 		params = &ecdsapb.EcdsaParams{
 			Curve:    commonpb.EllipticCurveType_NIST_P384,
 			Encoding: ecdsapb.EcdsaSignatureEncoding_DER,
-			HashType: commonpb.HashType_SHA512,
+			HashType: commonpb.HashType_SHA384,
 		}
 	case kms.ECDSAP521TypeDER:
 		params = &ecdsapb.EcdsaParams{
@@ -68,7 +68,7 @@ func (l *LocalKMS) importECDSAKey(privKey *ecdsa.PrivateKey, kt kms.KeyType,
 		params = &ecdsapb.EcdsaParams{
 			Curve:    commonpb.EllipticCurveType_NIST_P384,
 			Encoding: ecdsapb.EcdsaSignatureEncoding_IEEE_P1363,
-			HashType: commonpb.HashType_SHA512,
+			HashType: commonpb.HashType_SHA384,
 		}
 	case kms.ECDSAP521TypeIEEEP1363:
 		params = &ecdsapb.EcdsaParams{

--- a/pkg/kms/localkms/pubkey_export_import_test.go
+++ b/pkg/kms/localkms/pubkey_export_import_test.go
@@ -23,6 +23,15 @@ import (
 )
 
 func TestPubKeyExportAndRead(t *testing.T) {
+	p256DERTemplate, err := getKeyTemplate(kms.ECDSAP256TypeDER)
+	require.NoError(t, err)
+
+	p384DERTemplate, err := getKeyTemplate(kms.ECDSAP384TypeDER)
+	require.NoError(t, err)
+
+	p521DERTemplate, err := getKeyTemplate(kms.ECDSAP521TypeDER)
+	require.NoError(t, err)
+
 	flagTests := []struct {
 		tcName      string
 		keyType     kms.KeyType
@@ -32,19 +41,19 @@ func TestPubKeyExportAndRead(t *testing.T) {
 		{
 			tcName:      "export then read ECDSAP256DER public key",
 			keyType:     kms.ECDSAP256TypeDER,
-			keyTemplate: signature.ECDSAP256KeyWithoutPrefixTemplate(),
+			keyTemplate: p256DERTemplate,
 			doSign:      true,
 		},
 		{
 			tcName:      "export then read ECDSAP384DER public key",
 			keyType:     kms.ECDSAP384TypeDER,
-			keyTemplate: signature.ECDSAP384KeyWithoutPrefixTemplate(),
+			keyTemplate: p384DERTemplate,
 			doSign:      true,
 		},
 		{
 			tcName:      "export then read ECDSAP521DER public key",
 			keyType:     kms.ECDSAP521TypeDER,
-			keyTemplate: signature.ECDSAP521KeyWithoutPrefixTemplate(),
+			keyTemplate: p521DERTemplate,
 			doSign:      true,
 		},
 		{
@@ -56,7 +65,7 @@ func TestPubKeyExportAndRead(t *testing.T) {
 		{
 			tcName:      "export then read ECDSAP384IEEEP1363 public key",
 			keyType:     kms.ECDSAP384TypeIEEEP1363,
-			keyTemplate: createECDSAIEEE1363KeyTemplate(commonpb.HashType_SHA512, commonpb.EllipticCurveType_NIST_P384),
+			keyTemplate: createECDSAIEEE1363KeyTemplate(commonpb.HashType_SHA384, commonpb.EllipticCurveType_NIST_P384),
 			doSign:      true,
 		},
 		{

--- a/pkg/kms/localkms/pubkey_reader.go
+++ b/pkg/kms/localkms/pubkey_reader.go
@@ -94,7 +94,7 @@ func getMarshalledProtoKeyAndKeyURL(pubKey []byte, kt kms.KeyType) ([]byte, stri
 			pubKey,
 			"NIST_P384",
 			commonpb.EllipticCurveType_NIST_P384,
-			commonpb.HashType_SHA512)
+			commonpb.HashType_SHA384)
 		if err != nil {
 			return nil, "", err
 		}
@@ -127,7 +127,7 @@ func getMarshalledProtoKeyAndKeyURL(pubKey []byte, kt kms.KeyType) ([]byte, stri
 			pubKey,
 			"NIST_P384",
 			commonpb.EllipticCurveType_NIST_P384,
-			commonpb.HashType_SHA512)
+			commonpb.HashType_SHA384)
 		if err != nil {
 			return nil, "", err
 		}


### PR DESCRIPTION
Since P-384 DER format was using Tink's default signature template which uses SHA512, it was causing keys imported from a JWK to fail.
This change uses a template with SHA384 instead to keep signature/verification consistent in all cases (native kms key vs JWK imported key).


Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>
