### PR TITLE
fix(vcwallet): correct order of test arguments

### DIFF
--- a/pkg/controller/rest/vcwallet/operation_test.go
+++ b/pkg/controller/rest/vcwallet/operation_test.go
@@ -93,7 +93,7 @@ func TestOperation_CreateProfile(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodPost, CreateProfilePath, getReader(t, &request))
 		rw := httptest.NewRecorder()
 		cmd.CreateProfile(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 	})
 
 	t.Run("successfully create a new wallet profile (webkms/remotekms)", func(t *testing.T) {
@@ -110,7 +110,7 @@ func TestOperation_CreateProfile(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodPost, CreateProfilePath, getReader(t, &request))
 		rw := httptest.NewRecorder()
 		cmd.CreateProfile(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 	})
 
 	t.Run("successfully create a new wallet profile with EDV configuration", func(t *testing.T) {
@@ -134,7 +134,7 @@ func TestOperation_CreateProfile(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodPost, CreateProfilePath, getReader(t, &request))
 		rw := httptest.NewRecorder()
 		cmd.CreateProfile(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		// if wallet instance can be creates it means profile exists
 		walletInstance, err := wallet.New(request.UserID, mockctx)
@@ -154,7 +154,7 @@ func TestOperation_CreateProfile(t *testing.T) {
 		rq = httptest.NewRequest(http.MethodPost, CreateProfilePath, getReader(t, &request))
 		rw = httptest.NewRecorder()
 		cmd.CreateProfile(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 	})
 
 	t.Run("failed to create duplicate profile", func(t *testing.T) {
@@ -171,7 +171,7 @@ func TestOperation_CreateProfile(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodPost, CreateProfilePath, getReader(t, &request))
 		rw := httptest.NewRecorder()
 		cmd.CreateProfile(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		request = &vcwallet.CreateOrUpdateProfileRequest{
 			UserID:      sampleUserID,
@@ -181,7 +181,7 @@ func TestOperation_CreateProfile(t *testing.T) {
 		rq = httptest.NewRequest(http.MethodPost, CreateProfilePath, getReader(t, &request))
 		rw = httptest.NewRecorder()
 		cmd.CreateProfile(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 	})
 
 	t.Run("failed to create profile due to invalid settings", func(t *testing.T) {
@@ -197,7 +197,7 @@ func TestOperation_CreateProfile(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodPost, CreateProfilePath, getReader(t, &request))
 		rw := httptest.NewRecorder()
 		cmd.CreateProfile(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 	})
 
 	t.Run("failed to create profile due to invalid request", func(t *testing.T) {
@@ -209,7 +209,7 @@ func TestOperation_CreateProfile(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodPost, CreateProfilePath, getReader(t, "--"))
 		rw := httptest.NewRecorder()
 		cmd.CreateProfile(rw, rq)
-		require.Equal(t, rw.Code, http.StatusBadRequest)
+		require.Equal(t, http.StatusBadRequest, rw.Code)
 	})
 
 	t.Run("failed to create profile due to EDV key set creation failure", func(t *testing.T) {
@@ -236,7 +236,7 @@ func TestOperation_CreateProfile(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodPost, CreateProfilePath, getReader(t, &request))
 		rw := httptest.NewRecorder()
 		cmd.CreateProfile(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 	})
 }
 
@@ -254,7 +254,7 @@ func TestOperation_UpdateProfile(t *testing.T) {
 	rq := httptest.NewRequest(http.MethodPost, UpdateProfilePath, getReader(t, &createRqst))
 	rw := httptest.NewRecorder()
 	cmd.CreateProfile(rw, rq)
-	require.Equal(t, rw.Code, http.StatusOK)
+	require.Equal(t, http.StatusOK, rw.Code)
 
 	t.Run("successfully update a wallet profile", func(t *testing.T) {
 		request := &vcwallet.CreateOrUpdateProfileRequest{
@@ -265,7 +265,7 @@ func TestOperation_UpdateProfile(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodPost, UpdateProfilePath, getReader(t, &request))
 		rw := httptest.NewRecorder()
 		cmd.UpdateProfile(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 	})
 
 	t.Run("successfully update a wallet profile with EDV configuration", func(t *testing.T) {
@@ -284,7 +284,7 @@ func TestOperation_UpdateProfile(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodPost, UpdateProfilePath, getReader(t, &request))
 		rw := httptest.NewRecorder()
 		cmd.UpdateProfile(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 	})
 
 	t.Run("failed to update profile due to invalid settings", func(t *testing.T) {
@@ -295,14 +295,14 @@ func TestOperation_UpdateProfile(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodPost, UpdateProfilePath, getReader(t, &request))
 		rw := httptest.NewRecorder()
 		cmd.UpdateProfile(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 	})
 
 	t.Run("failed to update profile due to invalid request", func(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodPost, UpdateProfilePath, getReader(t, "---"))
 		rw := httptest.NewRecorder()
 		cmd.UpdateProfile(rw, rq)
-		require.Equal(t, rw.Code, http.StatusBadRequest)
+		require.Equal(t, http.StatusBadRequest, rw.Code)
 	})
 }
 
@@ -329,7 +329,7 @@ func TestCommand_ProfileExists(t *testing.T) {
 		})
 
 		cmd.ProfileExists(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 		require.Empty(t, rw.Body.String())
 	})
 
@@ -343,7 +343,7 @@ func TestCommand_ProfileExists(t *testing.T) {
 		})
 
 		cmd.ProfileExists(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 		require.Contains(t, rw.Body.String(), wallet.ErrProfileNotFound.Error())
 	})
 
@@ -355,7 +355,7 @@ func TestCommand_ProfileExists(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodGet, ProfileExistsPath, nil)
 
 		cmd.ProfileExists(rw, rq)
-		require.Equal(t, rw.Code, http.StatusBadRequest)
+		require.Equal(t, http.StatusBadRequest, rw.Code)
 		require.Contains(t, rw.Body.String(), "empty profile ID")
 	})
 }
@@ -400,21 +400,21 @@ func TestOperation_OpenAndClose(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodPost, OpenPath, getReader(t, request))
 		rw := httptest.NewRecorder()
 		cmd.Open(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 		require.NotEmpty(t, getUnlockToken(t, rw.Body))
 
 		// try again, should get error, wallet already unlocked
 		rq = httptest.NewRequest(http.MethodPost, OpenPath, getReader(t, request))
 		rw = httptest.NewRecorder()
 		cmd.Open(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 
 		// lock wallet
 		rq = httptest.NewRequest(http.MethodPost, ClosePath,
 			getReader(t, &vcwallet.LockWalletRequest{UserID: sampleUser1}))
 		rw = httptest.NewRecorder()
 		cmd.Close(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 		require.Contains(t, rw.Body.String(), `{"closed":true}`)
 
 		// lock wallet again
@@ -422,7 +422,7 @@ func TestOperation_OpenAndClose(t *testing.T) {
 			getReader(t, &vcwallet.LockWalletRequest{UserID: sampleUser1}))
 		rw = httptest.NewRecorder()
 		cmd.Close(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 		require.Contains(t, rw.Body.String(), `{"closed":false}`)
 	})
 
@@ -438,21 +438,21 @@ func TestOperation_OpenAndClose(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodPost, OpenPath, getReader(t, request))
 		rw := httptest.NewRecorder()
 		cmd.Open(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 		require.NotEmpty(t, getUnlockToken(t, rw.Body))
 
 		// try again, should get error, wallet already unlocked
 		rq = httptest.NewRequest(http.MethodPost, OpenPath, getReader(t, request))
 		rw = httptest.NewRecorder()
 		cmd.Open(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 
 		// lock wallet
 		rq = httptest.NewRequest(http.MethodPost, ClosePath,
 			getReader(t, &vcwallet.LockWalletRequest{UserID: sampleUser2}))
 		rw = httptest.NewRecorder()
 		cmd.Close(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 		require.Contains(t, rw.Body.String(), `{"closed":true}`)
 
 		// lock wallet again
@@ -460,7 +460,7 @@ func TestOperation_OpenAndClose(t *testing.T) {
 			getReader(t, &vcwallet.LockWalletRequest{UserID: sampleUser2}))
 		rw = httptest.NewRecorder()
 		cmd.Close(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 		require.Contains(t, rw.Body.String(), `{"closed":false}`)
 	})
 
@@ -479,21 +479,21 @@ func TestOperation_OpenAndClose(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodPost, OpenPath, getReader(t, request))
 		rw := httptest.NewRecorder()
 		cmd.Open(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 		require.NotEmpty(t, getUnlockToken(t, rw.Body))
 
 		// try again, should get error, wallet already unlocked
 		rq = httptest.NewRequest(http.MethodPost, OpenPath, getReader(t, request))
 		rw = httptest.NewRecorder()
 		cmd.Open(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 
 		// lock wallet
 		rq = httptest.NewRequest(http.MethodPost, ClosePath,
 			getReader(t, &vcwallet.LockWalletRequest{UserID: sampleUser3}))
 		rw = httptest.NewRecorder()
 		cmd.Close(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 		require.Contains(t, rw.Body.String(), `{"closed":true}`)
 
 		// lock wallet again
@@ -501,7 +501,7 @@ func TestOperation_OpenAndClose(t *testing.T) {
 			getReader(t, &vcwallet.LockWalletRequest{UserID: sampleUser3}))
 		rw = httptest.NewRecorder()
 		cmd.Close(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 		require.Contains(t, rw.Body.String(), `{"closed":false}`)
 	})
 
@@ -511,23 +511,23 @@ func TestOperation_OpenAndClose(t *testing.T) {
 		rq := httptest.NewRequest(http.MethodPost, OpenPath, getReader(t, vcwallet.UnlockWalletRequest{}))
 		rw := httptest.NewRecorder()
 		cmd.Open(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 
 		rq = httptest.NewRequest(http.MethodPost, OpenPath, nil)
 		rw = httptest.NewRecorder()
 		cmd.Open(rw, rq)
-		require.Equal(t, rw.Code, http.StatusBadRequest)
+		require.Equal(t, http.StatusBadRequest, rw.Code)
 
 		rq = httptest.NewRequest(http.MethodPost, ClosePath,
 			getReader(t, &vcwallet.LockWalletRequest{}))
 		rw = httptest.NewRecorder()
 		cmd.Close(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 
 		rq = httptest.NewRequest(http.MethodPost, ClosePath, nil)
 		rw = httptest.NewRecorder()
 		cmd.Close(rw, rq)
-		require.Equal(t, rw.Code, http.StatusBadRequest)
+		require.Equal(t, http.StatusBadRequest, rw.Code)
 	})
 }
 
@@ -568,7 +568,7 @@ func TestOperation_AddRemoveGetGetAll(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Add(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 	})
 
 	t.Run("add a metadata to wallet", func(t *testing.T) {
@@ -583,7 +583,7 @@ func TestOperation_AddRemoveGetGetAll(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Add(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 	})
 
 	t.Run("get a credential from wallet", func(t *testing.T) {
@@ -598,7 +598,7 @@ func TestOperation_AddRemoveGetGetAll(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Get(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 	})
 
 	t.Run("get all credentials from wallet", func(t *testing.T) {
@@ -618,7 +618,7 @@ func TestOperation_AddRemoveGetGetAll(t *testing.T) {
 			rw := httptest.NewRecorder()
 
 			cmd.Add(rw, rq)
-			require.Equal(t, rw.Code, http.StatusOK)
+			require.Equal(t, http.StatusOK, rw.Code)
 		}
 
 		request := &vcwallet.GetAllContentRequest{
@@ -630,7 +630,7 @@ func TestOperation_AddRemoveGetGetAll(t *testing.T) {
 		rw := httptest.NewRecorder()
 
 		cmd.GetAll(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		var response map[string]interface{}
 		require.NoError(t, json.NewDecoder(rw.Body).Decode(&response))
@@ -651,7 +651,7 @@ func TestOperation_AddRemoveGetGetAll(t *testing.T) {
 		rw := httptest.NewRecorder()
 
 		cmd.Remove(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 	})
 
 	t.Run("try content operations from invalid auth", func(t *testing.T) {
@@ -666,7 +666,7 @@ func TestOperation_AddRemoveGetGetAll(t *testing.T) {
 			WalletAuth:  vcwallet.WalletAuth{UserID: sampleUser1, Auth: sampleFakeTkn},
 		}))
 		cmd.Add(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 		require.Contains(t, rw.Body.String(), expectedErr)
 
 		rw = httptest.NewRecorder()
@@ -676,7 +676,7 @@ func TestOperation_AddRemoveGetGetAll(t *testing.T) {
 			WalletAuth:  vcwallet.WalletAuth{UserID: sampleUser1, Auth: sampleFakeTkn},
 		}))
 		cmd.Get(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 		require.Contains(t, rw.Body.String(), expectedErr)
 
 		rw = httptest.NewRecorder()
@@ -685,7 +685,7 @@ func TestOperation_AddRemoveGetGetAll(t *testing.T) {
 			WalletAuth:  vcwallet.WalletAuth{UserID: sampleUser1, Auth: sampleFakeTkn},
 		}))
 		cmd.GetAll(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 		require.Contains(t, rw.Body.String(), expectedErr)
 
 		rw = httptest.NewRecorder()
@@ -695,7 +695,7 @@ func TestOperation_AddRemoveGetGetAll(t *testing.T) {
 			WalletAuth:  vcwallet.WalletAuth{UserID: sampleUser1, Auth: sampleFakeTkn},
 		}))
 		cmd.Remove(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 		require.Contains(t, rw.Body.String(), expectedErr)
 	})
 }
@@ -753,7 +753,7 @@ func TestOperation_Query(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Query(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		var response map[string]interface{}
 		require.NoError(t, json.NewDecoder(rw.Body).Decode(&response))
@@ -781,7 +781,7 @@ func TestOperation_Query(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Query(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 		require.Contains(t, rw.Body.String(), "invalid auth token")
 	})
 
@@ -805,7 +805,7 @@ func TestOperation_Query(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Query(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 		require.Contains(t, rw.Body.String(), "unsupported query type")
 	})
 }
@@ -860,7 +860,7 @@ func TestOperation_IssueProveVerify(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Issue(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		credentialIssued := parseCredential(t, rw.Body)
 		require.Len(t, credentialIssued.Proofs, 1)
@@ -887,7 +887,7 @@ func TestOperation_IssueProveVerify(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Verify(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		var response verifyResponse
 		require.NoError(t, json.NewDecoder(rw.Body).Decode(&response))
@@ -906,7 +906,7 @@ func TestOperation_IssueProveVerify(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Verify(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		var response verifyResponse
 		require.NoError(t, json.NewDecoder(rw.Body).Decode(&response))
@@ -929,7 +929,7 @@ func TestOperation_IssueProveVerify(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Verify(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		var response verifyResponse
 		require.NoError(t, json.NewDecoder(rw.Body).Decode(&response))
@@ -955,7 +955,7 @@ func TestOperation_IssueProveVerify(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Prove(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		presentation = parsePresentation(t, rw.Body)
 		require.NotEmpty(t, presentation.Proofs)
@@ -979,7 +979,7 @@ func TestOperation_IssueProveVerify(t *testing.T) {
 		rw = httptest.NewRecorder()
 
 		cmd.Prove(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		presentation2 := parsePresentation(t, rw.Body)
 		require.NotEmpty(t, presentation2.Proofs)
@@ -1001,7 +1001,7 @@ func TestOperation_IssueProveVerify(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Verify(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		var response verifyResponse
 		require.NoError(t, json.NewDecoder(rw.Body).Decode(&response))
@@ -1021,7 +1021,7 @@ func TestOperation_IssueProveVerify(t *testing.T) {
 		rw = httptest.NewRecorder()
 
 		cmd.Verify(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		require.NoError(t, json.NewDecoder(rw.Body).Decode(&response))
 		require.False(t, response.Verified)
@@ -1043,7 +1043,7 @@ func TestOperation_IssueProveVerify(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Prove(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 		require.Contains(t, rw.Body.String(), "invalid auth token")
 
 		issuerRqst := &vcwallet.IssueRequest{
@@ -1058,7 +1058,7 @@ func TestOperation_IssueProveVerify(t *testing.T) {
 		rw = httptest.NewRecorder()
 
 		cmd.Issue(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 		require.Contains(t, rw.Body.String(), "wallet locked")
 	})
 }
@@ -1107,7 +1107,7 @@ func TestOperation_Derive(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Derive(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		var response deriveResponse
 		require.NoError(t, json.NewDecoder(rw.Body).Decode(&response))
@@ -1130,7 +1130,7 @@ func TestOperation_Derive(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Derive(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		var response deriveResponse
 		require.NoError(t, json.NewDecoder(rw.Body).Decode(&response))
@@ -1153,7 +1153,7 @@ func TestOperation_Derive(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Derive(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 		require.Contains(t, rw.Body.String(), "invalid auth token")
 	})
 }
@@ -1187,7 +1187,7 @@ func TestOperation_CreateKeyPair(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.CreateKeyPair(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		var r createKeyPairResponse
 		require.NoError(t, json.NewDecoder(rw.Body).Decode(&r.Response))
@@ -1208,7 +1208,7 @@ func TestOperation_CreateKeyPair(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.CreateKeyPair(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 		require.Contains(t, rw.Body.String(), "invalid auth token")
 	})
 }
@@ -1266,7 +1266,7 @@ func TestOperation_Connect(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Connect(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		var r connectResponse
 		require.NoError(t, json.NewDecoder(rw.Body).Decode(&r.Response))
@@ -1296,7 +1296,7 @@ func TestOperation_Connect(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.Connect(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 		require.Contains(t, rw.Body.String(), sampleCommandError)
 	})
 }
@@ -1389,7 +1389,7 @@ func TestOperation_ProposePresentation(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.ProposePresentation(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 
 		var r proposePresentationResponse
 		require.NoError(t, json.NewDecoder(rw.Body).Decode(&r.Response))
@@ -1417,7 +1417,7 @@ func TestOperation_ProposePresentation(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.ProposePresentation(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 		require.Contains(t, rw.Body.String(), sampleCommandError)
 	})
 }
@@ -1495,7 +1495,7 @@ func TestOperation_PresentProof(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.PresentProof(rw, rq)
-		require.Equal(t, rw.Code, http.StatusOK)
+		require.Equal(t, http.StatusOK, rw.Code)
 	})
 
 	t.Run("wallet present proof failure", func(t *testing.T) {
@@ -1518,7 +1518,7 @@ func TestOperation_PresentProof(t *testing.T) {
 
 		cmd := New(mockctx, &vcwallet.Config{})
 		cmd.PresentProof(rw, rq)
-		require.Equal(t, rw.Code, http.StatusInternalServerError)
+		require.Equal(t, http.StatusInternalServerError, rw.Code)
 		require.Contains(t, rw.Body.String(), sampleCommandError)
 	})
 }
@@ -1815,7 +1815,7 @@ func createSampleUserProfile(t *testing.T, ctx *mockprovider.Provider, request *
 	rq := httptest.NewRequest(http.MethodPost, CreateProfilePath, getReader(t, request))
 	rw := httptest.NewRecorder()
 	cmd.CreateProfile(rw, rq)
-	require.Equal(t, rw.Code, http.StatusOK)
+	require.Equal(t, http.StatusOK, rw.Code)
 }
 
 func getReader(t *testing.T, v interface{}) io.Reader {
@@ -1840,7 +1840,7 @@ func unlockWallet(t *testing.T, ctx *mockprovider.Provider, request *vcwallet.Un
 	cmd := New(ctx, &vcwallet.Config{})
 	cmd.Open(rw, rq)
 
-	require.Equal(t, rw.Code, http.StatusOK)
+	require.Equal(t, http.StatusOK, rw.Code)
 
 	return getUnlockToken(t, rw.Body), func() {
 		rq = httptest.NewRequest(http.MethodPost, ClosePath,
@@ -1855,7 +1855,7 @@ func addContent(t *testing.T, ctx *mockprovider.Provider, request *vcwallet.AddC
 
 	cmd := New(ctx, &vcwallet.Config{})
 	cmd.Add(rw, rq)
-	require.Equal(t, rw.Code, http.StatusOK)
+	require.Equal(t, http.StatusOK, rw.Code)
 }
 
 func newMockProvider(t *testing.T) *mockprovider.Provider {


### PR DESCRIPTION
Signed-off-by: Jan Christoph Ebersbach <jan-christoph.ebersbach@identinet.io>

Use the following template for your PR (make sure you follow our
[guidelines](CONTRIBUTING.md#pull-request):

**Title:**
Correct order of test arguments.

**Description:**
The order of test arguments is the wrong way around

**Summary:**

The patch swaps the order of arguments.

