### PR TITLE
feat: Credential Application

### DIFF
--- a/pkg/doc/credentialmanifest/common.go
+++ b/pkg/doc/credentialmanifest/common.go
@@ -1,0 +1,55 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package credentialmanifest
+
+import "github.com/hyperledger/aries-framework-go/pkg/doc/presexch"
+
+// hasAnyAlgorithmsOrProofTypes looks at the given Format object and determines if it has any algorithms or proof types
+// listed.
+func hasAnyAlgorithmsOrProofTypes(format presexch.Format) bool {
+	if anyJWTTypeHasAlgs(format) || anyLDPTypeHasProofTypes(format) {
+		return true
+	}
+
+	return false
+}
+
+func anyJWTTypeHasAlgs(format presexch.Format) bool {
+	if hasAnyAlgs(format.Jwt) ||
+		hasAnyAlgs(format.JwtVC) ||
+		hasAnyAlgs(format.JwtVP) {
+		return true
+	}
+
+	return false
+}
+
+func anyLDPTypeHasProofTypes(format presexch.Format) bool {
+	if hasAnyProofTypes(format.Ldp) ||
+		hasAnyProofTypes(format.LdpVC) ||
+		hasAnyProofTypes(format.LdpVP) {
+		return true
+	}
+
+	return false
+}
+
+func hasAnyAlgs(jwtType *presexch.JwtType) bool {
+	if jwtType != nil && len(jwtType.Alg) > 0 {
+		return true
+	}
+
+	return false
+}
+
+func hasAnyProofTypes(ldpType *presexch.LdpType) bool {
+	if ldpType != nil && len(ldpType.ProofType) > 0 {
+		return true
+	}
+
+	return false
+}

