### PR TITLE
Add option to enable remote document loading for mobile bindings

### DIFF
--- a/cmd/aries-agent-mobile/pkg/wrappers/config/options.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/config/options.go
@@ -21,6 +21,7 @@ type Options struct {
 	Label                string
 	AutoAccept           bool
 	TransportReturnRoute string
+	LoadRemoteDocuments  bool
 	LogLevel             string
 	Logger               api.LoggerProvider
 	Storage              api.Provider


### PR DESCRIPTION
when enabled, documents that are not available locally will be fetch remotely for mobile bindings.

Does replace pull request #3053.

Signed-off-by: Michel Sahli <michel.sahli@adnovum.ch>