### PR TITLE
fix: Skipped BDD tests

### DIFF
--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -57,7 +57,7 @@ type feature interface {
 
 func TestMain(m *testing.M) {
 	// default is to run all tests with tag @all
-	tags := "outofbandv2_controller"
+	tags := "all"
 
 	flag.Parse()
 


### PR DESCRIPTION
Fixed an issue where some BDD tests were being skipped unintentionally.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>