### PR TITLE
refactor: endpoint as object, goal-code with underscore

### DIFF
--- a/cmd/aries-agent-mobile/pkg/wrappers/command/outofband_test.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/command/outofband_test.go
@@ -124,7 +124,7 @@ func TestOutOfBand_CreateInvitation(t *testing.T) {
 
 		mockResponse := `{"invitation":{"@id":"2429a5d3-c500-4647-9bb5-e34207bce406",
 "@type":"https://didcomm.org/out-of-band/1.0/invitation","label":"label","goal":"goal",
-"goal-code":"goal_code","service":["s1"],"protocols":["s1"]}}
+"goal_code":"goal_code","service":["s1"],"protocols":["s1"]}}
 `
 		fakeHandler := mockCommandRunner{data: []byte(mockResponse)}
 		controller.handlers[outofband.CreateInvitation] = fakeHandler.exec

--- a/cmd/aries-agent-mobile/pkg/wrappers/command/outofbandv2_test.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/command/outofbandv2_test.go
@@ -56,7 +56,7 @@ func TestOutOfBandV2_CreateInvitation(t *testing.T) {
 
 		mockResponse := `{"invitation":{"@id":"2429a5d3-c500-4647-9bb5-e34207bce406",
 "@type":"https://didcomm.org/out-of-band/2.0/invitation","label":"label","body":{
-"goal":"goal","goal-code":"goal_code","accept":["didcomm/v2"]}}}
+"goal":"goal","goal_code":"goal_code","accept":["didcomm/v2"]}}}
 `
 		fakeHandler := mockCommandRunner{data: []byte(mockResponse)}
 		controller.handlers[outofbandv2.CreateInvitation] = fakeHandler.exec

--- a/cmd/aries-agent-mobile/pkg/wrappers/rest/outofband_test.go
+++ b/cmd/aries-agent-mobile/pkg/wrappers/rest/outofband_test.go
@@ -136,7 +136,7 @@ func TestOutOfBand_CreateInvitation(t *testing.T) {
 		reqData := `{"label":"label","goal":"goal","goal_code":"goal_code","service":["s1"],"protocols":["s1"]}`
 		mockResponse := `{"invitation":{"@id":"2429a5d3-c500-4647-9bb5-e34207bce406",
 "@type":"https://didcomm.org/out-of-band/1.0/invitation","label":"label","goal":"goal",
-"goal-code":"goal_code","service":["s1"],"protocols":["s1"]}}
+"goal_code":"goal_code","service":["s1"],"protocols":["s1"]}}
 `
 
 		controller.httpClient = &mockHTTPClient{
@@ -160,7 +160,7 @@ func TestOutOfBand_CreateRequest(t *testing.T) {
 		reqData := `{"label":"label","goal":"goal","goal_code":"goal_code","service":["s1"],
 "attachments":[{"lastmod_time":"0001-01-01T00:00:00Z","data":{}}]}`
 		mockResponse := `{"invitation":{"@id":"26169718-f261-48f1-addd-67018977a89f",
-"@type":"https://didcomm.org/out-of-band/1.0/invitation","label":"label","goal":"goal","goal-code":"goal_code",
+"@type":"https://didcomm.org/out-of-band/1.0/invitation","label":"label","goal":"goal","goal_code":"goal_code",
 "request~attach":[{"lastmod_time":"0001-01-01T00:00:00Z","data":{}}],"service":["s1"]}}`
 
 		controller.httpClient = &mockHTTPClient{

--- a/pkg/client/connection/client.go
+++ b/pkg/client/connection/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/middleware"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/peerdid"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
@@ -105,15 +106,18 @@ func (c *Client) CreateConnectionV2(myDID, theirDID string, opts ...CreateConnec
 	connID := uuid.New().String()
 
 	connRec := connection.Record{
-		ConnectionID:    connID,
-		State:           connection.StateNameCompleted,
-		TheirDID:        theirDID,
-		MyDID:           myDID,
-		ServiceEndPoint: destination.ServiceEndpoint,
-		RecipientKeys:   destination.RecipientKeys,
-		RoutingKeys:     destination.RoutingKeys,
-		Namespace:       connection.MyNSPrefix,
-		DIDCommVersion:  service.V2,
+		ConnectionID: connID,
+		State:        connection.StateNameCompleted,
+		TheirDID:     theirDID,
+		MyDID:        myDID,
+		ServiceEndPoint: model.Endpoint{
+			URI:         destination.ServiceEndpoint.URI,
+			Accept:      destination.ServiceEndpoint.Accept,
+			RoutingKeys: destination.ServiceEndpoint.RoutingKeys,
+		},
+		RecipientKeys:  destination.RecipientKeys,
+		Namespace:      connection.MyNSPrefix,
+		DIDCommVersion: service.V2,
 	}
 
 	for _, opt := range opts {

--- a/pkg/client/didexchange/client.go
+++ b/pkg/client/didexchange/client.go
@@ -437,7 +437,6 @@ func (c *Client) CreateConnection(myDID string, theirDID *did.Doc, options ...Co
 
 	conn.ServiceEndPoint = destination.ServiceEndpoint
 	conn.RecipientKeys = destination.RecipientKeys
-	conn.RoutingKeys = destination.RoutingKeys
 
 	err = c.didexchangeSvc.CreateConnection(conn.Record, theirDID)
 	if err != nil {

--- a/pkg/client/didexchange/client_test.go
+++ b/pkg/client/didexchange/client_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
@@ -772,13 +773,13 @@ func TestClient_CreateConnection(t *testing.T) {
 		require.NoError(t, err)
 
 		// empty ServiceEndpoint to trigger CreateDestination error
-		theirDID.Service[0].ServiceEndpoint = ""
+		theirDID.Service[0].ServiceEndpoint.URI = ""
 
 		_, err = c.CreateConnection(myDID.ID, theirDID,
 			WithTheirLabel(label), WithThreadID(threadID), WithParentThreadID(parentThreadID),
 			WithInvitationID(invitationID), WithInvitationDID(invitationDID), WithImplicit(implicit))
 		require.Contains(t, err.Error(), "createConnection: failed to create destination: "+
-			"create destination: no service endpoint on didcomm service block in diddoc:")
+			"create destination: no service endpoint URI on didcomm service block in diddoc:")
 	})
 }
 
@@ -1515,7 +1516,7 @@ func newPeerDID(t *testing.T) *did.Doc {
 	d, err := ctx.VDRegistry().Create(
 		peer.DIDMethod, &did.Doc{Service: []did.Service{{
 			Type:            "did-communication",
-			ServiceEndpoint: "http://agent.example.com/didcomm",
+			ServiceEndpoint: model.Endpoint{URI: "http://agent.example.com/didcomm"},
 		}}, VerificationMethod: []did.VerificationMethod{getSigningKey()}})
 	require.NoError(t, err)
 

--- a/pkg/client/messaging/client_test.go
+++ b/pkg/client/messaging/client_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
@@ -171,9 +172,11 @@ func TestCommand_Send(t *testing.T) { // nolint: gocognit, gocyclo
 			{
 				name: "send message to destination",
 				option: SendByDestination(&service.Destination{
-					RecipientKeys:   []string{"test"},
-					ServiceEndpoint: "sdfsdf",
-					RoutingKeys:     []string{"test"},
+					RecipientKeys: []string{"test"},
+					ServiceEndpoint: model.Endpoint{
+						URI:         "sdfsdf",
+						RoutingKeys: []string{"test"},
+					},
 				}),
 			},
 		}
@@ -266,9 +269,11 @@ func TestCommand_Send(t *testing.T) { // nolint: gocognit, gocyclo
 				name: "send message to destination",
 				option: []SendMessageOpions{
 					SendByDestination(&service.Destination{
-						RecipientKeys:   []string{"test"},
-						ServiceEndpoint: "sdfsdf",
-						RoutingKeys:     []string{"test"},
+						RecipientKeys: []string{"test"},
+						ServiceEndpoint: model.Endpoint{
+							URI:         "sdfsdf",
+							RoutingKeys: []string{"test"},
+						},
 					}),
 					WaitForResponse(context.Background(), "sample-response-type"),
 				},
@@ -417,9 +422,11 @@ func TestCommand_Send(t *testing.T) { // nolint: gocognit, gocyclo
 			{
 				name: "send message to destination - failure 1",
 				option: SendByDestination(&service.Destination{
-					RecipientKeys:   []string{"test"},
-					ServiceEndpoint: "sdfsdf",
-					RoutingKeys:     []string{"test"},
+					RecipientKeys: []string{"test"},
+					ServiceEndpoint: model.Endpoint{
+						URI:         "sdfsdf",
+						RoutingKeys: []string{"test"},
+					},
 				}),
 				messenger: &mocksvc.MockMessenger{ErrSendToDestination: fmt.Errorf("sample-err-01")},
 				errorMsg:  "sample-err-01",
@@ -428,9 +435,11 @@ func TestCommand_Send(t *testing.T) { // nolint: gocognit, gocyclo
 				name: "send message to destination - failure 2",
 				kms:  &mockkms.KeyManager{CrAndExportPubKeyErr: fmt.Errorf("sample-kmserr-01")},
 				option: SendByDestination(&service.Destination{
-					RecipientKeys:   []string{"test"},
-					ServiceEndpoint: "sdfsdf",
-					RoutingKeys:     []string{"test"},
+					RecipientKeys: []string{"test"},
+					ServiceEndpoint: model.Endpoint{
+						URI:         "sdfsdf",
+						RoutingKeys: []string{"test"},
+					},
 				}),
 				errorMsg: "sample-kmserr-01",
 			},

--- a/pkg/client/outofband/client.go
+++ b/pkg/client/outofband/client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
@@ -417,7 +418,7 @@ func (c *Client) didServiceBlockFunc(p Provider) func(routerConnID string, accep
 				ID:              uuid.New().String(),
 				Type:            didCommServiceType,
 				RecipientKeys:   []string{didKey},
-				ServiceEndpoint: p.ServiceEndpoint(),
+				ServiceEndpoint: model.Endpoint{URI: p.ServiceEndpoint()},
 			}, nil
 		}
 
@@ -432,11 +433,13 @@ func (c *Client) didServiceBlockFunc(p Provider) func(routerConnID string, accep
 		}
 
 		return &did.Service{
-			ID:              uuid.New().String(),
-			Type:            didCommServiceType,
-			RecipientKeys:   []string{didKey},
-			RoutingKeys:     routingKeys,
-			ServiceEndpoint: serviceEndpoint,
+			ID:            uuid.New().String(),
+			Type:          didCommServiceType,
+			RecipientKeys: []string{didKey},
+			ServiceEndpoint: model.Endpoint{
+				URI:         serviceEndpoint,
+				RoutingKeys: routingKeys,
+			},
 		}, nil
 	}
 }

--- a/pkg/client/outofband/client_test.go
+++ b/pkg/client/outofband/client_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	commonmodel "github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
@@ -74,13 +75,15 @@ func TestCreateInvitation(t *testing.T) {
 	})
 	t.Run("includes the diddoc Service block returned by provider", func(t *testing.T) {
 		expected := &did.Service{
-			ID:              uuid.New().String(),
-			Type:            uuid.New().String(),
-			Priority:        0,
-			RecipientKeys:   []string{uuid.New().String()},
-			RoutingKeys:     []string{uuid.New().String()},
-			ServiceEndpoint: uuid.New().String(),
-			Properties:      nil,
+			ID:            uuid.New().String(),
+			Type:          uuid.New().String(),
+			Priority:      0,
+			RecipientKeys: []string{uuid.New().String()},
+			ServiceEndpoint: commonmodel.Endpoint{
+				URI:         uuid.New().String(),
+				RoutingKeys: []string{uuid.New().String()},
+			},
+			Properties: nil,
 		}
 		c, err := New(withTestProvider())
 		require.NoError(t, err)
@@ -134,12 +137,18 @@ func TestCreateInvitation(t *testing.T) {
 				serviceType = vdr.DIDCommServiceType
 			}
 
-			return &did.Service{ServiceEndpoint: expectedConn, Type: serviceType}, nil
+			return &did.Service{
+				ServiceEndpoint: commonmodel.Endpoint{
+					URI:    expectedConn,
+					Accept: accept,
+				},
+				Type: serviceType,
+			}, nil
 		}
 
 		inv, err := c.CreateInvitation(nil, WithRouterConnections(expectedConn))
 		require.NoError(t, err)
-		require.Equal(t, expectedConn, inv.Services[0].(*did.Service).ServiceEndpoint)
+		require.Equal(t, expectedConn, inv.Services[0].(*did.Service).ServiceEndpoint.URI)
 	})
 	t.Run("WithGoal", func(t *testing.T) {
 		c, err := New(withTestProvider())
@@ -155,13 +164,15 @@ func TestCreateInvitation(t *testing.T) {
 		c, err := New(withTestProvider())
 		require.NoError(t, err)
 		expected := &did.Service{
-			ID:              uuid.New().String(),
-			Type:            uuid.New().String(),
-			Priority:        0,
-			RecipientKeys:   []string{uuid.New().String()},
-			RoutingKeys:     []string{uuid.New().String()},
-			ServiceEndpoint: uuid.New().String(),
-			Properties:      nil,
+			ID:            uuid.New().String(),
+			Type:          uuid.New().String(),
+			Priority:      0,
+			RecipientKeys: []string{uuid.New().String()},
+			ServiceEndpoint: commonmodel.Endpoint{
+				URI:         uuid.New().String(),
+				RoutingKeys: []string{uuid.New().String()},
+			},
+			Properties: nil,
 		}
 		inv, err := c.CreateInvitation([]interface{}{expected})
 		require.NoError(t, err)
@@ -182,13 +193,15 @@ func TestCreateInvitation(t *testing.T) {
 		require.NoError(t, err)
 		didRef := "did:example:234"
 		svc := &did.Service{
-			ID:              uuid.New().String(),
-			Type:            uuid.New().String(),
-			Priority:        0,
-			RecipientKeys:   []string{uuid.New().String()},
-			RoutingKeys:     []string{uuid.New().String()},
-			ServiceEndpoint: uuid.New().String(),
-			Properties:      nil,
+			ID:            uuid.New().String(),
+			Type:          uuid.New().String(),
+			Priority:      0,
+			RecipientKeys: []string{uuid.New().String()},
+			ServiceEndpoint: commonmodel.Endpoint{
+				URI:         uuid.New().String(),
+				RoutingKeys: []string{uuid.New().String()},
+			},
+			Properties: nil,
 		}
 		inv, err := c.CreateInvitation([]interface{}{svc, didRef})
 		require.NoError(t, err)

--- a/pkg/common/model/endpoint.go
+++ b/pkg/common/model/endpoint.go
@@ -1,0 +1,17 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package model
+
+// Endpoint contains endpoint specific content.
+type Endpoint struct {
+	// URI contains the endpoint URI.
+	URI string `json:"uri"`
+	// Accept contains the MediaType profiles accepted by this endpoint.
+	Accept []string `json:"accept,omitempty"`
+	// RoutingKeys contains the list of keys trusted as routing keys for the mediators/routers of this endpoint.
+	RoutingKeys []string `json:"routingKeys,omitempty"`
+}

--- a/pkg/controller/command/didexchange/command_test.go
+++ b/pkg/controller/command/didexchange/command_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
 	mockwebhook "github.com/hyperledger/aries-framework-go/pkg/controller/internal/mocks/webhook"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/webnotifier"
@@ -988,8 +989,10 @@ func newPeerDID(t *testing.T) *did.Doc {
 
 	d, err := ctx.VDRegistry().Create(
 		peer.DIDMethod, &did.Doc{Service: []did.Service{{
-			Type:            vdr.DIDCommServiceType,
-			ServiceEndpoint: "http://agent.example.com/didcomm",
+			Type: vdr.DIDCommServiceType,
+			ServiceEndpoint: model.Endpoint{
+				URI: "http://agent.example.com/didcomm",
+			},
 		}}, VerificationMethod: []did.VerificationMethod{getSigningKey()}},
 	)
 	require.NoError(t, err)

--- a/pkg/controller/command/messaging/command.go
+++ b/pkg/controller/command/messaging/command.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/client/messaging"
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/internal/cmdutil"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
@@ -187,9 +188,11 @@ func (o *Command) Send(rw io.Writer, req io.Reader) command.Error {
 	var destination *service.Destination
 	if request.ServiceEndpointDestination != nil {
 		destination = &service.Destination{
-			RoutingKeys:     request.ServiceEndpointDestination.RoutingKeys,
-			ServiceEndpoint: request.ServiceEndpointDestination.ServiceEndpoint,
-			RecipientKeys:   request.ServiceEndpointDestination.RecipientKeys,
+			ServiceEndpoint: model.Endpoint{
+				URI:         request.ServiceEndpointDestination.ServiceEndpoint,
+				RoutingKeys: request.ServiceEndpointDestination.RoutingKeys,
+			},
+			RecipientKeys: request.ServiceEndpointDestination.RecipientKeys,
 		}
 	}
 

--- a/pkg/controller/rest/didexchange/operation_test.go
+++ b/pkg/controller/rest/didexchange/operation_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/command/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/rest"
@@ -580,8 +581,10 @@ func newPeerDID(t *testing.T) *did.Doc {
 
 	d, err := ctx.VDRegistry().Create(
 		peer.DIDMethod, &did.Doc{Service: []did.Service{{
-			Type:            vdr.DIDCommServiceType,
-			ServiceEndpoint: "http://agent.example.com/didcomm",
+			Type: vdr.DIDCommServiceType,
+			ServiceEndpoint: model.Endpoint{
+				URI: "http://agent.example.com/didcomm",
+			},
 		}}, VerificationMethod: []did.VerificationMethod{getSigningKey()}},
 	)
 	require.NoError(t, err)

--- a/pkg/didcomm/common/middleware/middleware.go
+++ b/pkg/didcomm/common/middleware/middleware.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto"
 	didcomm "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
@@ -216,14 +217,16 @@ func (h *DIDCommMessageMiddleware) handleInboundInvitationAcceptance(senderDID, 
 	// if we created an invitation with this DID, and have no connection, we create a connection.
 
 	rec = &connection.Record{
-		ConnectionID:      uuid.New().String(),
-		MyDID:             recipientDID,
-		TheirDID:          senderDID,
-		InvitationID:      inv.ID,
-		State:             connection.StateNameCompleted,
-		Namespace:         connection.MyNSPrefix,
-		MediaTypeProfiles: h.mediaTypeProfiles,
-		DIDCommVersion:    didcomm.V2,
+		ConnectionID: uuid.New().String(),
+		MyDID:        recipientDID,
+		TheirDID:     senderDID,
+		InvitationID: inv.ID,
+		State:        connection.StateNameCompleted,
+		Namespace:    connection.MyNSPrefix,
+		ServiceEndPoint: model.Endpoint{
+			Accept: h.mediaTypeProfiles,
+		},
+		DIDCommVersion: didcomm.V2,
 	}
 
 	err = h.connStore.SaveConnectionRecord(rec)

--- a/pkg/didcomm/common/service/destination.go
+++ b/pkg/didcomm/common/service/destination.go
@@ -9,6 +9,7 @@ package service
 import (
 	"fmt"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	vdrapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
 )
@@ -16,10 +17,8 @@ import (
 // Destination provides the recipientKeys, routingKeys, and serviceEndpoint for an outbound message.
 type Destination struct {
 	RecipientKeys        []string
-	ServiceEndpoint      string
-	RoutingKeys          []string
+	ServiceEndpoint      model.Endpoint
 	TransportReturnRoute string
-	MediaTypeProfiles    []string
 	DIDDoc               *did.Doc
 }
 

--- a/pkg/didcomm/common/service/destination_test.go
+++ b/pkg/didcomm/common/service/destination_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	mockdiddoc "github.com/hyperledger/aries-framework-go/pkg/mock/diddoc"
 	mockvdr "github.com/hyperledger/aries-framework-go/pkg/mock/vdr"
@@ -85,7 +86,7 @@ func TestGetDestinationFromDID(t *testing.T) {
 	t.Run("fails if the service endpoint is missing", func(t *testing.T) {
 		diddoc := createDIDDoc()
 		for i := range diddoc.Service {
-			diddoc.Service[i].ServiceEndpoint = ""
+			diddoc.Service[i].ServiceEndpoint.URI = ""
 		}
 		vdr := &mockvdr.MockVDRegistry{ResolveValue: diddoc}
 		_, err := GetDestination(diddoc.ID, vdr)
@@ -117,8 +118,8 @@ func TestPrepareDestination(t *testing.T) {
 		dest, err := CreateDestination(doc)
 		require.NoError(t, err)
 		require.NotNil(t, dest)
-		require.Equal(t, dest.ServiceEndpoint, "https://localhost:8090")
-		require.Equal(t, doc.Service[0].RoutingKeys, dest.RoutingKeys)
+		require.Equal(t, dest.ServiceEndpoint.URI, "https://localhost:8090")
+		require.EqualValues(t, doc.Service[0].ServiceEndpoint.RoutingKeys, dest.ServiceEndpoint.RoutingKeys)
 	})
 
 	t.Run("error with destination having recipientKeys not did:keys", func(t *testing.T) {
@@ -182,11 +183,15 @@ func createDIDDocWithKey(pub string) *did.Doc {
 	}
 	services := []did.Service{
 		{
-			ID:              fmt.Sprintf(didServiceID, id, 1),
-			Type:            "did-communication",
-			ServiceEndpoint: "http://localhost:58416",
-			Priority:        0,
-			RecipientKeys:   []string{pubKeyID},
+			ID:   fmt.Sprintf(didServiceID, id, 1),
+			Type: "did-communication",
+			ServiceEndpoint: model.Endpoint{
+				URI:         "http://localhost:58416",
+				Accept:      nil,
+				RoutingKeys: nil,
+			},
+			Priority:      0,
+			RecipientKeys: []string{pubKeyID},
 		},
 	}
 	createdTime := time.Now()

--- a/pkg/didcomm/dispatcher/outbound/outbound_test.go
+++ b/pkg/didcomm/dispatcher/outbound/outbound_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/middleware"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
@@ -56,7 +57,9 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			mediaTypeProfiles:       []string{transport.MediaTypeV1PlaintextPayload},
 		})
 		require.NoError(t, err)
-		require.NoError(t, o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"}))
+		require.NoError(t, o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{
+			ServiceEndpoint: model.Endpoint{URI: "url"},
+		}))
 	})
 
 	t.Run("test success", func(t *testing.T) {
@@ -73,9 +76,11 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 		toDIDDoc := mockdiddoc.GetMockDIDDocWithDIDCommV2Bloc(t, "bob")
 
 		require.NoError(t, o.Send("data", fromDIDDoc.KeyAgreement[0].VerificationMethod.ID, &service.Destination{
-			RecipientKeys:     []string{toDIDDoc.KeyAgreement[0].VerificationMethod.ID},
-			ServiceEndpoint:   "url",
-			MediaTypeProfiles: []string{transport.MediaTypeDIDCommV2Profile},
+			RecipientKeys: []string{toDIDDoc.KeyAgreement[0].VerificationMethod.ID},
+			ServiceEndpoint: model.Endpoint{
+				URI:    "url",
+				Accept: []string{transport.MediaTypeDIDCommV2Profile},
+			},
 		}))
 	})
 
@@ -88,7 +93,9 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			mediaTypeProfiles:       []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
-		err = o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"})
+		err = o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{
+			ServiceEndpoint: model.Endpoint{URI: "url"},
+		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "outboundDispatcher.Send: no transport found for destination")
 	})
@@ -102,7 +109,9 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			mediaTypeProfiles:       []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
-		err = o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"})
+		err = o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{
+			ServiceEndpoint: model.Endpoint{URI: "url"},
+		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "pack error")
 	})
@@ -118,7 +127,8 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 			mediaTypeProfiles:    []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
-		err = o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"})
+		err = o.Send("data", mockdiddoc.MockDIDKey(t),
+			&service.Destination{ServiceEndpoint: model.Endpoint{URI: "url"}})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "send error")
 	})
@@ -134,9 +144,11 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{
-			ServiceEndpoint: "url",
-			RecipientKeys:   []string{"abc"},
-			RoutingKeys:     []string{"xyz"},
+			ServiceEndpoint: model.Endpoint{
+				URI:         "url",
+				RoutingKeys: []string{"xyz"},
+			},
+			RecipientKeys: []string{"abc"},
 		}))
 	})
 
@@ -155,9 +167,11 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{
-			ServiceEndpoint: "url",
-			RecipientKeys:   []string{"abc"},
-			RoutingKeys:     []string{"xyz"},
+			ServiceEndpoint: model.Endpoint{
+				URI:         "url",
+				RoutingKeys: []string{"xyz"},
+			},
+			RecipientKeys: []string{"abc"},
 		}))
 	})
 
