### PR TITLE
feat: websocket read limit support

### DIFF
--- a/cmd/aries-agent-mobile/pkg/wrappers/config/options.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/config/options.go
@@ -30,9 +30,10 @@ type Options struct {
 
 	// expected to be ignored by gomobile
 	// not intended to be used by golang code
-	HTTPResolvers     []string
-	OutboundTransport []string
-	WebsocketURL      string
+	HTTPResolvers      []string
+	OutboundTransport  []string
+	WebsocketURL       string
+	WebsocketReadLimit int64
 }
 
 // New returns an instance of Options which can be used to configure an aries controller instance.

--- a/cmd/aries-agent-rest/startcmd/start_test.go
+++ b/cmd/aries-agent-rest/startcmd/start_test.go
@@ -372,7 +372,7 @@ func TestStartCmdWithInvalidReadLimit(t *testing.T) {
 		httpProtocol + "@" + randomURL(),
 		"--" + agentInboundHostExternalFlagName,
 		httpProtocol + "@" + randomURL(),
-		"--" + agentInboundWebSocketReadLimitFlagName,
+		"--" + agentWebSocketReadLimitFlagName,
 		"invalid",
 		"--" + databaseTypeFlagName,
 		databaseTypeMemOption,
@@ -385,7 +385,7 @@ func TestStartCmdWithInvalidReadLimit(t *testing.T) {
 
 	err = startCmd.Execute()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to parse inbound websocket read limit")
+	require.Contains(t, err.Error(), "failed to parse web socket read limit")
 }
 
 func TestStartCmdWithLogLevel(t *testing.T) {
@@ -492,7 +492,7 @@ func TestStartCmdValidArgs(t *testing.T) {
 		httpProtocol + "@" + randomURL(),
 		"--" + agentInboundHostExternalFlagName,
 		httpProtocol + "@" + randomURL(),
-		"--" + agentInboundWebSocketReadLimitFlagName,
+		"--" + agentWebSocketReadLimitFlagName,
 		"65536",
 		"--" + databaseTypeFlagName,
 		databaseTypeMemOption,
@@ -648,12 +648,12 @@ func TestStartAriesWithInboundTransport(t *testing.T) {
 
 		go func() {
 			parameters := &agentParameters{
-				server:                    &HTTPServer{},
-				host:                      testHostURL,
-				inboundHostInternals:      []string{websocketProtocol + "@" + testInboundHostURL},
-				inboundWebSocketReadLimit: 65536,
-				dbParam:                   &dbParam{dbType: databaseTypeMemOption},
-				defaultLabel:              "x",
+				server:               &HTTPServer{},
+				host:                 testHostURL,
+				inboundHostInternals: []string{websocketProtocol + "@" + testInboundHostURL},
+				websocketReadLimit:   65536,
+				dbParam:              &dbParam{dbType: databaseTypeMemOption},
+				defaultLabel:         "x",
 			}
 
 			err := startAgent(parameters)

--- a/pkg/didcomm/transport/ws/inbound.go
+++ b/pkg/didcomm/transport/ws/inbound.go
@@ -18,8 +18,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
 )
 
-const defaultReadLimit = 32768
-
 var logger = log.New("aries-framework/ws")
 
 type inboundOpts struct {
@@ -47,9 +45,7 @@ type Inbound struct {
 
 // NewInbound creates a new WebSocket inbound transport instance.
 func NewInbound(internalAddr, externalAddr, certFile, keyFile string, opts ...InboundOpt) (*Inbound, error) {
-	inOpts := &inboundOpts{
-		readLimit: defaultReadLimit,
-	}
+	inOpts := &inboundOpts{}
 
 	for _, opt := range opts {
 		opt(inOpts)
@@ -122,7 +118,9 @@ func (i *Inbound) processRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c.SetReadLimit(i.readLimit)
+	if i.readLimit > 0 {
+		c.SetReadLimit(i.readLimit)
+	}
 
 	i.pool.listener(c, false)
 }

--- a/pkg/didcomm/transport/ws/inbound_test.go
+++ b/pkg/didcomm/transport/ws/inbound_test.go
@@ -24,6 +24,8 @@ import (
 	mockpackager "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/packager"
 )
 
+const defaultReadLimit = 32768
+
 func TestInboundTransport(t *testing.T) {
 	t.Run("test inbound transport - with host/port", func(t *testing.T) {
 		port := ":" + strconv.Itoa(transportutil.GetRandomPort(5))


### PR DESCRIPTION
This PR adds support for setting read limit for outbound web socket transport (in addition to inbound that was already supported).

Closes #3155

Signed-off-by: Andrii Holovko <andriy.holovko@gmail.com>
