### PR TITLE
Add RemoveCredentialByName to aries js helpers

### DIFF
--- a/cmd/aries-js-worker/src/agent-rest-client.js
+++ b/cmd/aries-js-worker/src/agent-rest-client.js
@@ -150,6 +150,11 @@ const pkgs = {
             method: "GET",
             pathParam: "name"
         },
+        RemoveCredentialByName: {
+            path: "/verifiable/credential/remove/name/{name}",
+            method: "POST",
+            pathParam: "name"
+        },
         GetCredentials: {
             path: "/verifiable/credentials",
             method: "GET",

--- a/cmd/aries-js-worker/src/aries.js
+++ b/cmd/aries-js-worker/src/aries.js
@@ -1086,6 +1086,10 @@ const Aries = function (opts) {
                 return invoke(aw, pending, this.pkgname, "GetCredentialByName", req, "timeout while retrieving verifiable credential by name")
             },
 
+            removeCredentialByName: async function (req) {
+                return invoke(aw, pending, this.pkgname, "RemoveCredentialByName", req, "timeout while removing credential")
+            },
+
             /**
              * Retrieves verifiable credential records containing name and id.
              *


### PR DESCRIPTION
Function was available in the core but was missing from the JavaScript
wrapper.

Signed-off-by: Boran Car <boran.car@gmail.com>

