### PR TITLE
fix: create oobv2 inviter's connection record on v1 messages, with invitation ID

### DIFF
--- a/pkg/didcomm/common/middleware/middleware.go
+++ b/pkg/didcomm/common/middleware/middleware.go
@@ -85,19 +85,18 @@ func (h *DIDCommMessageMiddleware) HandleInboundMessage( // nolint:gocyclo,funle
 	msg didcomm.DIDCommMsgMap,
 	theirDID, myDID string,
 ) error {
-	if isV2, err := didcomm.IsDIDCommV2(&msg); !isV2 || err != nil {
-		return err
-	}
-
 	// TODO: clean up connection record management across all the handler methods. Currently correct but messy.
-
 	// TODO: clean up some logic:
 	//  - inbound invitation acceptance cannot be a rotation
-
 	// GetConnectionRecordByDIDs(myDID, theirDID)
 	// if no connection, create connection
 	rec, err := h.handleInboundInvitationAcceptance(theirDID, myDID)
 	if err != nil {
+		return err
+	}
+
+	isV2, err := didcomm.IsDIDCommV2(&msg)
+	if !isV2 || err != nil {
 		return err
 	}
 
@@ -170,13 +169,15 @@ func (h *DIDCommMessageMiddleware) HandleOutboundMessage(msg didcomm.DIDCommMsgM
 
 type invitationStub struct {
 	Type string `json:"type"`
+	ID   string `json:"id"`
 }
 
 func (h *DIDCommMessageMiddleware) handleInboundInvitationAcceptance(senderDID, recipientDID string,
 ) (*connection.Record, error) {
 	didParsed, err := did.Parse(recipientDID)
 	if err != nil {
-		return nil, fmt.Errorf("parsing inbound recipient DID: %w", err)
+		logger.Warnf("failed to parse inbound recipient DID: %s", err.Error())
+		return nil, nil
 	}
 
 	if didParsed.Method == peer.DIDMethod { // TODO any more exception cases like peer?
@@ -195,10 +196,10 @@ func (h *DIDCommMessageMiddleware) handleInboundInvitationAcceptance(senderDID, 
 	}
 
 	rec, err := h.connStore.GetConnectionRecordByDIDs(recipientDID, senderDID)
-	if !errors.Is(err, storage.ErrDataNotFound) {
-		// either an error, or a record exists
-		logger.Warnf("record present, or error=%v", err)
-		return rec, err
+	if err == nil {
+		return rec, nil
+	} else if !errors.Is(err, storage.ErrDataNotFound) {
+		return rec, fmt.Errorf("failed to get connection record: %w", err)
 	}
 
 	// if we created an invitation with this DID, and have no connection, we create a connection.
@@ -207,6 +208,7 @@ func (h *DIDCommMessageMiddleware) handleInboundInvitationAcceptance(senderDID, 
 		ConnectionID:      uuid.New().String(),
 		MyDID:             recipientDID,
 		TheirDID:          senderDID,
+		InvitationID:      inv.ID,
 		State:             connection.StateNameCompleted,
 		Namespace:         connection.MyNSPrefix,
 		MediaTypeProfiles: h.mediaTypeProfiles,

--- a/pkg/didcomm/dispatcher/inbound/inbound_message_handler.go
+++ b/pkg/didcomm/dispatcher/inbound/inbound_message_handler.go
@@ -108,6 +108,8 @@ func (handler *MessageHandler) HandleInboundEnvelope(envelope *transport.Envelop
 		return err
 	}
 
+	isDIDEx := (&didexchange.Service{}).Accept(msg.Type())
+
 	isV2, err := service.IsDIDCommV2(&msg)
 	if err != nil {
 		return err
@@ -124,11 +126,11 @@ func (handler *MessageHandler) HandleInboundEnvelope(envelope *transport.Envelop
 		return fmt.Errorf("handling inbound peer DID: %w", err)
 	}
 
-	// if msg is a didcomm v2 message, do additional handling
-	if isV2 {
+	// if msg is not a didexchange message, do additional handling
+	if !isDIDEx {
 		myDID, theirDID, err = handler.getDIDs(envelope, msg)
 		if err != nil {
-			return fmt.Errorf("get DIDs for didcomm/v2 message: %w", err)
+			return fmt.Errorf("get DIDs for message: %w", err)
 		}
 
 		gotDIDs = true

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -269,12 +269,12 @@ func TestNewProvider(t *testing.T) {
 
 		inboundHandler := ctx.InboundMessageHandler()
 
-		err = inboundHandler(&transport.Envelope{Message: []byte(`
+		err = inboundHandler(&transport.Envelope{Message: []byte(fmt.Sprintf(`
 		{
 			"@frameworkID": "5678876542345",
 			"@id": "12345",
-			"@type": "valid-message-type"
-		}`), FromKey: []byte("fromKey"), ToKey: []byte("toKey")})
+			"@type": "%s"
+		}`, didexchange.RequestMsgType)), FromKey: []byte("fromKey"), ToKey: []byte("toKey")})
 		require.NoError(t, err)
 	})
 


### PR DESCRIPTION
- add invitation ID to inviter's implicit didcomm v2 connection
- allow all non-didexchange messages to use didcomm v2 handlers

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>