### PR TITLE
feat: add an option to disable required properties for CredentialParse.

### DIFF
--- a/pkg/doc/verifiable/support_test.go
+++ b/pkg/doc/verifiable/support_test.go
@@ -32,6 +32,9 @@ import (
 //go:embed testdata/valid_credential.jsonld
 var validCredential string //nolint:gochecknoglobals
 
+//go:embed testdata/credential_without_issuancedate.jsonld
+var credentialWithoutIssuanceDate string //nolint:gochecknoglobals
+
 func (rc *rawCredential) stringJSON(t *testing.T) string {
 	bytes, err := json.Marshal(rc)
 	require.NoError(t, err)

--- a/pkg/doc/verifiable/testdata/credential_without_issuancedate.jsonld
+++ b/pkg/doc/verifiable/testdata/credential_without_issuancedate.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1",
+	"https://w3id.org/security/jws/v1",
+    "https://trustbloc.github.io/context/vc/examples-v1.jsonld",
+    "https://w3id.org/security/suites/ed25519-2020/v1"
+  ],
+  "id": "http://example.edu/credentials/1872",
+  "type": "VerifiableCredential",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21"
+  },
+  "issuer": {
+    "id": "did:example:76e12ec712ebc6f1c221ebfeb1f",
+    "name": "Example University",
+    "image": "data:image/png;base64,iVBOR"
+  },
+  "expirationDate": "2020-01-01T19:23:24Z",
+  "credentialStatus": {
+    "id": "https://example.edu/status/24",
+    "type": "CredentialStatusList2017"
+  },
+  "evidence": [
+    {
+      "id": "https://example.edu/evidence/f2aeec97-fc0d-42bf-8ca7-0548192d4231",
+      "type": [
+        "DocumentVerification"
+      ],
+      "verifier": "https://example.edu/issuers/14",
+      "evidenceDocument": "DriversLicense",
+      "subjectPresence": "Physical",
+      "documentPresence": "Physical"
+    },
+    {
+      "id": "https://example.edu/evidence/f2aeec97-fc0d-42bf-8ca7-0548192dxyzab",
+      "type": [
+        "SupportingActivity"
+      ],
+      "verifier": "https://example.edu/issuers/14",
+      "evidenceDocument": "Fluid Dynamics Focus",
+      "subjectPresence": "Digital",
+      "documentPresence": "Digital"
+    }
+  ],
+  "termsOfUse": [
+    {
+      "type": "IssuerPolicy",
+      "id": "http://example.com/policies/credential/4",
+      "profile": "http://example.com/profiles/credential",
+      "prohibition": [
+        {
+          "assigner": "https://example.edu/issuers/14",
+          "assignee": "AllVerifiers",
+          "target": "http://example.edu/credentials/3732",
+          "action": [
+            "Archival"
+          ]
+        }
+      ]
+    }
+  ],
+  "refreshService": {
+    "id": "https://example.edu/refresh/3732",
+    "type": "ManualRefreshService2018"
+  }
+}


### PR DESCRIPTION
Signed-off-by: Volodymyr Kubiv <volodymyr.kubiv@euristiq.com>

**Title:**
Add an option for CredentialParse to use customized vc default schema.

**Description:**
https://github.com/trustbloc/vcs/issues/725

**Summary:**

Now CredentialParse can use a customized vc default schema. 
CreateDefaultSchema function added to simplify the creation of custom default schema.

