### PR TITLE
fix: allow payloads of any size in hkdf and pbkdf2 encrypt

### DIFF
--- a/pkg/secretlock/local/masterlock/hkdf/master_secret_lock.go
+++ b/pkg/secretlock/local/masterlock/hkdf/master_secret_lock.go
@@ -40,9 +40,8 @@ type masterLockHKDF struct {
 	aead cipher.AEAD
 }
 
-// NewMasterLock is responsible for encrypting/decrypting a master key expanded from a passphrase using HKDF
+// NewMasterLock is responsible for encrypting/decrypting with a master key expanded from a passphrase using HKDF
 // using `passphrase`, hash function `h`, `salt`.
-// The size of a master key passed to Encrypt() must match `h()`.Size() since the key will be used for AEAD operations.
 // The salt is optional and can be set to nil.
 // This implementation must not be used directly in Aries framework. It should be passed in
 // as the second argument to local secret lock service constructor:
@@ -86,10 +85,6 @@ func NewMasterLock(passphrase string, h func() hash.Hash, salt []byte) (secretlo
 // Encrypt a master key in req
 //  (keyURI is used for remote locks, it is ignored by this implementation)
 func (m *masterLockHKDF) Encrypt(keyURI string, req *secretlock.EncryptRequest) (*secretlock.EncryptResponse, error) {
-	if len(req.Plaintext) != m.h().Size() {
-		return nil, fmt.Errorf("invalid key size")
-	}
-
 	nonce := random.GetRandomBytes(uint32(m.aead.NonceSize()))
 	ct := m.aead.Seal(nil, nonce, []byte(req.Plaintext), []byte(req.AdditionalAuthenticatedData))
 	ct = append(nonce, ct...)

--- a/pkg/secretlock/local/masterlock/hkdf/master_secret_lock_test.go
+++ b/pkg/secretlock/local/masterlock/hkdf/master_secret_lock_test.go
@@ -42,11 +42,6 @@ func TestMasterLock(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testKey, []byte(decryptedMk.Plaintext))
 
-	// try encrypting a key with a size different than keySize
-	badEncryptedMk, err := mkLock.Encrypt("", &secretlock.EncryptRequest{Plaintext: "BadKey"})
-	require.EqualError(t, err, "invalid key size")
-	require.Empty(t, badEncryptedMk)
-
 	// try decrypting a non valid base64URL string
 	decryptedMk, err = mkLock.Decrypt("", &secretlock.DecryptRequest{Ciphertext: "bad{}base64URLstring[]"})
 	require.Error(t, err)

--- a/pkg/secretlock/local/masterlock/pbkdf2/master_secret_lock.go
+++ b/pkg/secretlock/local/masterlock/pbkdf2/master_secret_lock.go
@@ -31,9 +31,8 @@ type masterLockPBKDF2 struct {
 	aead cipher.AEAD
 }
 
-// NewMasterLock is responsible for encrypting/decrypting a master key expanded from a passphrase using PBKDF2
+// NewMasterLock is responsible for encrypting/decrypting with a master key expanded from a passphrase using PBKDF2
 // using `passphrase`, hash function `h`, `salt`.
-// The size of a master key passed to Encrypt() must match `h()`.Size() since the key will be used for AEAD operations.
 // The salt is optional and can be set to nil.
 // This implementation must not be used directly in Aries framework. It should be passed in
 // as the second argument to local secret lock service constructor:
@@ -69,10 +68,6 @@ func NewMasterLock(passphrase string, h func() hash.Hash, iterations int, salt [
 // Encrypt a master key in req
 //  (keyURI is used for remote locks, it is ignored by this implementation)
 func (m *masterLockPBKDF2) Encrypt(keyURI string, req *secretlock.EncryptRequest) (*secretlock.EncryptResponse, error) {
-	if len(req.Plaintext) != m.h().Size() {
-		return nil, fmt.Errorf("invalid key size")
-	}
-
 	nonce := random.GetRandomBytes(uint32(m.aead.NonceSize()))
 	ct := m.aead.Seal(nil, nonce, []byte(req.Plaintext), []byte(req.AdditionalAuthenticatedData))
 	ct = append(nonce, ct...)

--- a/pkg/secretlock/local/masterlock/pbkdf2/master_secret_lock_test.go
+++ b/pkg/secretlock/local/masterlock/pbkdf2/master_secret_lock_test.go
@@ -44,11 +44,6 @@ func TestMasterLock(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testKey, []byte(decryptedMk.Plaintext))
 
-	// try encrypting a key with a size different than keySize
-	badEncryptedMk, err := mkLock.Encrypt("", &secretlock.EncryptRequest{Plaintext: "BadKey"})
-	require.EqualError(t, err, "invalid key size")
-	require.Empty(t, badEncryptedMk)
-
 	// try decrypting a non valid base64URL string
 	decryptedMk, err = mkLock.Decrypt("", &secretlock.DecryptRequest{Ciphertext: "bad{}base64URLstring[]"})
 	require.Error(t, err)


### PR DESCRIPTION
Signed-off-by: Andrii Holovko <andriy.holovko@gmail.com>


