### PR TITLE
feat: In-memory store "ping" method

### DIFF
--- a/component/storageutil/mem/mem.go
+++ b/component/storageutil/mem/mem.go
@@ -132,6 +132,12 @@ func (p *Provider) Close() error {
 	return nil
 }
 
+// Ping always returns nil. It's here just to allow it to implement a "Pinger" sort of interface which may be defined
+// somewhere and implemented by other storage implementations that use a remote database.
+func (p *Provider) Ping() error {
+	return nil
+}
+
 func (p *Provider) removeStore(name string) {
 	p.lock.Lock()
 	defer p.lock.Unlock()

--- a/component/storageutil/mem/mem_test.go
+++ b/component/storageutil/mem/mem_test.go
@@ -60,3 +60,10 @@ func TestMemIterator(t *testing.T) {
 	require.EqualError(t, err, "iterator is exhausted")
 	require.Nil(t, tags)
 }
+
+func TestProvider_Ping(t *testing.T) {
+	provider := mem.NewProvider()
+
+	err := provider.Ping()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
The method always returns nil. It's there just to allow it to implement a "Pinger" sort of interface which may be defined somewhere.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>