### PR TITLE
add content type to webhook request

### DIFF
--- a/pkg/controller/webnotifier/webhook.go
+++ b/pkg/controller/webnotifier/webhook.go
@@ -61,6 +61,8 @@ func notifyWH(destination string, message []byte) error {
 		return fmt.Errorf("failed to create new http post request for %s: %w", destination, err)
 	}
 
+	req.Header.Add("Content-Type", "application/json")
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to post notification to %s: %w", destination, err)


### PR DESCRIPTION
**Title:**
Webhook message has no content type

**Description:**
Add the content type to the request header in webhook
 Issue: https://github.com/hyperledger/aries-framework-go/issues/3158
