### PR TITLE
feat: Added RequestCredential argument for Accept Offer endpoint

### DIFF
--- a/pkg/controller/command/issuecredential/command.go
+++ b/pkg/controller/command/issuecredential/command.go
@@ -465,7 +465,7 @@ func (c *Command) AcceptOffer(rw io.Writer, req io.Reader) command.Error {
 		return command.NewValidationError(InvalidRequestErrorCode, errors.New(errEmptyPIID))
 	}
 
-	if err := c.client.AcceptOffer(args.PIID, &issuecredential.RequestCredential{}); err != nil {
+	if err := c.client.AcceptOffer(args.PIID, &args.RequestCredential); err != nil {
 		logutil.LogError(logger, CommandName, AcceptOffer, err.Error())
 		return command.NewExecuteError(AcceptOfferErrorCode, err)
 	}

--- a/pkg/controller/command/issuecredential/models.go
+++ b/pkg/controller/command/issuecredential/models.go
@@ -55,8 +55,35 @@ type AcceptProposalResponse struct{}
 // This is used for accepting an offer.
 //
 type AcceptOfferArgs struct {
-	// PIID Protocol instance ID
+	// PIID Protocol instance I
 	PIID string `json:"piid"`
+	// RequestCredential is an optional message sent by the potential Holder to the Issuer to request the issuance of a
+	// credential.
+	RequestCredential issuecredential.RequestCredential `json:"request_credential,omitempty"`
+}
+
+// AcceptOfferArgsV2 model
+//
+// This is used for accepting an offer.
+//
+type AcceptOfferArgsV2 struct {
+	// PIID Protocol instance I
+	PIID string `json:"piid"`
+	// RequestCredential is an optional message sent by the potential Holder to the Issuer to request the issuance of a
+	// credential.
+	RequestCredential issuecredential.RequestCredentialV2 `json:"request_credential,omitempty"`
+}
+
+// AcceptOfferArgsV3 model
+//
+// This is used for accepting an offer.
+//
+type AcceptOfferArgsV3 struct {
+	// PIID Protocol instance I
+	PIID string `json:"piid"`
+	// RequestCredential is an optional message sent by the potential Holder to the Issuer to request the issuance of a
+	// credential.
+	RequestCredential issuecredential.RequestCredentialV3 `json:"request_credential,omitempty"`
 }
 
 // AcceptOfferResponse model


### PR DESCRIPTION
The Accept Offer endpoint in the REST API can now accept an optional RequestCredential object. This object will get passed to the underlying client instead of just assuming a blank RequestCredential. This is a required feature for the WACI issuance flow.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>