### PR TITLE
fix: vcwallet WACI issuance fixes

### DIFF
--- a/pkg/client/vcwallet/client.go
+++ b/pkg/client/vcwallet/client.go
@@ -408,10 +408,10 @@ func (c *Client) ProposePresentation(invitation *wallet.GenericInvitation, optio
 // 		- presentation: presentation to be sent.
 //
 // Returns:
-// 		- present proof status including web redirect info.
+// 		- Credential interaction status containing status, redirectURL.
 // 		- error if operation fails.
 //
-func (c *Client) PresentProof(thID string, presentProofFrom ...wallet.ConcludeInteractionOptions) (*wallet.PresentProofStatus, error) { //nolint: lll
+func (c *Client) PresentProof(thID string, presentProofFrom ...wallet.ConcludeInteractionOptions) (*wallet.CredentialInteractionStatus, error) { //nolint: lll
 	auth, err := c.auth()
 	if err != nil {
 		return nil, err
@@ -455,10 +455,10 @@ func (c *Client) ProposeCredential(invitation *outofband.Invitation, options ...
 // 		- concludeInteractionOptions: options to conclude interaction like presentation to be shared etc.
 //
 // Returns:
-// 		- RequestCredentialStatus containing status, redirectURL, credential fullfillment attachments.
+// 		- Credential interaction status containing status, redirectURL.
 // 		- error if operation fails.
 //
-func (c *Client) RequestCredential(thID string, options ...wallet.ConcludeInteractionOptions) (*wallet.RequestCredentialStatus, error) { // nolint: lll
+func (c *Client) RequestCredential(thID string, options ...wallet.ConcludeInteractionOptions) (*wallet.CredentialInteractionStatus, error) { // nolint: lll
 	auth, err := c.auth()
 	if err != nil {
 		return nil, err

--- a/pkg/client/vcwallet/client_test.go
+++ b/pkg/client/vcwallet/client_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	issuecredentialsvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/issuecredential"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
@@ -1929,8 +1928,6 @@ func TestClient_ProposeCredential(t *testing.T) {
 }
 
 func TestClient_RequestCredential(t *testing.T) {
-	const piidKey = "piid"
-
 	sampleUser := uuid.New().String()
 	mockctx := newMockProvider(t)
 
@@ -1955,30 +1952,18 @@ func TestClient_RequestCredential(t *testing.T) {
 	t.Run("test present proof success - wait for done", func(t *testing.T) {
 		thID := uuid.New().String()
 
-		loader, err := ldtestutil.DocumentLoader()
-		require.NoError(t, err)
-
-		vc, err := verifiable.ParseCredential([]byte(sampleUDCVC), verifiable.WithJSONLDDocumentLoader(loader))
-		require.NoError(t, err)
-		require.NotEmpty(t, vc)
-
 		icSvc := &mockissuecredential.MockIssueCredentialSvc{
-			RegisterActionEventHandle: func(ch chan<- service.DIDCommAction) error {
-				ch <- service.DIDCommAction{
-					Message: service.NewDIDCommMsgMap(&issuecredentialsvc.IssueCredential{
-						Type: issuecredentialsvc.IssueCredentialMsgTypeV2,
-						CredentialsAttach: []decorator.Attachment{
-							{Data: decorator.AttachmentData{JSON: vc}},
-						},
-					}),
+			RegisterMsgEventHandle: func(ch chan<- service.StateMsg) error {
+				ch <- service.StateMsg{
+					Type:    service.PostState,
+					StateID: "done",
 					Properties: &mockdidexchange.MockEventProperties{
 						Properties: map[string]interface{}{
-							piidKey:           thID,
-							webRedirectURLKey: exampleWebRedirect,
+							webRedirectStatusKey: model.AckStatusOK,
+							webRedirectURLKey:    exampleWebRedirect,
 						},
 					},
-					Continue: func(interface{}) {},
-					Stop:     func(error) {},
+					Msg: &mockMsg{thID: thID},
 				}
 
 				return nil
@@ -2000,11 +1985,6 @@ func TestClient_RequestCredential(t *testing.T) {
 		require.NotEmpty(t, response)
 		require.Equal(t, model.AckStatusOK, response.Status)
 		require.Equal(t, exampleWebRedirect, response.RedirectURL)
-
-		vcFulfilled, err := verifiable.ParseCredential(response.Credentials[0], verifiable.WithJSONLDDocumentLoader(loader))
-		require.NoError(t, err)
-		require.NotEmpty(t, vcFulfilled)
-		require.Equal(t, vc.ID, vcFulfilled.ID)
 	})
 
 	t.Run("test present proof failure - auth error", func(t *testing.T) {

--- a/pkg/controller/command/issuecredential/command.go
+++ b/pkg/controller/command/issuecredential/command.go
@@ -770,7 +770,15 @@ func (c *Command) AcceptCredential(rw io.Writer, req io.Reader) command.Error {
 		return command.NewValidationError(InvalidRequestErrorCode, errors.New(errEmptyPIID))
 	}
 
-	if err := c.client.AcceptCredential(args.PIID, issuecredential.AcceptByFriendlyNames(args.Names...)); err != nil {
+	opts := []issuecredential.AcceptCredentialOptions{
+		issuecredential.AcceptByFriendlyNames(args.Names...),
+	}
+
+	if args.SkipStore {
+		opts = append(opts, issuecredential.AcceptBySkippingStorage())
+	}
+
+	if err := c.client.AcceptCredential(args.PIID, opts...); err != nil {
 		logutil.LogError(logger, CommandName, AcceptCredential, err.Error())
 		return command.NewExecuteError(AcceptCredentialErrorCode, err)
 	}

--- a/pkg/controller/command/issuecredential/models.go
+++ b/pkg/controller/command/issuecredential/models.go
@@ -86,10 +86,13 @@ type AcceptRequestResponse struct{}
 // This is used for accepting a credential.
 //
 type AcceptCredentialArgs struct {
-	// PIID Protocol instance ID
+	// PIID Protocol instance ID.
 	PIID string `json:"piid"`
-	// Names represent the names of how credentials will be stored
+	// Names represent the names of how credentials will be stored.
 	Names []string `json:"names"`
+	// SkipStore if true then credential will not be saved in agent's verifiable store,
+	// but protocol state will be updated.
+	SkipStore bool `json:"skipStore"`
 }
 
 // AcceptCredentialResponse model

--- a/pkg/controller/command/vcwallet/command.go
+++ b/pkg/controller/command/vcwallet/command.go
@@ -235,8 +235,8 @@ func (o *Command) GetHandlers() []command.Handler {
 		cmdutil.NewCommandHandler(CommandName, ConnectMethod, o.Connect),
 		cmdutil.NewCommandHandler(CommandName, ProposePresentationMethod, o.ProposePresentation),
 		cmdutil.NewCommandHandler(CommandName, PresentProofMethod, o.PresentProof),
-		cmdutil.NewCommandHandler(CommandName, ProposeCredentialMethod, o.PresentProof),
-		cmdutil.NewCommandHandler(CommandName, RequestCredentialMethod, o.PresentProof),
+		cmdutil.NewCommandHandler(CommandName, ProposeCredentialMethod, o.ProposeCredential),
+		cmdutil.NewCommandHandler(CommandName, RequestCredentialMethod, o.RequestCredential),
 	}
 }
 
@@ -851,7 +851,7 @@ func (o *Command) PresentProof(rw io.Writer, req io.Reader) command.Error {
 }
 
 // ProposeCredential sends propose credential message from wallet to issuer.
-// https://w3c-ccg.github.io/universal-wallet-interop-spec/#requestcredential
+// https://w3c-ccg.github.io/universal-wallet-interop-spec/#proposecredential
 //
 // Currently Supporting : 0453-issueCredentialV2
 // https://github.com/hyperledger/aries-rfcs/blob/main/features/0453-issue-credential-v2/README.md
@@ -896,7 +896,7 @@ func (o *Command) ProposeCredential(rw io.Writer, req io.Reader) command.Error {
 
 // RequestCredential sends request credential message from wallet to issuer and
 // optionally waits for credential fulfillment.
-// https://w3c-ccg.github.io/universal-wallet-interop-spec/#proposecredential
+// https://w3c-ccg.github.io/universal-wallet-interop-spec/#requestcredential
 //
 // Currently Supporting : 0453-issueCredentialV2
 // https://github.com/hyperledger/aries-rfcs/blob/main/features/0453-issue-credential-v2/README.md

--- a/pkg/controller/command/vcwallet/command_test.go
+++ b/pkg/controller/command/vcwallet/command_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	issuecredentialsvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/issuecredential"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
@@ -2174,7 +2173,7 @@ func TestCommand_PresentProof(t *testing.T) {
 		cmdErr := cmd.PresentProof(&b, getReader(t, &request))
 		require.NoError(t, cmdErr)
 
-		var response wallet.PresentProofStatus
+		var response wallet.CredentialInteractionStatus
 		require.NoError(t, json.NewDecoder(&b).Decode(&response))
 		require.NotEmpty(t, response)
 		require.Equal(t, exampleWebRedirect, response.RedirectURL)
@@ -2394,10 +2393,7 @@ func TestCommand_ProposeCredential(t *testing.T) {
 }
 
 func TestCommand_RequestCredential(t *testing.T) {
-	const (
-		sampleDIDCommUser = "sample-didcomm-user03"
-		piidKey           = "piid"
-	)
+	const sampleDIDCommUser = "sample-didcomm-user03"
 
 	mockctx := newMockProvider(t)
 
@@ -2429,30 +2425,19 @@ func TestCommand_RequestCredential(t *testing.T) {
 
 	t.Run("successfully request credential - wait for done", func(t *testing.T) {
 		thID := uuid.New().String()
-		loader, err := ldtestutil.DocumentLoader()
-		require.NoError(t, err)
-
-		vc, err := verifiable.ParseCredential([]byte(sampleUDCVC), verifiable.WithJSONLDDocumentLoader(loader))
-		require.NoError(t, err)
-		require.NotEmpty(t, vc)
 
 		icSvc := &mockissuecredential.MockIssueCredentialSvc{
-			RegisterActionEventHandle: func(ch chan<- service.DIDCommAction) error {
-				ch <- service.DIDCommAction{
-					Message: service.NewDIDCommMsgMap(&issuecredentialsvc.IssueCredential{
-						Type: issuecredentialsvc.IssueCredentialMsgTypeV2,
-						CredentialsAttach: []decorator.Attachment{
-							{Data: decorator.AttachmentData{JSON: vc}},
-						},
-					}),
+			RegisterMsgEventHandle: func(ch chan<- service.StateMsg) error {
+				ch <- service.StateMsg{
+					Type:    service.PostState,
+					StateID: "done",
 					Properties: &mockdidexchange.MockEventProperties{
 						Properties: map[string]interface{}{
-							piidKey:           thID,
-							webRedirectURLKey: exampleWebRedirect,
+							webRedirectStatusKey: model.AckStatusOK,
+							webRedirectURLKey:    exampleWebRedirect,
 						},
 					},
-					Continue: func(interface{}) {},
-					Stop:     func(error) {},
+					Msg: &mockMsg{thID: thID},
 				}
 
 				return nil
@@ -2474,17 +2459,11 @@ func TestCommand_RequestCredential(t *testing.T) {
 		cmdErr := cmd.RequestCredential(&b, getReader(t, &request))
 		require.NoError(t, cmdErr)
 
-		var response wallet.RequestCredentialStatus
+		var response wallet.CredentialInteractionStatus
 		require.NoError(t, json.NewDecoder(&b).Decode(&response))
 		require.NotEmpty(t, response)
 		require.Equal(t, exampleWebRedirect, response.RedirectURL)
 		require.Equal(t, model.AckStatusOK, response.Status)
-		require.Len(t, response.Credentials, 1)
-
-		vcFulfilled, err := verifiable.ParseCredential(response.Credentials[0], verifiable.WithJSONLDDocumentLoader(loader))
-		require.NoError(t, err)
-		require.NotEmpty(t, vcFulfilled)
-		require.Equal(t, vc.ID, vcFulfilled.ID)
 	})
 
 	t.Run("failed to request credential", func(t *testing.T) {

--- a/pkg/controller/command/vcwallet/models.go
+++ b/pkg/controller/command/vcwallet/models.go
@@ -390,7 +390,7 @@ type PresentProofRequest struct {
 
 // PresentProofResponse is response model from wallet present proof operation.
 type PresentProofResponse struct {
-	wallet.PresentProofStatus
+	wallet.CredentialInteractionStatus
 }
 
 // ProposeCredentialRequest is request model for performing propose credential operation from wallet.
@@ -439,5 +439,5 @@ type RequestCredentialRequest struct {
 
 // RequestCredentialResponse is response model from wallet request credential operation.
 type RequestCredentialResponse struct {
-	wallet.RequestCredentialStatus
+	wallet.CredentialInteractionStatus
 }

--- a/pkg/controller/rest/issuecredential/models.go
+++ b/pkg/controller/rest/issuecredential/models.go
@@ -142,7 +142,11 @@ type issueCredentialAcceptCredentialRequest struct { // nolint: unused,deadcode
 	// in: body
 	Body struct {
 		// required: true
+		// Names represent the names of how credentials will be stored.
 		Names []string `json:"names"`
+
+		// SkipStore if true then credential will not be saved agent store, but protocol state will be updated.
+		SkipStore bool `json:"skipStore"`
 	}
 }
 

--- a/pkg/controller/rest/vcwallet/models.go
+++ b/pkg/controller/rest/vcwallet/models.go
@@ -320,7 +320,7 @@ type presentProofResponse struct {
 	// response containing status of present proof operation.
 	//
 	// in: body
-	Response *wallet.PresentProofStatus `json:"response"`
+	Response *wallet.CredentialInteractionStatus `json:"response"`
 }
 
 // proposeCredentialRequest is request model for performing propose credential operation from wallet to initiate
@@ -363,7 +363,7 @@ type requestCredentialResponse struct {
 	// response containing status of request credential operation.
 	//
 	// in: body
-	Response *wallet.RequestCredentialStatus `json:"response"`
+	Response *wallet.CredentialInteractionStatus `json:"response"`
 }
 
 // emptyRes model

--- a/pkg/controller/rest/vcwallet/operation.go
+++ b/pkg/controller/rest/vcwallet/operation.go
@@ -391,7 +391,7 @@ func (o *Operation) PresentProof(rw http.ResponseWriter, req *http.Request) {
 // ProposeCredential swagger:route POST /vcwallet/propose-credential vcwallet proposeCredReq
 //
 // Sends propose credential message from wallet to issuer and optionally waits for offer credential response.
-// https://w3c-ccg.github.io/universal-wallet-interop-spec/#requestcredential
+// https://w3c-ccg.github.io/universal-wallet-interop-spec/#proposecredential
 //
 // Currently Supporting : 0453-issueCredentialV2
 // https://github.com/hyperledger/aries-rfcs/blob/main/features/0453-issue-credential-v2/README.md
@@ -406,7 +406,7 @@ func (o *Operation) ProposeCredential(rw http.ResponseWriter, req *http.Request)
 // RequestCredential swagger:route POST /vcwallet/request-credential vcwallet requestCredReq
 //
 // Sends request credential message from wallet to issuer and optionally waits for credential fulfillment.
-// https://w3c-ccg.github.io/universal-wallet-interop-spec/#proposecredential
+// https://w3c-ccg.github.io/universal-wallet-interop-spec/#requestcredential
 //
 // Currently Supporting : 0453-issueCredentialV2
 // https://github.com/hyperledger/aries-rfcs/blob/main/features/0453-issue-credential-v2/README.md

--- a/pkg/wallet/models.go
+++ b/pkg/wallet/models.go
@@ -101,24 +101,12 @@ type KeyPair struct {
 	PublicKey string `json:"publicKey,omitempty"`
 }
 
-// PresentProofStatus holds the status of present proof action from wallet.
-// Typically holds web redirect info of present proof acknowledgement or problem-report.
-type PresentProofStatus struct {
-	// One of the status present proof interaction
+// CredentialInteractionStatus holds the status of credential share/issuance interaction from wallet.
+// Typically holds web redirect info of credential interaction conclusion or problem-report.
+type CredentialInteractionStatus struct {
+	// One of the status present proof or issue credential interaction
 	// Refer https://github.com/hyperledger/aries-rfcs/blob/main/features/0015-acks/README.md#ack-status.
 	Status string `json:"status"`
 	// Optional web redirect URL info sent by verifier.
 	RedirectURL string `json:"url,omitempty"`
-}
-
-// RequestCredentialStatus holds the status of request credential action from wallet.
-// Typically holds credential fulfillment & web redirect info of issue credential acknowledgement or problem-report.
-type RequestCredentialStatus struct {
-	// One of the status issue credential interaction
-	// Refer https://github.com/hyperledger/aries-rfcs/blob/main/features/0015-acks/README.md#ack-status.
-	Status string `json:"status"`
-	// Optional web redirect URL info sent by issuer.
-	RedirectURL string `json:"url,omitempty"`
-	// Credentials received by wallet.
-	Credentials []json.RawMessage
 }


### PR DESCRIPTION
- refactored WACI request credential to rely on state message rather
than action events, to fix event notification issues in JavaScript
bindings
- other minor fixes
- Part of #3073

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
