### PR TITLE
feat: implement did-core JSON-LD `@context` representation

### DIFF
--- a/pkg/doc/did/helpers_test.go
+++ b/pkg/doc/did/helpers_test.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package did_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,6 +14,148 @@ import (
 	. "github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	mockdiddoc "github.com/hyperledger/aries-framework-go/pkg/mock/diddoc"
 )
+
+func TestContextCleanup(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		var c0 Context = "stringval"
+		var c1 Context = ContextCleanup(c0)
+		require.Equal(t, c0, c1)
+	})
+
+	t.Run("[]string", func(t *testing.T) {
+		var c0 Context = []string{"stringval"}
+		var c1 Context = ContextCleanup(c0)
+		require.Equal(t, c0, c1)
+	})
+
+	t.Run("[]string empty", func(t *testing.T) {
+		var c0 Context = []string{""}
+		var c1 Context = ContextCleanup(c0)
+		require.Equal(t, c0, c1)
+	})
+
+	t.Run("[]string nil", func(t *testing.T) {
+		var c0 Context = []string{}
+		var c1 Context = ContextCleanup(c0)
+		require.Equal(t, []string{""}, c1)
+	})
+
+	t.Run("[]interface{} nil value", func(t *testing.T) {
+		var c0 Context = []interface{}{}
+		var c1 Context = ContextCleanup(c0)
+		require.Equal(t, "", c1)
+	})
+
+	t.Run("[]interface{} all strings", func(t *testing.T) {
+		var c0 Context = []interface{}{"alpha", "beta"}
+		var c1 Context = ContextCleanup(c0)
+		require.Equal(t, []string{"alpha", "beta"}, c1)
+	})
+
+	t.Run("[]interface{} with map", func(t *testing.T) {
+		var c0 Context = []interface{}{map[string]interface{}{"@key": "value"}}
+		var c1 Context = ContextCleanup(c0)
+		require.Equal(t, c0, c1)
+	})
+}
+
+func TestContextCopy(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		var c0 Context = "stringval"
+		var c1 Context = ContextCopy(c0)
+		require.Equal(t, c0, c1)
+	})
+
+	t.Run("[]string", func(t *testing.T) {
+		var c0 Context = []string{"stringval"}
+		var c1 Context = ContextCopy(c0)
+		require.Equal(t, c0, c1)
+
+		p0, p1 := reflect.ValueOf(c0).Pointer(), reflect.ValueOf(c1).Pointer()
+		require.NotEqual(t, p0, p1, "slices should not share pointers")
+	})
+
+	t.Run("[]interface{}", func(t *testing.T) {
+		var c0 Context = []interface{}{map[string]interface{}{"@key": "value"}}
+		var c1 Context = ContextCopy(c0)
+		require.Equal(t, c0, c1)
+
+		p0, p1 := reflect.ValueOf(c0).Pointer(), reflect.ValueOf(c1).Pointer()
+		require.NotEqual(t, p0, p1, "slices should not share pointers")
+
+		a0, ok := c0.([]interface{})
+		require.True(t, ok)
+
+		a1, ok := c1.([]interface{})
+		require.True(t, ok)
+
+		p0, p1 = reflect.ValueOf(a0[0]).Pointer(), reflect.ValueOf(a1[0]).Pointer()
+		require.NotEqual(t, p0, p1, "maps should not share pointers")
+	})
+}
+
+func TestContextPeekString(t *testing.T) {
+	const (
+		DoNotWant = "ContextDoNotWant"
+		Want      = "ContextWant"
+	)
+
+	tests := map[string]struct {
+		schema string
+		ok     bool
+		input  Context
+	}{
+		"present in 'string'":                   {schema: Want, ok: true, input: Want},
+		"present in '[]string' (single)":        {schema: Want, ok: true, input: []string{Want}},
+		"present in '[]string' (multiple)":      {schema: Want, ok: true, input: []string{Want, DoNotWant}},
+		"present in '[]interface{}' (single)":   {schema: Want, ok: true, input: []interface{}{Want}},
+		"present in '[]interface{}' (multiple)": {schema: Want, ok: true, input: []interface{}{Want, DoNotWant}},
+		"not present in 'string'":               {schema: "", ok: false, input: ""},
+		"not present in '[]string'":             {schema: "", ok: false, input: []string{}},
+		"not present in '[]interface{}'":        {schema: "", ok: false, input: []interface{}{}},
+		"context is nil":                        {schema: "", ok: false, input: nil},
+		"context is invalid":                    {schema: "", ok: false, input: 42},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			schema, ok := ContextPeekString(tc.input)
+			require.Equal(t, tc.ok, ok)
+			require.Equal(t, tc.schema, schema)
+		})
+	}
+}
+
+func TestContextContainsString(t *testing.T) {
+	const (
+		DoNotWant = "ContextDoNotWant"
+		Want      = "ContextWant"
+	)
+
+	tests := map[string]struct {
+		ok    bool
+		input Context
+	}{
+		"present in 'string'":                    {ok: true, input: Want},
+		"present in '[]string' (first)":          {ok: true, input: []string{Want}},
+		"present in '[]string' (not first)":      {ok: true, input: []string{DoNotWant, Want}},
+		"present in '[]interface{}' (first)":     {ok: true, input: []interface{}{Want}},
+		"present in '[]interface{}' (not first)": {ok: true, input: []interface{}{DoNotWant, Want}},
+		"present in '[]interface{}' (map)":       {ok: false, input: []interface{}{map[string]interface{}{"k": Want}}},
+		"not present in 'string'":                {ok: false, input: DoNotWant},
+		"not present in '[]string'":              {ok: false, input: []string{DoNotWant}},
+		"not present in '[]interface{}'":         {ok: false, input: []interface{}{DoNotWant}},
+		"context is nil":                         {ok: false, input: nil},
+		"context is invalid":                     {ok: false, input: 42},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ok := ContextContainsString(tc.input, Want)
+			require.Equal(t, tc.ok, ok)
+		})
+	}
+}
 
 func TestGetRecipientKeys(t *testing.T) {
 	t.Run("successfully getting recipient keys", func(t *testing.T) {

--- a/pkg/vdr/key/creator_test.go
+++ b/pkg/vdr/key/creator_test.go
@@ -258,8 +258,20 @@ func assertBase58Doc(t *testing.T, doc *did.Doc, didKey, didKeyID, didKeyType, p
 
 func assertDualBase58Doc(t *testing.T, doc *did.Doc, didKey, didKeyID, didKeyType, pubKeyBase58,
 	agreementKeyID, keyAgreementType, keyAgreementBase58 string) {
+	var context string
+	switch ctx := doc.Context.(type) {
+	case string:
+		context = ctx
+	case []string:
+		context = ctx[0]
+	case []interface{}:
+		var ok bool
+		context, ok = ctx[0].(string)
+		require.True(t, ok)
+	}
+
 	// validate @context
-	require.Equal(t, schemaDIDV1, doc.Context[0])
+	require.Equal(t, schemaDIDV1, context)
 
 	// validate id
 	require.Equal(t, didKey, doc.ID)
@@ -332,8 +344,20 @@ func createVerificationMethodFromXAndY(t *testing.T, didKeyID, didKey string,
 func assertDualJSONWebKeyDoc(t *testing.T, doc *did.Doc, didKey, didKeyID string,
 	pubKeyCurve elliptic.Curve, pubKeyX, pubKeyY *big.Int,
 	agreementKeyID string, keyAgreementCurve elliptic.Curve, keyAgreementX, keyAgreementY *big.Int) {
+	var context string
+	switch ctx := doc.Context.(type) {
+	case string:
+		context = ctx
+	case []string:
+		context = ctx[0]
+	case []interface{}:
+		var ok bool
+		context, ok = ctx[0].(string)
+		require.True(t, ok)
+	}
+
 	// validate @context
-	require.Equal(t, schemaDIDV1, doc.Context[0])
+	require.Equal(t, schemaDIDV1, context)
 
 	// validate id
 	require.Equal(t, didKey, doc.ID)


### PR DESCRIPTION
Signed-off-by: Chris Abernethy <brownoxford@gmail.com>

**Title:**
Implement did-core JSON-LD `@context` representation

**Description:**
Current implementation assumes `@context` can only be `[]string`, but did-core v1 defines `@context` for DID documents in JSON-LD representation to be either a string or a list containing maps and/or strings.

**Summary:**
* Created `type Context {}interface` to represent did document contexts with appropriate comment for IDE integration.
* Modified `did.parseContext` to add parsing of `string` and `[]interface{}` context representations.
* Added `LookupContextString` helper to search for context string through entire context (used by `requiresLegacyHandling`)
* Added `LookupSchemaFromContext` helper to peek first string in context. Replaces direct references to `context[0]`
* Modified existing tests to account for new context format
* Added tests for new helper functions