### PR TITLE
feat: vc wallet resolve manifest by credential ID

### DIFF
--- a/cmd/aries-js-worker/src/agent-rest-client.js
+++ b/cmd/aries-js-worker/src/agent-rest-client.js
@@ -537,6 +537,10 @@ const pkgs = {
             path: "/vcwallet/request-credential",
             method: "POST",
         },
+        ResolveCredentialManifest: {
+            path: "/vcwallet/resolve-credential-manifest",
+            method: "POST",
+        },
     },
     ld: {
         AddContexts: {

--- a/cmd/aries-js-worker/src/aries.js
+++ b/cmd/aries-js-worker/src/aries.js
@@ -1445,6 +1445,19 @@ const Aries = function (opts) {
             requestCredential: async function (req) {
                 return invoke(aw, pending, this.pkgname, "RequestCredential", req, "timeout while performing request credential from wallet")
             },
+
+            /**
+             *
+             * ResolveCredentialManifest resolves given credential manifest by credential fulfillment or credential.
+             * Supports: https://identity.foundation/credential-manifest/
+             *
+             *  Returns resolved descriptors.
+             *
+             * @returns {Promise<Object>}
+             */
+            resolveCredentialManifest: async function (req) {
+                return invoke(aw, pending, this.pkgname, "ResolveCredentialManifest", req, "timeout while resolving credential manifest from wallet")
+            },
         },
         /**
          * JSON-LD management API.

--- a/pkg/controller/command/vcwallet/command.go
+++ b/pkg/controller/command/vcwallet/command.go
@@ -1146,5 +1146,9 @@ func prepareResolveManifestOption(rqst *ResolveCredentialManifestRequest) wallet
 		return wallet.ResolveRawCredential(rqst.DescriptorID, rqst.Credential)
 	}
 
+	if rqst.CredentialID != "" {
+		return wallet.ResolveCredentialID(rqst.DescriptorID, rqst.CredentialID)
+	}
+
 	return nil
 }

--- a/pkg/controller/command/vcwallet/command_test.go
+++ b/pkg/controller/command/vcwallet/command_test.go
@@ -2352,6 +2352,12 @@ func TestCommand_ResolveCredentialManifest(t *testing.T) {
 
 	defer lock()
 
+	addContent(t, mockctx, &AddContentRequest{
+		Content:     testdata.SampleUDCVC,
+		ContentType: "credential",
+		WalletAuth:  WalletAuth{UserID: sampleUser1, Auth: token},
+	})
+
 	t.Run("successfully resolve credential fulfillment", func(t *testing.T) {
 		cmd := New(mockctx, &Config{})
 
@@ -2378,6 +2384,26 @@ func TestCommand_ResolveCredentialManifest(t *testing.T) {
 			WalletAuth:   WalletAuth{UserID: sampleUser1, Auth: token},
 			Manifest:     testdata.CredentialManifestMultipleVCs,
 			Credential:   testdata.SampleUDCVC,
+			DescriptorID: "udc_output",
+		}
+
+		var b bytes.Buffer
+		cmdErr := cmd.ResolveCredentialManifest(&b, getReader(t, &request))
+		require.NoError(t, cmdErr)
+
+		var response ResolveCredentialManifestResponse
+		require.NoError(t, json.NewDecoder(&b).Decode(&response))
+		require.NotEmpty(t, response)
+		require.Len(t, response.Resolved, 1)
+	})
+
+	t.Run("successfully resolve credential ID", func(t *testing.T) {
+		cmd := New(mockctx, &Config{})
+
+		request := &ResolveCredentialManifestRequest{
+			WalletAuth:   WalletAuth{UserID: sampleUser1, Auth: token},
+			Manifest:     testdata.CredentialManifestMultipleVCs,
+			CredentialID: "http://example.edu/credentials/1872",
 			DescriptorID: "udc_output",
 		}
 

--- a/pkg/controller/command/vcwallet/models.go
+++ b/pkg/controller/command/vcwallet/models.go
@@ -457,6 +457,9 @@ type ResolveCredentialManifestRequest struct {
 	// Credential to be be resolved, to be provided along with 'DescriptorID' to be used for resolving.
 	Credential json.RawMessage `json:"credential,omitempty"`
 
+	// ID of the Credential from wallet content to be be resolved, to be provided along with 'DescriptorID'.
+	CredentialID string `json:"credentialID,omitempty"`
+
 	// ID of the output descriptor to be used for resolving given credential.
 	DescriptorID string `json:"descriptorID,omitempty"`
 }

--- a/pkg/controller/rest/vcwallet/operation_test.go
+++ b/pkg/controller/rest/vcwallet/operation_test.go
@@ -1804,7 +1804,7 @@ func TestOperation_ResolveCredentialManifest(t *testing.T) {
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.ResolveCredentialManifest(rw, rq)
 		require.Equal(t, rw.Code, http.StatusInternalServerError)
-		require.Contains(t, rw.Body.String(), "failed to resolve given credential by descriptor ID")
+		require.Contains(t, rw.Body.String(), "failed to resolve raw credential by descriptor ID")
 	})
 }
 

--- a/pkg/wallet/options.go
+++ b/pkg/wallet/options.go
@@ -446,6 +446,7 @@ type resolveManifestOpts struct {
 	fulfillment    *verifiable.Presentation
 	rawFulfillment json.RawMessage
 	descriptorID   string
+	credentialID   string
 	credential     *verifiable.Credential
 	rawCredential  json.RawMessage
 }
@@ -480,5 +481,13 @@ func ResolveRawCredential(descriptorID string, rawCredential json.RawMessage) Re
 	return func(opts *resolveManifestOpts) {
 		opts.descriptorID = descriptorID
 		opts.rawCredential = rawCredential
+	}
+}
+
+// ResolveCredentialID options for resolving credential from wallet content store by given descriptor ID.
+func ResolveCredentialID(descriptorID, credentialID string) ResolveManifestOption {
+	return func(opts *resolveManifestOpts) {
+		opts.descriptorID = descriptorID
+		opts.credentialID = credentialID
 	}
 }

--- a/pkg/wallet/wallet_test.go
+++ b/pkg/wallet/wallet_test.go
@@ -4034,6 +4034,8 @@ func TestWallet_ResolveCredentialManifest(t *testing.T) {
 		verifiable.WithJSONLDDocumentLoader(mockctx.JSONLDDocumentLoader()))
 	require.NoError(t, err)
 
+	require.NoError(t, wallet.Add(token, Credential, testdata.SampleUDCVC))
+
 	t.Run("Test Resolving credential manifests", func(t *testing.T) {
 		testTable := map[string]struct {
 			manifest    []byte
@@ -4059,6 +4061,11 @@ func TestWallet_ResolveCredentialManifest(t *testing.T) {
 			"testing resolve by credential": {
 				manifest:    testdata.CredentialManifestMultipleVCs,
 				resolve:     ResolveCredential("udc_output", vc),
+				resultCount: 1,
+			},
+			"testing resolve by credential ID": {
+				manifest:    testdata.CredentialManifestMultipleVCs,
+				resolve:     ResolveCredentialID("udc_output", vc.ID),
 				resultCount: 1,
 			},
 			"testing failure - resolve by empty resolve option": {
@@ -4096,6 +4103,12 @@ func TestWallet_ResolveCredentialManifest(t *testing.T) {
 				resolve:     ResolveCredential("invalid", vc),
 				resultCount: 0,
 				error:       "unable to find matching descriptor",
+			},
+			"testing failure  - resolve credential by invalid credential ID": {
+				manifest:    testdata.CredentialManifestMultipleVCs,
+				resolve:     ResolveCredentialID("udc_output", "incorrect"),
+				resultCount: 0,
+				error:       "failed to get credential to resolve from wallet",
 			},
 		}
 


### PR DESCRIPTION
- added new option in vcwallet to resolve credential saved in wallet
content store just by providing credential ID
- refcatored credential mabnifest API to accept raw credential to avoid
repeated marshal/unmarshaling of credential object
- Part of #3120

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>
