### PR TITLE
refactor: web-redirector with underscore

### DIFF
--- a/pkg/didcomm/common/model/ack.go
+++ b/pkg/didcomm/common/model/ack.go
@@ -29,7 +29,7 @@ type Ack struct {
 type AckV2 struct {
 	ID          string      `json:"id,omitempty"`
 	Type        string      `json:"type,omitempty"`
-	WebRedirect interface{} `json:"web-redirect,omitempty"`
+	WebRedirect interface{} `json:"web_redirect,omitempty"`
 	Body        AckV2Body   `json:"body,omitempty"`
 }
 

--- a/pkg/didcomm/protocol/issuecredential/models.go
+++ b/pkg/didcomm/protocol/issuecredential/models.go
@@ -164,7 +164,7 @@ type IssueCredentialV3 struct { //nolint: golint
 	ID   string                `json:"id,omitempty"`
 	Body IssueCredentialV3Body `json:"body,omitempty"`
 	// WebRedirect contains optional web redirect info to be sent to holder for redirect.
-	WebRedirect *decorator.WebRedirect `json:"web-redirect,omitempty"`
+	WebRedirect *decorator.WebRedirect `json:"web_redirect,omitempty"`
 	// Attachments is an array of attachments containing the presentation in the requested format(s).
 	// Accepted values for the format attribute of each attachment are provided in the per format Attachment
 	// registry immediately below.

--- a/pkg/didcomm/protocol/issuecredential/service.go
+++ b/pkg/didcomm/protocol/issuecredential/service.go
@@ -909,7 +909,7 @@ func (s *Service) Accept(msgType string) bool {
 func redirectInfo(msg service.DIDCommMsg) map[string]interface{} {
 	var redirectInfo struct {
 		WebRedirectV2 map[string]interface{} `json:"~web-redirect,omitempty"`
-		WebRedirectV3 map[string]interface{} `json:"web-redirect,omitempty"`
+		WebRedirectV3 map[string]interface{} `json:"web_redirect,omitempty"`
 	}
 
 	err := msg.Decode(&redirectInfo)

--- a/pkg/didcomm/protocol/presentproof/states.go
+++ b/pkg/didcomm/protocol/presentproof/states.go
@@ -40,7 +40,7 @@ const (
 	codeInternalError = "internal"
 	codeRejectedError = "rejected"
 	webRedirect       = "~web-redirect"
-	webRedirectV2     = "web-redirect"
+	webRedirectV2     = "web_redirect"
 )
 
 // state action for network call.


### PR DESCRIPTION
Following this DIDcomm V2 spec udpate:
https://github.com/decentralized-identity/didcomm-messaging/pull/363
web-redirect is now web_redirect.

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>