--- a/pkg/doc/credentialmanifest/credentialapplication.go
+++ b/pkg/doc/credentialmanifest/credentialapplication.go
@@ -1,0 +1,239 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package credentialmanifest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/presexch"
+)
+
+// CredentialApplication represents a Credential Application object as defined in
+// https://identity.foundation/credential-manifest/#credential-application.
+type CredentialApplication struct {
+	CredentialApplication CredentialApplicationInfo `json:"credential_application,omitempty"`
+	// MUST be here IF the related Credential Manifest contains a PresentationDefinition.
+	// Its value MUST be a valid Presentation Submission
+	PresentationSubmission *presexch.PresentationSubmission `json:"presentation_submission,omitempty"`
+}
+
+// CredentialApplicationInfo represents the credential_application property contained within a CredentialApplication.
+type CredentialApplicationInfo struct {
+	ID string `json:"id,omitempty"`
+	// The value of this property MUST be the ID of a valid Credential Manifest.
+	ManifestID string `json:"manifest_id,omitempty"`
+	// Must be a subset of the format property of the CredentialManifest that this CredentialApplication is related to
+	Format presexch.Format `json:"format,omitempty"`
+}
+
+// UnmarshalAndValidateAgainstCredentialManifest unmarshals the credentialApplicationBytes into a CredentialApplication
+// object (performing verification in the process), and after that verifies that the Credential Application is valid
+// against the given Credential Manifest. It's simply a convenience method that allows you to unmarshal and perform
+// validation against a Credential Manifest in one call.
+func UnmarshalAndValidateAgainstCredentialManifest(credentialApplicationBytes []byte,
+	cm *CredentialManifest) (CredentialApplication, error) {
+	var credentialApplication CredentialApplication
+
+	err := json.Unmarshal(credentialApplicationBytes, &credentialApplication)
+	if err != nil {
+		return CredentialApplication{}, err
+	}
+
+	err = credentialApplication.ValidateAgainstCredentialManifest(cm)
+	if err != nil {
+		return CredentialApplication{}, err
+	}
+
+	return credentialApplication, nil
+}
+
+// UnmarshalJSON is the custom unmarshal function gets called automatically when the standard json.Unmarshal is called.
+// It also ensures that the given data is a valid CredentialApplication object per the specification.
+func (ca *CredentialApplication) UnmarshalJSON(data []byte) error {
+	err := ca.standardUnmarshal(data)
+	if err != nil {
+		return err
+	}
+
+	err = ca.validate()
+	if err != nil {
+		return fmt.Errorf("invalid Credential Application: %w", err)
+	}
+
+	return nil
+}
+
+// ValidateAgainstCredentialManifest verifies that the Credential Application is valid against the given
+// Credential Manifest.
+func (ca *CredentialApplication) ValidateAgainstCredentialManifest(cm *CredentialManifest) error {
+	if ca.CredentialApplication.ManifestID != cm.ID {
+		return fmt.Errorf("the Manifest ID of the Credential Application (%s) does not match the given "+
+			"Credential Manifest's ID (%s)", ca.CredentialApplication.ManifestID, cm.ID)
+	}
+
+	if cm.hasFormat() {
+		err := ca.validateFormatAgainstCredManifestFormat(cm.Format)
+		if err != nil {
+			return fmt.Errorf("invalid format for the given Credential Manifest: %w", err)
+		}
+	}
+
+	if cm.PresentationDefinition != nil {
+		if ca.PresentationSubmission == nil {
+			return errors.New("Credential Manifest " + //nolint:stylecheck // This is a proper noun per the spec
+				"has a Presentation Definition, but the Credential Application is missing a Presentation Submission")
+		}
+	}
+
+	return nil
+}
+
+func (ca *CredentialApplication) standardUnmarshal(data []byte) error {
+	// The type alias below is used as to allow the standard json.Unmarshal to be called within a custom unmarshal
+	// function without causing infinite recursion. See https://stackoverflow.com/a/43178272 for more information.
+	type credentialApplicationWithoutMethods *CredentialApplication
+
+	err := json.Unmarshal(data, credentialApplicationWithoutMethods(ca))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ca *CredentialApplication) validate() error {
+	if ca.CredentialApplication.ID == "" {
+		return errors.New("missing ID")
+	}
+
+	if ca.CredentialApplication.ManifestID == "" {
+		return errors.New("missing manifest ID")
+	}
+
+	return nil
+}
+
+func (ca *CredentialApplication) validateFormatAgainstCredManifestFormat(credManifestFormat presexch.Format) error {
+	if !ca.hasFormat() {
+		return errors.New("the Credential Manifest specifies a format but the Credential Application does not")
+	}
+
+	err := ca.CredentialApplication.ensureFormatIsSubsetOfCredManifestFormat(credManifestFormat)
+	if err != nil {
+		return fmt.Errorf("invalid format request: %w", err)
+	}
+
+	return nil
+}
+
+func (ca *CredentialApplication) hasFormat() bool {
+	return hasAnyAlgorithmsOrProofTypes(ca.CredentialApplication.Format)
+}
+
+func (cai *CredentialApplicationInfo) ensureFormatIsSubsetOfCredManifestFormat(credManiFmt presexch.Format) error {
+	err := ensureCredAppJWTAlgsAreSubsetOfCredManiJWTAlgs("JWT", cai.Format.Jwt, credManiFmt.Jwt)
+	if err != nil {
+		return err
+	}
+
+	err = ensureCredAppJWTAlgsAreSubsetOfCredManiJWTAlgs("JWT VC", cai.Format.JwtVC, credManiFmt.JwtVC)
+	if err != nil {
+		return err
+	}
+
+	err = ensureCredAppJWTAlgsAreSubsetOfCredManiJWTAlgs("JWT VP", cai.Format.JwtVP, credManiFmt.JwtVP)
+	if err != nil {
+		return err
+	}
+
+	err = ensureCredAppLDPProofTypesAreSubsetOfCredManiProofTypes("LDP", cai.Format.Ldp, credManiFmt.Ldp)
+	if err != nil {
+		return err
+	}
+
+	err = ensureCredAppLDPProofTypesAreSubsetOfCredManiProofTypes("LDP VC", cai.Format.LdpVC, credManiFmt.LdpVC)
+	if err != nil {
+		return err
+	}
+
+	err = ensureCredAppLDPProofTypesAreSubsetOfCredManiProofTypes("LDP VP", cai.Format.LdpVP, credManiFmt.LdpVP)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ensureCredAppJWTAlgsAreSubsetOfCredManiJWTAlgs(algType string,
+	credAppJWTType, credManifestJWTType *presexch.JwtType) error {
+	if credAppJWTType != nil { //nolint:nestif // hard to resolve without creating a worse issue
+		if credManifestJWTType != nil {
+			if !arrayIsSubsetOfAnother(credAppJWTType.Alg, credManifestJWTType.Alg) {
+				return makeAlgorithmsSubsetError(algType, credAppJWTType.Alg, credManifestJWTType.Alg)
+			}
+		} else {
+			if len(credAppJWTType.Alg) > 0 {
+				return makeAlgorithmsSubsetError(algType, credAppJWTType.Alg, nil)
+			}
+		}
+	}
+
+	return nil
+}
+
+func ensureCredAppLDPProofTypesAreSubsetOfCredManiProofTypes(ldpType string,
+	credAppLDPType, credManifestLDPType *presexch.LdpType) error {
+	if credAppLDPType != nil { //nolint:nestif // hard to resolve without creating a worse issue
+		if credManifestLDPType != nil {
+			if !arrayIsSubsetOfAnother(credAppLDPType.ProofType, credManifestLDPType.ProofType) {
+				return makeProofTypesSubsetError(ldpType, credAppLDPType.ProofType, credManifestLDPType.ProofType)
+			}
+		} else {
+			if len(credAppLDPType.ProofType) > 0 {
+				return makeProofTypesSubsetError(ldpType, credAppLDPType.ProofType, nil)
+			}
+		}
+	}
+
+	return nil
+}
+
+func makeAlgorithmsSubsetError(algType string, credAppJWTTypeAlgs, credManifestJWTTypeAlgs []string) error {
+	return makeSubsetError(algType, "algorithms", credAppJWTTypeAlgs, credManifestJWTTypeAlgs)
+}
+
+func makeProofTypesSubsetError(ldpType string, credAppLDPTypeProofTypes, credManifestLDPTypeProofTypes []string) error {
+	return makeSubsetError(ldpType, "proof types", credAppLDPTypeProofTypes, credManifestLDPTypeProofTypes)
+}
+
+func makeSubsetError(typeInCategory, category string, credAppJWTTypeAlgs, credManifestJWTTypeAlgs []string) error {
+	return fmt.Errorf("the Credential Application lists the following %s %s: %v. "+
+		"One or more of these are not in the Credential Manifest's supported %s %s: %v",
+		typeInCategory, category, credAppJWTTypeAlgs, typeInCategory, category, credManifestJWTTypeAlgs)
+}
+
+func arrayIsSubsetOfAnother(array1, array2 []string) bool {
+	for _, element := range array1 {
+		if !contains(array2, element) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func contains(array []string, element string) bool {
+	for _, arrayElement := range array {
+		if arrayElement == element {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/doc/credentialmanifest/credentialapplication_test.go
+++ b/pkg/doc/credentialmanifest/credentialapplication_test.go
@@ -1,0 +1,293 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package credentialmanifest_test
+
+import (
+	_ "embed"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/credentialmanifest"
+)
+
+const unknownFormatName = "SomeUnknownFormat"
+
+//go:embed testdata/valid_credential_application.json
+var validCredentialApplication []byte //nolint:gochecknoglobals
+
+//go:embed testdata/valid_credential_application_with_format.json
+var validCredentialApplicationWithFormat []byte //nolint:gochecknoglobals
+
+func TestUnmarshalAndValidateAgainstCredentialManifest(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifest)
+
+		credentialApplication, err := credentialmanifest.UnmarshalAndValidateAgainstCredentialManifest(
+			validCredentialApplication, &credentialManifest)
+		require.NoError(t, err)
+		require.Equal(t, "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d", credentialApplication.CredentialApplication.ID)
+	})
+	t.Run("Failure during validation", func(t *testing.T) {
+		credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifestWithFormat)
+
+		_, err := credentialmanifest.UnmarshalAndValidateAgainstCredentialManifest(
+			validCredentialApplication, &credentialManifest)
+		require.EqualError(t, err, "invalid format for the given Credential Manifest: the Credential "+
+			"Manifest specifies a format but the Credential Application does not")
+	})
+}
+
+func TestCredentialApplication_Unmarshal(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		makeCredentialApplicationFromBytes(t, validCredentialApplication)
+	})
+	t.Run("Missing ID", func(t *testing.T) {
+		credentialApplicationBytes := makeCredentialApplicationWithMissingID(t)
+
+		var credentialApplication credentialmanifest.CredentialApplication
+
+		err := json.Unmarshal(credentialApplicationBytes, &credentialApplication)
+		require.EqualError(t, err, "invalid Credential Application: missing ID")
+	})
+	t.Run("Missing Manifest ID", func(t *testing.T) {
+		credentialApplicationBytes := makeCredentialApplicationWithMissingManifestID(t)
+
+		var credentialApplication credentialmanifest.CredentialApplication
+
+		err := json.Unmarshal(credentialApplicationBytes, &credentialApplication)
+		require.EqualError(t, err, "invalid Credential Application: missing manifest ID")
+	})
+}
+
+func TestCredentialApplication_ValidateAgainstCredentialManifest(t *testing.T) {
+	t.Run("Credential Manifest has no format and no presentation definition", func(t *testing.T) {
+		t.Run("Credential Application has no format and no presentation definition", func(t *testing.T) {
+			credentialApplication := makeCredentialApplicationFromBytes(t, validCredentialApplication)
+
+			credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifest)
+
+			err := credentialApplication.ValidateAgainstCredentialManifest(&credentialManifest)
+			require.NoError(t, err)
+		})
+	})
+	t.Run("Credential Manifest has a format", func(t *testing.T) {
+		t.Run("Credential Application has no format", func(t *testing.T) {
+			credentialApplication := makeCredentialApplicationFromBytes(t, validCredentialApplication)
+
+			credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifestWithFormat)
+
+			err := credentialApplication.ValidateAgainstCredentialManifest(&credentialManifest)
+			require.EqualError(t, err, "invalid format for the given Credential Manifest: the Credential "+
+				"Manifest specifies a format but the Credential Application does not")
+		})
+		t.Run("Credential App requests a JWT format not allowed by the Credential Manifest", func(t *testing.T) {
+			credentialApplication := makeCredentialApplicationWithUnknownJWTAlg(t)
+
+			credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifestWithFormat)
+
+			err := credentialApplication.ValidateAgainstCredentialManifest(&credentialManifest)
+			require.EqualError(t, err, "invalid format for the given Credential Manifest: invalid format "+
+				"request: the Credential Application lists the following JWT algorithms: [SomeUnknownFormat ES256K "+
+				"ES384]. One or more of these are not in the Credential Manifest's supported JWT algorithms: [EdDSA "+
+				"ES256K ES384]")
+		})
+		t.Run("Cred App requests a JWT VC format not allowed by the Cred Manifest", func(t *testing.T) {
+			credentialApplication := makeCredentialApplicationWithUnknownJWTVCAlg(t)
+
+			credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifestWithFormat)
+
+			err := credentialApplication.ValidateAgainstCredentialManifest(&credentialManifest)
+			require.EqualError(t, err, "invalid format for the given Credential Manifest: invalid format "+
+				"request: the Credential Application lists the following JWT VC algorithms: [SomeUnknownFormat "+
+				"ES384]. One or more of these are not in the Credential Manifest's supported JWT VC algorithms: "+
+				"[ES256K ES384]")
+		})
+		t.Run("Cred App requests a JWT VP format not allowed by the Cred Manifest", func(t *testing.T) {
+			credentialApplication := makeCredentialApplicationWithUnknownJWTVPAlg(t)
+
+			credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifestWithFormat)
+
+			err := credentialApplication.ValidateAgainstCredentialManifest(&credentialManifest)
+			require.EqualError(t, err, "invalid format for the given Credential Manifest: invalid format "+
+				"request: the Credential Application lists the following JWT VP algorithms: [SomeUnknownFormat "+
+				"ES256K]. One or more of these are not in the Credential Manifest's supported JWT VP algorithms: "+
+				"[EdDSA ES256K]")
+		})
+		t.Run("Cred App requests an LDP proof type not allowed by the Cred Manifest", func(t *testing.T) {
+			credentialApplication := makeCredentialApplicationWithUnknownLDPProofType(t)
+
+			credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifestWithFormat)
+
+			err := credentialApplication.ValidateAgainstCredentialManifest(&credentialManifest)
+			require.EqualError(t, err, "invalid format for the given Credential Manifest: invalid format "+
+				"request: the Credential Application lists the following LDP proof types: [SomeUnknownFormat]. "+
+				"One or more of these are not in the Credential Manifest's supported LDP proof types: "+
+				"[RsaSignature2018]")
+		})
+		t.Run("Cred App requests an LDP VC proof type not allowed by the Cred Manifest", func(t *testing.T) {
+			credentialApplication := makeCredentialApplicationWithUnknownLDPVCProofType(t)
+
+			credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifestWithFormat)
+
+			err := credentialApplication.ValidateAgainstCredentialManifest(&credentialManifest)
+			require.EqualError(t, err, "invalid format for the given Credential Manifest: invalid format "+
+				"request: the Credential Application lists the following LDP VC proof types: [SomeUnknownFormat "+
+				"EcdsaSecp256k1Signature2019 Ed25519Signature2018]. One or more of these are not in the "+
+				"Credential Manifest's supported LDP VC proof types: [JsonWebSignature2020 Ed25519Signature2018 "+
+				"EcdsaSecp256k1Signature2019 RsaSignature2018]")
+		})
+		t.Run("Cred App requests an LDP VC proof type not allowed by the Cred Manifest", func(t *testing.T) {
+			credentialApplication := makeCredentialApplicationWithUnknownLDPVPProofType(t)
+
+			credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifestWithFormat)
+
+			err := credentialApplication.ValidateAgainstCredentialManifest(&credentialManifest)
+			require.EqualError(t, err, "invalid format for the given Credential Manifest: invalid format "+
+				"request: the Credential Application lists the following LDP VP proof types: [SomeUnknownFormat]. "+
+				"One or more of these are not in the Credential Manifest's supported LDP VP proof types: "+
+				"[Ed25519Signature2018]")
+		})
+		t.Run("Cred App requests JWT formats but the Cred Manifest's JWT format is nil", func(t *testing.T) {
+			credentialApplication := makeCredentialApplicationFromBytes(t, validCredentialApplicationWithFormat)
+
+			credentialManifest := createCredentialManifestWithNilJWTFormat(t)
+
+			err := credentialApplication.ValidateAgainstCredentialManifest(&credentialManifest)
+			require.EqualError(t, err, "invalid format for the given Credential Manifest: invalid format "+
+				"request: the Credential Application lists the following JWT algorithms: [EdDSA ES256K ES384]. "+
+				"One or more of these are not in the Credential Manifest's supported JWT algorithms: []")
+		})
+		t.Run("Cred App requests JWT formats but the Cred Manifest's LDP format is nil", func(t *testing.T) {
+			credentialApplication := makeCredentialApplicationFromBytes(t, validCredentialApplicationWithFormat)
+
+			credentialManifest := createCredentialManifestWithNilLDPFormat(t)
+
+			err := credentialApplication.ValidateAgainstCredentialManifest(&credentialManifest)
+			require.EqualError(t, err, "invalid format for the given Credential Manifest: invalid format "+
+				"request: the Credential Application lists the following LDP proof types: [RsaSignature2018]. One "+
+				"or more of these are not in the Credential Manifest's supported LDP proof types: []")
+		})
+		t.Run("Credential Application has a valid format", func(t *testing.T) {
+			credentialApplication := makeCredentialApplicationFromBytes(t, validCredentialApplicationWithFormat)
+
+			credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifestWithFormat)
+
+			err := credentialApplication.ValidateAgainstCredentialManifest(&credentialManifest)
+			require.NoError(t, err)
+		})
+	})
+	t.Run("Credential Manifest has a presentation definition", func(t *testing.T) {
+		t.Run("Credential Application has no Presentation Submission", func(t *testing.T) {
+			credentialApplication := makeCredentialApplicationFromBytes(t, validCredentialApplication)
+
+			credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifestWithPresentationSubmission)
+
+			err := credentialApplication.ValidateAgainstCredentialManifest(&credentialManifest)
+			require.EqualError(t, err, "Credential Manifest has a Presentation Definition, "+
+				"but the Credential Application is missing a Presentation Submission")
+		})
+	})
+	t.Run("Credential App's manifest ID does not match the given Credential Manifest", func(t *testing.T) {
+		credentialApplication := makeCredentialApplicationWithUnknownManifestID(t)
+
+		credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifest)
+
+		err := credentialApplication.ValidateAgainstCredentialManifest(&credentialManifest)
+		require.EqualError(t, err, "the Manifest ID of the Credential Application (SomeUnknownManifestID) "+
+			"does not match the given Credential Manifest's ID (university_degree)")
+	})
+}
+
+func makeCredentialApplicationFromBytes(t *testing.T,
+	credentialApplicationBytes []byte) credentialmanifest.CredentialApplication {
+	var credentialApplication credentialmanifest.CredentialApplication
+
+	err := json.Unmarshal(credentialApplicationBytes, &credentialApplication)
+	require.NoError(t, err)
+
+	return credentialApplication
+}
+
+func makeCredentialApplicationWithMissingID(t *testing.T) []byte {
+	credentialApplication := makeCredentialApplicationFromBytes(t, validCredentialApplication)
+
+	credentialApplication.CredentialApplication.ID = ""
+
+	credentialApplicationBytes, err := json.Marshal(credentialApplication)
+	require.NoError(t, err)
+
+	return credentialApplicationBytes
+}
+
+func makeCredentialApplicationWithMissingManifestID(t *testing.T) []byte {
+	credentialApplication := makeCredentialApplicationFromBytes(t, validCredentialApplication)
+
+	credentialApplication.CredentialApplication.ManifestID = ""
+
+	credentialApplicationBytes, err := json.Marshal(credentialApplication)
+	require.NoError(t, err)
+
+	return credentialApplicationBytes
+}
+
+func makeCredentialApplicationWithUnknownJWTAlg(t *testing.T) credentialmanifest.CredentialApplication {
+	credentialApplication := makeCredentialApplicationFromBytes(t, validCredentialApplicationWithFormat)
+
+	credentialApplication.CredentialApplication.Format.Jwt.Alg[0] = unknownFormatName
+
+	return credentialApplication
+}
+
+func makeCredentialApplicationWithUnknownJWTVCAlg(t *testing.T) credentialmanifest.CredentialApplication {
+	credentialApplication := makeCredentialApplicationFromBytes(t, validCredentialApplicationWithFormat)
+
+	credentialApplication.CredentialApplication.Format.JwtVC.Alg[0] = unknownFormatName
+
+	return credentialApplication
+}
+
+func makeCredentialApplicationWithUnknownJWTVPAlg(t *testing.T) credentialmanifest.CredentialApplication {
+	credentialApplication := makeCredentialApplicationFromBytes(t, validCredentialApplicationWithFormat)
+
+	credentialApplication.CredentialApplication.Format.JwtVP.Alg[0] = unknownFormatName
+
+	return credentialApplication
+}
+
+func makeCredentialApplicationWithUnknownLDPProofType(t *testing.T) credentialmanifest.CredentialApplication {
+	credentialApplication := makeCredentialApplicationFromBytes(t, validCredentialApplicationWithFormat)
+
+	credentialApplication.CredentialApplication.Format.Ldp.ProofType[0] = unknownFormatName
+
+	return credentialApplication
+}
+
+func makeCredentialApplicationWithUnknownLDPVCProofType(t *testing.T) credentialmanifest.CredentialApplication {
+	credentialApplication := makeCredentialApplicationFromBytes(t, validCredentialApplicationWithFormat)
+
+	credentialApplication.CredentialApplication.Format.LdpVC.ProofType[0] = unknownFormatName
+
+	return credentialApplication
+}
+
+func makeCredentialApplicationWithUnknownLDPVPProofType(t *testing.T) credentialmanifest.CredentialApplication {
+	credentialApplication := makeCredentialApplicationFromBytes(t, validCredentialApplicationWithFormat)
+
+	credentialApplication.CredentialApplication.Format.LdpVP.ProofType[0] = unknownFormatName
+
+	return credentialApplication
+}
+
+func makeCredentialApplicationWithUnknownManifestID(t *testing.T) credentialmanifest.CredentialApplication {
+	credentialApplication := makeCredentialApplicationFromBytes(t, validCredentialApplicationWithFormat)
+
+	credentialApplication.CredentialApplication.ManifestID = "SomeUnknownManifestID"
+
+	return credentialApplication
+}

