### PR TITLE
fix: move resolve credential manifest from didcommwallet to vcwallet.

### DIFF
--- a/pkg/controller/command/didcommwallet/models.go
+++ b/pkg/controller/command/didcommwallet/models.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/client/outofband"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/command/vcwallet"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/cm"
 	"github.com/hyperledger/aries-framework-go/pkg/wallet"
 )
 
@@ -148,31 +147,4 @@ type RequestCredentialRequest struct {
 // RequestCredentialResponse is response model from wallet request credential operation.
 type RequestCredentialResponse struct {
 	wallet.CredentialInteractionStatus
-}
-
-// ResolveCredentialManifestRequest is request model for resolving credential manifest from wallet.
-type ResolveCredentialManifestRequest struct {
-	vcwallet.WalletAuth
-
-	// Credential Manifest on which given credential fulfillment or credential needs to be resolved.
-	Manifest json.RawMessage `json:"manifest,omitempty"`
-
-	// Fulfillment to be be resolved.
-	// If provided, then this option takes precedence over credential resolve option.
-	Fulfillment json.RawMessage `json:"fulfillment,omitempty"`
-
-	// Credential to be be resolved, to be provided along with 'DescriptorID' to be used for resolving.
-	Credential json.RawMessage `json:"credential,omitempty"`
-
-	// ID of the Credential from wallet content to be be resolved, to be provided along with 'DescriptorID'.
-	CredentialID string `json:"credentialID,omitempty"`
-
-	// ID of the output descriptor to be used for resolving given credential.
-	DescriptorID string `json:"descriptorID,omitempty"`
-}
-
-// ResolveCredentialManifestResponse is response model from wallet credential manifest resolve operation.
-type ResolveCredentialManifestResponse struct {
-	// List of Resolved Descriptor results.
-	Resolved []*cm.ResolvedDescriptor `json:"resolved,omitempty"`
 }

--- a/pkg/controller/command/vcwallet/models.go
+++ b/pkg/controller/command/vcwallet/models.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/hyperledger/aries-framework-go/pkg/doc/cm"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/wallet"
@@ -309,4 +310,31 @@ type CreateKeyPairRequest struct {
 // CreateKeyPairResponse is response model for creating key pair from wallet.
 type CreateKeyPairResponse struct {
 	*wallet.KeyPair
+}
+
+// ResolveCredentialManifestRequest is request model for resolving credential manifest from wallet.
+type ResolveCredentialManifestRequest struct {
+	WalletAuth
+
+	// Credential Manifest on which given credential fulfillment or credential needs to be resolved.
+	Manifest json.RawMessage `json:"manifest,omitempty"`
+
+	// Fulfillment to be be resolved.
+	// If provided, then this option takes precedence over credential resolve option.
+	Fulfillment json.RawMessage `json:"fulfillment,omitempty"`
+
+	// Credential to be be resolved, to be provided along with 'DescriptorID' to be used for resolving.
+	Credential json.RawMessage `json:"credential,omitempty"`
+
+	// ID of the Credential from wallet content to be be resolved, to be provided along with 'DescriptorID'.
+	CredentialID string `json:"credentialID,omitempty"`
+
+	// ID of the output descriptor to be used for resolving given credential.
+	DescriptorID string `json:"descriptorID,omitempty"`
+}
+
+// ResolveCredentialManifestResponse is response model from wallet credential manifest resolve operation.
+type ResolveCredentialManifestResponse struct {
+	// List of Resolved Descriptor results.
+	Resolved []*cm.ResolvedDescriptor `json:"resolved,omitempty"`
 }

--- a/pkg/controller/rest/vcwallet/models.go
+++ b/pkg/controller/rest/vcwallet/models.go
@@ -379,7 +379,7 @@ type resolveCredentialManifestRequest struct { // nolint: unused,deadcode
 	// Params for resolving credential manifests from wallet.
 	//
 	// in: body
-	Params *didcommwallet.ResolveCredentialManifestRequest
+	Params *vcwallet.ResolveCredentialManifestRequest
 }
 
 // resolveCredentialManifestResponse is response model for resolving credential manifests from wallet.
@@ -389,5 +389,5 @@ type resolveCredentialManifestResponse struct {
 	// Response containing resolve credential manifest descriptors.
 	//
 	// in: body
-	Response *didcommwallet.ResolveCredentialManifestResponse `json:"response"`
+	Response *vcwallet.ResolveCredentialManifestResponse `json:"response"`
 }

--- a/pkg/controller/rest/vcwallet/operation_test.go
+++ b/pkg/controller/rest/vcwallet/operation_test.go
@@ -1772,7 +1772,7 @@ func TestOperation_ResolveCredentialManifest(t *testing.T) {
 	defer lock()
 
 	t.Run("resolve credential manifest", func(t *testing.T) {
-		request := &didcommwallet.ResolveCredentialManifestRequest{
+		request := &vcwallet.ResolveCredentialManifestRequest{
 			WalletAuth:  vcwallet.WalletAuth{UserID: sampleUser1, Auth: token},
 			Manifest:    testdata.CredentialManifestMultipleVCs,
 			Fulfillment: testdata.CredentialFulfillmentWithMultipleVCs,
@@ -1793,7 +1793,7 @@ func TestOperation_ResolveCredentialManifest(t *testing.T) {
 	})
 
 	t.Run("resolve credential manifest failure", func(t *testing.T) {
-		request := &didcommwallet.ResolveCredentialManifestRequest{
+		request := &vcwallet.ResolveCredentialManifestRequest{
 			WalletAuth: vcwallet.WalletAuth{UserID: sampleUser1, Auth: token},
 			Manifest:   testdata.CredentialManifestMultipleVCs,
 			Credential: testdata.SampleUDCVC,


### PR DESCRIPTION
Signed-off-by: Volodymyr Kubiv <volodymyr.kubiv@euristiq.com>

**Title:**
Move ResolveCredentialManifest from didcommwallet to vcwallet.

**Summary:**

ResolveCredentialManifest is related to vcwallet.