@@ -175,9 +189,11 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 		require.NoError(t, err)
 
 		err = o.Send("data", mockdiddoc.MockDIDKey(t), &service.Destination{
-			ServiceEndpoint: "url",
-			RecipientKeys:   []string{"abc"},
-			RoutingKeys:     []string{"xyz"},
+			ServiceEndpoint: model.Endpoint{
+				URI:         "url",
+				RoutingKeys: []string{"xyz"},
+			},
+			RecipientKeys: []string{"abc"},
 		})
 		require.EqualError(t, err, "outboundDispatcher.Send: failed to create forward msg: failed Create "+
 			"and export Encryption Key: create and export key error")
@@ -194,9 +210,11 @@ func TestOutboundDispatcher_Send(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = o.createForwardMessage(createPackedMsgForForward(t), &service.Destination{
-			ServiceEndpoint: "url",
-			RecipientKeys:   []string{"abc"},
-			RoutingKeys:     []string{"xyz"},
+			ServiceEndpoint: model.Endpoint{
+				URI:         "url",
+				RoutingKeys: []string{"xyz"},
+			},
+			RecipientKeys: []string{"abc"},
 		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "pack forward msg")
@@ -536,7 +554,8 @@ func TestOutboundDispatcherTransportReturnRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		require.NoError(t, o.Send(req, mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"}))
+		require.NoError(t, o.Send(req, mockdiddoc.MockDIDKey(t),
+			&service.Destination{ServiceEndpoint: model.Endpoint{URI: "url"}}))
 	})
 
 	t.Run("transport route option - value set thread", func(t *testing.T) {
@@ -570,7 +589,8 @@ func TestOutboundDispatcherTransportReturnRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		require.NoError(t, o.Send(req, mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"}))
+		require.NoError(t, o.Send(req, mockdiddoc.MockDIDKey(t),
+			&service.Destination{ServiceEndpoint: model.Endpoint{URI: "url"}}))
 	})
 
 	t.Run("transport route option - no value set", func(t *testing.T) {
@@ -596,7 +616,8 @@ func TestOutboundDispatcherTransportReturnRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		require.NoError(t, o.Send(req, mockdiddoc.MockDIDKey(t), &service.Destination{ServiceEndpoint: "url"}))
+		require.NoError(t, o.Send(req, mockdiddoc.MockDIDKey(t),
+			&service.Destination{ServiceEndpoint: model.Endpoint{URI: "url"}}))
 	})
 
 	t.Run("transport route option - forward message", func(t *testing.T) {
@@ -612,7 +633,8 @@ func TestOutboundDispatcherTransportReturnRoute(t *testing.T) {
 
 		testData := []byte("testData")
 
-		data, err := o.addTransportRouteOptions(testData, &service.Destination{RoutingKeys: []string{"abc"}})
+		data, err := o.addTransportRouteOptions(testData,
+			&service.Destination{ServiceEndpoint: model.Endpoint{RoutingKeys: []string{"abc"}}})
 		require.NoError(t, err)
 		require.Equal(t, testData, data)
 	})
@@ -628,7 +650,7 @@ func TestOutboundDispatcher_Forward(t *testing.T) {
 			mediaTypeProfiles:       []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
-		require.NoError(t, o.Forward("data", &service.Destination{ServiceEndpoint: "url"}))
+		require.NoError(t, o.Forward("data", &service.Destination{ServiceEndpoint: model.Endpoint{URI: "url"}}))
 	})
 
 	t.Run("test forward - no outbound transport found", func(t *testing.T) {
@@ -640,7 +662,7 @@ func TestOutboundDispatcher_Forward(t *testing.T) {
 			mediaTypeProfiles:       []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
-		err = o.Forward("data", &service.Destination{ServiceEndpoint: "url"})
+		err = o.Forward("data", &service.Destination{ServiceEndpoint: model.Endpoint{URI: "url"}})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "outboundDispatcher.Forward: no transport found for serviceEndpoint: url")
 	})
@@ -656,7 +678,7 @@ func TestOutboundDispatcher_Forward(t *testing.T) {
 			mediaTypeProfiles:    []string{transport.MediaTypeDIDCommV2Profile},
 		})
 		require.NoError(t, err)
-		err = o.Forward("data", &service.Destination{ServiceEndpoint: "url"})
+		err = o.Forward("data", &service.Destination{ServiceEndpoint: model.Endpoint{URI: "url"}})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "send error")
 	})

