### PR TITLE
feat: allow mediator GetConnections APIs to filter by didcomm version.

### DIFF
--- a/pkg/client/mediator/client.go
+++ b/pkg/client/mediator/client.go
@@ -39,7 +39,7 @@ type protocolService interface {
 	Unregister(connID string) error
 
 	// GetConnections returns router`s connections.
-	GetConnections() ([]string, error)
+	GetConnections(...mediator.ConnectionOption) ([]string, error)
 
 	// Config returns the router's configuration.
 	Config(connID string) (*mediator.Config, error)
@@ -91,8 +91,8 @@ func (c *Client) Unregister(connID string) error {
 }
 
 // GetConnections returns router`s connections.
-func (c *Client) GetConnections() ([]string, error) {
-	connections, err := c.routeSvc.GetConnections()
+func (c *Client) GetConnections(options ...ConnectionOption) ([]string, error) {
+	connections, err := c.routeSvc.GetConnections(options...)
 	if err != nil {
 		return nil, fmt.Errorf("get router connections: %w", err)
 	}

--- a/pkg/client/mediator/models.go
+++ b/pkg/client/mediator/models.go
@@ -22,6 +22,9 @@ const (
 // Request is the route-request message of this protocol.
 type Request = mediator.Request
 
+// ConnectionOption option for Client.GetConnections.
+type ConnectionOption = mediator.ConnectionOption
+
 // NewRequest creates a new request.
 func NewRequest() *Request {
 	return &Request{

--- a/pkg/controller/command/mediator/models.go
+++ b/pkg/controller/command/mediator/models.go
@@ -16,6 +16,12 @@ type RegisterRoute struct {
 	ConnectionID string `json:"connectionID"`
 }
 
+// ConnectionsRequest contains parameters for filtering when requesting router connections.
+type ConnectionsRequest struct {
+	DIDCommV1Only bool `json:"didcomm_v1"`
+	DIDCommV2Only bool `json:"didcomm_v2"`
+}
+
 // ConnectionsResponse is response for router`s connections.
 type ConnectionsResponse struct {
 	Connections []string `json:"connections"`

--- a/pkg/didcomm/protocol/mediator/api.go
+++ b/pkg/didcomm/protocol/mediator/api.go
@@ -15,5 +15,5 @@ type ProtocolService interface {
 	Config(connID string) (*Config, error)
 
 	// GetConnections returns all router connections
-	GetConnections() ([]string, error)
+	GetConnections(options ...ConnectionOption) ([]string, error)
 }

--- a/pkg/didcomm/protocol/mediator/util_test.go
+++ b/pkg/didcomm/protocol/mediator/util_test.go
@@ -87,7 +87,7 @@ func (m *mockRouteSvc) AddKey(connID, recKey string) error {
 }
 
 // AddKey adds agents recKey to the router.
-func (m *mockRouteSvc) GetConnections() ([]string, error) {
+func (m *mockRouteSvc) GetConnections(...ConnectionOption) ([]string, error) {
 	return m.Connections, m.ConnectionsErr
 }
 

--- a/pkg/mock/didcomm/protocol/mediator/mock_mediator.go
+++ b/pkg/mock/didcomm/protocol/mediator/mock_mediator.go
@@ -115,7 +115,7 @@ func (m *MockMediatorSvc) Config(connID string) (*mediator.Config, error) {
 }
 
 // GetConnections returns router`s connections.
-func (m *MockMediatorSvc) GetConnections() ([]string, error) {
+func (m *MockMediatorSvc) GetConnections(...mediator.ConnectionOption) ([]string, error) {
 	if m.GetConnectionsErr != nil {
 		return nil, m.GetConnectionsErr
 	}


### PR DESCRIPTION
Fixes #3321 

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>