### PR TITLE
feat: add support of multibase encoding for proofValue.

### DIFF
--- a/pkg/doc/did/doc.go
+++ b/pkg/doc/did/doc.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/jwk"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
+	sigproof "github.com/hyperledger/aries-framework-go/pkg/doc/signature/proof"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 )
 
@@ -597,9 +598,9 @@ func populateProofs(context, didID, baseURI string, rawProofs []interface{}) ([]
 			proofKey = jsonldSignatureValue
 		}
 
-		proofValue, err := base64.RawURLEncoding.DecodeString(stringEntry(emap[proofKey]))
+		proofValue, err := sigproof.DecodeProofValue(stringEntry(emap[proofKey]), stringEntry(emap[jsonldType]))
 		if err != nil {
-			return nil, err
+			return nil, errors.New("unsupported encoding")
 		}
 
 		nonce, err := base64.RawURLEncoding.DecodeString(stringEntry(emap[jsonldNonce]))
@@ -1438,7 +1439,7 @@ func populateRawProofs(context, didID, baseURI string, proofs []Proof) []interfa
 			jsonldType:         p.Type,
 			jsonldCreated:      p.Created,
 			jsonldCreator:      creator,
-			k:                  base64.RawURLEncoding.EncodeToString(p.ProofValue),
+			k:                  sigproof.EncodeProofValue(p.ProofValue, p.Type),
 			jsonldDomain:       p.Domain,
 			jsonldNonce:        base64.RawURLEncoding.EncodeToString(p.Nonce),
 			jsonldProofPurpose: p.ProofPurpose,

--- a/pkg/doc/did/doc_test.go
+++ b/pkg/doc/did/doc_test.go
@@ -357,7 +357,7 @@ func TestInvalidEncodingInProof(t *testing.T) {
 		doc, err = populateProofs(c, "", "", rawProofs)
 		require.NotNil(t, err)
 		require.Nil(t, doc)
-		require.Contains(t, err.Error(), "illegal base64 data")
+		require.Contains(t, err.Error(), "unsupported encoding")
 	}
 }
 

--- a/pkg/doc/signature/suite/bbsblssignatureproof2020/testdata/doc_with_many_proofs.jsonld
+++ b/pkg/doc/signature/suite/bbsblssignatureproof2020/testdata/doc_with_many_proofs.jsonld
@@ -37,7 +37,7 @@
       "type": "BbsBlsSignature2020",
       "created": "2020-12-06T19:23:10Z",
       "proofPurpose": "assertionMethod",
-      "proofValue": "jj3Xd3+KxmbQo85PFDjQJ7dAZlhj8A8W1Um8Vk7Xoiv6+jWRx5d8s0rgPk5dAXy6HwaJ4fQOde/MBb7E4QaGMlfK6y5eEKDUYzoGG0DScWIvaGcSZug6DwvWVXi+214P5MtlKnNwO6gJdemEgj8T/A==",
+      "proofValue": "mjj3Xd3+KxmbQo85PFDjQJ7dAZlhj8A8W1Um8Vk7Xoiv6+jWRx5d8s0rgPk5dAXy6HwaJ4fQOde/MBb7E4QaGMlfK6y5eEKDUYzoGG0DScWIvaGcSZug6DwvWVXi+214P5MtlKnNwO6gJdemEgj8T/A==",
       "verificationMethod": "did:example:489398593#test"
     },
     {


### PR DESCRIPTION
Signed-off-by: Volodymyr Kubiv <volodymyr.kubiv@euristiq.com>

**Title:**
Add support of multibase encoding for proofValue.

**Description:**
https://github.com/hyperledger/aries-framework-go/issues/3228

**Summary:**

Add support of multibase encoding for proofValue and update unit tests to reflect this change.

