### PR TITLE
fix(vcwallet): correct path to profile existence endpoint

### DIFF
--- a/pkg/controller/rest/vcwallet/operation.go
+++ b/pkg/controller/rest/vcwallet/operation.go
@@ -30,7 +30,7 @@ const (
 	// command Paths.
 	CreateProfilePath       = OperationID + "/create-profile"
 	UpdateProfilePath       = OperationID + "/update-profile"
-	ProfileExistsPath       = OperationID + "profile/{id}"
+	ProfileExistsPath       = OperationID + "/profile/{id}"
 	OpenPath                = OperationID + "/open"
 	ClosePath               = OperationID + "/close"
 	AddPath                 = OperationID + "/add"


### PR DESCRIPTION
**Title:**

VC wallet: REST endpoint /vcwallet/profile/{id} responds with 404

**Description:**

Closes #3051

**Summary:**

Adds a missing `/` to the rest endpoint.

