### PR TITLE
feat: add did document support for alsoKnownAs

### DIFF
--- a/pkg/doc/did/schema.go
+++ b/pkg/doc/did/schema.go
@@ -44,6 +44,14 @@ const (
     "id": {
       "type": "string"
     },
+    "alsoKnownAs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      },
+      "uniqueItems": true
+    },
     "publicKey": {
       "type": "array",
       "items": {
@@ -218,6 +226,14 @@ const (
     },
     "id": {
       "type": "string"
+    },
+    "alsoKnownAs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      },
+      "uniqueItems": true
     },
     "publicKey": {
       "type": "array",
@@ -405,6 +421,14 @@ const (
     },
     "id": {
       "type": "string"
+    },
+    "alsoKnownAs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      },
+      "uniqueItems": true
     },
     "publicKey": {
       "type": "array",

--- a/pkg/doc/did/testdata/valid_doc.jsonld
+++ b/pkg/doc/did/testdata/valid_doc.jsonld
@@ -1,6 +1,9 @@
 {
   "@context": ["https://www.w3.org/ns/did/v1"],
   "id": "did:example:21tDAKCERh95uGgKbJNHYp",
+  "alsoKnownAs": [
+    "did:example:123"
+  ],
   "verificationMethod": [
     {
       "id": "did:example:123456789abcdefghi#keys-1",

--- a/pkg/doc/did/testdata/valid_doc_resolution.jsonld
+++ b/pkg/doc/did/testdata/valid_doc_resolution.jsonld
@@ -5,6 +5,9 @@
       "https://w3id.org/did/v1"
     ],
     "id": "did:example:21tDAKCERh95uGgKbJNHYp",
+    "alsoKnownAs": [
+      "did:example:123"
+    ],
     "verificationMethod": [
       {
         "id": "did:example:123456789abcdefghi#keys-1",

--- a/pkg/doc/did/testdata/valid_doc_v0.11.jsonld
+++ b/pkg/doc/did/testdata/valid_doc_v0.11.jsonld
@@ -1,6 +1,9 @@
 {
   "@context": ["https://w3id.org/did/v0.11"],
   "id": "did:example:21tDAKCERh95uGgKbJNHYp",
+  "alsoKnownAs": [
+    "did:example:123"
+  ],
   "publicKey": [
     {
       "id": "did:example:123456789abcdefghi#keys-1",

--- a/pkg/doc/did/testdata/valid_doc_with_base.jsonld
+++ b/pkg/doc/did/testdata/valid_doc_with_base.jsonld
@@ -2,6 +2,9 @@
   "@context": ["https://www.w3.org/ns/did/v1",
    { "@base": "did:example:123456789abcdefghi"}],
   "id": "did:example:123456789abcdefghi",
+  "alsoKnownAs": [
+    "did:example:123"
+  ],
   "verificationMethod": [
     {
       "id": "#keys-1",


### PR DESCRIPTION
Signed-off-by: Chris Abernethy <brownoxford@gmail.com>

**Title:**
Add `alsoKnownAs` support to DID document

**Description:**
Implement support for `alsoKnownAs` DID document element [as described in DID Core v1](https://www.w3.org/TR/did-core/#dfn-alsoknownas)

**Summary:**
Add `AlsoKnownAs` element to `did.Doc` and populate value in `did.ParseDocument()`
Add `AlsoKnownAs` element to `did.rawDoc` and populate value in `did.Doc.JSONBytes()`
Add `did.populateRawAlsoKnownAs()` helper function to convert `alsoKnownAs` from `[]string` to `[]interface{}`
Add `alsoKnownAs` to schemas used for DID Schema Validation