--- a/pkg/didcomm/protocol/didexchange/service.go
+++ b/pkg/didcomm/protocol/didexchange/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
@@ -737,17 +738,19 @@ func (s *Service) oobInvitationMsgRecord(msg service.DIDCommMsg) (*connection.Re
 	}
 
 	connRecord := &connection.Record{
-		ConnectionID:      generateRandomID(),
-		ThreadID:          thID,
-		ParentThreadID:    oobInvitation.ThreadID,
-		State:             stateNameNull,
-		InvitationID:      oobInvitation.ID,
-		ServiceEndPoint:   svc.ServiceEndpoint, // TODO: service endpoint should be 'theirs' not 'mine'.
-		RecipientKeys:     svc.RecipientKeys,   // TODO: recipient keys should be 'theirs' not 'mine'.
-		TheirLabel:        oobInvitation.TheirLabel,
-		Namespace:         findNamespace(msg.Type()),
-		MediaTypeProfiles: svc.Accept,
-		DIDCommVersion:    service.V1,
+		ConnectionID:   generateRandomID(),
+		ThreadID:       thID,
+		ParentThreadID: oobInvitation.ThreadID,
+		State:          stateNameNull,
+		InvitationID:   oobInvitation.ID,
+		ServiceEndPoint: model.Endpoint{
+			URI:    svc.ServiceEndpoint.URI, // TODO: service endpoint should be 'theirs' not 'mine'.
+			Accept: svc.ServiceEndpoint.Accept,
+		},
+		RecipientKeys:  svc.RecipientKeys, // TODO: recipient keys should be 'theirs' not 'mine'.
+		TheirLabel:     oobInvitation.TheirLabel,
+		Namespace:      findNamespace(msg.Type()),
+		DIDCommVersion: service.V1,
 	}
 
 	publicDID, ok := oobInvitation.Target.(string)
