### PR TITLE
fix(vcwallet): convert key to kid before issuing vc

### DIFF
--- a/internal/testdata/samples/wallet/sample_content_keybase58.json
+++ b/internal/testdata/samples/wallet/sample_content_keybase58.json
@@ -1,7 +1,7 @@
 {
   "@context": ["https://w3id.org/wallet/v1"],
-  "id": "did:key:z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5#z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5",
+  "id": "",
   "controller": "did:example:123456789abcdefghi",
   "type": "Ed25519VerificationKey2018",
-  "privateKeyBase58":"2MP5gWCnf67jvW3E4Lz8PpVrDWAXMYY1sDxjnkEnKhkkbKD7yP2mkVeyVpu5nAtr3TeDgMNjBPirk2XcQacs3dvZ"
+  "privateKeyBase58": "2MP5gWCnf67jvW3E4Lz8PpVrDWAXMYY1sDxjnkEnKhkkbKD7yP2mkVeyVpu5nAtr3TeDgMNjBPirk2XcQacs3dvZ"
 }

--- a/internal/testdata/samples/wallet/sample_content_keybase58_with_fragment_id.json
+++ b/internal/testdata/samples/wallet/sample_content_keybase58_with_fragment_id.json
@@ -1,0 +1,7 @@
+{
+  "@context": ["https://w3id.org/wallet/v1"],
+  "id": "did:key:z6MknT4m3MtA9UD1npGehFuBNiv6Bu8M25egHCaDbVcdHtia#z6MknT4m3MtA9UD1npGehFuBNiv6Bu8M25egHCaDbVcdHtia",
+  "controller": "did:key:z6MknT4m3MtA9UD1npGehFuBNiv6Bu8M25egHCaDbVcdHtia",
+  "type": "Ed25519VerificationKey2018",
+  "privateKeyBase58": "2UX4xA7k2DYGjrTZgbCdv2FPLJcwEMC6eFkyTK2CtUpaUWdiJiF8SB2mX1jTvGnYKr7sx8XZrkyQsPaV6LPAAN6i"
+}

--- a/internal/testdata/samples/wallet/sample_content_keybase58_with_id.json
+++ b/internal/testdata/samples/wallet/sample_content_keybase58_with_id.json
@@ -1,0 +1,7 @@
+{
+  "@context": ["https://w3id.org/wallet/v1"],
+  "id": "23",
+  "controller": "did:key:z6Mkj76JBAoTyqKM87ggSWDA9Zudnw1qFdpBv5Lm67jjGdcP",
+  "type": "Ed25519VerificationKey2018",
+  "privateKeyBase58": "5GR6rg39p47FKv6ujFfSYLK2SZc7Edhy2ck2Uu2B7GWzCnVRKhrUARukQVbciWAXew1BFzKi3pky5QA435AwrDum"
+}

