### PR TITLE
feat: add support of general key prefixes for LocalKMS

### DIFF
--- a/pkg/kms/localkms/internal/keywrapper/kms_aead_test.go
+++ b/pkg/kms/localkms/internal/keywrapper/kms_aead_test.go
@@ -34,16 +34,30 @@ func TestLocalKMS_New_AEAD(t *testing.T) {
 	require.Error(t, err)
 	require.Empty(t, aeadKW)
 
-	validURI := LocalKeyURIPrefix + "master/key"
-	invalidURI := "bad-prefix://master/key"
+	validURIs := []string{
+		LocalKeyURIPrefix + "master/key",
+		"aws-kms://arn:aws:kms:ca-central-1:235739564943:key/3ee50705-5a82-4f5b-9753-05c4f473922f",
+		"gcp-kms://projects/aries-test-infrastructure/aead-key",
+	}
+	invalidURIs := []string{
+		"://master/key",
+		"master/key",
+		LocalKeyURIPrefix,
+		"aws-kms://",
+		"",
+	}
 
-	aeadKW, err = New(mockSecLck, invalidURI)
-	require.Error(t, err)
-	require.Empty(t, aeadKW)
+	for _, invalidURI := range invalidURIs {
+		aeadKW, err = New(mockSecLck, invalidURI)
+		require.Error(t, err)
+		require.Empty(t, aeadKW)
+	}
 
-	aeadKW, err = New(mockSecLck, validURI)
-	require.NoError(t, err)
-	require.NotEmpty(t, aeadKW)
+	for _, validURI := range validURIs {
+		aeadKW, err = New(mockSecLck, validURI)
+		require.NoError(t, err)
+		require.NotEmpty(t, aeadKW)
+	}
 }
 
 func TestLocalKMS_EncryptDecrypt(t *testing.T) {

--- a/pkg/kms/localkms/localkms_test.go
+++ b/pkg/kms/localkms/localkms_test.go
@@ -69,7 +69,7 @@ func TestNewKMS_Failure(t *testing.T) {
 	})
 
 	t.Run("test New() error creating new KMS client with bad master key prefix", func(t *testing.T) {
-		badKeyURI := "bad-prefix://test/key/uri"
+		badKeyURI := "://test/key/uri"
 
 		kmsStorage, err := New(badKeyURI, &mockProvider{
 			storage: mockstorage.NewMockStoreProvider(),


### PR DESCRIPTION
Signed-off-by: Volodymyr Kubiv <volodymyr.kubiv@euristiq.com>


**Title:**
Add support of general key prefixes for LocalKMS

**Summary:**

Now LocalKMS support not only local key prefix but other prefixes with the form "anyprefixname://".