@@ -782,16 +785,20 @@ func (s *Service) invitationMsgRecord(msg service.DIDCommMsg) (*connection.Recor
 	}
 
 	connRecord := &connection.Record{
-		ConnectionID:    generateRandomID(),
-		ThreadID:        thID,
-		State:           stateNameNull,
-		InvitationID:    invitation.ID,
-		InvitationDID:   invitation.DID,
-		ServiceEndPoint: invitation.ServiceEndpoint,
-		RecipientKeys:   []string{recKey},
-		TheirLabel:      invitation.Label,
-		Namespace:       findNamespace(msg.Type()),
-		DIDCommVersion:  service.V1,
+		ConnectionID:  generateRandomID(),
+		ThreadID:      thID,
+		State:         stateNameNull,
+		InvitationID:  invitation.ID,
+		InvitationDID: invitation.DID,
+		ServiceEndPoint: model.Endpoint{
+			URI:         invitation.ServiceEndpoint,
+			Accept:      nil,
+			RoutingKeys: nil,
+		},
+		RecipientKeys:  []string{recKey},
+		TheirLabel:     invitation.Label,
+		Namespace:      findNamespace(msg.Type()),
+		DIDCommVersion: service.V1,
 	}
 
 	if err := s.connectionRecorder.SaveConnectionRecord(connRecord); err != nil {

--- a/pkg/didcomm/protocol/didexchange/service_test.go
+++ b/pkg/didcomm/protocol/didexchange/service_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	commonmodel "github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
@@ -405,7 +406,7 @@ func TestService_Handle_Invitee(t *testing.T) {
 	require.Equal(t, (&requested{}).Name(), connRecord.State)
 	require.Equal(t, invitation.ID, connRecord.InvitationID)
 	require.Equal(t, invitation.RecipientKeys, connRecord.RecipientKeys)
-	require.Equal(t, invitation.ServiceEndpoint, connRecord.ServiceEndPoint)
+	require.Equal(t, invitation.ServiceEndpoint, connRecord.ServiceEndPoint.URI)
 
 	didKey, err := ctx.getVerKey(invitation.ID)
 	require.NoError(t, err)
@@ -693,7 +694,7 @@ func TestCreateConnection(t *testing.T) {
 			TheirLabel:      uuid.New().String(),
 			TheirDID:        theirDID.ID,
 			MyDID:           newPeerDID(t, k).ID,
-			ServiceEndPoint: "http://example.com",
+			ServiceEndPoint: commonmodel.Endpoint{URI: "http://example.com"},
 			RecipientKeys:   []string{"testkeys"},
 			InvitationID:    uuid.New().String(),
 			Namespace:       myNSPrefix,
@@ -2182,7 +2183,7 @@ func TestRespondTo(t *testing.T) {
 			ID:              uuid.New().String(),
 			Type:            "did-communication",
 			RecipientKeys:   []string{"did:key:1234567"},
-			ServiceEndpoint: "http://example.com",
+			ServiceEndpoint: commonmodel.Endpoint{URI: "http://example.com"},
 		}), nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, connID)
@@ -2323,7 +2324,7 @@ func newPeerDID(t *testing.T, k kms.KeyManager) *did.Doc {
 			Type:            "did-communication",
 			Priority:        0,
 			RecipientKeys:   []string{base58.Encode(pubKey)},
-			ServiceEndpoint: "http://example.com",
+			ServiceEndpoint: commonmodel.Endpoint{URI: "http://example.com"},
 		}}),
 	)
 	require.NoError(t, err)

--- a/pkg/didcomm/protocol/introduce/models.go
+++ b/pkg/didcomm/protocol/introduce/models.go
@@ -17,7 +17,7 @@ type Proposal struct {
 	Thread   *decorator.Thread `json:"~thread,omitempty"`
 	Timing   *decorator.Timing `json:"~timing,omitempty"`
 	Goal     string            `json:"goal,omitempty"`
-	GoalCode string            `json:"goal-code,omitempty"`
+	GoalCode string            `json:"goal_code,omitempty"`
 }
 
 // To introducee descriptor keeps information about the introduction