--- a/internal/testdata/testdata.go
+++ b/internal/testdata/testdata.go
@@ -33,6 +33,10 @@ var (
 	SampleWalletContentMetadata []byte
 	//go:embed samples/wallet/sample_content_keybase58.json
 	SampleWalletContentKeyBase58 []byte
+	//go:embed samples/wallet/sample_content_keybase58_with_id.json
+	SampleWalletContentKeyBase58WithID []byte
+	//go:embed samples/wallet/sample_content_keybase58_with_fragment_id.json
+	SampleWalletContentKeyBase58WithFragmentID []byte
 	//go:embed samples/wallet/sample_query_by_frame.json
 	SampleWalletQueryByFrame []byte
 	//go:embed samples/wallet/sample_query_by_example.json

--- a/pkg/controller/command/verifiable/command.go
+++ b/pkg/controller/command/verifiable/command.go
@@ -142,8 +142,14 @@ const (
 	// P521KeyCurve EC P-521 curve.
 	P521KeyCurve = "P-521"
 
-	// Ed25519VerificationKey ED25519 verification key type.
-	Ed25519VerificationKey = "Ed25519VerificationKey"
+	// Ed25519VerificationKeyPrefix ED25519 verification key type.
+	Ed25519VerificationKeyPrefix = "Ed25519VerificationKey"
+
+	// Ed25519VerificationKey2018 ED25519 2018 verification key type.
+	Ed25519VerificationKey2018 = "Ed25519VerificationKey2018"
+
+	// Bls12381G2Key2020 BLS12-381 signature key type.
+	Bls12381G2Key2020 = "Bls12381G2Key2020"
 
 	// JSONWebKey2020 verification key type.
 	JSONWebKey2020 = "JsonWebKey2020"
@@ -1082,9 +1088,11 @@ func buildKIDOption(opts *ProofOptions, vms []did.VerificationMethod) error {
 				kt := kms.ED25519Type
 
 				switch vm.Type {
-				case Ed25519VerificationKey:
+				case Ed25519VerificationKey2018:
+				case Bls12381G2Key2020:
+					kt = kms.BLS12381G2Type
 				case JSONWebKey2020:
-					kt = kmsKeyTypeByJWKCurve(vm.JSONWebKey().Crv)
+					kt = KmsKeyTypeByJWKCurve(vm.JSONWebKey().Crv)
 				}
 
 				kid, err := localkms.CreateKID(vm.Value, kt)
@@ -1100,7 +1108,8 @@ func buildKIDOption(opts *ProofOptions, vms []did.VerificationMethod) error {
 	return nil
 }
 
-func kmsKeyTypeByJWKCurve(crv string) kms.KeyType {
+// KmsKeyTypeByJWKCurve returns key type for the JWK curve's name.
+func KmsKeyTypeByJWKCurve(crv string) kms.KeyType {
 	kt := kms.ED25519Type
 
 	switch crv {
@@ -1123,7 +1132,7 @@ func getDefaultVerificationMethod(didDoc *did.Doc) (string, error) {
 		var publicKeyID string
 
 		for _, k := range didDoc.VerificationMethod {
-			if strings.HasPrefix(k.Type, Ed25519VerificationKey) {
+			if strings.HasPrefix(k.Type, Ed25519VerificationKeyPrefix) {
 				publicKeyID = k.ID
 
 				break

--- a/pkg/doc/util/jwkkid/kid_creator.go
+++ b/pkg/doc/util/jwkkid/kid_creator.go
@@ -97,7 +97,7 @@ func BuildJWK(keyBytes []byte, kt kms.KeyType) (*jwk.JWK, error) {
 	//		return nil, fmt.Errorf("buildJWK: failed to build JWK from ed25519 key: %w", err)
 	//	}
 	case kms.ECDSAP256TypeIEEEP1363, kms.ECDSAP384TypeIEEEP1363, kms.ECDSAP521TypeIEEEP1363:
-		c := getCurveByKMSKeyType(kt)
+		c := GetCurveByKMSKeyType(kt)
 		x, y := elliptic.Unmarshal(c, keyBytes)
 
 		pubKey := &ecdsa.PublicKey{
@@ -161,7 +161,8 @@ func generateJWKFromECDH(keyBytes []byte) (*jwk.JWK, error) {
 	return jwksupport.JWKFromKey(pubKey)
 }
 
-func getCurveByKMSKeyType(kt kms.KeyType) elliptic.Curve {
+// GetCurveByKMSKeyType get curve for KeyType.
+func GetCurveByKMSKeyType(kt kms.KeyType) elliptic.Curve {
 	switch kt {
 	case kms.ECDSAP256TypeIEEEP1363:
 		return elliptic.P256()

--- a/pkg/doc/util/jwkkid/kid_creator_test.go
+++ b/pkg/doc/util/jwkkid/kid_creator_test.go
@@ -145,10 +145,10 @@ func TestCreateKIDFromFixedKey(t *testing.T) {
 }
 
 func TestGetCurve(t *testing.T) {
-	c := getCurveByKMSKeyType(kms.ECDSAP384TypeIEEEP1363)
+	c := GetCurveByKMSKeyType(kms.ECDSAP384TypeIEEEP1363)
 	require.Equal(t, c, elliptic.P384())
 
-	c = getCurveByKMSKeyType(kms.AES128GCMType) // default P-256 if curve not found
+	c = GetCurveByKMSKeyType(kms.AES128GCMType) // default P-256 if curve not found
 	require.Equal(t, c, elliptic.P256())
 }
 

--- a/pkg/kms/localkms/kid_creator.go
+++ b/pkg/kms/localkms/kid_creator.go
@@ -12,7 +12,7 @@ import (
 )
 
 // CreateKID creates a KID value based on the marshalled keyBytes of type kt. This function should be called for
-// asymmetric public keys only (ECDSA DER or IEEE1363, ED25519).
+// asymmetric public keys only (ECDSA DER or IEEE1363, ED25519, BLS12-381).
 // returns:
 //  - base64 raw (no padding) URL encoded KID
 //  - error in case of error

--- a/pkg/wallet/contents.go
+++ b/pkg/wallet/contents.go
@@ -219,6 +219,9 @@ func (cs *contentStore) Save(auth string, ct ContentType, content []byte, option
 			return fmt.Errorf("failed to read key contents: %w", err)
 		}
 
+		// clear key ID because the user won't be able to access the key via the id
+		key.ID = ""
+
 		return saveKey(auth, &key)
 	default:
 		return fmt.Errorf("invalid content type '%s', supported types are %s", ct,
@@ -272,14 +275,14 @@ func (cs *contentStore) mapCollection(auth, key, collectionID string, ct Content
 
 func saveKey(auth string, key *keyContent) error {
 	if len(key.PrivateKeyJwk) > 0 {
-		err := importKeyJWK(auth, key)
+		_, err := importKeyJWK(auth, key)
 		if err != nil {
 			return fmt.Errorf("failed to import private key jwk: %w", err)
 		}
 	}
 
 	if key.PrivateKeyBase58 != "" {
-		err := importKeyBase58(auth, key)
+		_, err := importKeyBase58(auth, key)
 		if err != nil {
 			return fmt.Errorf("failed to import private key base58: %w", err)
 		}

--- a/pkg/wallet/contents.go
+++ b/pkg/wallet/contents.go
@@ -219,9 +219,6 @@ func (cs *contentStore) Save(auth string, ct ContentType, content []byte, option
 			return fmt.Errorf("failed to read key contents: %w", err)
 		}
 
-		// clear key ID because the user won't be able to access the key via the id
-		key.ID = ""
-
 		return saveKey(auth, &key)
 	default:
 		return fmt.Errorf("invalid content type '%s', supported types are %s", ct,

--- a/pkg/wallet/kmsclient.go
+++ b/pkg/wallet/kmsclient.go
@@ -389,7 +389,7 @@ func getKID(id string) string {
 		return cSplit[1]
 	}
 
-	return ""
+	return id
 }
 
 func getKIDFromJWK(id string, j *jwk.JWK) string {

--- a/pkg/wallet/kmsclient.go
+++ b/pkg/wallet/kmsclient.go
@@ -268,7 +268,7 @@ func newKMSSigner(authToken string, c crypto.Crypto, opts *ProofOptions) (*kmsSi
 		return nil, errors.New("invalid verification method format")
 	}
 
-	keyHandler, err := keyManager.Get(vmSplit[vmSectionCount-1])
+	keyHandler, err := keyManager.Get(opts.KID)
 	if err != nil {
 		return nil, err
 	}
@@ -304,69 +304,82 @@ func (s *kmsSigner) Sign(data []byte) ([]byte, error) {
 
 // importKeyJWK imports private key jwk found in key contents,
 // supported curve types - Ed25519, P-256, BLS12381G2.
-func importKeyJWK(auth string, key *keyContent) error {
+func importKeyJWK(auth string, key *keyContent) (string, error) {
 	keyManager, err := keyManager().getKeyManger(auth)
 	if err != nil {
 		if errors.Is(err, gcache.KeyNotFoundError) {
-			return ErrWalletLocked
+			return "", ErrWalletLocked
 		}
 
-		return fmt.Errorf("failed to get key manager: %w", err)
+		return "", fmt.Errorf("failed to get key manager: %w", err)
 	}
 
 	var j jwk.JWK
 	if e := j.UnmarshalJSON(key.PrivateKeyJwk); e != nil {
-		return fmt.Errorf("failed to unmarshal jwk : %w", e)
+		return "", fmt.Errorf("failed to unmarshal jwk : %w", e)
 	}
 
 	keyType, ok := jwkCurves[j.Crv]
 	if !ok {
-		return fmt.Errorf("unsupported Key type %s", j.Crv)
+		return "", fmt.Errorf("unsupported Key type %s", j.Crv)
 	}
 
-	_, _, err = keyManager.ImportPrivateKey(j.Key, keyType, kms.WithKeyID(getKIDFromJWK(key.ID, &j)))
+	opts := make([]kms.PrivateKeyOpts, 0)
+	if key.ID != "" {
+		opts = append(opts, kms.WithKeyID(getKIDFromJWK(key.ID, &j)))
+	}
+
+	kid, _, err := keyManager.ImportPrivateKey(j.Key, keyType, opts...)
 	if err != nil {
-		return fmt.Errorf("failed to import jwk key : %w", err)
+		return "", fmt.Errorf("failed to import jwk key : %w", err)
 	}
 
-	return nil
+	return kid, nil
 }
 
 // importKeyBase58 imports private key base58 found in key contents,
 // supported types - Ed25519Signature2018, Bls12381G1Key2020.
-func importKeyBase58(auth string, key *keyContent) error {
+//nolint:unparam // no test uses the kid return value yet but it should nevertheless be there
+func importKeyBase58(auth string, key *keyContent) (string, error) {
+	var kid string
+
 	keyManager, err := keyManager().getKeyManger(auth)
 	if err != nil {
 		if errors.Is(err, gcache.KeyNotFoundError) {
-			return ErrWalletLocked
+			return "", ErrWalletLocked
 		}
 
-		return fmt.Errorf("failed to get key manager: %w", err)
+		return "", fmt.Errorf("failed to get key manager: %w", err)
+	}
+
+	opts := make([]kms.PrivateKeyOpts, 0)
+	if key.ID != "" {
+		opts = append(opts, kms.WithKeyID(getKID(key.ID)))
 	}
 
 	switch strings.ToLower(key.KeyType) {
 	case Ed25519VerificationKey2018:
 		edPriv := ed25519.PrivateKey(base58.Decode(key.PrivateKeyBase58))
 
-		_, _, err := keyManager.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(getKID(key.ID)))
+		kid, _, err = keyManager.ImportPrivateKey(edPriv, kms.ED25519, opts...)
 		if err != nil {
-			return fmt.Errorf("failed to import Ed25519Signature2018 key : %w", err)
+			return "", fmt.Errorf("failed to import Ed25519Signature2018 key : %w", err)
 		}
 	case Bls12381G1Key2020:
 		blsKey, err := bbs12381g2pub.UnmarshalPrivateKey(base58.Decode(key.PrivateKeyBase58))
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal %s private key : %w", kms.BLS12381G2Type, err)
+			return "", fmt.Errorf("failed to unmarshal %s private key : %w", kms.BLS12381G2Type, err)
 		}
 
-		_, _, err = keyManager.ImportPrivateKey(blsKey, kms.BLS12381G2, kms.WithKeyID(getKID(key.ID)))
+		kid, _, err = keyManager.ImportPrivateKey(blsKey, kms.BLS12381G2, opts...)
 		if err != nil {
-			return fmt.Errorf("failed to import Ed25519Signature2018 key : %w", err)
+			return "", fmt.Errorf("failed to import Ed25519Signature2018 key : %w", err)
 		}
 	default:
-		return errors.New("only Ed25519VerificationKey2018 &  Bls12381G1Key2020 are supported in base58 format")
+		return "", errors.New("only Ed25519VerificationKey2018 &  Bls12381G1Key2020 are supported in base58 format")
 	}
 
-	return nil
+	return kid, nil
 }
 
 func getKID(id string) string {

--- a/pkg/wallet/kmsclient_test.go
+++ b/pkg/wallet/kmsclient_test.go
@@ -283,9 +283,9 @@ func TestImportKeyJWK(t *testing.T) {
 				name: "import Ed25519",
 				sampleJWK: []byte(`{
 							"kty": "OKP",
-							"d":"Dq5t2WS3OMzcpkh8AyVxJs5r9v4L39ocIz9CpUOqM40",
+							"d": "PZ1PSb0Szy6VG8_ht-vWCFHOyLCeLYForcoanFXqSgs",
 							"crv": "Ed25519",
-							"x": "ODaPFurJgFcoVCUYEmgOJpWOtPlOYbHSugasscKWqDM",
+							"x": "6F3EgB2EcymlT50_UOplrSWKVTF2pXFZ1dg_ZWlu9O0",
 							"kid":"z6MkiEh8RQL83nkPo8ehDeE7"
 				}`),
 				ID: "did:example:123#z6MkiEh8RQL83nkPo8ehDeE7",
@@ -294,9 +294,9 @@ func TestImportKeyJWK(t *testing.T) {
 				name: "import Ed25519, use document id for missing kid",
 				sampleJWK: []byte(`{
 							"kty": "OKP",
-							"d":"Dq5t2WS3OMzcpkh8AyVxJs5r9v4L39ocIz9CpUOqM40",
+							"d":"70u3yNq94C2f06zHhkcAu2Yqs1AMA99u5Z9bjkcFGE8",
 							"crv": "Ed25519",
-							"x": "ODaPFurJgFcoVCUYEmgOJpWOtPlOYbHSugasscKWqDM"
+							"x": "14Xchu6CUKOmmSWZMAXwM_jV9cwVyt28H8467LBDFxE"
 				}`),
 				ID: "did:example:123#z6MkiEh8RQL83nkPo8ehDeE8",
 			},
@@ -352,7 +352,7 @@ func TestImportKeyJWK(t *testing.T) {
 					"x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ"
       				}`),
 				ID:    "did:example:123#z6MkiEh8RQL83nkPo8ehDeE7",
-				error: "mport private key does not support this key type or key is public",
+				error: "import private key does not support this key type or key is public",
 			},
 		}
 
@@ -362,20 +362,20 @@ func TestImportKeyJWK(t *testing.T) {
 			tc := test
 			t.Run(tc.name, func(t *testing.T) {
 				if tc.error != "" {
-					err := importKeyJWK(tkn, &keyContent{PrivateKeyJwk: tc.sampleJWK, ID: tc.ID})
+					_, err := importKeyJWK(tkn, &keyContent{PrivateKeyJwk: tc.sampleJWK, ID: tc.ID})
 					require.Error(t, err)
 					require.Contains(t, err.Error(), tc.error)
 
 					return
 				}
 
-				err := importKeyJWK(tkn, &keyContent{PrivateKeyJwk: tc.sampleJWK, ID: tc.ID})
+				kid, err := importKeyJWK(tkn, &keyContent{PrivateKeyJwk: tc.sampleJWK, ID: tc.ID})
 				require.NoError(t, err)
 
 				kmgr, err := keyManager().getKeyManger(tkn)
 				require.NoError(t, err)
 
-				handle, err := kmgr.Get(getKID(tc.ID))
+				handle, err := kmgr.Get(kid)
 				require.NoError(t, err)
 				require.NotEmpty(t, handle)
 			})
@@ -383,7 +383,7 @@ func TestImportKeyJWK(t *testing.T) {
 	})
 
 	t.Run("test key ID already exists", func(t *testing.T) {
-		err := importKeyJWK(tkn, &keyContent{PrivateKeyJwk: []byte(`{
+		_, err := importKeyJWK(tkn, &keyContent{PrivateKeyJwk: []byte(`{
 							"kty": "OKP",
 							"d":"Dq5t2WS3OMzcpkh8AyVxJs5r9v4L39ocIz9CpUOqM40",
 							"crv": "Ed25519",
@@ -393,7 +393,7 @@ func TestImportKeyJWK(t *testing.T) {
 		require.NoError(t, err)
 
 		// import different key with same key ID
-		err = importKeyJWK(tkn, &keyContent{PrivateKeyJwk: []byte(`{
+		_, err = importKeyJWK(tkn, &keyContent{PrivateKeyJwk: []byte(`{
       						"kty": "EC",
       						"crv": "P-384",
       						"x": "eQbMauiHc9HuiqXT894gW5XTCrOpeY8cjLXAckfRtdVBLzVHKaiXAAxBFeVrSB75",
@@ -405,7 +405,7 @@ func TestImportKeyJWK(t *testing.T) {
 		require.Contains(t, err.Error(), "requested ID 'z6MkiEh8RQL83nkPo8ehDeX7' already exists")
 
 		// import different key with same content ID (missing kid)
-		err = importKeyJWK(tkn, &keyContent{PrivateKeyJwk: []byte(`{
+		_, err = importKeyJWK(tkn, &keyContent{PrivateKeyJwk: []byte(`{
       						"kty": "EC",
       						"crv": "P-384",
       						"x": "eQbMauiHc9HuiqXT894gW5XTCrOpeY8cjLXAckfRtdVBLzVHKaiXAAxBFeVrSB75",
@@ -416,7 +416,7 @@ func TestImportKeyJWK(t *testing.T) {
 		require.Contains(t, err.Error(), "requested ID 'z6MkiEh8RQL83nkPo8ehDeX7' already exists")
 
 		// no KID
-		err = importKeyJWK(tkn, &keyContent{PrivateKeyJwk: []byte(`{
+		_, err = importKeyJWK(tkn, &keyContent{PrivateKeyJwk: []byte(`{
 							"kty": "OKP",
 							"d":"Dq5t2WS3OMzcpkh8AyVxJs5r9v4L39ocIz9CpUOqM40",
 							"crv": "Ed25519",
@@ -426,7 +426,7 @@ func TestImportKeyJWK(t *testing.T) {
 	})
 
 	t.Run("test key manager errors", func(t *testing.T) {
-		err := importKeyJWK(tkn+"invalid", &keyContent{PrivateKeyJwk: []byte(`{
+		_, err := importKeyJWK(tkn+"invalid", &keyContent{PrivateKeyJwk: []byte(`{
 							"kty": "OKP",
 							"d":"Dq5t2WS3OMzcpkh8AyVxJs5r9v4L39ocIz9CpUOqM40",
 							"crv": "Ed25519",
@@ -498,7 +498,7 @@ func TestImportKeyBase58(t *testing.T) {
 			tc := test
 			t.Run(tc.name, func(t *testing.T) {
 				if tc.error != "" {
-					err := importKeyBase58(tkn, &keyContent{
+					_, err := importKeyBase58(tkn, &keyContent{
 						ID:               tc.ID,
 						PrivateKeyBase58: tc.keyBase58,
 						KeyType:          tc.keyType,
@@ -509,7 +509,7 @@ func TestImportKeyBase58(t *testing.T) {
 					return
 				}
 
-				err := importKeyBase58(tkn, &keyContent{
+				_, err := importKeyBase58(tkn, &keyContent{
 					ID:               tc.ID,
 					PrivateKeyBase58: tc.keyBase58,
 					KeyType:          tc.keyType,
@@ -527,14 +527,14 @@ func TestImportKeyBase58(t *testing.T) {
 	})
 
 	t.Run("test key ID already exists", func(t *testing.T) {
-		err := importKeyBase58(tkn, &keyContent{
+		_, err := importKeyBase58(tkn, &keyContent{
 			ID:               "did:example:123#z6MkiEh8RQL83nkPo8ehDeE4",
 			PrivateKeyBase58: "zJRjGFZydU5DBdS2p5qbiUzDFAxbXTkjiDuGPksMBbY5TNyEsGfK4a4WGKjBCh1zeNryeuKtPotp8W1ESnwP71y",
 			KeyType:          "Ed25519VerificationKey2018",
 		})
 		require.NoError(t, err)
 
-		err = importKeyBase58(tkn, &keyContent{
+		_, err = importKeyBase58(tkn, &keyContent{
 			ID:               "did:example:123#z6MkiEh8RQL83nkPo8ehDeE4",
 			PrivateKeyBase58: "zJRjGFZydU5DBdS2p5qbiUzDFAxbXTkjiDuGPksMBbY5TNyEsGfK4a4WGKjBCh1zeNryeuKtPotp8W1ESnwP71y",
 			KeyType:          "Ed25519VerificationKey2018",
@@ -544,7 +544,7 @@ func TestImportKeyBase58(t *testing.T) {
 	})
 
 	t.Run("test key manager errors", func(t *testing.T) {
-		err := importKeyBase58(tkn+"invalid", &keyContent{
+		_, err := importKeyBase58(tkn+"invalid", &keyContent{
 			ID:               "did:example:123#z6MkiEh8RQL83nkPo8ehDeE5",
 			PrivateKeyBase58: "zJRjGFZydU5DBdS2p5qbiUzDFAxbXTkjiDuGPksMBbY5TNyEsGfK4a4WGKjBCh1zeNryeuKtPotp8W1ESnwP71y",
 			KeyType:          "Ed25519VerificationKey2018",
@@ -561,7 +561,7 @@ func TestImportKeyBase58(t *testing.T) {
 			&mockkms.KeyManager{ImportPrivateKeyErr: sampleErr}, 0)
 		require.NoError(t, err)
 
-		err = importKeyBase58(mockToken, &keyContent{
+		_, err = importKeyBase58(mockToken, &keyContent{
 			ID:               "did:example:123#z6MkiEh8RQL83nkPo8ehDeE5",
 			PrivateKeyBase58: "zJRjGFZydU5DBdS2p5qbiUzDFAxbXTkjiDuGPksMBbY5TNyEsGfK4a4WGKjBCh1zeNryeuKtPotp8W1ESnwP71y",
 			KeyType:          "Ed25519VerificationKey2018",
@@ -569,7 +569,7 @@ func TestImportKeyBase58(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, errors.Is(err, sampleErr))
 
-		err = importKeyBase58(mockToken, &keyContent{
+		_, err = importKeyBase58(mockToken, &keyContent{
 			ID:               "did:example:123#z6MkiEh8RQL83nkPo8ehDeE5",
 			PrivateKeyBase58: "6gsgGpdx7p1nYoKJ4b5fKt1xEomWdnemg9nJFX6mqNCh",
 			KeyType:          "Bls12381G1Key2020",

--- a/pkg/wallet/models.go
+++ b/pkg/wallet/models.go
@@ -30,6 +30,7 @@ type QueryParams struct {
 // To be used as options for issue/prove wallet features.
 //
 type ProofOptions struct {
+	KID string `json:"kid,omitempty"`
 	// Controller is a DID to be for signing. This option is required for issue/prove wallet features.
 	Controller string `json:"controller,omitempty"`
 	// VerificationMethod is the URI of the verificationMethod used for the proof.

--- a/pkg/wallet/models.go
+++ b/pkg/wallet/models.go
@@ -30,6 +30,8 @@ type QueryParams struct {
 // To be used as options for issue/prove wallet features.
 //
 type ProofOptions struct {
+	// KID is the key ID of the key in the KMS that shall be used for the proof.
+	// Optional, by default, VerificationMethod is used. If KID is present, it takes precedence over VerificationMethod.
 	KID string `json:"kid,omitempty"`
 	// Controller is a DID to be for signing. This option is required for issue/prove wallet features.
 	Controller string `json:"controller,omitempty"`

--- a/pkg/wallet/wallet_test.go
+++ b/pkg/wallet/wallet_test.go
@@ -80,10 +80,8 @@ const (
 	sampleVerificationMethod = "did:key:z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5#z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5"
 	didKey                   = "did:key:z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5"
 	pkBase58                 = "2MP5gWCnf67jvW3E4Lz8PpVrDWAXMYY1sDxjnkEnKhkkbKD7yP2mkVeyVpu5nAtr3TeDgMNjBPirk2XcQacs3dvZ"
-	kid                      = "z6MknC1wwS6DEYwtGbZZo2QvjQjkh2qSBjb4GYmbye8dv4S5"
 	didKeyBBS                = "did:key:zUC72c7u4BYVmfYinDceXkNAwzPEyuEE23kUmJDjLy8495KH3pjLwFhae1Fww9qxxRdLnS2VNNwni6W3KbYZKsicDtiNNEp76fYWR6HCD8jAz6ihwmLRjcHH6kB294Xfg1SL1qQ"
 	pkBBSBase58              = "6gsgGpdx7p1nYoKJ4b5fKt1xEomWdnemg9nJFX6mqNCh"
-	keyIDBBS                 = "zUC72c7u4BYVmfYinDceXkNAwzPEyuEE23kUmJDjLy8495KH3pjLwFhae1Fww9qxxRdLnS2VNNwni6W3KbYZKsicDtiNNEp76fYWR6HCD8jAz6ihwmLRjcHH6kB294Xfg1SL1qQ"
 	sampleEDVServerURL       = "sample-edv-url"
 	sampleEDVVaultID         = "sample-edv-vault-id"
 	sampleEDVEncryptionKID   = "sample-edv-encryption-kid"
@@ -1186,7 +1184,7 @@ func TestWallet_Issue(t *testing.T) {
 		require.NoError(t, err)
 		edPriv := ed25519.PrivateKey(base58.Decode(pkBase58))
 		// nolint: errcheck, gosec
-		kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
+		kmgr.ImportPrivateKey(edPriv, kms.ED25519)
 
 		// sign with just controller
 		result, err := walletInstance.Issue(authToken, testdata.SampleUDCVC, &ProofOptions{
@@ -1214,7 +1212,7 @@ func TestWallet_Issue(t *testing.T) {
 		require.NoError(t, err)
 		edPriv := ed25519.PrivateKey(base58.Decode(pkBase58))
 		// nolint: errcheck, gosec
-		kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
+		kmgr.ImportPrivateKey(edPriv, kms.ED25519)
 
 		// sign with just controller
 		result, err := walletInstance.Issue(authToken, testdata.SampleUDCVC, &ProofOptions{
@@ -1243,7 +1241,7 @@ func TestWallet_Issue(t *testing.T) {
 		require.NoError(t, err)
 		edPriv := ed25519.PrivateKey(base58.Decode(pkBase58))
 		// nolint: errcheck, gosec
-		kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
+		kmgr.ImportPrivateKey(edPriv, kms.ED25519)
 
 		// issue
 		result, err := walletInstance.Issue(authToken, testdata.SampleUDCVC, &ProofOptions{
@@ -1272,7 +1270,7 @@ func TestWallet_Issue(t *testing.T) {
 		require.NoError(t, err)
 		edPriv := ed25519.PrivateKey(base58.Decode(pkBase58))
 		// nolint: errcheck, gosec
-		kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
+		kmgr.ImportPrivateKey(edPriv, kms.ED25519)
 
 		// issue credential
 		proofRepr := verifiable.SignatureJWS
@@ -1320,7 +1318,7 @@ func TestWallet_Issue(t *testing.T) {
 		privKeyBBS, err := bbs12381g2pub.UnmarshalPrivateKey(base58.Decode(pkBBSBase58))
 		require.NoError(t, err)
 		// nolint: errcheck, gosec
-		kmgr.ImportPrivateKey(privKeyBBS, kms.BLS12381G2Type, kms.WithKeyID(keyIDBBS))
+		kmgr.ImportPrivateKey(privKeyBBS, kms.BLS12381G2Type)
 
 		// sign with just controller
 		proofRepr := verifiable.SignatureProofValue
@@ -1358,7 +1356,7 @@ func TestWallet_Issue(t *testing.T) {
 		require.NoError(t, err)
 		edPriv := ed25519.PrivateKey(base58.Decode(pkBase58))
 		// nolint: errcheck, gosec
-		kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
+		kmgr.ImportPrivateKey(edPriv, kms.ED25519)
 
 		// save DID Resolution response
 		err = walletInstance.Add(authToken, DIDResolutionResponse, testdata.SampleDocResolutionResponse)
@@ -1451,7 +1449,7 @@ func TestWallet_Issue(t *testing.T) {
 		require.NoError(t, err)
 		edPriv := ed25519.PrivateKey(base58.Decode(pkBase58))
 		// nolint: errcheck, gosec
-		kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
+		kmgr.ImportPrivateKey(edPriv, kms.ED25519)
 
 		// invalid signature type
 		result, err = walletInstance.Issue(authToken, testdata.SampleUDCVC, &ProofOptions{
@@ -1519,12 +1517,12 @@ func TestWallet_Prove(t *testing.T) {
 
 	edPriv := ed25519.PrivateKey(base58.Decode(pkBase58))
 	// nolint: errcheck, gosec
-	kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
+	kmgr.ImportPrivateKey(edPriv, kms.ED25519)
 
 	privKeyBBS, err := bbs12381g2pub.UnmarshalPrivateKey(base58.Decode(pkBBSBase58))
 	require.NoError(t, err)
 	// nolint: errcheck, gosec
-	kmgr.ImportPrivateKey(privKeyBBS, kms.BLS12381G2Type, kms.WithKeyID(keyIDBBS))
+	kmgr.ImportPrivateKey(privKeyBBS, kms.BLS12381G2Type)
 
 	// issue a credential with Ed25519Signature2018
 	result, err := walletForIssue.Issue(authToken, testdata.SampleUDCVC, &ProofOptions{
@@ -1570,7 +1568,7 @@ func TestWallet_Prove(t *testing.T) {
 		require.NoError(t, err)
 		edPriv := ed25519.PrivateKey(base58.Decode(pkBase58))
 		// nolint: errcheck, gosec
-		kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
+		kmgr.ImportPrivateKey(edPriv, kms.ED25519)
 
 		edVCBytes, err := json.Marshal(vcs["edvc"])
 		require.NoError(t, err)
@@ -1623,7 +1621,7 @@ func TestWallet_Prove(t *testing.T) {
 		require.NoError(t, err)
 		edPriv := ed25519.PrivateKey(base58.Decode(pkBase58))
 		// nolint: errcheck, gosec
-		kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
+		kmgr.ImportPrivateKey(edPriv, kms.ED25519)
 
 		bbsVCBytes, err := json.Marshal(vcs["bbsvc"])
 		require.NoError(t, err)
@@ -1683,7 +1681,7 @@ func TestWallet_Prove(t *testing.T) {
 		require.NoError(t, err)
 		edPriv := ed25519.PrivateKey(base58.Decode(pkBase58))
 		// nolint: errcheck, gosec
-		kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
+		kmgr.ImportPrivateKey(edPriv, kms.ED25519)
 
 		bbsVCBytes, err := json.Marshal(vcs["bbsvc"])
 		require.NoError(t, err)
@@ -1746,7 +1744,7 @@ func TestWallet_Prove(t *testing.T) {
 		require.NoError(t, err)
 		edPriv := ed25519.PrivateKey(base58.Decode(pkBase58))
 		// nolint: errcheck, gosec
-		kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
+		kmgr.ImportPrivateKey(edPriv, kms.ED25519)
 
 		// prepare opts
 		proofRepr := verifiable.SignatureJWS
@@ -1794,7 +1792,7 @@ func TestWallet_Prove(t *testing.T) {
 		require.NoError(t, err)
 		edPriv := ed25519.PrivateKey(base58.Decode(pkBase58))
 		// nolint: errcheck, gosec
-		kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
+		kmgr.ImportPrivateKey(edPriv, kms.ED25519)
 
 		// prepare opts
 		proofRepr := verifiable.SignatureJWS
@@ -1936,7 +1934,7 @@ func TestWallet_Prove(t *testing.T) {
 		require.NoError(t, err)
 		edPriv := ed25519.PrivateKey(base58.Decode(pkBase58))
 		// nolint: errcheck, gosec
-		kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
+		kmgr.ImportPrivateKey(edPriv, kms.ED25519)
 
 		// invalid signature type
 		result, err = walletInstance.Prove(authToken, &ProofOptions{
@@ -2018,7 +2016,7 @@ func TestWallet_Verify(t *testing.T) {
 
 	edPriv := ed25519.PrivateKey(base58.Decode(pkBase58))
 	// nolint: errcheck, gosec
-	kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
+	kmgr.ImportPrivateKey(edPriv, kms.ED25519)
 
 	// issue a credential
 	sampleVC, err := walletForIssue.Issue(tkn, testdata.SampleUDCVC, &ProofOptions{
@@ -2258,12 +2256,12 @@ func TestWallet_Derive(t *testing.T) {
 
 	edPriv := ed25519.PrivateKey(base58.Decode(pkBase58))
 	// nolint: errcheck, gosec
-	kmgr.ImportPrivateKey(edPriv, kms.ED25519, kms.WithKeyID(kid))
+	kmgr.ImportPrivateKey(edPriv, kms.ED25519)
 
 	privKeyBBS, err := bbs12381g2pub.UnmarshalPrivateKey(base58.Decode(pkBBSBase58))
 	require.NoError(t, err)
 	// nolint: errcheck, gosec
-	kmgr.ImportPrivateKey(privKeyBBS, kms.BLS12381G2Type, kms.WithKeyID(keyIDBBS))
+	kmgr.ImportPrivateKey(privKeyBBS, kms.BLS12381G2Type)
 
 	// issue a credential with Ed25519Signature2018
 	result, err := walletForIssue.Issue(authToken, testdata.SampleUDCVC, &ProofOptions{


### PR DESCRIPTION
**Title:**

Fix VC wallet: Unable to issue credential

**Description:**

Fixes #3029

**Summary:**

Converts the verification method / public key to the key ID that's required by keyManager to retrieve the private key for signing. The conversion steps were taken from the standard VC issuing endpoint.