### PR TITLE
refactor: move oobv2 'From' field up from attachment

### DIFF
--- a/pkg/client/outofbandv2/client.go
+++ b/pkg/client/outofbandv2/client.go
@@ -29,6 +29,7 @@ type message struct {
 	Label              string
 	Goal               string
 	GoalCode           string
+	From               string
 	RouterConnections  []string
 	Service            []interface{}
 	HandshakeProtocols []string
@@ -96,6 +97,7 @@ func (c *Client) CreateInvitation(opts ...MessageOption) *oobv2.Invitation {
 		ID:    uuid.New().String(),
 		Type:  InvitationMsgType,
 		Label: msg.Label,
+		From:  msg.From,
 		Body: &oobv2.InvitationBody{
 			Goal:     msg.Goal,
 			GoalCode: msg.GoalCode,
@@ -125,6 +127,13 @@ func (c *Client) AcceptInvitation(i *oobv2.Invitation) (string, error) {
 func WithLabel(l string) MessageOption {
 	return func(m *message) {
 		m.Label = l
+	}
+}
+
+// WithFrom allows you to specify the sender's DID on the message.
+func WithFrom(f string) MessageOption {
+	return func(m *message) {
+		m.From = f
 	}
 }
 

--- a/pkg/client/outofbandv2/client_test.go
+++ b/pkg/client/outofbandv2/client_test.go
@@ -73,6 +73,13 @@ func TestCreateInvitation(t *testing.T) {
 		inv := c.CreateInvitation(WithLabel(expected))
 		require.Equal(t, expected, inv.Label)
 	})
+	t.Run("WithFrom", func(t *testing.T) {
+		c, err := New(withTestProvider())
+		require.NoError(t, err)
+		expected := uuid.New().String()
+		inv := c.CreateInvitation(WithFrom(expected))
+		require.Equal(t, expected, inv.From)
+	})
 	t.Run("WithGoal", func(t *testing.T) {
 		c, err := New(withTestProvider())
 		require.NoError(t, err)

--- a/pkg/controller/command/outofbandv2/command.go
+++ b/pkg/controller/command/outofbandv2/command.go
@@ -82,6 +82,7 @@ func (c *Command) CreateInvitation(rw io.Writer, req io.Reader) command.Error {
 	invitation := c.client.CreateInvitation(
 		outofbandv2.WithGoal(args.Body.Goal, args.Body.GoalCode),
 		outofbandv2.WithLabel(args.Label),
+		outofbandv2.WithFrom(args.From),
 		outofbandv2.WithAccept(args.Body.Accept...),
 		outofbandv2.WithAttachments(args.Attachments...),
 	)

--- a/pkg/controller/command/outofbandv2/models.go
+++ b/pkg/controller/command/outofbandv2/models.go
@@ -18,6 +18,7 @@ import (
 type CreateInvitationArgs struct {
 	Label string                     `json:"label"`
 	Body  outofbandv2.InvitationBody `json:"body"`
+	From  string                     `json:"from"`
 	// Attachments are intended to provide the possibility to include files, links or even JSON payload to the message.
 	Attachments []*decorator.AttachmentV2 `json:"attachments"`
 }

--- a/pkg/didcomm/protocol/outofbandv2/models.go
+++ b/pkg/didcomm/protocol/outofbandv2/models.go
@@ -13,6 +13,7 @@ type Invitation struct {
 	ID       string                    `json:"id"`
 	Type     string                    `json:"type"`
 	Label    string                    `json:"label,omitempty"`
+	From     string                    `json:"from"`
 	Body     *InvitationBody           `json:"body"`
 	Requests []*decorator.AttachmentV2 `json:"attachments,omitempty"`
 }

--- a/pkg/wallet/invitation.go
+++ b/pkg/wallet/invitation.go
@@ -19,6 +19,7 @@ import (
 type rawInvitation struct {
 	IDv1       string                   `json:"@id"`
 	TypeV1     string                   `json:"@type"`
+	From       string                   `json:"from,omitempty"`
 	Label      string                   `json:"label,omitempty"`
 	GoalV1     string                   `json:"goal,omitempty"`
 	GoalCodeV1 string                   `json:"goal_code,omitempty"`
@@ -36,6 +37,7 @@ type rawInvitation struct {
 type GenericInvitation struct {
 	ID        string                        `json:"id"`
 	Type      string                        `json:"type"`
+	From      string                        `json:"from,omitempty"`
 	Label     string                        `json:"label,omitempty"`
 	Goal      string                        `json:"goal,omitempty"`
 	GoalCode  string                        `json:"goal-code,omitempty"`
@@ -70,6 +72,7 @@ func (gi *GenericInvitation) UnmarshalJSON(data []byte) error {
 	case service.V2:
 		gi.ID = raw.IDv2
 		gi.Type = raw.TypeV2
+		gi.From = raw.From
 		gi.Label = raw.Label
 		gi.Goal = raw.Body.Goal
 		gi.GoalCode = raw.Body.GoalCode
@@ -128,6 +131,7 @@ func (gi *GenericInvitation) AsV2() *oobv2.Invitation {
 	return &oobv2.Invitation{
 		ID:    gi.ID,
 		Type:  gi.Type,
+		From:  gi.From,
 		Label: gi.Label,
 		Body: &oobv2.InvitationBody{
 			Goal:     gi.Goal,

--- a/test/bdd/pkg/outofband/outofband_controller_steps.go
+++ b/test/bdd/pkg/outofband/outofband_controller_steps.go
@@ -346,8 +346,6 @@ func (s *ControllerSteps) createOOBV2WithPresentProof(agentID string) error {
 		}},
 	})
 
-	ppfv3Req["from"] = agentIDDIDDoc.ID
-
 	ppfv3Attachment := []*decorator.AttachmentV2{{
 		ID:          uuid.New().String(),
 		Description: "PresentProof V3 propose presentation request",
@@ -361,6 +359,7 @@ func (s *ControllerSteps) createOOBV2WithPresentProof(agentID string) error {
 
 	createOOBInv := outofbandcmdv2.CreateInvitationArgs{
 		Label: agentID,
+		From:  agentIDDIDDoc.ID,
 		Body: oobv2.InvitationBody{
 			Goal:     ppfGoal,
 			GoalCode: ppfGoalCode,

--- a/test/bdd/pkg/outofband/outofband_sdk_steps.go
+++ b/test/bdd/pkg/outofband/outofband_sdk_steps.go
@@ -787,8 +787,6 @@ func (sdk *SDKSteps) createOOBV2WithPresentProof(agent1 string) error {
 		}},
 	})
 
-	ppfv3Req["from"] = agentDIDDoc.ID
-
 	ppfv3Attachment := []*decorator.AttachmentV2{{
 		ID:          uuid.New().String(),
 		Description: "PresentProof V3 propose presentation request",
@@ -803,6 +801,7 @@ func (sdk *SDKSteps) createOOBV2WithPresentProof(agent1 string) error {
 	inv := oobv2Client1.CreateInvitation(
 		outofbandv2.WithGoal(ppfGoal, ppfGoalCode),
 		outofbandv2.WithAttachments(ppfv3Attachment...),
+		outofbandv2.WithFrom(agentDIDDoc.ID),
 	)
 
 	sdk.pendingV2Invites[agent1] = inv


### PR DESCRIPTION
As per the DIDComm V2 spec, the From field should be in the oobv2 struct directly, not in the attachment.

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>

