### PR TITLE
docs: Updated storage interface documentation

### DIFF
--- a/spi/storage/storage.go
+++ b/spi/storage/storage.go
@@ -184,6 +184,7 @@ type Store interface {
 	// with data put in and data retrieved, as the marshalled representation may be different - always unmarshal data
 	// first before comparing.
 	// If key is empty or value is nil, then an error will be returned.
+	// A single key-value pair cannot have multiple tags that share the same tag name.
 	Put(key string, value []byte, tags ...Tag) error
 
 	// Get fetches the value associated with the given key.


### PR DESCRIPTION
Updated the documentation for the Put method to indicate that in the set of tags used on a single Put call, those tags must have unique tag names. The reason for this is because several of our major storage implementations in aries-framework-go-ext have this implementation, so this note was added to help ensure consistent behaviour.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>