### PR TITLE
feat: Size computation for allocation may overflow

### DIFF
--- a/pkg/vdr/fingerprint/fingerprint.go
+++ b/pkg/vdr/fingerprint/fingerprint.go
@@ -5,14 +5,17 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 package fingerprint
+package main
 
 import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
+	"encoding/json"
 	"encoding/binary"
 	"errors"
 	"fmt"
+
 
 	"github.com/btcsuite/btcutil/base58"
 
@@ -145,6 +148,16 @@ func KeyFingerprint(code uint64, pubKeyValue []byte) string {
 	return fmt.Sprintf("z%s", base58.Encode(buf))
 }
 
+func encryptValue(v interface{}) ([]byte, error) {
+	jsonData, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	size := len(jsonData) + (len(jsonData) % 16)
+	buffer := make([]byte, size)
+	copy(buffer, jsonData)
+	return encryptBuffer(buffer)
+	
 func multicodec(code uint64) []byte {
 	buf := make([]byte, binary.MaxVarintLen64)
 	bw := binary.PutUvarint(buf, code)


### PR DESCRIPTION
Performing calculations involving the size of potentially large strings or slices can result in an overflow (for signed integer types) or a wraparound (for unsigned types). An overflow causes the result of the calculation to become negative, while a wraparound results in a small (positive) number.

This can cause further issues. If, for example, the result is then used in an allocation, it will cause a runtime panic if it is negative, and allocate an unexpectedly small buffer otherwise.

Signed-off-by: Bhaskar <ram@hacker.ind.in>
