### PR TITLE
feat: Credential Fulfillment

### DIFF
--- a/pkg/doc/credentialmanifest/credentialfulfillment.go
+++ b/pkg/doc/credentialmanifest/credentialfulfillment.go
@@ -1,0 +1,124 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package credentialmanifest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/PaesslerAG/jsonpath"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/presexch"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+)
+
+// CredentialFulfillment represents a Credential Fulfillment object as defined in
+// https://identity.foundation/credential-manifest/#credential-fulfillment.
+type CredentialFulfillment struct {
+	ID                             string                `json:"id,omitempty"`
+	ManifestID                     string                `json:"manifest_id,omitempty"`
+	OutputDescriptorMappingObjects []OutputDescriptorMap `json:"descriptor_map,omitempty"`
+}
+
+// OutputDescriptorMap represents an Output Descriptor Mapping Object as defined in
+// https://identity.foundation/credential-manifest/#credential-fulfillment.
+// It has the same format as the InputDescriptorMapping object from the presexch package, but has a different meaning
+// here.
+type OutputDescriptorMap presexch.InputDescriptorMapping
+
+// UnmarshalJSON is the custom unmarshal function gets called automatically when the standard json.Unmarshal is called.
+// It also ensures that the given data is a valid CredentialFulfillment object per the specification.
+func (cf *CredentialFulfillment) UnmarshalJSON(data []byte) error {
+	err := cf.standardUnmarshal(data)
+	if err != nil {
+		return err
+	}
+
+	err = cf.validate()
+	if err != nil {
+		return fmt.Errorf("invalid Credential Fulfillment: %w", err)
+	}
+
+	return nil
+}
+
+// ResolveDescriptorMaps resolves Verifiable Credentials based on this Credential Fulfillment's descriptor maps.
+// This function looks at each OutputDescriptorMap's path property and checks for that path in the given JSON data,
+// which is expected to be from
+// the attachment of an Issue Credential message (i.e. issuecredential.IssueCredentialV3.Attachments[i].Data.JSON).
+// See the TestCredentialFulfillment_ResolveDescriptorMap method for examples.
+// If a VC is found at that path's location, then it is added to the array of VCs that will be returned by this method.
+// Once all OutputDescriptorMaps are done being scanned, the array of VCs will be returned.
+func (cf *CredentialFulfillment) ResolveDescriptorMaps(jsonDataFromAttachment interface{},
+	parseCredentialOpts ...verifiable.CredentialOpt) ([]verifiable.Credential, error) {
+	// The jsonpath library needs a map[string]interface{}.
+	// The issuecredential.IssueCredentialV3.Attachments[i].Data.JSON object (expected to be passed in here) is of type
+	// interface{}, but the Go unmarshaler should have set it to a map[string]interface{}.
+	jsonDataFromAttachmentAsMap, ok := jsonDataFromAttachment.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("the given JSON data could not be asserted as a map[string]interface{}")
+	}
+
+	verifiableCredentials := make([]verifiable.Credential, len(cf.OutputDescriptorMappingObjects))
+
+	for i, descriptorMap := range cf.OutputDescriptorMappingObjects {
+		vc, err := resolveDescriptorMap(descriptorMap, jsonDataFromAttachmentAsMap, parseCredentialOpts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve descriptor map at index %d: %w", i, err)
+		}
+
+		verifiableCredentials[i] = *vc
+	}
+
+	return verifiableCredentials, nil
+}
+
+func (cf *CredentialFulfillment) standardUnmarshal(data []byte) error {
+	// The type alias below is used as to allow the standard json.Unmarshal to be called within a custom unmarshal
+	// function without causing infinite recursion. See https://stackoverflow.com/a/43178272 for more information.
+	type credentialFulfillmentWithoutMethods *CredentialFulfillment
+
+	err := json.Unmarshal(data, credentialFulfillmentWithoutMethods(cf))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cf *CredentialFulfillment) validate() error {
+	if cf.ID == "" {
+		return errors.New("missing ID")
+	}
+
+	if cf.ManifestID == "" {
+		return errors.New("missing manifest ID")
+	}
+
+	return nil
+}
+
+func resolveDescriptorMap(descriptorMap OutputDescriptorMap, jsonDataFromAttachmentAsMap map[string]interface{},
+	parseCredentialOpts []verifiable.CredentialOpt) (*verifiable.Credential, error) {
+	vcRaw, err := jsonpath.Get(descriptorMap.Path, jsonDataFromAttachmentAsMap)
+	if err != nil {
+		return nil, err
+	}
+
+	vcBytes, err := json.Marshal(vcRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	vc, err := verifiable.ParseCredential(vcBytes, parseCredentialOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse credential: %w", err)
+	}
+
+	return vc, nil
+}

--- a/pkg/doc/credentialmanifest/credentialfulfillment_test.go
+++ b/pkg/doc/credentialmanifest/credentialfulfillment_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package credentialmanifest_test
+
+import (
+	_ "embed"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/issuecredential"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/credentialmanifest"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+)
+
+var (
+	//go:embed testdata/valid_credential_fulfillment.json
+	validCredentialFulfillment []byte //nolint:gochecknoglobals
+	//go:embed testdata/valid_issue_credential_message.json
+	validIssueCredentialMessage []byte //nolint:gochecknoglobals
+)
+
+func TestCredentialFulfillment_Unmarshal(t *testing.T) {
+	t.Run("Valid Credential Fulfillment", func(t *testing.T) {
+		makeValidCredentialFulfillment(t)
+	})
+	t.Run("Missing ID", func(t *testing.T) {
+		credentialFulfillmentBytes := makeCredentialFulfillmentWithMissingID(t)
+
+		var credentialFulfillment credentialmanifest.CredentialFulfillment
+
+		err := json.Unmarshal(credentialFulfillmentBytes, &credentialFulfillment)
+		require.EqualError(t, err, "invalid Credential Fulfillment: missing ID")
+	})
+	t.Run("Missing Manifest ID", func(t *testing.T) {
+		credentialFulfillmentBytes := makeCredentialFulfillmentWithMissingManifestID(t)
+
+		var credentialFulfillment credentialmanifest.CredentialFulfillment
+
+		err := json.Unmarshal(credentialFulfillmentBytes, &credentialFulfillment)
+		require.EqualError(t, err, "invalid Credential Fulfillment: missing manifest ID")
+	})
+}
+
+func TestCredentialFulfillment_ResolveDescriptorMap(t *testing.T) {
+	testDocumentLoaderOption := verifiable.WithJSONLDDocumentLoader(createTestDocumentLoader(t))
+
+	t.Run("Success", func(t *testing.T) {
+		credentialFulfillment := makeValidCredentialFulfillment(t)
+		issueCredentialMessage := makeValidIssueCredentialMessage(t)
+
+		verifiableCredentials, err := credentialFulfillment.ResolveDescriptorMaps(
+			issueCredentialMessage.Attachments[0].Data.JSON, testDocumentLoaderOption)
+		require.NoError(t, err)
+		require.Len(t, verifiableCredentials, 1)
+
+		originalVC := getVCFromValidIssueCredentialMessage(t)
+
+		require.True(t, reflect.DeepEqual(verifiableCredentials[0], originalVC),
+			"resolved VC differs from the original VC")
+	})
+	t.Run("Invalid JSONPath", func(t *testing.T) {
+		credentialFulfillment := makeCredentialFulfillmentWithInvalidJSONPath(t)
+		issueCredentialMessage := makeValidIssueCredentialMessage(t)
+
+		verifiableCredentials, err := credentialFulfillment.ResolveDescriptorMaps(
+			issueCredentialMessage.Attachments[0].Data.JSON, testDocumentLoaderOption)
+		require.EqualError(t, err, "failed to resolve descriptor map at index 0: parsing error: "+
+			`%InvalidJSONPath	:1:1 - 1:2 unexpected "%" while scanning extensions`)
+		require.Nil(t, verifiableCredentials)
+	})
+	t.Run("JSON data is not a map[string]interface{}", func(t *testing.T) {
+		credentialFulfillment := makeValidCredentialFulfillment(t)
+
+		verifiableCredentials, err := credentialFulfillment.ResolveDescriptorMaps(1)
+		require.EqualError(t, err, "the given JSON data could not be asserted as a map[string]interface{}")
+		require.Nil(t, verifiableCredentials)
+	})
+	t.Run("Failed to parse VC", func(t *testing.T) {
+		credentialFulfillment := makeValidCredentialFulfillment(t)
+		issueCredentialMessage := makeIssueCredentialMessageWithInvalidVC(t)
+
+		verifiableCredentials, err := credentialFulfillment.ResolveDescriptorMaps(
+			issueCredentialMessage.Attachments[0].Data.JSON)
+		require.EqualError(t, err, "failed to resolve descriptor map at index 0: failed to parse "+
+			"credential: decode new credential: embedded proof is not JSON: json: cannot unmarshal string "+
+			"into Go value of type map[string]interface {}")
+		require.Nil(t, verifiableCredentials)
+	})
+}
+
+func makeValidCredentialFulfillment(t *testing.T) credentialmanifest.CredentialFulfillment {
+	var credentialFulfillment credentialmanifest.CredentialFulfillment
+
+	err := json.Unmarshal(validCredentialFulfillment, &credentialFulfillment)
+	require.NoError(t, err)
+
+	return credentialFulfillment
+}
+
+func makeValidIssueCredentialMessage(t *testing.T) issuecredential.IssueCredentialV3 {
+	var issueCredentialMessage issuecredential.IssueCredentialV3
+
+	err := json.Unmarshal(validIssueCredentialMessage, &issueCredentialMessage)
+	require.NoError(t, err)
+
+	return issueCredentialMessage
+}
+
+func getVCFromValidIssueCredentialMessage(t *testing.T) verifiable.Credential {
+	issueCredentialMessage := makeValidIssueCredentialMessage(t)
+
+	jsonAttachmentAsMap, ok := issueCredentialMessage.Attachments[0].Data.JSON.(map[string]interface{})
+	require.True(t, ok)
+
+	verifiableCredentialsRaw := jsonAttachmentAsMap["verifiableCredential"]
+
+	verifiableCredentialsAsArrayOfInterface, ok := verifiableCredentialsRaw.([]interface{})
+	require.True(t, ok)
+
+	vcBytes, err := json.Marshal(verifiableCredentialsAsArrayOfInterface[0])
+	require.NoError(t, err)
+
+	vc, err := verifiable.ParseCredential(vcBytes, verifiable.WithJSONLDDocumentLoader(createTestDocumentLoader(t)))
+	require.NoError(t, err)
+
+	return *vc
+}
+
+func makeCredentialFulfillmentWithMissingID(t *testing.T) []byte {
+	credentialFulfillment := makeValidCredentialFulfillment(t)
+
+	credentialFulfillment.ID = ""
+
+	credentialFulfillmentBytes, err := json.Marshal(credentialFulfillment)
+	require.NoError(t, err)
+
+	return credentialFulfillmentBytes
+}
+
+func makeCredentialFulfillmentWithMissingManifestID(t *testing.T) []byte {
+	credentialFulfillment := makeValidCredentialFulfillment(t)
+
+	credentialFulfillment.ManifestID = ""
+
+	credentialFulfillmentBytes, err := json.Marshal(credentialFulfillment)
+	require.NoError(t, err)
+
+	return credentialFulfillmentBytes
+}
+
+func makeCredentialFulfillmentWithInvalidJSONPath(t *testing.T) credentialmanifest.CredentialFulfillment {
+	credentialFulfillment := makeValidCredentialFulfillment(t)
+
+	credentialFulfillment.OutputDescriptorMappingObjects[0].Path = invalidJSONPath
+
+	return credentialFulfillment
+}
+
+func makeIssueCredentialMessageWithInvalidVC(t *testing.T) issuecredential.IssueCredentialV3 {
+	var issueCredentialMessage issuecredential.IssueCredentialV3
+
+	err := json.Unmarshal(validIssueCredentialMessage, &issueCredentialMessage)
+	require.NoError(t, err)
+
+	jsonAttachmentAsMap, ok := issueCredentialMessage.Attachments[0].Data.JSON.(map[string]interface{})
+	require.True(t, ok)
+
+	jsonAttachmentAsMap["verifiableCredential"] = []interface{}{"NotAValidVC"}
+
+	return issueCredentialMessage
+}

--- a/pkg/doc/credentialmanifest/credentialmanifest.go
+++ b/pkg/doc/credentialmanifest/credentialmanifest.go
@@ -4,7 +4,8 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Package credentialmanifest implements https://identity.foundation/credential-manifest/#credential-manifest-2.
+// Package credentialmanifest contains methods that are useful for parsing and validating the objects defined in
+// https://identity.foundation/credential-manifest.
 package credentialmanifest
 
 import (
@@ -16,6 +17,7 @@ import (
 	"github.com/PaesslerAG/jsonpath"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/presexch"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 )
 
 // CredentialManifest represents a Credential Manifest object as defined in
@@ -147,11 +149,17 @@ func (cm *CredentialManifest) UnmarshalJSON(data []byte) error {
 // return the first one that resolves successfully. If none of the paths are resolvable, then we return the fallback.
 // If no fallback is specified, then a blank string is returned. This isn't considered an error.
 // If the text field is used instead of paths, then that will simply be returned without needing to look at vc.
-func (cm *CredentialManifest) ResolveOutputDescriptors(vc []byte) ([]ResolvedDataDisplayDescriptor, error) {
+func (cm *CredentialManifest) ResolveOutputDescriptors(vc *verifiable.Credential) ([]ResolvedDataDisplayDescriptor,
+	error) {
+	vcBytes, err := json.Marshal(vc)
+	if err != nil {
+		return nil, err
+	}
+
 	// The jsonpath library needs the JSON unmarshalled into a map[string]interface{}.
 	vcUnmarshalledIntoMap := map[string]interface{}{}
 
-	err := json.Unmarshal(vc, &vcUnmarshalledIntoMap)
+	err = json.Unmarshal(vcBytes, &vcUnmarshalledIntoMap)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/doc/credentialmanifest/testdata/valid_credential_fulfillment.json
+++ b/pkg/doc/credentialmanifest/testdata/valid_credential_fulfillment.json
@@ -1,0 +1,11 @@
+{
+  "id": "a30e3b91-fb77-4d22-95fa-871689c322e2",
+  "manifest_id": "university_degree",
+  "descriptor_map":[
+    {
+      "id": "bachelor_degree",
+      "format": "jwt_vc",
+      "path": "$.verifiableCredential[0]"
+    }
+  ]
+}

--- a/pkg/doc/credentialmanifest/testdata/valid_issue_credential_message.json
+++ b/pkg/doc/credentialmanifest/testdata/valid_issue_credential_message.json
@@ -1,0 +1,112 @@
+{
+  "type":"https://didcomm.org/issue-credential/3.0/issue-credential",
+  "id":"7a476bd8-cc3f-4d80-b784-caeb2ff265da",
+  "pthid":"f137e0db-db7b-4776-9530-83c808a34a42",
+  "from":"did:example:issuer",
+  "to":[
+    "did:example:holder"
+  ],
+  "attachments":[
+    {
+      "id":"e00e11d4-906d-4c88-ba72-7c66c7113a78",
+      "media_type":"application/json",
+      "format":"dif/credential-manifest/fulfillment@v1.0",
+      "data":{
+        "json":{
+          "@context":[
+            "https://www.w3.org/2018/credentials/v1",
+            "https://identity.foundation/credential-manifest/fulfillment/v1"
+          ],
+          "type":[
+            "VerifiablePresentation",
+            "CredentialFulfillment"
+          ],
+          "credential_fulfillment":{
+            "id": "a30e3b91-fb77-4d22-95fa-871689c322e2",
+            "manifest_id": "university_degree",
+            "descriptor_map":[
+              {
+                "id": "bachelor_degree",
+                "format": "jwt_vc",
+                "path": "$.verifiableCredential[0]"
+              }
+            ]
+          },
+          "verifiableCredential":[
+            {
+              "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                "https://www.w3.org/2018/credentials/examples/v1",
+                "https://w3id.org/security/jws/v1",
+                "https://trustbloc.github.io/context/vc/examples-v1.jsonld"
+              ],
+              "id": "http://example.edu/credentials/1872",
+              "type": "VerifiableCredential",
+              "credentialSubject": {
+                "id": "did:example:ebfeb1f712ebc6f1c276e12ec21"
+              },
+              "issuer": {
+                "id": "did:example:76e12ec712ebc6f1c221ebfeb1f",
+                "name": "Example University",
+                "image": "data:image/png;base64,iVBOR"
+              },
+              "issuanceDate": "2010-01-01T19:23:24Z",
+              "expirationDate": "2020-01-01T19:23:24Z",
+              "credentialStatus": {
+                "id": "https://example.edu/status/24",
+                "type": "CredentialStatusList2017"
+              },
+              "evidence": [
+                {
+                  "id": "https://example.edu/evidence/f2aeec97-fc0d-42bf-8ca7-0548192d4231",
+                  "type": [
+                    "DocumentVerification"
+                  ],
+                  "verifier": "https://example.edu/issuers/14",
+                  "evidenceDocument": "DriversLicense",
+                  "subjectPresence": "Physical",
+                  "documentPresence": "Physical"
+                },
+                {
+                  "id": "https://example.edu/evidence/f2aeec97-fc0d-42bf-8ca7-0548192dxyzab",
+                  "type": [
+                    "SupportingActivity"
+                  ],
+                  "verifier": "https://example.edu/issuers/14",
+                  "evidenceDocument": "Fluid Dynamics Focus",
+                  "subjectPresence": "Digital",
+                  "documentPresence": "Digital"
+                }
+              ],
+              "termsOfUse": [
+                {
+                  "type": "IssuerPolicy",
+                  "id": "http://example.com/policies/credential/4",
+                  "profile": "http://example.com/profiles/credential",
+                  "prohibition": [
+                    {
+                      "assigner": "https://example.edu/issuers/14",
+                      "assignee": "AllVerifiers",
+                      "target": "http://example.edu/credentials/3732",
+                      "action": [
+                        "Archival"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refreshService": {
+                "id": "https://example.edu/refresh/3732",
+                "type": "ManualRefreshService2018"
+              },
+              "title": "Bachelor of Applied Science",
+              "minor": "Electrical Systems Specialty",
+              "withDistinction": true,
+              "yearsStudied": 4
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Added a library that allows you to parse Credential Fulfillment objects and resolve VCs from them based on an Issue Credential Message's attachment. This Credential Fulfillment implementation is based on the specification at https://identity.foundation/credential-manifest/#credential-fulfillment.

- Refactored the CredentialManifest.ResolveOutputDescriptors method to take in a *verifiable.Credential object instead of a []byte, in order to make the expected type more explicit.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>