--- a/pkg/didcomm/protocol/issuecredential/params_test.go
+++ b/pkg/didcomm/protocol/issuecredential/params_test.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	commentText   = "this is a comment"
-	goalCodeText  = "goal-code"
+	goalCodeText  = "goal_code"
 	messageIDText = "message-id-123"
 )
 
@@ -47,7 +47,7 @@ func previewCredV3(t *testing.T) map[string]interface{} {
 		Type: CredentialPreviewMsgTypeV3,
 		ID:   "bar-baz-qux",
 		Body: IssueCredentialV3Body{
-			GoalCode:      "goal-code",
+			GoalCode:      "goal_code",
 			ReplacementID: "blah-id",
 			Comment:       commentText,
 		},

--- a/pkg/didcomm/protocol/outofband/service_test.go
+++ b/pkg/didcomm/protocol/outofband/service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	commonmodel "github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
@@ -977,12 +978,14 @@ func TestChooseTarget(t *testing.T) {
 	})
 	t.Run("chooses a did service entry", func(t *testing.T) {
 		expected := &did.Service{
-			ID:              uuid.New().String(),
-			Type:            "did-communication",
-			Priority:        0,
-			RecipientKeys:   []string{"my ver key"},
-			RoutingKeys:     []string{"my routing key"},
-			ServiceEndpoint: "my service endpoint",
+			ID:            uuid.New().String(),
+			Type:          "did-communication",
+			Priority:      0,
+			RecipientKeys: []string{"my ver key"},
+			ServiceEndpoint: commonmodel.Endpoint{
+				URI:         "my service endpoint",
+				RoutingKeys: []string{"my routing key"},
+			},
 		}
 		result, err := chooseTarget([]interface{}{expected})
 		require.NoError(t, err)
@@ -990,12 +993,14 @@ func TestChooseTarget(t *testing.T) {
 	})
 	t.Run("chooses a map-type service", func(t *testing.T) {
 		expected := map[string]interface{}{
-			"id":              uuid.New().String(),
-			"type":            "did-communication",
-			"priority":        uint(0),
-			"recipientKeys":   []string{"my ver key"},
-			"routingKeys":     []string{"my routing key"},
-			"serviceEndpoint": "my service endpoint",
+			"id":            uuid.New().String(),
+			"type":          "did-communication",
+			"priority":      uint(0),
+			"recipientKeys": []string{"my ver key"},
+			"serviceEndpoint": commonmodel.Endpoint{
+				URI:         "my service endpoint",
+				RoutingKeys: []string{"my routing key"},
+			},
 		}
 		svc, err := chooseTarget([]interface{}{expected})
 		require.NoError(t, err)
@@ -1005,7 +1010,6 @@ func TestChooseTarget(t *testing.T) {
 		require.Equal(t, expected["type"], result.Type)
 		require.Equal(t, expected["priority"], result.Priority)
 		require.Equal(t, expected["recipientKeys"], result.RecipientKeys)
-		require.Equal(t, expected["routingKeys"], result.RoutingKeys)
 		require.Equal(t, expected["serviceEndpoint"], result.ServiceEndpoint)
 	})
 	t.Run("fails if not services are specified", func(t *testing.T) {

--- a/pkg/didcomm/protocol/outofbandv2/models.go
+++ b/pkg/didcomm/protocol/outofbandv2/models.go
@@ -21,6 +21,6 @@ type Invitation struct {
 // InvitationBody contains invitation's goal and accept headers.
 type InvitationBody struct {
 	Goal     string   `json:"goal,omitempty"`
-	GoalCode string   `json:"goal-code,omitempty"`
+	GoalCode string   `json:"goal_code,omitempty"`
 	Accept   []string `json:"accept,omitempty"`
 }

--- a/pkg/didcomm/protocol/outofbandv2/service.go
+++ b/pkg/didcomm/protocol/outofbandv2/service.go
@@ -16,6 +16,7 @@ import (
 	gojose "github.com/square/go-jose/v3"
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
@@ -267,10 +268,13 @@ func (s *Service) AcceptInvitation(i *Invitation, opts ...AcceptOption) (string,
 		}
 
 		services = append(services, did.Service{
-			ServiceEndpoint: serviceEndpoint,
-			RecipientKeys:   []string{recKey},
-			RoutingKeys:     routingKeys,
-			Type:            vdrapi.DIDCommV2ServiceType,
+			ServiceEndpoint: model.Endpoint{
+				URI:         serviceEndpoint,
+				Accept:      s.myMediaTypeProfiles,
+				RoutingKeys: routingKeys,
+			},
+			RecipientKeys: []string{recKey},
+			Type:          vdrapi.DIDCommV2ServiceType,
 		})
 	}
 
@@ -340,12 +344,10 @@ func (s *Service) AcceptInvitation(i *Invitation, opts ...AcceptOption) (string,
 		InvitationID:        i.ID,
 		ServiceEndPoint:     destination.ServiceEndpoint,
 		RecipientKeys:       destination.RecipientKeys,
-		RoutingKeys:         destination.RoutingKeys,
 		TheirLabel:          i.Label,
 		TheirDID:            i.From,
 		MyDID:               myDID.DIDDocument.ID,
 		Namespace:           connection.MyNSPrefix,
-		MediaTypeProfiles:   s.myMediaTypeProfiles,
 		Implicit:            true,
 		InvitationDID:       myDID.DIDDocument.ID,
 		DIDCommVersion:      service.V2,

--- a/pkg/didcomm/protocol/outofbandv2/service_test.go
+++ b/pkg/didcomm/protocol/outofbandv2/service_test.go
@@ -280,8 +280,8 @@ func TestAcceptInvitation(t *testing.T) {
 		docSvc, ok := did.LookupService(createdDoc, vdrapi.DIDCommV2ServiceType)
 		require.True(t, ok)
 
-		require.Len(t, docSvc.RoutingKeys, 1)
-		require.Equal(t, testKey, docSvc.RoutingKeys[0])
+		require.Len(t, docSvc.ServiceEndpoint.RoutingKeys, 1)
+		require.Equal(t, testKey, docSvc.ServiceEndpoint.RoutingKeys[0])
 	})
 
 	t.Run("error fetching mediator config", func(t *testing.T) {

--- a/pkg/didcomm/transport/http/outbound.go
+++ b/pkg/didcomm/transport/http/outbound.go
@@ -92,7 +92,7 @@ func (cs *OutboundHTTPClient) Start(prov transport.Provider) error {
 
 // Send sends a2a exchange data via HTTP (client side).
 func (cs *OutboundHTTPClient) Send(data []byte, destination *service.Destination) (string, error) {
-	resp, err := cs.client.Post(destination.ServiceEndpoint, commContentType, bytes.NewBuffer(data))
+	resp, err := cs.client.Post(destination.ServiceEndpoint.URI, commContentType, bytes.NewBuffer(data))
 	if err != nil {
 		logger.Errorf("posting DID envelope to agent failed [%s, %v]", destination.ServiceEndpoint, err)
 		return "", err

--- a/pkg/didcomm/transport/http/outbound_test.go
+++ b/pkg/didcomm/transport/http/outbound_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 )
 
@@ -101,6 +102,6 @@ func TestOutboundHTTPTransport(t *testing.T) {
 
 func prepareDestination(endPoint string) *service.Destination {
 	return &service.Destination{
-		ServiceEndpoint: endPoint,
+		ServiceEndpoint: model.Endpoint{URI: endPoint},
 	}
 }

--- a/pkg/didcomm/transport/ws/outbound.go
+++ b/pkg/didcomm/transport/ws/outbound.go
@@ -92,8 +92,8 @@ func (cs *OutboundClient) getConnection(destination *service.Destination) (*webs
 
 	// get the connection for the routing or recipient keys
 	keys := destination.RecipientKeys
-	if len(destination.RoutingKeys) != 0 {
-		keys = destination.RoutingKeys
+	if len(destination.ServiceEndpoint.RoutingKeys) != 0 {
+		keys = destination.ServiceEndpoint.RoutingKeys
 	}
 
 	for _, v := range keys {
@@ -112,7 +112,7 @@ func (cs *OutboundClient) getConnection(destination *service.Destination) (*webs
 
 	var err error
 
-	conn, _, err = websocket.Dial(context.Background(), destination.ServiceEndpoint, nil)
+	conn, _, err = websocket.Dial(context.Background(), destination.ServiceEndpoint.URI, nil)
 	if err != nil {
 		return nil, cleanup, fmt.Errorf("websocket client : %w", err)
 	}

--- a/pkg/didcomm/transport/ws/outbound_test.go
+++ b/pkg/didcomm/transport/ws/outbound_test.go
@@ -126,7 +126,7 @@ func TestClient(t *testing.T) {
 		addr := startWebSocketServer(t, echo)
 
 		des := prepareDestinationWithTransport("ws://"+addr, decorator.TransportReturnRouteAll, recKey)
-		des.RoutingKeys = routingKeys
+		des.ServiceEndpoint.RoutingKeys = routingKeys
 
 		data := "didcomm-message"
 		resp, err := outbound.Send([]byte(data), des)

--- a/pkg/didcomm/transport/ws/support_test.go
+++ b/pkg/didcomm/transport/ws/support_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"nhooyr.io/websocket"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
@@ -66,13 +67,13 @@ func websocketClient(t *testing.T, port string) (*websocket.Conn, func()) {
 
 func prepareDestination(endPoint string) *service.Destination {
 	return &service.Destination{
-		ServiceEndpoint: endPoint,
+		ServiceEndpoint: model.Endpoint{URI: endPoint},
 	}
 }
 
 func prepareDestinationWithTransport(endPoint, returnRoute string, recipientKeys []string) *service.Destination {
 	return &service.Destination{
-		ServiceEndpoint:      endPoint,
+		ServiceEndpoint:      model.Endpoint{URI: endPoint},
 		RecipientKeys:        recipientKeys,
 		TransportReturnRoute: returnRoute,
 	}

--- a/pkg/doc/did/doc_test.go
+++ b/pkg/doc/did/doc_test.go
@@ -23,6 +23,7 @@ import (
 	gojose "github.com/square/go-jose/v3"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/jwk"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/signer"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
@@ -143,17 +144,19 @@ func TestValidWithDocBase(t *testing.T) {
 				ID:              "did:example:123456789abcdefghi#inbox",
 				Type:            "SocialWebInboxService",
 				relativeURL:     true,
-				ServiceEndpoint: "https://social.example.com/83hfh37dj",
+				ServiceEndpoint: model.Endpoint{URI: "https://social.example.com/83hfh37dj"},
 				Properties:      map[string]interface{}{"spamCost": map[string]interface{}{"amount": "0.50", "currency": "USD"}},
 			},
 			{
-				ID:                       "did:example:123456789abcdefghi#did-communication",
-				Type:                     "did-communication",
-				Priority:                 0,
-				relativeURL:              true,
-				RecipientKeys:            []string{"did:example:123456789abcdefghi#key2"},
-				RoutingKeys:              []string{"did:example:123456789abcdefghi#key2"},
-				ServiceEndpoint:          "https://agent.example.com/",
+				ID:            "did:example:123456789abcdefghi#did-communication",
+				Type:          "did-communication",
+				Priority:      0,
+				relativeURL:   true,
+				RecipientKeys: []string{"did:example:123456789abcdefghi#key2"},
+				ServiceEndpoint: model.Endpoint{
+					URI:         "https://agent.example.com/",
+					RoutingKeys: []string{"did:example:123456789abcdefghi#key2"},
+				},
 				Properties:               map[string]interface{}{},
 				recipientKeysRelativeURL: map[string]bool{"did:example:123456789abcdefghi#key2": true},
 				routingKeysRelativeURL:   map[string]bool{"did:example:123456789abcdefghi#key2": true},
@@ -250,16 +253,18 @@ func TestValid(t *testing.T) {
 			{
 				ID:              "did:example:123456789abcdefghi#inbox",
 				Type:            "SocialWebInboxService",
-				ServiceEndpoint: "https://social.example.com/83hfh37dj",
+				ServiceEndpoint: model.Endpoint{URI: "https://social.example.com/83hfh37dj"},
 				Properties:      map[string]interface{}{"spamCost": map[string]interface{}{"amount": "0.50", "currency": "USD"}},
 			},
 			{
-				ID:                       "did:example:123456789abcdefghi#did-communication",
-				Type:                     "did-communication",
-				Priority:                 0,
-				RecipientKeys:            []string{"did:example:123456789abcdefghi#key2"},
-				RoutingKeys:              []string{"did:example:123456789abcdefghi#key2"},
-				ServiceEndpoint:          "https://agent.example.com/",
+				ID:            "did:example:123456789abcdefghi#did-communication",
+				Type:          "did-communication",
+				Priority:      0,
+				RecipientKeys: []string{"did:example:123456789abcdefghi#key2"},
+				ServiceEndpoint: model.Endpoint{
+					URI:         "https://agent.example.com/",
+					RoutingKeys: []string{"did:example:123456789abcdefghi#key2"},
+				},
 				Properties:               map[string]interface{}{},
 				recipientKeysRelativeURL: map[string]bool{"did:example:123456789abcdefghi#key2": false},
 				routingKeysRelativeURL:   map[string]bool{"did:example:123456789abcdefghi#key2": false},

--- a/pkg/doc/did/schema.go
+++ b/pkg/doc/did/schema.go
@@ -150,8 +150,30 @@ const (
           "type": "string"
         },
         "serviceEndpoint": {
-          "type": "string",
-          "format": "uri"
+           "oneOf": [
+            {
+              "type": "object",
+              "minProperties": 1,
+              "properties": {
+              	"uri": {
+              	   "type": "string",
+                   "format": "uri"
+              	},
+                "accept": {
+                   "type": "array",
+                   "items": [
+                      {
+                         "type": "string"
+                      }
+                   ]
+                }
+              }
+            },
+            {
+              "type": "string",
+              "format": "uri"
+            }
+          ]
         }
       }
     }
@@ -299,8 +321,30 @@ const (
           "type": "string"
         },
         "serviceEndpoint": {
-          "type": "string",
-          "format": "uri"
+           "oneOf": [
+            {
+              "type": "object",
+              "minProperties": 1,
+              "properties": {
+              	"uri": {
+              	   "type": "string",
+                   "format": "uri"
+              	},
+                "accept": {
+                   "type": "array",
+                   "items": [
+                      {
+                         "type": "string"
+                      }
+                   ]
+                }
+              }
+            },
+            {
+              "type": "string",
+              "format": "uri"
+            }
+          ]
         }
       }
     }
@@ -418,8 +462,30 @@ const (
           "type": "string"
         },
         "serviceEndpoint": {
-          "type": "string",
-          "format": "uri"
+           "oneOf": [
+            {
+              "type": "object",
+              "minProperties": 1,
+              "properties": {
+              	"uri": {
+              	   "type": "string",
+                   "format": "uri"
+              	},
+                "accept": {
+                   "type": "array",
+                   "items": [
+                      {
+                         "type": "string"
+                      }
+                   ]
+                }
+              }
+            },
+            {
+              "type": "string",
+              "format": "uri"
+            }
+          ]
         }
       }
     }

--- a/pkg/doc/verifiable/credential_jwt_proof_test.go
+++ b/pkg/doc/verifiable/credential_jwt_proof_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
@@ -239,7 +240,7 @@ func createDIDKeyFetcher(t *testing.T, pub ed25519.PublicKey, didID string) Publ
 		{
 			ID:              fmt.Sprintf(didServiceID, id, 1),
 			Type:            "did-communication",
-			ServiceEndpoint: "http://localhost:47582",
+			ServiceEndpoint: model.Endpoint{URI: "http://localhost:47582"},
 			Priority:        0,
 			RecipientKeys:   []string{pubKeyID},
 		},

--- a/pkg/framework/aries/framework_test.go
+++ b/pkg/framework/aries/framework_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/packer"
@@ -125,7 +126,7 @@ func TestFramework(t *testing.T) {
 		e := ctx.OutboundDispatcher().Send(
 			[]byte("Hello World"),
 			mockdiddoc.MockDIDKey(t),
-			&service.Destination{ServiceEndpoint: serverURL},
+			&service.Destination{ServiceEndpoint: model.Endpoint{URI: serverURL}},
 		)
 		require.NoError(t, e)
 	})
@@ -582,10 +583,12 @@ func TestFramework(t *testing.T) {
 			&didcomm.MockOutboundTransport{ExpectedResponse: "data1"}))
 		require.NoError(t, err)
 		require.Equal(t, 2, len(aries.outboundTransports))
-		r, err := aries.outboundTransports[0].Send([]byte("data"), &service.Destination{ServiceEndpoint: "url"})
+		r, err := aries.outboundTransports[0].Send([]byte("data"),
+			&service.Destination{ServiceEndpoint: model.Endpoint{URI: "url"}})
 		require.NoError(t, err)
 		require.Equal(t, "data", r)
-		r, err = aries.outboundTransports[1].Send([]byte("data1"), &service.Destination{ServiceEndpoint: "url"})
+		r, err = aries.outboundTransports[1].Send([]byte("data1"),
+			&service.Destination{ServiceEndpoint: model.Endpoint{URI: "url"}})
 		require.NoError(t, err)
 		require.Equal(t, "data1", r)
 		require.NoError(t, aries.Close())

--- a/pkg/framework/context/context_test.go
+++ b/pkg/framework/context/context_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/middleware"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher/inbound"
@@ -768,10 +769,13 @@ func TestNewProvider(t *testing.T) {
 			&mockdidcomm.MockOutboundTransport{ExpectedResponse: "data1"}))
 		require.NoError(t, err)
 		require.Len(t, prov.OutboundTransports(), 2)
-		r, err := prov.outboundTransports[0].Send([]byte("data"), &service.Destination{ServiceEndpoint: "url"})
+		r, err := prov.outboundTransports[0].Send([]byte("data"),
+			&service.Destination{ServiceEndpoint: model.Endpoint{URI: "url"}},
+		)
 		require.NoError(t, err)
 		require.Equal(t, "data", r)
-		r, err = prov.outboundTransports[1].Send([]byte("data1"), &service.Destination{ServiceEndpoint: "url"})
+		r, err = prov.outboundTransports[1].Send([]byte("data1"),
+			&service.Destination{ServiceEndpoint: model.Endpoint{URI: "url"}})
 		require.NoError(t, err)
 		require.Equal(t, "data1", r)
 	})

--- a/pkg/mock/diddoc/mock_diddoc.go
+++ b/pkg/mock/diddoc/mock_diddoc.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
 )
@@ -26,11 +27,13 @@ func GetMockDIDDoc(t *testing.T) *did.Doc {
 		ID:      "did:peer:123456789abcdefghi",
 		Service: []did.Service{
 			{
-				ServiceEndpoint: "https://localhost:8090",
-				Type:            "did-communication",
-				Priority:        0,
-				RecipientKeys:   []string{MockDIDKey(t)},
-				RoutingKeys:     []string{MockDIDKey(t)},
+				ServiceEndpoint: model.Endpoint{
+					URI:         "https://localhost:8090",
+					RoutingKeys: []string{MockDIDKey(t)},
+				},
+				Type:          "did-communication",
+				Priority:      0,
+				RecipientKeys: []string{MockDIDKey(t)},
 			},
 		},
 		VerificationMethod: []did.VerificationMethod{
@@ -69,16 +72,20 @@ func GetLegacyInteropMockDIDDoc(t *testing.T, id string, ed25519PubKey []byte) *
 		ID:      peerDID,
 		Service: []did.Service{
 			{
-				ServiceEndpoint: "https://localhost:8090",
-				Type:            "did-communication",
-				Priority:        0,
-				RecipientKeys:   []string{pubKeyBase58},
+				ServiceEndpoint: model.Endpoint{
+					URI: "https://localhost:8090",
+				},
+				Type:          "did-communication",
+				Priority:      0,
+				RecipientKeys: []string{pubKeyBase58},
 			},
 			{
-				ServiceEndpoint: "https://localhost:8090",
-				Type:            "IndyAgent",
-				Priority:        0,
-				RecipientKeys:   []string{pubKeyBase58},
+				ServiceEndpoint: model.Endpoint{
+					URI: "https://localhost:8090",
+				},
+				Type:          "IndyAgent",
+				Priority:      0,
+				RecipientKeys: []string{pubKeyBase58},
 			},
 		},
 		VerificationMethod: []did.VerificationMethod{
@@ -129,11 +136,13 @@ func GetMockDIDDocWithDIDCommV2Bloc(t *testing.T, id string) *did.Doc {
 		ID:      peerDID,
 		Service: []did.Service{
 			{
-				ServiceEndpoint: "https://localhost:8090",
-				Type:            "DIDCommMessaging",
-				Priority:        0,
-				RecipientKeys:   []string{MockDIDKey(t)},
-				RoutingKeys:     []string{MockDIDKey(t)},
+				ServiceEndpoint: model.Endpoint{
+					URI:         "https://localhost:8090",
+					RoutingKeys: []string{MockDIDKey(t)},
+				},
+				Type:          "DIDCommMessaging",
+				Priority:      0,
+				RecipientKeys: []string{MockDIDKey(t)},
 			},
 		},
 		VerificationMethod: []did.VerificationMethod{
@@ -188,11 +197,13 @@ func GetMockIndyDoc(t *testing.T) *did.Doc {
 		},
 		Service: []did.Service{
 			{
-				ID:              "did:sov:AyRHrP7u6rF1dKViGf5shA;indy",
-				Type:            "IndyAgent",
-				Priority:        0,
-				RecipientKeys:   []string{"6SFxbqdqGKtVVmLvXDnq9JP4ziZCG2fJzETpMYHt1VNx"},
-				ServiceEndpoint: "https://localhost:8090",
+				ID:            "did:sov:AyRHrP7u6rF1dKViGf5shA;indy",
+				Type:          "IndyAgent",
+				Priority:      0,
+				RecipientKeys: []string{"6SFxbqdqGKtVVmLvXDnq9JP4ziZCG2fJzETpMYHt1VNx"},
+				ServiceEndpoint: model.Endpoint{
+					URI: "https://localhost:8090",
+				},
 			},
 		},
 		Authentication: []did.Verification{

--- a/pkg/mock/vdr/mock_registry.go
+++ b/pkg/mock/vdr/mock_registry.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rand"
 	"time"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	vdrapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
 )
@@ -101,11 +102,13 @@ func createDefaultDID() *did.Doc {
 	}
 
 	service := did.Service{
-		ID:              "did:example:123456789abcdefghi#did-communication",
-		Type:            "did-communication",
-		ServiceEndpoint: "https://agent.example.com/",
-		RecipientKeys:   []string{creator},
-		Priority:        0,
+		ID:   "did:example:123456789abcdefghi#did-communication",
+		Type: "did-communication",
+		ServiceEndpoint: model.Endpoint{
+			URI: "https://agent.example.com/",
+		},
+		RecipientKeys: []string{creator},
+		Priority:      0,
 	}
 
 	signingKey := did.VerificationMethod{

--- a/pkg/store/connection/connection_lookup.go
+++ b/pkg/store/connection/connection_lookup.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	didcomm "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/spi/storage"
 )
@@ -61,14 +62,12 @@ type Record struct {
 	TheirLabel          string
 	TheirDID            string
 	MyDID               string
-	ServiceEndPoint     string   // ServiceEndPoint is 'their' DIDComm service endpoint.
-	RecipientKeys       []string // RecipientKeys holds 'their' DIDComm recipient keys.
-	RoutingKeys         []string // RoutingKeys holds 'their' DIDComm routing keys.
+	ServiceEndPoint     model.Endpoint // ServiceEndPoint is 'their' DIDComm service endpoint.
+	RecipientKeys       []string       // RecipientKeys holds 'their' DIDComm recipient keys.
 	InvitationID        string
 	InvitationDID       string
 	Implicit            bool
 	Namespace           string
-	MediaTypeProfiles   []string
 	DIDCommVersion      didcomm.Version
 	PeerDIDInitialState string
 	MyDIDRotation       *DIDRotationRecord `json:"myDIDRotation,omitempty"`

--- a/pkg/store/did/store_test.go
+++ b/pkg/store/did/store_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
 	mockstore "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
@@ -257,7 +258,7 @@ func createDIDDocWithKey(pub string) *did.Doc {
 		{
 			ID:              fmt.Sprintf(didServiceID, id, 1),
 			Type:            "did-communication",
-			ServiceEndpoint: "http://localhost:58416",
+			ServiceEndpoint: model.Endpoint{URI: "http://localhost:58416"},
 			Priority:        0,
 			RecipientKeys:   []string{pubKeyID},
 		},

--- a/pkg/vdr/peer/creator.go
+++ b/pkg/vdr/peer/creator.go
@@ -89,13 +89,13 @@ func build(didDoc *did.Doc, docOpts *vdrapi.DIDMethodOpts) (*did.DocResolution, 
 			didDoc.Service[i].Type = v
 		}
 
-		if didDoc.Service[i].ServiceEndpoint == "" && docOpts.Values[DefaultServiceEndpoint] != nil {
+		if didDoc.Service[i].ServiceEndpoint.URI == "" && docOpts.Values[DefaultServiceEndpoint] != nil {
 			v, ok := docOpts.Values[DefaultServiceEndpoint].(string)
 			if !ok {
 				return nil, fmt.Errorf("defaultServiceEndpoint not string")
 			}
 
-			didDoc.Service[i].ServiceEndpoint = v
+			didDoc.Service[i].ServiceEndpoint.URI = v
 		}
 
 		applyDIDCommKeys(i, didDoc)

--- a/pkg/vdr/peer/creator_test.go
+++ b/pkg/vdr/peer/creator_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/util/jwkkid"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
@@ -74,9 +75,11 @@ func TestDIDCreator(t *testing.T) {
 		routingKeys := []string{"abc", "xyz"}
 		docResolution, err := c.Create(
 			&did.Doc{VerificationMethod: []did.VerificationMethod{getSigningKey()}, Service: []did.Service{{
-				ServiceEndpoint: "request-endpoint",
-				Type:            "request-type",
-				RoutingKeys:     routingKeys,
+				ServiceEndpoint: model.Endpoint{
+					URI:         "request-endpoint",
+					RoutingKeys: routingKeys,
+				},
+				Type: "request-type",
 			}}})
 
 		require.NoError(t, err)
@@ -85,8 +88,8 @@ func TestDIDCreator(t *testing.T) {
 		// verify service not empty, type and endpoint from request options
 		require.NotEmpty(t, docResolution.DIDDocument.Service)
 		require.Equal(t, "request-type", docResolution.DIDDocument.Service[0].Type)
-		require.Equal(t, "request-endpoint", docResolution.DIDDocument.Service[0].ServiceEndpoint)
-		require.Equal(t, routingKeys, docResolution.DIDDocument.Service[0].RoutingKeys)
+		require.Equal(t, "request-endpoint", docResolution.DIDDocument.Service[0].ServiceEndpoint.URI)
+		require.Equal(t, routingKeys, docResolution.DIDDocument.Service[0].ServiceEndpoint.RoutingKeys)
 	})
 
 	t.Run("test request overrides with keyAgreement", func(t *testing.T) {
@@ -100,9 +103,11 @@ func TestDIDCreator(t *testing.T) {
 		docResolution, err := c.Create(
 			&did.Doc{
 				VerificationMethod: []did.VerificationMethod{sVM}, Service: []did.Service{{
-					ServiceEndpoint: "request-endpoint",
-					Type:            "request-type",
-					RoutingKeys:     routingKeys,
+					ServiceEndpoint: model.Endpoint{
+						URI:         "request-endpoint",
+						RoutingKeys: routingKeys,
+					},
+					Type: "request-type",
 				}},
 				KeyAgreement: []did.Verification{eVM},
 			})
@@ -113,8 +118,8 @@ func TestDIDCreator(t *testing.T) {
 		// verify service not empty, type and endpoint from request options
 		require.NotEmpty(t, docResolution.DIDDocument.Service)
 		require.Equal(t, "request-type", docResolution.DIDDocument.Service[0].Type)
-		require.Equal(t, "request-endpoint", docResolution.DIDDocument.Service[0].ServiceEndpoint)
-		require.Equal(t, routingKeys, docResolution.DIDDocument.Service[0].RoutingKeys)
+		require.Equal(t, "request-endpoint", docResolution.DIDDocument.Service[0].ServiceEndpoint.URI)
+		require.Equal(t, routingKeys, docResolution.DIDDocument.Service[0].ServiceEndpoint.RoutingKeys)
 
 		// verify KeyAgreement
 		require.Len(t, docResolution.DIDDocument.KeyAgreement, 1)

--- a/pkg/vdr/verifiable_compat_test.go
+++ b/pkg/vdr/verifiable_compat_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
@@ -152,7 +153,7 @@ func createPeerDIDLikeDIDExchangeService(t *testing.T, a *context.Provider) *did
 	docResolution, err := a.VDRegistry().Create(
 		peer.DIDMethod, &did.Doc{
 			Service: []did.Service{
-				{ServiceEndpoint: "http://example.com/didcomm"},
+				{ServiceEndpoint: model.Endpoint{URI: "http://example.com/didcomm"}},
 			},
 			VerificationMethod: []did.VerificationMethod{
 				authVM,

--- a/pkg/wallet/invitation.go
+++ b/pkg/wallet/invitation.go
@@ -40,7 +40,7 @@ type GenericInvitation struct {
 	From      string                        `json:"from,omitempty"`
 	Label     string                        `json:"label,omitempty"`
 	Goal      string                        `json:"goal,omitempty"`
-	GoalCode  string                        `json:"goal-code,omitempty"`
+	GoalCode  string                        `json:"goal_code,omitempty"`
 	Services  []interface{}                 `json:"services"`
 	Accept    []string                      `json:"accept,omitempty"`
 	Protocols []string                      `json:"handshake_protocols,omitempty"`

--- a/test/bdd/features/waci_issuance_didcomm_v1.feature
+++ b/test/bdd/features/waci_issuance_didcomm_v1.feature
@@ -19,7 +19,7 @@ Feature: WACI Issuance (Go API, DIDComm V1 + Issue Credential V2)
     And "Holder" creates public DID for did method "sidetree"
     Then "Issuer" waits for public did to become available in sidetree for up to 10 seconds
     And "Holder" waits for public did to become available in sidetree for up to 10 seconds
-    Then "Issuer" creates an out-of-band-v1 invitation with streamlined-vc goal-code
+    Then "Issuer" creates an out-of-band-v1 invitation with streamlined-vc goal_code
     And "Issuer" sends the out-of-band-v1 invitation to "Holder" and they accept it
     Then "Holder" sends proposal credential V2 to the "Issuer" (WACI, DIDComm V1)
     And "Issuer" accepts a proposal V2 and sends an offer to the Holder (WACI, DIDComm V1)

--- a/test/bdd/features/waci_issuance_didcomm_v2.feature
+++ b/test/bdd/features/waci_issuance_didcomm_v2.feature
@@ -19,7 +19,7 @@ Feature: WACI Issuance (Go API, DIDComm V2 + Issue Credential V3)
     And "Holder" creates public DID for did method "sidetree"
     Then "Issuer" waits for public did to become available in sidetree for up to 10 seconds
     And "Holder" waits for public did to become available in sidetree for up to 10 seconds
-    Then "Issuer" creates an out-of-band-v2 invitation with streamlined-vc goal-code
+    Then "Issuer" creates an out-of-band-v2 invitation with streamlined-vc goal_code
     And "Issuer" sends the request to "Holder" and they accept it
     Then "Holder" sends proposal credential V3 to the "Issuer" (WACI)
     And "Issuer" accepts a proposal V3 and sends an offer to the Holder (WACI)

--- a/test/bdd/pkg/connection/connection_sdk_steps.go
+++ b/test/bdd/pkg/connection/connection_sdk_steps.go
@@ -179,7 +179,6 @@ func (s *SDKSteps) createConnection(agentCtx *context.Provider, myDID string, ta
 
 	conn.ServiceEndPoint = destination.ServiceEndpoint
 	conn.RecipientKeys = destination.RecipientKeys
-	conn.RoutingKeys = destination.RoutingKeys
 
 	didConnStore := agentCtx.DIDConnectionStore()
 

--- a/test/bdd/pkg/waci/waci_issuance_didcomm_v1_sdk_steps.go
+++ b/test/bdd/pkg/waci/waci_issuance_didcomm_v1_sdk_steps.go
@@ -76,7 +76,7 @@ func (i *IssuanceSDKDIDCommV1Steps) SetContext(ctx *context.BDDContext) {
 // RegisterSteps registers the BDD test steps on the suite.
 // Note that VC proofs are not checked in this test suite.
 func (i *IssuanceSDKDIDCommV1Steps) RegisterSteps(suite *godog.Suite) {
-	suite.Step(`^"([^"]*)" creates an out-of-band-v1 invitation with streamlined-vc goal-code$`,
+	suite.Step(`^"([^"]*)" creates an out-of-band-v1 invitation with streamlined-vc goal_code$`,
 		i.createOOBV1WithStreamlinedVCGoalCode)
 	suite.Step(`^"([^"]*)" sends the out-of-band-v1 invitation to "([^"]*)" and they accept it$`,
 		i.acceptOOBV1Invitation)

--- a/test/bdd/pkg/waci/waci_issuance_didcomm_v2_sdk_steps.go
+++ b/test/bdd/pkg/waci/waci_issuance_didcomm_v2_sdk_steps.go
@@ -79,7 +79,7 @@ func (i *IssuanceSDKDIDCommV2Steps) SetContext(ctx *context.BDDContext) {
 // RegisterSteps registers the BDD test steps on the suite.
 // Note that VC proofs are not checked in this test suite.
 func (i *IssuanceSDKDIDCommV2Steps) RegisterSteps(suite *godog.Suite) {
-	suite.Step(`^"([^"]*)" creates an out-of-band-v2 invitation with streamlined-vc goal-code$`,
+	suite.Step(`^"([^"]*)" creates an out-of-band-v2 invitation with streamlined-vc goal_code$`,
 		i.createOOBV2WithStreamlinedVCGoalCode)
 	suite.Step(`^"([^"]*)" sends the request to "([^"]*)" and they accept it$`, i.acceptOOBV2Invitation)
 	suite.Step(`^"([^"]*)" sends proposal credential V3 to the "([^"]*)" \(WACI\)$`, i.sendsProposalV3)


### PR DESCRIPTION
Following this DIDcomm V2 spec udpate:
https://github.com/decentralized-identity/didcomm-messaging/pull/352
The endpoint field is now a structure containing a URI, Accept and the RoutingKeys.
and
https://github.com/decentralized-identity/didcomm-messaging/pull/363
goal-code is now goal_code.

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
