### PR TITLE
refactor: Reduce code duplication in WACI Issuance tests

### DIFF
--- a/test/bdd/pkg/waci/common.go
+++ b/test/bdd/pkg/waci/common.go
@@ -6,4 +6,555 @@ SPDX-License-Identifier: Apache-2.0
 
 package waci
 
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	issuecredentialclient "github.com/hyperledger/aries-framework-go/pkg/client/issuecredential"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/cm"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/ld"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/presexch"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	ldstore "github.com/hyperledger/aries-framework-go/pkg/store/ld"
+	bddldcontext "github.com/hyperledger/aries-framework-go/test/bdd/pkg/ldcontext"
+)
+
 const expectedVCID = "https://eu.com/claims/DriversLicense"
+
+func getAttachmentFromDIDCommMsg(didCommMsg service.DIDCommMsg,
+	attachmentFieldName string) (decorator.GenericAttachment, error) {
+	var didCommMsgAsMap map[string]interface{}
+
+	err := didCommMsg.Decode(&didCommMsgAsMap)
+	if err != nil {
+		return decorator.GenericAttachment{}, err
+	}
+
+	attachmentsRaw, ok := didCommMsgAsMap[attachmentFieldName]
+	if !ok {
+		return decorator.GenericAttachment{}, errors.New("missing attachments from DIDComm message map")
+	}
+
+	attachments, ok := attachmentsRaw.([]interface{})
+	if !ok {
+		return decorator.GenericAttachment{}, errors.New("attachments were not an array of interfaces as expected")
+	}
+
+	attachmentRaw := attachments[0]
+
+	attachmentBytes, err := json.Marshal(attachmentRaw)
+	if err != nil {
+		return decorator.GenericAttachment{}, err
+	}
+
+	var attachment decorator.GenericAttachment
+
+	err = json.Unmarshal(attachmentBytes, &attachment)
+	if err != nil {
+		return decorator.GenericAttachment{}, err
+	}
+
+	return attachment, nil
+}
+
+func getAttachments(action service.DIDCommAction, fieldName string) ([]decorator.GenericAttachment, error) {
+	var didCommMsgAsMap map[string]interface{}
+
+	err := action.Message.Decode(&didCommMsgAsMap)
+	if err != nil {
+		return nil, err
+	}
+
+	attachmentsRaw, ok := didCommMsgAsMap[fieldName]
+	if !ok {
+		return nil, errors.New("missing attachments from DIDComm message map")
+	}
+
+	attachmentsAsArrayOfInterfaces, ok := attachmentsRaw.([]interface{})
+	if !ok {
+		return nil, errors.New("attachments were not an array of interfaces as expected")
+	}
+
+	attachmentsBytes, err := json.Marshal(attachmentsAsArrayOfInterfaces)
+	if err != nil {
+		return nil, err
+	}
+
+	var attachments []decorator.GenericAttachment
+
+	err = json.Unmarshal(attachmentsBytes, &attachments)
+	if err != nil {
+		return nil, err
+	}
+
+	return attachments, nil
+}
+
+func getActionID(actionChan <-chan service.DIDCommAction) (string, error) {
+	select {
+	case action := <-actionChan:
+		err := checkProperties(action)
+		if err != nil {
+			return "", fmt.Errorf("check properties: %w", err)
+		}
+
+		return action.Properties.All()["piid"].(string), nil
+	case <-time.After(timeoutDuration):
+		return "", errors.New("timeout")
+	}
+}
+
+type property interface {
+	MyDID() string
+	TheirDID() string
+}
+
+func checkProperties(action service.DIDCommAction) error {
+	properties, ok := action.Properties.(property)
+	if !ok {
+		return errors.New("no properties")
+	}
+
+	if properties.MyDID() == "" {
+		return errors.New("myDID is empty")
+	}
+
+	if properties.TheirDID() == "" {
+		return errors.New("theirDID is empty")
+	}
+
+	return nil
+}
+
+func generateOfferCredentialMsg(msgType string) (*issuecredentialclient.OfferCredential, error) {
+	credentialManifestAttachment, err := generateCredentialManifestAttachment()
+	if err != nil {
+		return nil, err
+	}
+
+	// A Credential Fulfillment attachment is sent here as a preview of the VC so the Holder can see what
+	// the credential will look like.
+	credentialFulfillmentAttachment, err := generateCredentialFulfillmentAttachmentWithoutProof()
+	if err != nil {
+		return nil, err
+	}
+
+	attachments := []decorator.GenericAttachment{*credentialManifestAttachment, *credentialFulfillmentAttachment}
+
+	offerCredential := issuecredentialclient.OfferCredential{
+		Type:        msgType,
+		ID:          uuid.New().String(),
+		Attachments: attachments,
+	}
+
+	return &offerCredential, nil
+}
+
+func generateCredentialManifestAttachment() (*decorator.GenericAttachment, error) {
+	credentialManifest, err := generateCredentialManifest()
+	if err != nil {
+		return nil, err
+	}
+
+	options := map[string]string{
+		"challenge": "508adef4-b8e0-4edf-a53d-a260371c1423",
+		"domain":    "9rf25a28rs96",
+	}
+
+	attachmentData := map[string]interface{}{
+		"options":             options,
+		"credential_manifest": credentialManifest,
+	}
+
+	credentialManifestAttachment := decorator.GenericAttachment{
+		ID:        uuid.New().String(),
+		MediaType: "application/json",
+		Format:    cm.CredentialManifestAttachmentFormat,
+		Data:      decorator.AttachmentData{JSON: attachmentData},
+	}
+
+	return &credentialManifestAttachment, nil
+}
+
+func generateCredentialManifest() (*cm.CredentialManifest, error) {
+	var credentialManifest cm.CredentialManifest
+
+	err := json.Unmarshal(credentialManifestDriversLicense, &credentialManifest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialManifest, nil
+}
+
+func generateCredentialFulfillmentAttachmentWithoutProof() (*decorator.GenericAttachment, error) {
+	var credentialFulfillment cm.CredentialFulfillment
+
+	err := json.Unmarshal(credentialFulfillmentDriversLicense, &credentialFulfillment)
+	if err != nil {
+		return nil, err
+	}
+
+	cxt := []string{
+		"https://www.w3.org/2018/credentials/v1",
+		cm.CredentialFulfillmentPresentationContext,
+	}
+
+	types := []string{
+		"VerifiablePresentation",
+		"CredentialFulfillment",
+	}
+
+	documentLoader, err := createDocumentLoader()
+	if err != nil {
+		return nil, err
+	}
+
+	vcPreview, err := verifiable.ParseCredential(vcDriversLicenseWithoutProof,
+		verifiable.WithJSONLDDocumentLoader(documentLoader))
+	if err != nil {
+		return nil, err
+	}
+
+	verifiableCredentials := []*verifiable.Credential{vcPreview}
+
+	attachmentData := map[string]interface{}{
+		"@context":               cxt,
+		"type":                   types,
+		"credential_fulfillment": credentialFulfillment,
+		"verifiableCredential":   verifiableCredentials,
+	}
+
+	credentialFulfillmentAttachment := decorator.GenericAttachment{
+		ID:        uuid.New().String(),
+		MediaType: "application/json",
+		Format:    cm.CredentialFulfillmentAttachmentFormat,
+		Data:      decorator.AttachmentData{JSON: attachmentData},
+	}
+
+	return &credentialFulfillmentAttachment, nil
+}
+
+func generateRequestCredentialMsg(credentialManifest *cm.CredentialManifest, msgType string) (
+	*issuecredentialclient.RequestCredential, error) {
+	credentialApplicationAttachment, err := generateCredentialApplicationAttachment(credentialManifest)
+	if err != nil {
+		return nil, err
+	}
+
+	attachments := []decorator.GenericAttachment{*credentialApplicationAttachment}
+
+	requestCredential := issuecredentialclient.RequestCredential{
+		Type:        msgType,
+		ID:          uuid.New().String(),
+		Attachments: attachments,
+	}
+
+	return &requestCredential, nil
+}
+
+func generateCredentialApplicationAttachment(credentialManifest *cm.CredentialManifest) (*decorator.GenericAttachment,
+	error) {
+	cxt := []string{
+		"https://www.w3.org/2018/credentials/v1",
+		cm.CredentialApplicationPresentationContext,
+	}
+
+	types := []string{
+		"VerifiablePresentation",
+		"CredentialApplication",
+	}
+
+	credentialApplication, err :=
+		cm.UnmarshalAndValidateAgainstCredentialManifest(credentialApplicationDriversLicense, credentialManifest)
+	if err != nil {
+		return nil, err
+	}
+
+	var presentationSubmission presexch.PresentationSubmission
+
+	err = json.Unmarshal(presentationSubmissionPRC, &presentationSubmission)
+	if err != nil {
+		return nil, err
+	}
+
+	documentLoader, err := createDocumentLoader()
+	if err != nil {
+		return nil, err
+	}
+
+	verifiableCredential, err := verifiable.ParseCredential(vcPRC,
+		verifiable.WithJSONLDDocumentLoader(documentLoader), verifiable.WithDisabledProofCheck())
+	if err != nil {
+		return nil, err
+	}
+
+	verifiableCredentials := []*verifiable.Credential{verifiableCredential}
+
+	proof := generateCredentialApplicationProof()
+
+	attachmentData := map[string]interface{}{
+		"@context":                cxt,
+		"type":                    types,
+		"credential_application":  credentialApplication,
+		"presentation_submission": presentationSubmission,
+		"verifiableCredential":    verifiableCredentials,
+		"proof":                   proof,
+	}
+
+	credentialApplicationAttachment := decorator.GenericAttachment{
+		ID:        uuid.New().String(),
+		MediaType: "application/json",
+		Format:    cm.CredentialApplicationAttachmentFormat,
+		Data:      decorator.AttachmentData{JSON: attachmentData},
+	}
+
+	return &credentialApplicationAttachment, nil
+}
+
+func generateCredentialApplicationProof() map[string]string {
+	return map[string]string{
+		"type":               "Ed25519Signature2018",
+		"verificationMethod": "did:example:123#key-0",
+		"created":            "2021-05-14T20:16:29.565377",
+		"proofPurpose":       "authentication",
+		"challenge":          "3fa85f64-5717-4562-b3fc-2c963f66afa7",
+		"jws": "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0IjogWyJiNjQiXX0..7M9LwdJR1_SQayHIWVHF5eSSRhbVsr" +
+			"jQHKUrfRhRRrlbuKlggm8mm_4EI_kTPeBpalQWiGiyCb_0OWFPtn2wAQ",
+	}
+}
+
+func generateIssueCredentialMsg(msgType string) (*issuecredentialclient.IssueCredential, error) {
+	cxt := []string{
+		"https://www.w3.org/2018/credentials/v1",
+		cm.CredentialFulfillmentPresentationContext,
+	}
+
+	types := []string{
+		"VerifiablePresentation",
+		"CredentialFulfillment",
+	}
+
+	var credentialFulfillment cm.CredentialFulfillment
+
+	err := json.Unmarshal(credentialFulfillmentDriversLicense, &credentialFulfillment)
+	if err != nil {
+		return nil, err
+	}
+
+	documentLoader, err := createDocumentLoader()
+	if err != nil {
+		return nil, err
+	}
+
+	verifiableCredential, err := verifiable.ParseCredential(vcDriversLicense,
+		verifiable.WithJSONLDDocumentLoader(documentLoader), verifiable.WithDisabledProofCheck())
+	if err != nil {
+		return nil, err
+	}
+
+	verifiableCredentials := []*verifiable.Credential{verifiableCredential}
+
+	proof := generateCredentialFulfillmentProof()
+
+	attachmentData := map[string]interface{}{
+		"@context":               cxt,
+		"type":                   types,
+		"credential_fulfillment": credentialFulfillment,
+		"verifiableCredential":   verifiableCredentials,
+		"proof":                  proof,
+	}
+
+	issueCredentialAttachment := decorator.GenericAttachment{
+		ID:        uuid.New().String(),
+		MediaType: "application/json",
+		Format:    cm.CredentialFulfillmentAttachmentFormat,
+		Data:      decorator.AttachmentData{JSON: attachmentData},
+	}
+
+	attachments := []decorator.GenericAttachment{issueCredentialAttachment}
+
+	issueCredentialMsg := issuecredentialclient.IssueCredential{
+		Type:        msgType,
+		ID:          uuid.New().String(),
+		Attachments: attachments,
+	}
+
+	return &issueCredentialMsg, nil
+}
+
+func generateCredentialFulfillmentProof() map[string]string {
+	return map[string]string{
+		"type": "Ed25519Signature2018",
+		"verificationMethod": "did:orb:EiA3Xmv8A8vUH5lRRZeKakd-cjAxGC2A4aoPDjLysjghow#tMIstfHSzXfBUF" +
+			"7O0m2FiBEfTb93_j_4ron47IXPgEo",
+		"created":      "2021-06-07T20:02:44.730614315Z",
+		"proofPurpose": "authentication",
+		"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19.." +
+			"NVum9BeYkhzwslZXm2cDOveQB9njlrCRSrdMZgwV3zZfLRXmZQ1AXdKLLmo4ClTYXFX_TWNyB8aFt9cN6sSvCg",
+	}
+}
+
+func getCredentialManifestFromAttachment(attachment *decorator.GenericAttachment) (*cm.CredentialManifest, error) {
+	attachmentAsMap, ok := attachment.Data.JSON.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("couldn't assert attachment as a map")
+	}
+
+	credentialManifestRaw, ok := attachmentAsMap["credential_manifest"]
+	if !ok {
+		return nil, errors.New("credential_manifest object missing from attachment")
+	}
+
+	credentialManifestBytes, err := json.Marshal(credentialManifestRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	var credentialManifest cm.CredentialManifest
+
+	// This unmarshal call also triggers the credential manifest validation code, which ensures that the
+	// credential manifest is valid under the spec.
+	err = json.Unmarshal(credentialManifestBytes, &credentialManifest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialManifest, nil
+}
+
+func getCredentialFulfillmentFromAttachment(attachment *decorator.GenericAttachment) (*cm.CredentialFulfillment,
+	error) {
+	attachmentAsMap, ok := attachment.Data.JSON.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("couldn't assert attachment as a map")
+	}
+
+	credentialFulfillmentRaw, ok := attachmentAsMap["credential_fulfillment"]
+	if !ok {
+		return nil, errors.New("credential_fulfillment object missing from attachment")
+	}
+
+	credentialFulfillmentBytes, err := json.Marshal(credentialFulfillmentRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	var credentialFulfillment cm.CredentialFulfillment
+
+	// This unmarshal call also triggers the credential fulfillment validation code, which ensures that the
+	// credential fulfillment object is valid under the spec.
+	err = json.Unmarshal(credentialFulfillmentBytes, &credentialFulfillment)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialFulfillment, nil
+}
+
+func getCredentialApplicationFromAttachment(attachment *decorator.GenericAttachment) ([]byte, error) {
+	attachmentAsMap, ok := attachment.Data.JSON.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("couldn't assert attachment as a map")
+	}
+
+	credentialApplicationRaw, ok := attachmentAsMap["credential_application"]
+	if !ok {
+		return nil, errors.New("credential_application object missing from attachment")
+	}
+
+	credentialApplicationBytes, err := json.Marshal(credentialApplicationRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	return credentialApplicationBytes, nil
+}
+
+func getVCFromCredentialFulfillmentAttachment(credentialFulfillmentAttachment *decorator.GenericAttachment) (
+	verifiable.Credential, error) {
+	attachmentRaw := credentialFulfillmentAttachment.Data.JSON
+
+	attachmentAsMap, ok := attachmentRaw.(map[string]interface{})
+	if !ok {
+		return verifiable.Credential{}, errors.New("couldn't assert attachment as a map")
+	}
+
+	credentialFulfillmentRaw, ok := attachmentAsMap["credential_fulfillment"]
+	if !ok {
+		return verifiable.Credential{}, errors.New("credential_fulfillment object missing from attachment")
+	}
+
+	credentialFulfillmentBytes, err := json.Marshal(credentialFulfillmentRaw)
+	if err != nil {
+		return verifiable.Credential{}, err
+	}
+
+	var credentialFulfillment cm.CredentialFulfillment
+
+	err = json.Unmarshal(credentialFulfillmentBytes, &credentialFulfillment)
+	if err != nil {
+		return verifiable.Credential{}, err
+	}
+
+	documentLoader, err := createDocumentLoader()
+	if err != nil {
+		return verifiable.Credential{}, err
+	}
+
+	vcs, err := credentialFulfillment.ResolveDescriptorMaps(credentialFulfillmentAttachment.Data.JSON,
+		verifiable.WithDisabledProofCheck(), verifiable.WithJSONLDDocumentLoader(documentLoader))
+	if err != nil {
+		return verifiable.Credential{}, err
+	}
+
+	if len(vcs) != 1 {
+		return verifiable.Credential{}, fmt.Errorf("received %d VCs, but expected only one", len(vcs))
+	}
+
+	return vcs[0], nil
+}
+
+type docLoaderProvider struct {
+	ContextStore        ldstore.ContextStore
+	RemoteProviderStore ldstore.RemoteProviderStore
+}
+
+func (p *docLoaderProvider) JSONLDContextStore() ldstore.ContextStore {
+	return p.ContextStore
+}
+
+func (p *docLoaderProvider) JSONLDRemoteProviderStore() ldstore.RemoteProviderStore {
+	return p.RemoteProviderStore
+}
+
+func createDocumentLoader() (*ld.DocumentLoader, error) {
+	contextStore, err := ldstore.NewContextStore(mem.NewProvider())
+	if err != nil {
+		return nil, err
+	}
+
+	remoteProviderStore, err := ldstore.NewRemoteProviderStore(mem.NewProvider())
+	if err != nil {
+		return nil, err
+	}
+
+	p := &docLoaderProvider{
+		ContextStore:        contextStore,
+		RemoteProviderStore: remoteProviderStore,
+	}
+
+	loader, err := ld.NewDocumentLoader(p, ld.WithExtraContexts(bddldcontext.Extra()...))
+	if err != nil {
+		return nil, err
+	}
+
+	return loader, nil
+}

--- a/test/bdd/pkg/waci/waci_issuance_didcomm_v2_sdk_steps.go
+++ b/test/bdd/pkg/waci/waci_issuance_didcomm_v2_sdk_steps.go
@@ -8,7 +8,6 @@ package waci
 
 import (
 	_ "embed" //nolint // This is needed to use go:embed
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -16,7 +15,6 @@ import (
 	"github.com/cucumber/godog"
 	"github.com/google/uuid"
 
-	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
 	didexClient "github.com/hyperledger/aries-framework-go/pkg/client/didexchange"
 	issuecredentialclient "github.com/hyperledger/aries-framework-go/pkg/client/issuecredential"
 	"github.com/hyperledger/aries-framework-go/pkg/client/outofbandv2"
@@ -25,12 +23,8 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/issuecredential"
 	oobv2 "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/outofbandv2"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/cm"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/ld"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/presexch"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
-	ldstore "github.com/hyperledger/aries-framework-go/pkg/store/ld"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/context"
-	bddldcontext "github.com/hyperledger/aries-framework-go/test/bdd/pkg/ldcontext"
 )
 
 var (
@@ -162,7 +156,7 @@ func (i *IssuanceSDKDIDCommV2Steps) sendsProposalV3(holderName, issuerName strin
 		InvitationID: i.oobV2InviteFromIssuerToHolder.ID,
 	}
 
-	connection, err := i.GetConnection(holderName, issuerName)
+	connection, err := i.getConnection(holderName, issuerName)
 	if err != nil {
 		return err
 	}
@@ -190,7 +184,7 @@ func (i *IssuanceSDKDIDCommV2Steps) acceptProposalV3(issuerName string) error {
 			"(%s) but got %s instead", i.oobV2InviteFromIssuerToHolder.ID, parentThreadID)
 	}
 
-	offerCredential, err := generateOfferCredentialMsg()
+	offerCredential, err := generateOfferCredentialMsgV3()
 	if err != nil {
 		return err
 	}
@@ -214,7 +208,7 @@ func (i *IssuanceSDKDIDCommV2Steps) acceptOffer(holderName string) error {
 		return err
 	}
 
-	requestCredential, err := generateRequestCredentialMsg(i.credentialManifestReceivedByHolder)
+	requestCredential, err := generateRequestCredentialMsgV3(i.credentialManifestReceivedByHolder)
 	if err != nil {
 		return err
 	}
@@ -249,7 +243,7 @@ func (i *IssuanceSDKDIDCommV2Steps) acceptCredentialApplication(issuerName strin
 		return err
 	}
 
-	issueCredentialMsg, err := generateIssueCredentialMsg()
+	issueCredentialMsg, err := generateIssueCredentialMsgV3()
 	if err != nil {
 		return err
 	}
@@ -263,7 +257,7 @@ func (i *IssuanceSDKDIDCommV2Steps) acceptCredentialApplication(issuerName strin
 }
 
 func (i *IssuanceSDKDIDCommV2Steps) acceptCredential(holderName string) error {
-	piid, err := i.getActionID(holderName)
+	piid, err := getActionID(i.actions[holderName])
 	if err != nil {
 		return err
 	}
@@ -340,20 +334,6 @@ func (i *IssuanceSDKDIDCommV2Steps) registerActionsAndEvents(holderName, issuerN
 	return err
 }
 
-func (i *IssuanceSDKDIDCommV2Steps) getActionID(agent string) (string, error) {
-	select {
-	case action := <-i.actions[agent]:
-		err := checkProperties(action)
-		if err != nil {
-			return "", fmt.Errorf("check properties: %w", err)
-		}
-
-		return action.Properties.All()["piid"].(string), nil
-	case <-time.After(timeoutDuration):
-		return "", errors.New("timeout")
-	}
-}
-
 func (i *IssuanceSDKDIDCommV2Steps) getActionIDAndParentThreadID(agent string) (string, string, error) {
 	select {
 	case action := <-i.actions[agent]:
@@ -384,7 +364,7 @@ func (i *IssuanceSDKDIDCommV2Steps) getActionIDAndAttachments(agent string) (str
 
 		var attachments []decorator.GenericAttachment
 
-		attachments, err = getAttachments(action)
+		attachments, err = getAttachmentsV3(action)
 		if err != nil {
 			return "", nil, err
 		}
@@ -445,169 +425,12 @@ func (i *IssuanceSDKDIDCommV2Steps) checkAttachments(attachmentsFromOfferMsg []d
 	return nil
 }
 
-func getCredentialManifestFromAttachment(attachment *decorator.GenericAttachment) (*cm.CredentialManifest, error) {
-	attachmentAsMap, ok := attachment.Data.JSON.(map[string]interface{})
-	if !ok {
-		return nil, errors.New("couldn't assert attachment as a map")
-	}
-
-	credentialManifestRaw, ok := attachmentAsMap["credential_manifest"]
-	if !ok {
-		return nil, errors.New("credential_manifest object missing from attachment")
-	}
-
-	credentialManifestBytes, err := json.Marshal(credentialManifestRaw)
-	if err != nil {
-		return nil, err
-	}
-
-	var credentialManifest cm.CredentialManifest
-
-	// This unmarshal call also triggers the credential manifest validation code, which ensures that the
-	// credential manifest is valid under the spec.
-	err = json.Unmarshal(credentialManifestBytes, &credentialManifest)
-	if err != nil {
-		return nil, err
-	}
-
-	return &credentialManifest, nil
-}
-
-func getCredentialFulfillmentFromAttachment(attachment *decorator.GenericAttachment) (*cm.CredentialFulfillment,
-	error) {
-	attachmentAsMap, ok := attachment.Data.JSON.(map[string]interface{})
-	if !ok {
-		return nil, errors.New("couldn't assert attachment as a map")
-	}
-
-	credentialFulfillmentRaw, ok := attachmentAsMap["credential_fulfillment"]
-	if !ok {
-		return nil, errors.New("credential_fulfillment object missing from attachment")
-	}
-
-	credentialFulfillmentBytes, err := json.Marshal(credentialFulfillmentRaw)
-	if err != nil {
-		return nil, err
-	}
-
-	var credentialFulfillment cm.CredentialFulfillment
-
-	// This unmarshal call also triggers the credential fulfillment validation code, which ensures that the
-	// credential fulfillment object is valid under the spec.
-	err = json.Unmarshal(credentialFulfillmentBytes, &credentialFulfillment)
-	if err != nil {
-		return nil, err
-	}
-
-	return &credentialFulfillment, nil
-}
-
-func getCredentialApplicationFromAttachment(attachment *decorator.GenericAttachment) ([]byte, error) {
-	attachmentAsMap, ok := attachment.Data.JSON.(map[string]interface{})
-	if !ok {
-		return nil, errors.New("couldn't assert attachment as a map")
-	}
-
-	credentialApplicationRaw, ok := attachmentAsMap["credential_application"]
-	if !ok {
-		return nil, errors.New("credential_application object missing from attachment")
-	}
-
-	credentialApplicationBytes, err := json.Marshal(credentialApplicationRaw)
-	if err != nil {
-		return nil, err
-	}
-
-	return credentialApplicationBytes, nil
-}
-
-func getVCFromCredentialFulfillmentAttachment(credentialFulfillmentAttachment *decorator.GenericAttachment) (
-	verifiable.Credential, error) {
-	attachmentRaw := credentialFulfillmentAttachment.Data.JSON
-
-	attachmentAsMap, ok := attachmentRaw.(map[string]interface{})
-	if !ok {
-		return verifiable.Credential{}, errors.New("couldn't assert attachment as a map")
-	}
-
-	credentialFulfillmentRaw, ok := attachmentAsMap["credential_fulfillment"]
-	if !ok {
-		return verifiable.Credential{}, errors.New("credential_fulfillment object missing from attachment")
-	}
-
-	credentialFulfillmentBytes, err := json.Marshal(credentialFulfillmentRaw)
-	if err != nil {
-		return verifiable.Credential{}, err
-	}
-
-	var credentialFulfillment cm.CredentialFulfillment
-
-	err = json.Unmarshal(credentialFulfillmentBytes, &credentialFulfillment)
-	if err != nil {
-		return verifiable.Credential{}, err
-	}
-
-	documentLoader, err := createDocumentLoader()
-	if err != nil {
-		return verifiable.Credential{}, err
-	}
-
-	vcs, err := credentialFulfillment.ResolveDescriptorMaps(credentialFulfillmentAttachment.Data.JSON,
-		verifiable.WithDisabledProofCheck(), verifiable.WithJSONLDDocumentLoader(documentLoader))
-	if err != nil {
-		return verifiable.Credential{}, err
-	}
-
-	if len(vcs) != 1 {
-		return verifiable.Credential{}, fmt.Errorf("received %d VCs, but expected only one", len(vcs))
-	}
-
-	return vcs[0], nil
-}
-
-type docLoaderProvider struct {
-	ContextStore        ldstore.ContextStore
-	RemoteProviderStore ldstore.RemoteProviderStore
-}
-
-func (p *docLoaderProvider) JSONLDContextStore() ldstore.ContextStore {
-	return p.ContextStore
-}
-
-func (p *docLoaderProvider) JSONLDRemoteProviderStore() ldstore.RemoteProviderStore {
-	return p.RemoteProviderStore
-}
-
-func createDocumentLoader() (*ld.DocumentLoader, error) {
-	contextStore, err := ldstore.NewContextStore(mem.NewProvider())
-	if err != nil {
-		return nil, err
-	}
-
-	remoteProviderStore, err := ldstore.NewRemoteProviderStore(mem.NewProvider())
-	if err != nil {
-		return nil, err
-	}
-
-	p := &docLoaderProvider{
-		ContextStore:        contextStore,
-		RemoteProviderStore: remoteProviderStore,
-	}
-
-	loader, err := ld.NewDocumentLoader(p, ld.WithExtraContexts(bddldcontext.Extra()...))
-	if err != nil {
-		return nil, err
-	}
-
-	return loader, nil
-}
-
 func (i *IssuanceSDKDIDCommV2Steps) getCredentialFulfillmentAttachment() (decorator.GenericAttachment, error) {
 	for {
 		select {
 		case msg := <-i.holderEvent:
 			if msg.StateID == "done" {
-				attachment, err := getAttachmentFromDIDCommMsg(msg.Msg)
+				attachment, err := getAttachmentFromDIDCommMsgV2(msg.Msg)
 				if err != nil {
 					return decorator.GenericAttachment{}, err
 				}
@@ -620,43 +443,7 @@ func (i *IssuanceSDKDIDCommV2Steps) getCredentialFulfillmentAttachment() (decora
 	}
 }
 
-func getAttachmentFromDIDCommMsg(didCommMsg service.DIDCommMsg) (decorator.GenericAttachment, error) {
-	var didCommMsgAsMap map[string]interface{}
-
-	err := didCommMsg.Decode(&didCommMsgAsMap)
-	if err != nil {
-		return decorator.GenericAttachment{}, err
-	}
-
-	attachmentsRaw, ok := didCommMsgAsMap["attachments"]
-	if !ok {
-		return decorator.GenericAttachment{}, errors.New("missing attachments from DIDComm message map")
-	}
-
-	attachments, ok := attachmentsRaw.([]interface{})
-	if !ok {
-		return decorator.GenericAttachment{}, errors.New("attachments were not an array of interfaces as expected")
-	}
-
-	attachmentRaw := attachments[0]
-
-	attachmentBytes, err := json.Marshal(attachmentRaw)
-	if err != nil {
-		return decorator.GenericAttachment{}, err
-	}
-
-	var attachment decorator.GenericAttachment
-
-	err = json.Unmarshal(attachmentBytes, &attachment)
-	if err != nil {
-		return decorator.GenericAttachment{}, err
-	}
-
-	return attachment, nil
-}
-
-// GetConnection return the connection between agents.
-func (i *IssuanceSDKDIDCommV2Steps) GetConnection(from, to string) (*didexClient.Connection, error) {
+func (i *IssuanceSDKDIDCommV2Steps) getConnection(from, to string) (*didexClient.Connection, error) {
 	connections, err := i.context.DIDExchangeClients[from].QueryConnections(&didexClient.QueryConnectionsParams{})
 	if err != nil {
 		return nil, fmt.Errorf("%s failed to fetch their connections : %w", from, err)
@@ -671,295 +458,21 @@ func (i *IssuanceSDKDIDCommV2Steps) GetConnection(from, to string) (*didexClient
 	return nil, fmt.Errorf("no connection %s -> %s", from, to)
 }
 
-type prop interface {
-	MyDID() string
-	TheirDID() string
+func getAttachmentFromDIDCommMsgV2(didCommMsg service.DIDCommMsg) (decorator.GenericAttachment, error) {
+	return getAttachmentFromDIDCommMsg(didCommMsg, "attachments")
 }
 
-func generateOfferCredentialMsg() (*issuecredentialclient.OfferCredential, error) {
-	credentialManifestAttachment, err := generateCredentialManifestAttachment()
-	if err != nil {
-		return nil, err
-	}
-
-	// A Credential Fulfillment attachment is sent here as a preview of the VC so the Holder can see what
-	// the credential will look like.
-	credentialFulfillmentAttachment, err := generateCredentialFulfillmentAttachmentWithoutProof()
-	if err != nil {
-		return nil, err
-	}
-
-	attachments := []decorator.GenericAttachment{*credentialManifestAttachment, *credentialFulfillmentAttachment}
-
-	offerCredential := issuecredentialclient.OfferCredential{
-		Type:        issuecredential.OfferCredentialMsgTypeV3,
-		ID:          uuid.New().String(),
-		Attachments: attachments,
-	}
-
-	return &offerCredential, nil
+func generateOfferCredentialMsgV3() (*issuecredentialclient.OfferCredential, error) {
+	return generateOfferCredentialMsg(issuecredential.OfferCredentialMsgTypeV3)
 }
 
-func generateRequestCredentialMsg(credentialManifest *cm.CredentialManifest) (*issuecredentialclient.RequestCredential,
-	error) {
-	credentialApplicationAttachment, err := generateCredentialApplicationAttachment(credentialManifest)
-	if err != nil {
-		return nil, err
-	}
-
-	attachments := []decorator.GenericAttachment{*credentialApplicationAttachment}
-
-	requestCredential := issuecredentialclient.RequestCredential{
-		Type:        issuecredential.RequestCredentialMsgTypeV3,
-		ID:          uuid.New().String(),
-		Attachments: attachments,
-	}
-
-	return &requestCredential, nil
+func generateRequestCredentialMsgV3(credentialManifest *cm.CredentialManifest) (
+	*issuecredentialclient.RequestCredential, error) {
+	return generateRequestCredentialMsg(credentialManifest, issuecredential.RequestCredentialMsgTypeV3)
 }
 
-func generateIssueCredentialMsg() (*issuecredentialclient.IssueCredential, error) {
-	cxt := []string{
-		"https://www.w3.org/2018/credentials/v1",
-		cm.CredentialFulfillmentPresentationContext,
-	}
-
-	types := []string{
-		"VerifiablePresentation",
-		"CredentialFulfillment",
-	}
-
-	var credentialFulfillment cm.CredentialFulfillment
-
-	err := json.Unmarshal(credentialFulfillmentDriversLicense, &credentialFulfillment)
-	if err != nil {
-		return nil, err
-	}
-
-	documentLoader, err := createDocumentLoader()
-	if err != nil {
-		return nil, err
-	}
-
-	verifiableCredential, err := verifiable.ParseCredential(vcDriversLicense,
-		verifiable.WithJSONLDDocumentLoader(documentLoader), verifiable.WithDisabledProofCheck())
-	if err != nil {
-		return nil, err
-	}
-
-	verifiableCredentials := []*verifiable.Credential{verifiableCredential}
-
-	proof := generateCredentialFulfillmentProof()
-
-	attachmentData := map[string]interface{}{
-		"@context":               cxt,
-		"type":                   types,
-		"credential_fulfillment": credentialFulfillment,
-		"verifiableCredential":   verifiableCredentials,
-		"proof":                  proof,
-	}
-
-	issueCredentialAttachment := decorator.GenericAttachment{
-		ID:        uuid.New().String(),
-		MediaType: "application/json",
-		Format:    cm.CredentialFulfillmentAttachmentFormat,
-		Data:      decorator.AttachmentData{JSON: attachmentData},
-	}
-
-	attachments := []decorator.GenericAttachment{issueCredentialAttachment}
-
-	issueCredentialMsg := issuecredentialclient.IssueCredential{
-		Type:        issuecredential.IssueCredentialMsgTypeV3,
-		ID:          uuid.New().String(),
-		Attachments: attachments,
-	}
-
-	return &issueCredentialMsg, nil
-}
-
-func generateCredentialManifestAttachment() (*decorator.GenericAttachment, error) {
-	credentialManifest, err := generateCredentialManifest()
-	if err != nil {
-		return nil, err
-	}
-
-	options := map[string]string{
-		"challenge": "508adef4-b8e0-4edf-a53d-a260371c1423",
-		"domain":    "9rf25a28rs96",
-	}
-
-	attachmentData := map[string]interface{}{
-		"options":             options,
-		"credential_manifest": credentialManifest,
-	}
-
-	credentialManifestAttachment := decorator.GenericAttachment{
-		ID:        uuid.New().String(),
-		MediaType: "application/json",
-		Format:    cm.CredentialManifestAttachmentFormat,
-		Data:      decorator.AttachmentData{JSON: attachmentData},
-	}
-
-	return &credentialManifestAttachment, nil
-}
-
-func generateCredentialApplicationAttachment(credentialManifest *cm.CredentialManifest) (*decorator.GenericAttachment,
-	error) {
-	cxt := []string{
-		"https://www.w3.org/2018/credentials/v1",
-		cm.CredentialApplicationPresentationContext,
-	}
-
-	types := []string{
-		"VerifiablePresentation",
-		"CredentialApplication",
-	}
-
-	credentialApplication, err :=
-		cm.UnmarshalAndValidateAgainstCredentialManifest(credentialApplicationDriversLicense, credentialManifest)
-	if err != nil {
-		return nil, err
-	}
-
-	var presentationSubmission presexch.PresentationSubmission
-
-	err = json.Unmarshal(presentationSubmissionPRC, &presentationSubmission)
-	if err != nil {
-		return nil, err
-	}
-
-	documentLoader, err := createDocumentLoader()
-	if err != nil {
-		return nil, err
-	}
-
-	verifiableCredential, err := verifiable.ParseCredential(vcPRC,
-		verifiable.WithJSONLDDocumentLoader(documentLoader), verifiable.WithDisabledProofCheck())
-	if err != nil {
-		return nil, err
-	}
-
-	verifiableCredentials := []*verifiable.Credential{verifiableCredential}
-
-	proof := generateCredentialApplicationProof()
-
-	attachmentData := map[string]interface{}{
-		"@context":                cxt,
-		"type":                    types,
-		"credential_application":  credentialApplication,
-		"presentation_submission": presentationSubmission,
-		"verifiableCredential":    verifiableCredentials,
-		"proof":                   proof,
-	}
-
-	credentialApplicationAttachment := decorator.GenericAttachment{
-		ID:        uuid.New().String(),
-		MediaType: "application/json",
-		Format:    cm.CredentialApplicationAttachmentFormat,
-		Data:      decorator.AttachmentData{JSON: attachmentData},
-	}
-
-	return &credentialApplicationAttachment, nil
-}
-
-func generateCredentialManifest() (*cm.CredentialManifest, error) {
-	var credentialManifest cm.CredentialManifest
-
-	err := json.Unmarshal(credentialManifestDriversLicense, &credentialManifest)
-	if err != nil {
-		return nil, err
-	}
-
-	return &credentialManifest, nil
-}
-
-func generateCredentialFulfillmentAttachmentWithoutProof() (*decorator.GenericAttachment, error) {
-	var credentialFulfillment cm.CredentialFulfillment
-
-	err := json.Unmarshal(credentialFulfillmentDriversLicense, &credentialFulfillment)
-	if err != nil {
-		return nil, err
-	}
-
-	cxt := []string{
-		"https://www.w3.org/2018/credentials/v1",
-		cm.CredentialFulfillmentPresentationContext,
-	}
-
-	types := []string{
-		"VerifiablePresentation",
-		"CredentialFulfillment",
-	}
-
-	documentLoader, err := createDocumentLoader()
-	if err != nil {
-		return nil, err
-	}
-
-	vcPreview, err := verifiable.ParseCredential(vcDriversLicenseWithoutProof,
-		verifiable.WithJSONLDDocumentLoader(documentLoader))
-	if err != nil {
-		return nil, err
-	}
-
-	verifiableCredentials := []*verifiable.Credential{vcPreview}
-
-	attachmentData := map[string]interface{}{
-		"@context":               cxt,
-		"type":                   types,
-		"credential_fulfillment": credentialFulfillment,
-		"verifiableCredential":   verifiableCredentials,
-	}
-
-	credentialFulfillmentAttachment := decorator.GenericAttachment{
-		ID:        uuid.New().String(),
-		MediaType: "application/json",
-		Format:    cm.CredentialFulfillmentAttachmentFormat,
-		Data:      decorator.AttachmentData{JSON: attachmentData},
-	}
-
-	return &credentialFulfillmentAttachment, nil
-}
-
-func generateCredentialFulfillmentProof() map[string]string {
-	return map[string]string{
-		"type": "Ed25519Signature2018",
-		"verificationMethod": "did:orb:EiA3Xmv8A8vUH5lRRZeKakd-cjAxGC2A4aoPDjLysjghow#tMIstfHSzXfBUF" +
-			"7O0m2FiBEfTb93_j_4ron47IXPgEo",
-		"created":      "2021-06-07T20:02:44.730614315Z",
-		"proofPurpose": "authentication",
-		"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19.." +
-			"NVum9BeYkhzwslZXm2cDOveQB9njlrCRSrdMZgwV3zZfLRXmZQ1AXdKLLmo4ClTYXFX_TWNyB8aFt9cN6sSvCg",
-	}
-}
-
-func generateCredentialApplicationProof() map[string]string {
-	return map[string]string{
-		"type":               "Ed25519Signature2018",
-		"verificationMethod": "did:example:123#key-0",
-		"created":            "2021-05-14T20:16:29.565377",
-		"proofPurpose":       "authentication",
-		"challenge":          "3fa85f64-5717-4562-b3fc-2c963f66afa7",
-		"jws": "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0IjogWyJiNjQiXX0..7M9LwdJR1_SQayHIWVHF5eSSRhbVsr" +
-			"jQHKUrfRhRRrlbuKlggm8mm_4EI_kTPeBpalQWiGiyCb_0OWFPtn2wAQ",
-	}
-}
-
-func checkProperties(action service.DIDCommAction) error {
-	properties, ok := action.Properties.(prop)
-	if !ok {
-		return errors.New("no properties")
-	}
-
-	if properties.MyDID() == "" {
-		return errors.New("myDID is empty")
-	}
-
-	if properties.TheirDID() == "" {
-		return errors.New("theirDID is empty")
-	}
-
-	return nil
+func generateIssueCredentialMsgV3() (*issuecredentialclient.IssueCredential, error) {
+	return generateIssueCredentialMsg(issuecredential.IssueCredentialMsgTypeV3)
 }
 
 func getParentThreadID(action service.DIDCommAction) (string, error) {
@@ -978,35 +491,6 @@ func getParentThreadID(action service.DIDCommAction) (string, error) {
 	return msgParentThreadID.(string), nil
 }
 
-func getAttachments(action service.DIDCommAction) ([]decorator.GenericAttachment, error) {
-	var didCommMsgAsMap map[string]interface{}
-
-	err := action.Message.Decode(&didCommMsgAsMap)
-	if err != nil {
-		return nil, err
-	}
-
-	attachmentsRaw, ok := didCommMsgAsMap["attachments"]
-	if !ok {
-		return nil, errors.New("missing attachments from DIDComm message map")
-	}
-
-	attachmentsAsArrayOfInterfaces, ok := attachmentsRaw.([]interface{})
-	if !ok {
-		return nil, errors.New("attachments were not an array of interfaces as expected")
-	}
-
-	attachmentsBytes, err := json.Marshal(attachmentsAsArrayOfInterfaces)
-	if err != nil {
-		return nil, err
-	}
-
-	var attachments []decorator.GenericAttachment
-
-	err = json.Unmarshal(attachmentsBytes, &attachments)
-	if err != nil {
-		return nil, err
-	}
-
-	return attachments, nil
+func getAttachmentsV3(action service.DIDCommAction) ([]decorator.GenericAttachment, error) {
+	return getAttachments(action, "attachments")
 }


### PR DESCRIPTION
Refactored the WACI Issuance tests using V1 and V2 so that there's less code duplication.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>

closes #3143