### PR TITLE
feat: correlating invitation with propose credential message

### DIFF
--- a/pkg/didcomm/protocol/issuecredential/models.go
+++ b/pkg/didcomm/protocol/issuecredential/models.go
@@ -26,6 +26,8 @@ type ProposeCredentialV2 struct {
 	// FiltersAttach is an array of attachments that further define the credential being proposed.
 	// This might be used to clarify which formats or format versions are wanted.
 	FiltersAttach []decorator.Attachment `json:"filters~attach,omitempty"`
+	// Optional field containing ID of the invitation which initiated this protocol.
+	InvitationID string `json:"invitationID,omitempty"`
 }
 
 // ProposeCredentialV3 is an optional message sent by the potential Holder to the Issuer
@@ -39,6 +41,8 @@ type ProposeCredentialV3 struct {
 	// Accepted values for the format attribute of each attachment are provided in the per format Attachment
 	// registry immediately below.
 	Attachments []decorator.AttachmentV2 `json:"attachments,omitempty"`
+	// Optional field containing ID of the invitation which initiated this protocol.
+	InvitationID string `json:"pthid,omitempty"`
 }
 
 // ProposeCredentialV3Body represents body for ProposeCredentialV3.

--- a/pkg/didcomm/protocol/issuecredential/params.go
+++ b/pkg/didcomm/protocol/issuecredential/params.go
@@ -22,6 +22,7 @@ type ProposeCredentialParams struct {
 	Formats            []Format
 	GoalCode           string
 	CredentialPreview  interface{}
+	InvitationID       string
 }
 
 // AsV2 translates this credential proposal into an issue credential 2.0 proposal message.
@@ -32,14 +33,16 @@ func (p *ProposeCredentialParams) AsV2() *ProposeCredentialV2 {
 		CredentialProposal: p.CredentialProposal,
 		Formats:            p.Formats,
 		FiltersAttach:      decorator.GenericAttachmentsToV1(p.Attachments),
+		InvitationID:       p.InvitationID,
 	}
 }
 
 // AsV3 translates this credential proposal into an issue credential 3.0 proposal message.
 func (p *ProposeCredentialParams) AsV3() *ProposeCredentialV3 {
 	return &ProposeCredentialV3{
-		Type: p.Type,
-		ID:   p.ID,
+		Type:         p.Type,
+		ID:           p.ID,
+		InvitationID: p.InvitationID,
 		Body: ProposeCredentialV3Body{
 			GoalCode:          p.GoalCode,
 			Comment:           p.Comment,

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -866,7 +866,10 @@ func (c *Wallet) ProposeCredential(authToken string, invitation *GenericInvitati
 
 	opts = prepareInteractionOpts(connRecord, opts)
 
-	_, err = c.issueCredentialClient.SendProposal(&issuecredential.ProposeCredential{}, connRecord)
+	_, err = c.issueCredentialClient.SendProposal(
+		&issuecredential.ProposeCredential{InvitationID: invitation.ID},
+		connRecord,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to propose credential from wallet: %w", err)
 	}


### PR DESCRIPTION
- WACI way of using invitation as parent threadID may not work with
DIDCommV1 where parent thread ID gets reset by messenger while sending
propose credential message
- As a work around, invitation ID can be explicitly used while sending
propose credential message
- Part of #3073

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