--- a/pkg/doc/credentialmanifest/credentialmanifest.go
+++ b/pkg/doc/credentialmanifest/credentialmanifest.go
@@ -21,12 +21,12 @@ import (
 // CredentialManifest represents a Credential Manifest object as defined in
 // https://identity.foundation/credential-manifest/#credential-manifest-2.
 type CredentialManifest struct {
-	ID                     string                          `json:"id,omitempty"`
-	Version                string                          `json:"version,omitempty"`
-	Issuer                 Issuer                          `json:"issuer,omitempty"`
-	OutputDescriptors      []OutputDescriptor              `json:"output_descriptors,omitempty"`
-	Format                 presexch.Format                 `json:"format,omitempty"`
-	PresentationDefinition presexch.PresentationDefinition `json:"presentation_definition,omitempty"`
+	ID                     string                           `json:"id,omitempty"`
+	Version                string                           `json:"version,omitempty"`
+	Issuer                 Issuer                           `json:"issuer,omitempty"`
+	OutputDescriptors      []OutputDescriptor               `json:"output_descriptors,omitempty"`
+	Format                 presexch.Format                  `json:"format,omitempty"`
+	PresentationDefinition *presexch.PresentationDefinition `json:"presentation_definition,omitempty"`
 }
 
 // Issuer represents the issuer object defined in https://identity.foundation/credential-manifest/#general-composition.
@@ -123,6 +123,7 @@ type staticDisplayMappingObjects struct {
 }
 
 // UnmarshalJSON is the custom unmarshal function gets called automatically when the standard json.Unmarshal is called.
+// It also ensures that the given data is a valid CredentialManifest object per the specification.
 func (cm *CredentialManifest) UnmarshalJSON(data []byte) error {
 	err := cm.standardUnmarshal(data)
 	if err != nil {
@@ -168,6 +169,10 @@ func (cm *CredentialManifest) ResolveOutputDescriptors(vc []byte) ([]ResolvedDat
 	}
 
 	return resolvedDataDisplayDescriptors, nil
+}
+
+func (cm *CredentialManifest) hasFormat() bool {
+	return hasAnyAlgorithmsOrProofTypes(cm.Format)
 }
 
 func resolveOutputDescriptor(outputDescriptor *OutputDescriptor,

--- a/pkg/doc/credentialmanifest/credentialmanifest_test.go
+++ b/pkg/doc/credentialmanifest/credentialmanifest_test.go
@@ -19,6 +19,10 @@ import (
 var (
 	//go:embed testdata/valid_credential_manifest.json
 	validCredentialManifest []byte //nolint:gochecknoglobals
+	//go:embed testdata/valid_credential_manifest_with_format.json
+	validCredentialManifestWithFormat []byte //nolint:gochecknoglobals
+	//go:embed testdata/valid_credential_manifest_with_presentation_definition.json
+	validCredentialManifestWithPresentationSubmission []byte //nolint:gochecknoglobals
 	//go:embed testdata/valid_credential.jsonld
 	validVC []byte //nolint:gochecknoglobals
 )
@@ -27,10 +31,10 @@ const invalidJSONPath = "%InvalidJSONPath"
 
 func TestCredentialManifest_Unmarshal(t *testing.T) {
 	t.Run("Valid credential manifest", func(t *testing.T) {
-		makeValidCredentialManifest(t)
+		makeCredentialManifestFromBytes(t, validCredentialManifest)
 	})
 	t.Run("Missing issuer ID", func(t *testing.T) {
-		credentialManifest := makeValidCredentialManifest(t)
+		credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifest)
 
 		credentialManifest.Issuer.ID = ""
 
@@ -41,7 +45,7 @@ func TestCredentialManifest_Unmarshal(t *testing.T) {
 		require.EqualError(t, err, "invalid credential manifest: issuer ID missing")
 	})
 	t.Run("No output descriptors", func(t *testing.T) {
-		credentialManifest := makeValidCredentialManifest(t)
+		credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifest)
 
 		credentialManifest.OutputDescriptors = nil
 
@@ -52,7 +56,7 @@ func TestCredentialManifest_Unmarshal(t *testing.T) {
 		require.EqualError(t, err, "invalid credential manifest: no output descriptors found")
 	})
 	t.Run("Output descriptor missing ID", func(t *testing.T) {
-		credentialManifest := makeValidCredentialManifest(t)
+		credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifest)
 
 		credentialManifest.OutputDescriptors[0].ID = ""
 
@@ -63,7 +67,7 @@ func TestCredentialManifest_Unmarshal(t *testing.T) {
 		require.EqualError(t, err, "invalid credential manifest: missing ID for output descriptor at index 0")
 	})
 	t.Run("Duplicate output descriptor IDs", func(t *testing.T) {
-		credentialManifest := makeValidCredentialManifest(t)
+		credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifest)
 
 		credentialManifest.OutputDescriptors =
 			append(credentialManifest.OutputDescriptors,
@@ -77,7 +81,7 @@ func TestCredentialManifest_Unmarshal(t *testing.T) {
 			"in multiple output descriptors")
 	})
 	t.Run("Missing schema for output descriptor", func(t *testing.T) {
-		credentialManifest := makeValidCredentialManifest(t)
+		credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifest)
 
 		credentialManifest.OutputDescriptors[0].Schema = ""
 
@@ -237,7 +241,7 @@ func createMarshalledCredentialManifestWithInvalidTitleJSONPath(t *testing.T) []
 }
 
 func createCredentialManifestWithInvalidTitleJSONPath(t *testing.T) credentialmanifest.CredentialManifest {
-	credentialManifest := makeValidCredentialManifest(t)
+	credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifest)
 
 	credentialManifest.OutputDescriptors[0].Display.Title.Paths[0] = invalidJSONPath
 
@@ -254,7 +258,7 @@ func createMarshalledCredentialManifestWithInvalidSubtitleJSONPath(t *testing.T)
 }
 
 func createCredentialManifestWithInvalidSubtitleJSONPath(t *testing.T) credentialmanifest.CredentialManifest {
-	credentialManifest := makeValidCredentialManifest(t)
+	credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifest)
 
 	credentialManifest.OutputDescriptors[0].Display.Subtitle.Paths[0] = invalidJSONPath
 
@@ -271,7 +275,7 @@ func createMarshalledCredentialManifestWithInvalidDescriptionJSONPath(t *testing
 }
 
 func createCredentialManifestWithInvalidDescriptionJSONPath(t *testing.T) credentialmanifest.CredentialManifest {
-	credentialManifest := makeValidCredentialManifest(t)
+	credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifest)
 
 	credentialManifest.OutputDescriptors[0].Display.Description.Paths = []string{invalidJSONPath}
 
@@ -288,7 +292,7 @@ func createMarshalledCredentialManifestWithInvalidPropertyJSONPath(t *testing.T)
 }
 
 func createCredentialManifestWithInvalidPropertyJSONPath(t *testing.T) credentialmanifest.CredentialManifest {
-	credentialManifest := makeValidCredentialManifest(t)
+	credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifest)
 
 	credentialManifest.OutputDescriptors[0].Display.Properties[0].Paths[0] = invalidJSONPath
 
@@ -305,7 +309,7 @@ func createMarshalledCredentialManifestWithInvalidSchemaType(t *testing.T) []byt
 }
 
 func createCredentialManifestWithInvalidSchemaType(t *testing.T) credentialmanifest.CredentialManifest {
-	credentialManifest := makeValidCredentialManifest(t)
+	credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifest)
 
 	credentialManifest.OutputDescriptors[0].Display.Title.Schema.Type = "InvalidSchemaType"
 
@@ -322,7 +326,7 @@ func createMarshalledCredentialManifestWithInvalidSchemaFormat(t *testing.T) []b
 }
 
 func createCredentialManifestWithInvalidSchemaFormat(t *testing.T) credentialmanifest.CredentialManifest {
-	credentialManifest := makeValidCredentialManifest(t)
+	credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifest)
 
 	credentialManifest.OutputDescriptors[0].Display.Title.Schema = credentialmanifest.Schema{
 		Type:   "string",
@@ -332,10 +336,27 @@ func createCredentialManifestWithInvalidSchemaFormat(t *testing.T) credentialman
 	return credentialManifest
 }
 
-func makeValidCredentialManifest(t *testing.T) credentialmanifest.CredentialManifest {
+func createCredentialManifestWithNilJWTFormat(t *testing.T) credentialmanifest.CredentialManifest {
+	credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifestWithFormat)
+
+	credentialManifest.Format.Jwt = nil
+
+	return credentialManifest
+}
+
+func createCredentialManifestWithNilLDPFormat(t *testing.T) credentialmanifest.CredentialManifest {
+	credentialManifest := makeCredentialManifestFromBytes(t, validCredentialManifestWithFormat)
+
+	credentialManifest.Format.Ldp = nil
+
+	return credentialManifest
+}
+
+func makeCredentialManifestFromBytes(t *testing.T,
+	credentialManifestBytes []byte) credentialmanifest.CredentialManifest {
 	var credentialManifest credentialmanifest.CredentialManifest
 
-	err := json.Unmarshal(validCredentialManifest, &credentialManifest)
+	err := json.Unmarshal(credentialManifestBytes, &credentialManifest)
 	require.NoError(t, err)
 
 	return credentialManifest

--- a/pkg/doc/credentialmanifest/testdata/valid_credential_application.json
+++ b/pkg/doc/credentialmanifest/testdata/valid_credential_application.json
@@ -1,0 +1,6 @@
+{
+  "credential_application": {
+    "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
+    "manifest_id": "university_degree"
+  }
+}

--- a/pkg/doc/credentialmanifest/testdata/valid_credential_application_with_format.json
+++ b/pkg/doc/credentialmanifest/testdata/valid_credential_application_with_format.json
@@ -1,0 +1,30 @@
+{
+  "credential_application": {
+    "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
+    "manifest_id": "university_degree",
+    "format": {
+      "jwt": {
+        "alg": ["EdDSA", "ES256K", "ES384"]
+      },
+      "jwt_vc": {
+        "alg": ["ES256K", "ES384"]
+      },
+      "jwt_vp": {
+        "alg": ["EdDSA", "ES256K"]
+      },
+      "ldp": {
+        "proof_type": ["RsaSignature2018"]
+      },
+      "ldp_vc": {
+        "proof_type": [
+          "JsonWebSignature2020",
+          "EcdsaSecp256k1Signature2019",
+          "Ed25519Signature2018"
+        ]
+      },
+      "ldp_vp": {
+        "proof_type": ["Ed25519Signature2018"]
+      }
+    }
+  }
+}

--- a/pkg/doc/credentialmanifest/testdata/valid_credential_application_with_presentation_submission.json
+++ b/pkg/doc/credentialmanifest/testdata/valid_credential_application_with_presentation_submission.json
@@ -1,0 +1,27 @@
+{
+  "credential_application": {
+    "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
+    "manifest_id": "university_degree"
+  },
+  "presentation_submission": {
+    "id": "a30e3b91-fb77-4d22-95fa-871689c322e2",
+    "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "descriptor_map": [
+      {
+        "id": "input_1",
+        "format": "jwt_vc",
+        "path": "$.verifiableCredential[0]"
+      },
+      {
+        "id": "input_2",
+        "format": "ldp_vc",
+        "path": "$.verifiableCredential[1]"
+      },
+      {
+        "id": "input_3",
+        "format": "ldp_vc",
+        "path": "$.verifiableCredential[2]"
+      }
+    ]
+  }
+}

--- a/pkg/doc/credentialmanifest/testdata/valid_credential_manifest_with_format.json
+++ b/pkg/doc/credentialmanifest/testdata/valid_credential_manifest_with_format.json
@@ -76,5 +76,30 @@
         }
       }
     }
-  ]
+  ],
+  "format": {
+    "jwt": {
+      "alg": ["EdDSA", "ES256K", "ES384"]
+    },
+    "jwt_vc": {
+      "alg": ["ES256K", "ES384"]
+    },
+    "jwt_vp": {
+      "alg": ["EdDSA", "ES256K"]
+    },
+    "ldp": {
+      "proof_type": ["RsaSignature2018"]
+    },
+    "ldp_vc": {
+      "proof_type": [
+        "JsonWebSignature2020",
+        "Ed25519Signature2018",
+        "EcdsaSecp256k1Signature2019",
+        "RsaSignature2018"
+      ]
+    },
+    "ldp_vp": {
+      "proof_type": ["Ed25519Signature2018"]
+    }
+  }
 }

--- a/pkg/doc/credentialmanifest/testdata/valid_credential_manifest_with_presentation_definition.json
+++ b/pkg/doc/credentialmanifest/testdata/valid_credential_manifest_with_presentation_definition.json
@@ -76,5 +76,15 @@
         }
       }
     }
-  ]
+  ],
+  "presentation_definition": {
+    "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "input_descriptors": [
+      {
+        "id": "bachelors_degree",
+        "name": "Bachelor's Degree",
+        "purpose": "To determine education qualifications"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Added a library for parsing Credential Application objects and ensuring they're valid against given Credential Manifests, per the specification at https://identity.foundation/credential-manifest/#credential-application.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>