### PR TITLE
feat: Add client, rest and command handlers for legacy-connection pro…

### DIFF
--- a/.repolint.json
+++ b/.repolint.json
@@ -98,7 +98,7 @@
             "!**/mocks/*.go",
             "!**/third_party/**"
           ],
-          "lineCount": 7,
+          "lineCount": 8,
           "patterns": ["Copyright", "License"],
           "flags": "i"
         }

--- a/pkg/client/legacyconnection/client.go
+++ b/pkg/client/legacyconnection/client.go
@@ -1,0 +1,443 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package legacyconnection
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcutil/base58"
+	"github.com/google/uuid"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/legacyconnection"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/transport"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+)
+
+// InvitationMsgType defines the connection invite message type.
+const InvitationMsgType = legacyconnection.InvitationMsgType
+
+// ErrConnectionNotFound is returned when connection not found.
+var ErrConnectionNotFound = errors.New("connection not found")
+
+type options struct {
+	routerConnections  []string
+	routerConnectionID string
+}
+
+func applyOptions(args ...Opt) *options {
+	opts := &options{}
+
+	for i := range args {
+		args[i](opts)
+	}
+
+	return opts
+}
+
+// Opt represents option function.
+type Opt func(*options)
+
+// InvOpt represents option for the CreateInvitation function.
+type InvOpt Opt
+
+// WithRouterConnectionID allows you to specify the router connection ID.
+func WithRouterConnectionID(conn string) InvOpt {
+	return func(opts *options) {
+		opts.routerConnectionID = conn
+	}
+}
+
+// WithRouterConnections allows you to specify the router connections.
+func WithRouterConnections(conns ...string) Opt {
+	return func(opts *options) {
+		for _, conn := range conns {
+			// filters out empty connections
+			if conn != "" {
+				opts.routerConnections = append(opts.routerConnections, conn)
+			}
+		}
+	}
+}
+
+// provider contains dependencies for the legacy-connection protocol and is typically created by using aries.Context().
+type provider interface {
+	Service(id string) (interface{}, error)
+	KMS() kms.KeyManager
+	ServiceEndpoint() string
+	StorageProvider() storage.Provider
+	ProtocolStateStorageProvider() storage.Provider
+	MediaTypeProfiles() []string
+}
+
+// Client enable access to legacyconnection api.
+type Client struct {
+	service.Event
+	legacyconnectionSvc protocolService
+	routeSvc            mediator.ProtocolService
+	kms                 kms.KeyManager
+	serviceEndpoint     string
+	connectionStore     *connection.Recorder
+	mediaTypeProfiles   []string
+}
+
+// protocolService defines legacy-connection service.
+type protocolService interface {
+	// DIDComm service
+	service.DIDComm
+
+	// Accepts/Approves connection request
+	AcceptConnectionRequest(connectionID, publicDID, label string, routerConnections []string) error
+
+	// Accepts/Approves connection invitation
+	AcceptInvitation(connectionID, publicDID, label string, routerConnections []string) error
+
+	// CreateImplicitInvitation creates implicit invitation. Inviter DID is required, invitee DID is optional.
+	// If invitee DID is not provided new peer DID will be created for implicit invitation connection request.
+	CreateImplicitInvitation(inviterLabel, inviterDID, inviteeLabel,
+		inviteeDID string, routerConnections []string) (string, error)
+
+	// CreateConnection saves the connection record.
+	CreateConnection(*connection.Record, *did.Doc) error
+}
+
+// New return new instance of legacyconnection client.
+func New(ctx provider) (*Client, error) {
+	svc, err := ctx.Service(legacyconnection.LegacyConnection)
+	if err != nil {
+		return nil, err
+	}
+
+	legacyconnectionSvc, ok := svc.(protocolService)
+	if !ok {
+		return nil, errors.New("cast service to legacyconnection Service failed")
+	}
+
+	s, err := ctx.Service(mediator.Coordination)
+	if err != nil {
+		return nil, err
+	}
+
+	routeSvc, ok := s.(mediator.ProtocolService)
+	if !ok {
+		return nil, errors.New("cast service to Route Service failed")
+	}
+
+	connectionStore, err := connection.NewRecorder(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	mtp := ctx.MediaTypeProfiles()
+	if len(mtp) == 0 {
+		mtp = []string{transport.MediaTypeRFC0019EncryptedEnvelope}
+	}
+
+	return &Client{
+		Event:               legacyconnectionSvc,
+		legacyconnectionSvc: legacyconnectionSvc,
+		routeSvc:            routeSvc,
+		kms:                 ctx.KMS(),
+		serviceEndpoint:     ctx.ServiceEndpoint(),
+		connectionStore:     connectionStore,
+		mediaTypeProfiles:   mtp,
+	}, nil
+}
+
+// CreateInvitation creates an invitation. New key pair will be generated and did:key encoded public key will be
+// used as basis for invitation. This invitation will be stored so client can cross-reference this invitation during
+// connection protocol.
+func (c *Client) CreateInvitation(label string, args ...InvOpt) (*Invitation, error) {
+	opts := &options{}
+
+	for i := range args {
+		args[i](opts)
+	}
+
+	_, pubKey, err := c.kms.CreateAndExportPubKeyBytes(kms.ED25519Type)
+	if err != nil {
+		return nil, fmt.Errorf("createInvitation: failed to extract public SigningKey bytes from handle: %w", err)
+	}
+
+	recKey := base58.Encode(pubKey)
+
+	var (
+		serviceEndpoint = c.serviceEndpoint
+		routingKeys     []string
+	)
+
+	if opts.routerConnectionID != "" {
+		// get the route configs
+		serviceEndpoint, routingKeys, err = mediator.GetRouterConfig(c.routeSvc,
+			opts.routerConnectionID, c.serviceEndpoint)
+		if err != nil {
+			return nil, fmt.Errorf("createInvitation: getRouterConfig: %w", err)
+		}
+
+		if err = mediator.AddKeyToRouter(c.routeSvc, opts.routerConnectionID, recKey); err != nil {
+			return nil, fmt.Errorf("createInvitation: AddKeyToRouter: %w", err)
+		}
+	}
+
+	invitation := &legacyconnection.Invitation{
+		ID:              uuid.New().String(),
+		Label:           label,
+		RecipientKeys:   []string{recKey},
+		ServiceEndpoint: serviceEndpoint,
+		Type:            legacyconnection.InvitationMsgType,
+		RoutingKeys:     routingKeys,
+	}
+
+	err = c.connectionStore.SaveInvitation(invitation.ID, invitation)
+	if err != nil {
+		return nil, fmt.Errorf("createInvitation: failed to save invitation: %w", err)
+	}
+
+	return &Invitation{invitation}, nil
+}
+
+// CreateInvitationWithDID creates an invitation with specified public DID. This invitation will be stored
+// so client can cross reference this invitation during connection protocol.
+func (c *Client) CreateInvitationWithDID(label, publicDID string) (*Invitation, error) {
+	invitation := &legacyconnection.Invitation{
+		ID:    uuid.New().String(),
+		Label: label,
+		DID:   publicDID,
+		Type:  legacyconnection.InvitationMsgType,
+	}
+
+	err := c.connectionStore.SaveInvitation(invitation.ID, invitation)
+	if err != nil {
+		return nil, fmt.Errorf("createInvitationWithDID: failed to save invitation with DID: %w", err)
+	}
+
+	return &Invitation{invitation}, nil
+}
+
+// HandleInvitation handle incoming invitation and returns the connectionID that can be used to query the state
+// of legacy connection protocol. Upon successful completion of protocol, connection details will be used
+// for securing communication between agents.
+func (c *Client) HandleInvitation(invitation *Invitation) (string, error) {
+	payload, err := json.Marshal(invitation)
+	if err != nil {
+		return "", fmt.Errorf("handleInvitation: failed marshal invitation: %w", err)
+	}
+
+	msg, err := service.ParseDIDCommMsgMap(payload)
+	if err != nil {
+		return "", fmt.Errorf("handleInvitation: failed to create DIDCommMsg: %w", err)
+	}
+
+	connectionID, err := c.legacyconnectionSvc.HandleInbound(msg, service.EmptyDIDCommContext())
+	if err != nil {
+		return "", fmt.Errorf("handleInvitation: failed from legacyconnection service handle: %w", err)
+	}
+
+	return connectionID, nil
+}
+
+// AcceptInvitation accepts/approves connection invitation. This call is not used if auto execute is setup
+// for this client (see package example for more details about how to setup auto execute).
+func (c *Client) AcceptInvitation(connectionID, publicDID, label string, args ...Opt) error {
+	opts := applyOptions(args...)
+
+	if err := c.legacyconnectionSvc.AcceptInvitation(connectionID, publicDID, label, opts.routerConnections); err != nil {
+		return fmt.Errorf("legacyconnection client - accept connection invitation: %w", err)
+	}
+
+	return nil
+}
+
+// AcceptConnectionRequest accepts/approves connection request. This call is not used if auto execute is setup
+// for this client (see package example for more details about how to setup auto execute).
+func (c *Client) AcceptConnectionRequest(connectionID, publicDID, label string, args ...Opt) error {
+	err := c.legacyconnectionSvc.AcceptConnectionRequest(connectionID, publicDID, label,
+		applyOptions(args...).routerConnections)
+	if err != nil {
+		return fmt.Errorf("legacyconnection client - accept connection request: %w", err)
+	}
+
+	return nil
+}
+
+// CreateImplicitInvitation enables invitee to create and send connection request using inviter public DID.
+func (c *Client) CreateImplicitInvitation(inviterLabel, inviterDID string, args ...Opt) (string, error) {
+	return c.legacyconnectionSvc.CreateImplicitInvitation(inviterLabel, inviterDID,
+		"", "", applyOptions(args...).routerConnections)
+}
+
+// CreateImplicitInvitationWithDID enables invitee to create implicit invitation using inviter and invitee public DID.
+func (c *Client) CreateImplicitInvitationWithDID(inviter, invitee *DIDInfo) (string, error) {
+	if inviter == nil || invitee == nil {
+		return "", errors.New("missing inviter and/or invitee public DID(s)")
+	}
+
+	return c.legacyconnectionSvc.CreateImplicitInvitation(inviter.Label, inviter.DID, invitee.Label, invitee.DID, nil)
+}
+
+// QueryConnections queries connections matching given criteria(parameters).
+func (c *Client) QueryConnections(request *QueryConnectionsParams) ([]*Connection, error) { //nolint: gocyclo
+	// TODO https://github.com/hyperledger/aries-framework-go/issues/655 - query all connections from all criteria and
+	//  also results needs to be paged.
+	records, err := c.connectionStore.QueryConnectionRecords()
+	if err != nil {
+		return nil, fmt.Errorf("failed query connections: %w", err)
+	}
+
+	var result []*Connection
+
+	for _, record := range records {
+		if request.State != "" && request.State != record.State {
+			continue
+		}
+
+		if request.InvitationID != "" && request.InvitationID != record.InvitationID {
+			continue
+		}
+
+		if request.ParentThreadID != "" && request.ParentThreadID != record.ParentThreadID {
+			continue
+		}
+
+		if request.MyDID != "" && request.MyDID != record.MyDID {
+			continue
+		}
+
+		if request.TheirDID != "" && request.TheirDID != record.TheirDID {
+			continue
+		}
+
+		result = append(result, &Connection{Record: record})
+	}
+
+	return result, nil
+}
+
+// GetConnection fetches single connection record for given id.
+func (c *Client) GetConnection(connectionID string) (*Connection, error) {
+	conn, err := c.connectionStore.GetConnectionRecord(connectionID)
+	if err != nil {
+		if errors.Is(err, storage.ErrDataNotFound) {
+			return nil, ErrConnectionNotFound
+		}
+
+		return nil, fmt.Errorf("cannot fetch state from store: connectionid=%s err=%w", connectionID, err)
+	}
+
+	return &Connection{
+		conn,
+	}, nil
+}
+
+// GetConnectionAtState fetches connection record for connection id at particular state.
+func (c *Client) GetConnectionAtState(connectionID, stateID string) (*Connection, error) {
+	conn, err := c.connectionStore.GetConnectionRecordAtState(connectionID, stateID)
+	if err != nil {
+		if errors.Is(err, storage.ErrDataNotFound) {
+			return nil, ErrConnectionNotFound
+		}
+
+		return nil, fmt.Errorf("cannot fetch state from store: connectionid=%s err=%w", connectionID, err)
+	}
+
+	return &Connection{
+		conn,
+	}, nil
+}
+
+// CreateConnection creates a new connection between myDID and theirDID and returns the connectionID.
+func (c *Client) CreateConnection(myDID string, theirDID *did.Doc, options ...ConnectionOption) (string, error) {
+	conn := &Connection{&connection.Record{
+		ConnectionID: uuid.New().String(),
+		State:        connection.StateNameCompleted,
+		TheirDID:     theirDID.ID,
+		MyDID:        myDID,
+		Namespace:    connection.MyNSPrefix,
+	}}
+
+	for i := range options {
+		options[i](conn)
+	}
+
+	destination, err := service.CreateDestination(theirDID)
+	if err != nil {
+		return "", fmt.Errorf("createConnection: failed to create destination: %w", err)
+	}
+
+	conn.ServiceEndPoint = destination.ServiceEndpoint
+	conn.RecipientKeys = destination.RecipientKeys
+	conn.RoutingKeys = destination.RoutingKeys
+	conn.MediaTypeProfiles = destination.MediaTypeProfiles
+
+	err = c.legacyconnectionSvc.CreateConnection(conn.Record, theirDID)
+	if err != nil {
+		return "", fmt.Errorf("createConnection: err: %w", err)
+	}
+
+	return conn.ConnectionID, nil
+}
+
+// RemoveConnection removes connection record for given id.
+func (c *Client) RemoveConnection(connectionID string) error {
+	err := c.connectionStore.RemoveConnection(connectionID)
+	if err != nil {
+		return fmt.Errorf("cannot remove connection from the store: err=%w", err)
+	}
+
+	return nil
+}
+
+// ConnectionOption allows you to customize details of the connection record.
+type ConnectionOption func(*Connection)
+
+// WithTheirLabel sets TheirLabel on the connection record.
+func WithTheirLabel(l string) ConnectionOption {
+	return func(c *Connection) {
+		c.TheirLabel = l
+	}
+}
+
+// WithThreadID sets ThreadID on the connection record.
+func WithThreadID(thid string) ConnectionOption {
+	return func(c *Connection) {
+		c.ThreadID = thid
+	}
+}
+
+// WithParentThreadID sets ParentThreadID on the connection record.
+func WithParentThreadID(pthid string) ConnectionOption {
+	return func(c *Connection) {
+		c.ParentThreadID = pthid
+	}
+}
+
+// WithInvitationID sets InvitationID on the connection record.
+func WithInvitationID(id string) ConnectionOption {
+	return func(c *Connection) {
+		c.InvitationID = id
+	}
+}
+
+// WithInvitationDID sets InvitationDID on the connection record.
+func WithInvitationDID(didID string) ConnectionOption {
+	return func(c *Connection) {
+		c.InvitationDID = didID
+	}
+}
+
+// WithImplicit sets Implicit on the connection record.
+func WithImplicit(i bool) ConnectionOption {
+	return func(c *Connection) {
+		c.Implicit = i
+	}
+}

--- a/pkg/client/legacyconnection/client_test.go
+++ b/pkg/client/legacyconnection/client_test.go
@@ -1,0 +1,1450 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package legacyconnection
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcutil/base58"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/legacyconnection"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+	mockprotocol "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol"
+	mocksvc "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/legacyconnection"
+	mockroute "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/mediator"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
+	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
+	mockstore "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	mockvdr "github.com/hyperledger/aries-framework-go/pkg/mock/vdr"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
+	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/peer"
+	spi "github.com/hyperledger/aries-framework-go/spi/storage"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("test new client", func(t *testing.T) {
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		_, err = New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("test error from get service from context", func(t *testing.T) {
+		_, err := New(&mockprovider.Provider{ServiceErr: fmt.Errorf("service error")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "service error")
+	})
+
+	t.Run("test error from cast service", func(t *testing.T) {
+		_, err := New(&mockprovider.Provider{ServiceValue: nil})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cast service to legacyconnection Service failed")
+	})
+
+	t.Run("test route service cast error", func(t *testing.T) {
+		_, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: &mocksvc.MockLegacyConnectionSvc{},
+				mediator.Coordination:             &mocksvc.MockLegacyConnectionSvc{},
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cast service to Route Service failed")
+	})
+
+	t.Run("test error from open store", func(t *testing.T) {
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		_, err = New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue: &mockstore.MockStoreProvider{
+				ErrOpenStoreHandle: fmt.Errorf("failed to open store"),
+			},
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+			ServiceEndpointValue: "endpoint",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to open store")
+	})
+
+	t.Run("test error from open protocol state store", func(t *testing.T) {
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		_, err = New(&mockprovider.Provider{
+			StorageProviderValue: mockstore.NewMockStoreProvider(),
+			ProtocolStateStorageProviderValue: &mockstore.MockStoreProvider{
+				ErrOpenStoreHandle: fmt.Errorf("failed to open protocol state store"),
+			},
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+			ServiceEndpointValue: "endpoint",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to open protocol state store")
+	})
+}
+
+func TestClient_CreateInvitation(t *testing.T) {
+	t.Run("test success", func(t *testing.T) {
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		ed25519KH, err := mockkms.CreateMockED25519KeyHandle()
+		require.NoError(t, err)
+
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+			KMSValue:             &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+			ServiceEndpointValue: "endpoint",
+		})
+
+		require.NoError(t, err)
+		inviteReq, err := c.CreateInvitation("agent")
+		require.NoError(t, err)
+		require.NotNil(t, inviteReq)
+		require.NotEmpty(t, inviteReq.Label)
+		require.NotEmpty(t, inviteReq.ID)
+		require.Nil(t, inviteReq.RoutingKeys)
+		require.Equal(t, "endpoint", inviteReq.ServiceEndpoint)
+	})
+
+	t.Run("test error from createSigningKey", func(t *testing.T) {
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+			KMSValue: &mockkms.KeyManager{CrAndExportPubKeyErr: fmt.Errorf("createKeyErr")},
+		})
+		require.NoError(t, err)
+		_, err = c.CreateInvitation("agent")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "createKeyErr")
+	})
+
+	t.Run("test error from save record", func(t *testing.T) {
+		store := &mockstore.MockStore{
+			Store:  make(map[string]mockstore.DBEntry),
+			ErrPut: fmt.Errorf("store error"),
+		}
+
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			StoreProvider: mockstore.NewCustomMockStoreProvider(store),
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewCustomMockStoreProvider(store),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+			KMSValue: &mockkms.KeyManager{},
+		})
+		require.NoError(t, err)
+		_, err = c.CreateInvitation("agent")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to save invitation")
+	})
+
+	t.Run("test success with router registered", func(t *testing.T) {
+		endpoint := "http://router.example.com"
+		routingKeys := []string{"abc", "xyz"}
+
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		ed25519KH, err := mockkms.CreateMockED25519KeyHandle()
+		require.NoError(t, err)
+
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination: &mockroute.MockMediatorSvc{
+					Connections:    []string{"xyz"},
+					RoutingKeys:    routingKeys,
+					RouterEndpoint: endpoint,
+				},
+			},
+			KMSValue:             &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+			ServiceEndpointValue: "endpoint",
+		})
+		require.NoError(t, err)
+
+		inviteReq, err := c.CreateInvitation("agent", WithRouterConnectionID("xyz"))
+		require.NoError(t, err)
+		require.NotNil(t, inviteReq)
+		require.NotEmpty(t, inviteReq.Label)
+		require.NotEmpty(t, inviteReq.ID)
+		require.Equal(t, endpoint, inviteReq.ServiceEndpoint)
+		require.Equal(t, routingKeys, inviteReq.RoutingKeys)
+	})
+
+	t.Run("test create invitation with router config error", func(t *testing.T) {
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		ed25519KH, err := mockkms.CreateMockED25519KeyHandle()
+		require.NoError(t, err)
+
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination: &mockroute.MockMediatorSvc{
+					Connections: []string{"xyz"},
+					ConfigErr:   errors.New("router config error"),
+				},
+			},
+			KMSValue:             &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+			ServiceEndpointValue: "endpoint",
+		})
+		require.NoError(t, err)
+
+		inviteReq, err := c.CreateInvitation("agent", WithRouterConnectionID("xyz"))
+		require.EqualError(t, err, "createInvitation: getRouterConfig: fetch router config: router config error")
+		require.Nil(t, inviteReq)
+	})
+
+	t.Run("test create invitation with adding key to router error", func(t *testing.T) {
+		endpoint := "http://router.example.com"
+		routingKeys := []string{"abc", "xyz"}
+
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		ed25519KH, err := mockkms.CreateMockED25519KeyHandle()
+		require.NoError(t, err)
+
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination: &mockroute.MockMediatorSvc{
+					Connections:    []string{"xyz"},
+					RoutingKeys:    routingKeys,
+					RouterEndpoint: endpoint,
+					AddKeyErr:      errors.New("failed to add key to the router"),
+				},
+			},
+			KMSValue:             &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+			ServiceEndpointValue: "endpoint",
+		})
+		require.NoError(t, err)
+
+		inviteReq, err := c.CreateInvitation("agent", WithRouterConnectionID("xyz"))
+		require.EqualError(t, err, "createInvitation: AddKeyToRouter: addKey: failed to add key to the router")
+		require.Nil(t, inviteReq)
+	})
+}
+
+func TestClient_CreateInvitationWithDID(t *testing.T) {
+	t.Run("test success", func(t *testing.T) {
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		ed25519KH, err := mockkms.CreateMockED25519KeyHandle()
+		require.NoError(t, err)
+
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+			KMSValue:             &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+			ServiceEndpointValue: "endpoint",
+		})
+		require.NoError(t, err)
+
+		const label = "agent"
+		const id = "did:peer:123"
+		inviteReq, err := c.CreateInvitationWithDID(label, id)
+		require.NoError(t, err)
+		require.NotNil(t, inviteReq)
+		require.Equal(t, label, inviteReq.Label)
+		require.NotEmpty(t, inviteReq.ID)
+		require.Equal(t, id, inviteReq.DID)
+	})
+
+	t.Run("test error from save invitation", func(t *testing.T) {
+		store := &mockstore.MockStore{
+			Store:  make(map[string]mockstore.DBEntry),
+			ErrPut: fmt.Errorf("store error"),
+		}
+
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			StoreProvider: mockstore.NewCustomMockStoreProvider(store),
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewCustomMockStoreProvider(store),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+			KMSValue: &mockkms.KeyManager{},
+		})
+		require.NoError(t, err)
+
+		_, err = c.CreateInvitationWithDID("agent", "did:peer:123")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to save invitation")
+	})
+}
+
+func TestClient_QueryConnectionByID(t *testing.T) {
+	const (
+		connID   = "id1"
+		threadID = "thid1"
+	)
+
+	ed25519KH, err := mockkms.CreateMockED25519KeyHandle()
+	require.NoError(t, err)
+
+	t.Run("test success", func(t *testing.T) {
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+			KMSValue:             &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+			ServiceEndpointValue: "endpoint",
+		})
+		require.NoError(t, err)
+
+		connRec := &connection.Record{ConnectionID: connID, ThreadID: threadID, State: "complete"}
+
+		require.NoError(t, err)
+		require.NoError(t, c.connectionStore.SaveConnectionRecord(connRec))
+		result, err := c.GetConnection(connID)
+		require.NoError(t, err)
+		require.Equal(t, "complete", result.State)
+		require.Equal(t, "id1", result.ConnectionID)
+	})
+
+	t.Run("test error", func(t *testing.T) {
+		const errMsg = "query connection error"
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		store := &mockstore.MockStore{
+			Store:  make(map[string]mockstore.DBEntry),
+			ErrGet: fmt.Errorf(errMsg),
+		}
+
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewCustomMockStoreProvider(store),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+			KMSValue:             &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+			ServiceEndpointValue: "endpoint",
+		})
+		require.NoError(t, err)
+
+		connRec := &connection.Record{ConnectionID: connID, ThreadID: threadID, State: "complete"}
+
+		require.NoError(t, err)
+		require.NoError(t, c.connectionStore.SaveConnectionRecord(connRec))
+		_, err = c.GetConnection(connID)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errMsg)
+	})
+
+	t.Run("test data not found", func(t *testing.T) {
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+			KMSValue:             &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+			ServiceEndpointValue: "endpoint",
+		})
+		require.NoError(t, err)
+
+		result, err := c.GetConnection(connID)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrConnectionNotFound))
+		require.Nil(t, result)
+	})
+}
+
+func TestClient_GetConnection(t *testing.T) {
+	connID := "id1"
+	threadID := "thid1"
+
+	t.Run("test failure", func(t *testing.T) {
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+		s := &mockstore.MockStore{Store: make(map[string]mockstore.DBEntry), ErrGet: ErrConnectionNotFound}
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		connRec := &connection.Record{ConnectionID: connID, ThreadID: threadID, State: "complete"}
+		connBytes, err := json.Marshal(connRec)
+		require.NoError(t, err)
+		require.NoError(t, s.Put("conn_id1", connBytes))
+		result, err := c.GetConnection(connID)
+		require.Equal(t, err.Error(), ErrConnectionNotFound.Error())
+		require.Nil(t, result)
+	})
+}
+
+func TestClientGetConnectionAtState(t *testing.T) {
+	// create service
+	svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+		ServiceMap: map[string]interface{}{
+			mediator.Coordination: &mockroute.MockMediatorSvc{},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+
+	// create client
+	c, err := New(&mockprovider.Provider{
+		ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+		StorageProviderValue:              mockstore.NewMockStoreProvider(),
+		ServiceMap: map[string]interface{}{
+			legacyconnection.LegacyConnection: svc,
+			mediator.Coordination:             &mockroute.MockMediatorSvc{},
+		},
+	})
+	require.NoError(t, err)
+
+	// not found
+	result, err := c.GetConnectionAtState("id1", "complete")
+	require.Equal(t, err.Error(), ErrConnectionNotFound.Error())
+	require.Nil(t, result)
+}
+
+func TestClient_CreateConnection(t *testing.T) {
+	t.Run("test create connection - success", func(t *testing.T) {
+		theirDID := newPeerDID(t)
+		myDID := newPeerDID(t)
+		threadID := uuid.New().String()
+		parentThreadID := uuid.New().String()
+		label := uuid.New().String()
+		invitationID := uuid.New().String()
+		invitationDID := newPeerDID(t).ID
+		implicit := true
+		storageProvider := &mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+		}
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: storageProvider.ProtocolStateStorageProvider(),
+			StorageProviderValue:              storageProvider.StorageProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: &mocksvc.MockLegacyConnectionSvc{
+					CreateConnRecordFunc: func(r *connection.Record, td *did.Doc) error {
+						recorder, err := connection.NewRecorder(storageProvider)
+						require.NoError(t, err)
+						err = recorder.SaveConnectionRecord(r)
+						require.NoError(t, err)
+
+						return nil
+					},
+				},
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+
+		id, err := c.CreateConnection(myDID.ID, theirDID,
+			WithTheirLabel(label), WithThreadID(threadID), WithParentThreadID(parentThreadID),
+			WithInvitationID(invitationID), WithInvitationDID(invitationDID), WithImplicit(implicit))
+		require.NoError(t, err)
+
+		conn, err := c.GetConnection(id)
+		require.NoError(t, err)
+		require.Equal(t, connection.StateNameCompleted, conn.State)
+		require.Equal(t, threadID, conn.ThreadID)
+		require.Equal(t, parentThreadID, conn.ParentThreadID)
+		require.Equal(t, label, conn.TheirLabel)
+		require.Equal(t, theirDID.ID, conn.TheirDID)
+		require.Equal(t, myDID.ID, conn.MyDID)
+		require.Equal(t, invitationID, conn.InvitationID)
+		require.Equal(t, invitationDID, conn.InvitationDID)
+		require.Equal(t, theirDID.Service[0].ServiceEndpoint, conn.ServiceEndPoint)
+		require.Equal(t, implicit, conn.Implicit)
+	})
+
+	t.Run("test create connection - error", func(t *testing.T) {
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: &mocksvc.MockLegacyConnectionSvc{
+					CreateConnRecordFunc: func(*connection.Record, *did.Doc) error {
+						return errors.New("save connection")
+					},
+				},
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+
+		id, err := c.CreateConnection(newPeerDID(t).ID, newPeerDID(t))
+		require.EqualError(t, err, "createConnection: err: save connection")
+		require.Empty(t, id)
+	})
+
+	t.Run("test create connection - error from CreateDestination", func(t *testing.T) {
+		theirDID := newPeerDID(t)
+		myDID := newPeerDID(t)
+		threadID := uuid.New().String()
+		parentThreadID := uuid.New().String()
+		label := uuid.New().String()
+		invitationID := uuid.New().String()
+		invitationDID := newPeerDID(t).ID
+		implicit := true
+		storageProvider := &mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+		}
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: storageProvider.ProtocolStateStorageProvider(),
+			StorageProviderValue:              storageProvider.StorageProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: &mocksvc.MockLegacyConnectionSvc{
+					CreateConnRecordFunc: func(r *connection.Record, td *did.Doc) error {
+						recorder, err := connection.NewRecorder(storageProvider)
+						require.NoError(t, err)
+						err = recorder.SaveConnectionRecord(r)
+						require.NoError(t, err)
+
+						return nil
+					},
+				},
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+
+		// empty ServiceEndpoint to trigger CreateDestination error
+		theirDID.Service[0].ServiceEndpoint = model.NewDIDCommV1Endpoint("")
+
+		_, err = c.CreateConnection(myDID.ID, theirDID,
+			WithTheirLabel(label), WithThreadID(threadID), WithParentThreadID(parentThreadID),
+			WithInvitationID(invitationID), WithInvitationDID(invitationDID), WithImplicit(implicit))
+		require.Contains(t, err.Error(), "createConnection: failed to create destination: "+
+			"create destination: service endpoint URI on didcomm v1 service block in diddoc error:")
+	})
+}
+
+func TestClient_RemoveConnection(t *testing.T) {
+	t.Run("test success", func(t *testing.T) {
+		connID := "id1"
+		threadID := "thid1"
+
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mem.NewProvider(),
+			StorageProviderValue:              mem.NewProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+
+		connRec := &connection.Record{ConnectionID: connID, ThreadID: threadID, State: "complete"}
+
+		require.NoError(t, err)
+		require.NoError(t, c.connectionStore.SaveConnectionRecord(connRec))
+
+		_, err = c.GetConnection(connID)
+		require.NoError(t, err)
+
+		err = c.RemoveConnection(connID)
+		require.NoError(t, err)
+
+		_, err = c.GetConnection(connID)
+		require.Error(t, err)
+		require.Equal(t, err.Error(), ErrConnectionNotFound.Error())
+	})
+	t.Run("test error data not found", func(t *testing.T) {
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+
+		err = c.RemoveConnection("sample-id")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "data not found")
+	})
+}
+
+func TestClient_HandleInvitation(t *testing.T) {
+	ed25519KH, err := mockkms.CreateMockED25519KeyHandle()
+	require.NoError(t, err)
+
+	t.Run("test success", func(t *testing.T) {
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: &mocksvc.MockLegacyConnectionSvc{},
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+			KMSValue:             &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+			ServiceEndpointValue: "endpoint",
+		})
+
+		require.NoError(t, err)
+		inviteReq, err := c.CreateInvitation("agent")
+		require.NoError(t, err)
+
+		connectionID, err := c.HandleInvitation(inviteReq)
+		require.NoError(t, err)
+		require.NotEmpty(t, connectionID)
+	})
+
+	t.Run("test error from handle msg", func(t *testing.T) {
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: &mocksvc.MockLegacyConnectionSvc{
+					HandleFunc: func(msg service.DIDCommMsg) (string, error) {
+						return "", fmt.Errorf("handle error")
+					},
+				},
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+
+			KMSValue:             &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+			ServiceEndpointValue: "endpoint",
+		})
+		require.NoError(t, err)
+		inviteReq, err := c.CreateInvitation("agent")
+		require.NoError(t, err)
+
+		_, err = c.HandleInvitation(inviteReq)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "handle error")
+	})
+}
+
+func TestClient_CreateImplicitInvitation(t *testing.T) {
+	ed25519KH, err := mockkms.CreateMockED25519KeyHandle()
+	require.NoError(t, err)
+
+	t.Run("test success", func(t *testing.T) {
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: &mocksvc.MockLegacyConnectionSvc{},
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+			KMSValue:             &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+			ServiceEndpointValue: "endpoint",
+		})
+		require.NoError(t, err)
+
+		connectionID, err := c.CreateImplicitInvitation("alice", "did:example:123")
+		require.NoError(t, err)
+		require.NotEmpty(t, connectionID)
+	})
+
+	t.Run("test error from service", func(t *testing.T) {
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: &mocksvc.MockLegacyConnectionSvc{
+					ImplicitInvitationErr: errors.New("implicit error"),
+				},
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+			KMSValue:             &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+			ServiceEndpointValue: "endpoint",
+		})
+		require.NoError(t, err)
+
+		connectionID, err := c.CreateImplicitInvitation("Alice", "did:example:123")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "implicit error")
+		require.Empty(t, connectionID)
+	})
+}
+
+func TestClient_CreateImplicitInvitationWithDID(t *testing.T) {
+	inviter := &DIDInfo{Label: "alice", DID: "did:example:alice"}
+	invitee := &DIDInfo{Label: "bob", DID: "did:example:bob"}
+
+	ed25519KH, err := mockkms.CreateMockED25519KeyHandle()
+	require.NoError(t, err)
+
+	t.Run("test success", func(t *testing.T) {
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: &mocksvc.MockLegacyConnectionSvc{},
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+			KMSValue:             &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+			ServiceEndpointValue: "endpoint",
+		})
+		require.NoError(t, err)
+
+		connectionID, err := c.CreateImplicitInvitationWithDID(inviter, invitee)
+		require.NoError(t, err)
+		require.NotEmpty(t, connectionID)
+	})
+
+	t.Run("test error from service", func(t *testing.T) {
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: &mocksvc.MockLegacyConnectionSvc{
+					ImplicitInvitationErr: errors.New("implicit with DID error"),
+				},
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+			KMSValue:             &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+			ServiceEndpointValue: "endpoint",
+		})
+		require.NoError(t, err)
+
+		connectionID, err := c.CreateImplicitInvitationWithDID(inviter, invitee)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "implicit with DID error")
+		require.Empty(t, connectionID)
+	})
+
+	t.Run("test missing required DID info", func(t *testing.T) {
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: &mocksvc.MockLegacyConnectionSvc{},
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+			KMSValue:             &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+			ServiceEndpointValue: "endpoint",
+		})
+		require.NoError(t, err)
+
+		connectionID, err := c.CreateImplicitInvitationWithDID(inviter, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing inviter and/or invitee public DID(s)")
+		require.Empty(t, connectionID)
+
+		connectionID, err = c.CreateImplicitInvitationWithDID(nil, invitee)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing inviter and/or invitee public DID(s)")
+		require.Empty(t, connectionID)
+	})
+}
+
+func TestClient_QueryConnectionsByParams(t *testing.T) { // nolint: gocyclo
+	t.Run("test get all connections", func(t *testing.T) {
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		storageProvider := mem.NewProvider()
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mem.NewProvider(),
+			StorageProviderValue:              storageProvider,
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+
+		store, err := storageProvider.OpenStore("didexchange")
+		require.NoError(t, err)
+
+		const count = 10
+		const keyPrefix = "conn_"
+		const state = "completed"
+		for i := 0; i < count; i++ {
+			val, e := json.Marshal(&connection.Record{
+				ConnectionID: fmt.Sprint(i),
+				State:        state,
+			})
+			require.NoError(t, e)
+			require.NoError(t,
+				store.Put(fmt.Sprintf("%sabc%d", keyPrefix, i), val, spi.Tag{Name: keyPrefix}))
+		}
+
+		results, err := c.QueryConnections(&QueryConnectionsParams{})
+		require.NoError(t, err)
+		require.Len(t, results, count)
+		for _, result := range results {
+			require.NotEmpty(t, result.ConnectionID)
+		}
+	})
+	t.Run("test get connections with params", func(t *testing.T) {
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+
+		storageProvider := mem.NewProvider()
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mem.NewProvider(),
+			StorageProviderValue:              storageProvider,
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+
+		store, err := storageProvider.OpenStore("didexchange")
+		require.NoError(t, err)
+
+		const count = 10
+		const countWithState = 5
+		const keyPrefix = "conn_"
+		const state = "completed"
+		const myDID = "my_did"
+		const theirDID = "their_did"
+		for i := 0; i < count; i++ {
+			var queryState string
+			if i < countWithState {
+				queryState = state
+			}
+
+			val, e := json.Marshal(&connection.Record{
+				ConnectionID:   fmt.Sprint(i),
+				InvitationID:   fmt.Sprintf("inv-%d", i),
+				ParentThreadID: fmt.Sprintf("ptid-%d", i),
+				State:          queryState,
+				MyDID:          myDID + strconv.Itoa(i),
+				TheirDID:       theirDID + strconv.Itoa(i),
+			})
+			require.NoError(t, e)
+			require.NoError(t,
+				store.Put(fmt.Sprintf("%sabc%d", keyPrefix, i), val, spi.Tag{Name: keyPrefix}))
+		}
+
+		results, err := c.QueryConnections(&QueryConnectionsParams{})
+		require.NoError(t, err)
+		require.Len(t, results, count)
+		for _, result := range results {
+			require.NotEmpty(t, result.ConnectionID)
+		}
+
+		results, err = c.QueryConnections(&QueryConnectionsParams{State: state})
+		require.NoError(t, err)
+		require.Len(t, results, countWithState)
+		for _, result := range results {
+			require.NotEmpty(t, result.ConnectionID)
+			require.Equal(t, result.State, state)
+		}
+
+		params := &QueryConnectionsParams{MyDID: myDID + strconv.Itoa(count-1)}
+		results, err = c.QueryConnections(params)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		for _, result := range results {
+			require.NotEmpty(t, result.ConnectionID)
+			require.Equal(t, result.MyDID, params.MyDID)
+		}
+
+		params = &QueryConnectionsParams{TheirDID: theirDID + strconv.Itoa(count-1)}
+		results, err = c.QueryConnections(params)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		for _, result := range results {
+			require.NotEmpty(t, result.ConnectionID)
+			require.Equal(t, result.TheirDID, params.TheirDID)
+		}
+
+		params = &QueryConnectionsParams{
+			MyDID:    myDID + strconv.Itoa(count-1),
+			TheirDID: theirDID + strconv.Itoa(count-1),
+		}
+		results, err = c.QueryConnections(params)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		for _, result := range results {
+			require.NotEmpty(t, result.ConnectionID)
+			require.Equal(t, result.MyDID, params.MyDID)
+			require.Equal(t, result.TheirDID, params.TheirDID)
+		}
+
+		params = &QueryConnectionsParams{
+			InvitationID: fmt.Sprintf("inv-%d", count-1),
+		}
+		results, err = c.QueryConnections(params)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		for _, result := range results {
+			require.NotEmpty(t, result.ConnectionID)
+			require.Equal(t, result.InvitationID, params.InvitationID)
+		}
+
+		params = &QueryConnectionsParams{
+			ParentThreadID: fmt.Sprintf("ptid-%d", count-1),
+		}
+		results, err = c.QueryConnections(params)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		for _, result := range results {
+			require.NotEmpty(t, result.ConnectionID)
+			require.Equal(t, result.ParentThreadID, params.ParentThreadID)
+		}
+	})
+
+	t.Run("test get connections error", func(t *testing.T) {
+		svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, svc)
+		const keyPrefix = "conn_"
+
+		storageProvider := mem.NewProvider()
+		c, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: mem.NewProvider(),
+			StorageProviderValue:              storageProvider,
+			ServiceMap: map[string]interface{}{
+				legacyconnection.LegacyConnection: svc,
+				mediator.Coordination:             &mockroute.MockMediatorSvc{},
+			},
+		})
+		require.NoError(t, err)
+
+		store, err := storageProvider.OpenStore("didexchange")
+		require.NoError(t, err)
+
+		require.NoError(t,
+			store.Put(fmt.Sprintf("%sabc", keyPrefix), []byte("----"), spi.Tag{Name: keyPrefix}))
+
+		results, err := c.QueryConnections(&QueryConnectionsParams{})
+		require.Error(t, err)
+		require.Empty(t, results)
+	})
+}
+
+func TestServiceEvents(t *testing.T) {
+	protocolStateStore := mockstore.NewMockStoreProvider()
+	store := mockstore.NewMockStoreProvider()
+	km := newKMS(t, store)
+	didExSvc, err := legacyconnection.New(&mockprotocol.MockProvider{
+		ProtocolStateStoreProvider: protocolStateStore,
+		StoreProvider:              store,
+		ServiceMap: map[string]interface{}{
+			mediator.Coordination: &mockroute.MockMediatorSvc{},
+		},
+		CustomKMS:             km,
+		KeyTypeValue:          kms.ED25519Type,
+		KeyAgreementTypeValue: kms.X25519ECDHKWType,
+	})
+	require.NoError(t, err)
+
+	// create the client
+	c, err := New(&mockprovider.Provider{
+		ProtocolStateStorageProviderValue: protocolStateStore,
+		StorageProviderValue:              store,
+		ServiceMap: map[string]interface{}{
+			legacyconnection.LegacyConnection: didExSvc,
+			mediator.Coordination:             &mockroute.MockMediatorSvc{},
+		},
+		KMSValue:              km,
+		KeyTypeValue:          kms.ED25519Type,
+		KeyAgreementTypeValue: kms.X25519ECDHKWType,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	// register action event channel
+	aCh := make(chan service.DIDCommAction, 10)
+	err = c.RegisterActionEvent(aCh)
+	require.NoError(t, err)
+
+	go func() {
+		service.AutoExecuteActionEvent(aCh)
+	}()
+
+	// register message event channel
+	mCh := make(chan service.StateMsg, 10)
+	err = c.RegisterMsgEvent(mCh)
+	require.NoError(t, err)
+
+	stateMsg := make(chan service.StateMsg)
+
+	go func() {
+		for e := range mCh {
+			if e.Type == service.PostState && e.StateID == "responded" {
+				stateMsg <- e
+			}
+		}
+	}()
+
+	// send connection request message
+	id := "valid-thread-id"
+	doc, err := (&mockvdr.MockVDRegistry{}).Create("test", nil)
+	require.NoError(t, err)
+
+	invitation, err := c.CreateInvitation("alice")
+	require.NoError(t, err)
+
+	request, err := json.Marshal(
+		&legacyconnection.Request{
+			Type:  legacyconnection.RequestMsgType,
+			ID:    id,
+			Label: "test",
+			Thread: &decorator.Thread{
+				PID: invitation.ID,
+			},
+			Connection: &legacyconnection.Connection{
+				DID:    doc.DIDDocument.ID,
+				DIDDoc: doc.DIDDocument,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	msg, err := service.ParseDIDCommMsgMap(request)
+	require.NoError(t, err)
+	_, err = didExSvc.HandleInbound(msg, service.EmptyDIDCommContext())
+	require.NoError(t, err)
+
+	select {
+	case e := <-stateMsg:
+		switch v := e.Properties.(type) {
+		case Event:
+			props := v
+			conn, err := c.GetConnectionAtState(props.ConnectionID(), e.StateID)
+			require.NoError(t, err)
+			require.Equal(t, e.StateID, conn.State)
+		default:
+			require.Fail(t, "unable to cast to did exchange event")
+		}
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "tests are not validated due to timeout")
+	}
+}
+
+func TestAcceptConnectionRequest(t *testing.T) {
+	store := mockstore.NewMockStoreProvider()
+	km := newKMS(t, store)
+	svc, err := legacyconnection.New(&mockprotocol.MockProvider{
+		StoreProvider: store,
+		ServiceMap: map[string]interface{}{
+			mediator.Coordination: &mockroute.MockMediatorSvc{},
+		},
+		CustomKMS:             km,
+		KeyTypeValue:          kms.ED25519Type,
+		KeyAgreementTypeValue: kms.X25519ECDHKWType,
+	})
+	require.NoError(t, err)
+
+	// create the client
+	c, err := New(&mockprovider.Provider{
+		ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+		StorageProviderValue:              store,
+		ServiceMap: map[string]interface{}{
+			legacyconnection.LegacyConnection: svc,
+			mediator.Coordination:             &mockroute.MockMediatorSvc{},
+		},
+		KMSValue:              km,
+		KeyTypeValue:          kms.ED25519Type,
+		KeyAgreementTypeValue: kms.X25519ECDHKWType,
+	},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	// register action event channel
+	aCh := make(chan service.DIDCommAction, 10)
+	err = c.RegisterActionEvent(aCh)
+	require.NoError(t, err)
+
+	go func() {
+		for e := range aCh {
+			prop, ok := e.Properties.(Event)
+			if !ok {
+				require.Fail(t, "Failed to cast the event properties to service.Event")
+			}
+
+			require.NoError(t, c.AcceptConnectionRequest(prop.ConnectionID(), "", ""))
+		}
+	}()
+
+	// register message event channel
+	mCh := make(chan service.StateMsg, 10)
+	err = c.RegisterMsgEvent(mCh)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+
+	go func() {
+		for e := range mCh {
+			if e.Type == service.PostState && e.StateID == "responded" {
+				close(done)
+			}
+		}
+	}()
+
+	invitation, err := c.CreateInvitation("alice")
+	require.NoError(t, err)
+	// send connection request message
+	id := "valid-thread-id"
+	doc, err := (&mockvdr.MockVDRegistry{}).Create("test", nil)
+	require.NoError(t, err)
+
+	request, err := json.Marshal(
+		&legacyconnection.Request{
+			Type:  legacyconnection.RequestMsgType,
+			ID:    id,
+			Label: "test",
+			Thread: &decorator.Thread{
+				PID: invitation.ID,
+			},
+			Connection: &legacyconnection.Connection{
+				DID:    doc.DIDDocument.ID,
+				DIDDoc: doc.DIDDocument,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	msg, err := service.ParseDIDCommMsgMap(request)
+	require.NoError(t, err)
+	_, err = svc.HandleInbound(msg, service.EmptyDIDCommContext())
+	require.NoError(t, err)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "tests are not validated due to timeout")
+	}
+
+	err = c.AcceptConnectionRequest("invalid-id", "", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "legacyconnection client - accept connection request:")
+}
+
+func TestAcceptInvitation(t *testing.T) {
+	store := mockstore.NewMockStoreProvider()
+	km := newKMS(t, store)
+	didExSvc, err := legacyconnection.New(&mockprotocol.MockProvider{
+		StoreProvider: store,
+		ServiceMap: map[string]interface{}{
+			mediator.Coordination: &mockroute.MockMediatorSvc{},
+		},
+		CustomKMS:             km,
+		KeyTypeValue:          kms.ED25519Type,
+		KeyAgreementTypeValue: kms.X25519ECDHKWType,
+	})
+	require.NoError(t, err)
+
+	// create the client
+	c, err := New(&mockprovider.Provider{
+		ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+		StorageProviderValue:              store,
+		ServiceMap: map[string]interface{}{
+			legacyconnection.LegacyConnection: didExSvc,
+			mediator.Coordination:             &mockroute.MockMediatorSvc{},
+		},
+		KMSValue:              km,
+		KeyTypeValue:          kms.ED25519Type,
+		KeyAgreementTypeValue: kms.X25519ECDHKWType,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	t.Run("accept invitation - success", func(t *testing.T) {
+		// register action event channel
+		aCh := make(chan service.DIDCommAction, 10)
+		err = c.RegisterActionEvent(aCh)
+		require.NoError(t, err)
+
+		go func() {
+			for e := range aCh {
+				_, ok := e.Properties.(Event)
+				require.True(t, ok, "Failed to cast the event properties to service.Event")
+
+				// ignore action event
+			}
+		}()
+
+		// register message event channel
+		mCh := make(chan service.StateMsg, 10)
+		err = c.RegisterMsgEvent(mCh)
+		require.NoError(t, err)
+
+		done := make(chan struct{})
+
+		go func() {
+			for e := range mCh {
+				prop, ok := e.Properties.(Event)
+				if !ok {
+					require.Fail(t, "Failed to cast the event properties to service.Event")
+				}
+
+				if e.Type == service.PostState && e.StateID == "invited" {
+					require.NoError(t, c.AcceptInvitation(prop.ConnectionID(), "", ""))
+				}
+
+				if e.Type == service.PostState && e.StateID == "requested" {
+					close(done)
+				}
+			}
+		}()
+
+		_, pubKey, e := km.CreateAndExportPubKeyBytes(kms.ED25519Type)
+		require.NoError(t, e)
+
+		// send connection invitation message
+		invitation, jsonErr := json.Marshal(
+			&legacyconnection.Invitation{
+				Type:          InvitationMsgType,
+				ID:            "abc",
+				Label:         "test",
+				RecipientKeys: []string{base58.Encode(pubKey)},
+			},
+		)
+		require.NoError(t, jsonErr)
+
+		msg, svcErr := service.ParseDIDCommMsgMap(invitation)
+		require.NoError(t, svcErr)
+		_, err = didExSvc.HandleInbound(msg, service.EmptyDIDCommContext())
+		require.NoError(t, err)
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "tests are not validated due to timeout")
+		}
+	})
+
+	t.Run("accept invitation - error", func(t *testing.T) {
+		err = c.AcceptInvitation("invalid-id", "", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "legacyconnection client - accept connection invitation")
+	})
+}
+
+func newPeerDID(t *testing.T) *did.Doc {
+	t.Helper()
+
+	a, err := aries.New(
+		aries.WithStoreProvider(mem.NewProvider()),
+		aries.WithProtocolStateStoreProvider(mem.NewProvider()),
+	)
+	require.NoError(t, err)
+
+	ctx, err := a.Context()
+	require.NoError(t, err)
+
+	d, err := ctx.VDRegistry().Create(
+		peer.DIDMethod, &did.Doc{Service: []did.Service{{
+			Type:            "did-communication",
+			ServiceEndpoint: model.NewDIDCommV1Endpoint("http://agent.example.com/didcomm"),
+		}}, VerificationMethod: []did.VerificationMethod{getSigningKey()}})
+	require.NoError(t, err)
+
+	return d.DIDDocument
+}
+
+func getSigningKey() did.VerificationMethod {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+
+	return did.VerificationMethod{Value: pub[:], Type: "Ed25519VerificationKey2018"}
+}
+
+func newKMS(t *testing.T, store spi.Provider) kms.KeyManager {
+	t.Helper()
+
+	kmsProv := &mockprotocol.MockProvider{
+		StoreProvider: store,
+		CustomLock:    &noop.NoLock{},
+	}
+
+	customKMS, err := localkms.New("local-lock://primary/test/", kmsProv)
+	require.NoError(t, err)
+
+	return customKMS
+}

--- a/pkg/client/legacyconnection/doc.go
+++ b/pkg/client/legacyconnection/doc.go
@@ -1,0 +1,22 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package legacyconnection enables relationship between two agents via Connection RFC-0160 Protocol.
+// The connection request message is used to communicate the DID document of the invitee to the inviter
+// using the provisional service information present in the invitation message. The connection response message
+// is used to complete the connection and communicate the DID document of the inviter to the invitee.
+// After inviter receives the connection response, the establishment of connection is technically complete
+// however it is still unconfirmed to the inviter. The invitee sends ACK message to inviter to confirm the connection.
+//
+//  Basic Flow:
+//  1) Prepare client context
+//  2) Create client
+//  3) Register for action events (enables auto execution)
+//  4) Create Invitation
+//  5) Handle invitation
+//  6) Use connection
+//
+package legacyconnection

--- a/pkg/client/legacyconnection/event.go
+++ b/pkg/client/legacyconnection/event.go
@@ -1,15 +1,14 @@
 /*
-Copyright SecureKey Technologies Inc. All Rights Reserved.
 Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
 
-package didexchange
+package legacyconnection
 
 import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/model"
 )
 
-// Event properties related api. This can be used to cast Generic event properties to DID Exchange specific props.
+// Event properties related api. This can be used to cast Generic event properties to connection specific props.
 type Event model.Event

--- a/pkg/client/legacyconnection/example_test.go
+++ b/pkg/client/legacyconnection/example_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package legacyconnection
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/legacyconnection"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
+	mockprotocol "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol"
+	mockroute "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/mediator"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
+	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
+	mockstore "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+)
+
+func Example() {
+	bob, err := New(mockContext())
+	if err != nil {
+		fmt.Println("failed to create client for Bob")
+	}
+
+	bobActions := make(chan service.DIDCommAction, 1)
+
+	err = bob.RegisterActionEvent(bobActions)
+	if err != nil {
+		fmt.Println("failed to create Bob's action channel")
+	}
+
+	go func() {
+		service.AutoExecuteActionEvent(bobActions)
+	}()
+
+	alice, err := New(mockContext())
+	if err != nil {
+		fmt.Println("failed to create client for Alice")
+	}
+
+	aliceActions := make(chan service.DIDCommAction, 1)
+
+	err = alice.RegisterActionEvent(aliceActions)
+	if err != nil {
+		fmt.Println("failed to create Alice's action channel")
+	}
+
+	go func() {
+		service.AutoExecuteActionEvent(aliceActions)
+	}()
+
+	invitation, err := bob.CreateInvitation("bob invites alice")
+	if err != nil {
+		fmt.Printf("failed to create invitation: %s\n", err)
+	}
+
+	connectionID, err := alice.HandleInvitation(invitation)
+	if err != nil {
+		fmt.Printf("failed to handle invitation: %s\n", err)
+	}
+
+	connection, err := alice.GetConnection(connectionID)
+	if err != nil {
+		fmt.Printf("failed to get connection: %s\n", err)
+	}
+
+	fmt.Println(connection.TheirLabel)
+
+	// Output: bob invites alice
+}
+
+func ExampleNew() {
+	ctx := mockContext()
+
+	c, err := New(ctx)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	if c != nil {
+		fmt.Println("client created")
+	} else {
+		fmt.Println("client is nil")
+	}
+
+	// Output: client created
+}
+
+func ExampleClient_CreateInvitation() {
+	bob, err := New(mockContext())
+	if err != nil {
+		fmt.Println("failed to create client for Bob")
+	}
+
+	invitation, err := bob.CreateInvitation("bob invites julia")
+	if err != nil {
+		fmt.Printf("failed to create invitation: %s\n", err)
+	}
+
+	fmt.Println(invitation.Label)
+
+	// Output: bob invites julia
+}
+
+func ExampleClient_CreateInvitationWithDID() {
+	bob, err := New(mockContext())
+	if err != nil {
+		fmt.Println("failed to create client for Bob")
+	}
+
+	invitation, err := bob.CreateInvitationWithDID("bob invites maria", "did:example:abc-123")
+	if err != nil {
+		fmt.Printf("failed to create invitation with DID: %s\n", err)
+	}
+
+	fmt.Println(invitation.DID)
+
+	// Output: did:example:abc-123
+}
+
+func mockContext() provider {
+	protocolStateStoreProvider := mockstore.NewMockStoreProvider()
+	storeProvider := mockstore.NewMockStoreProvider()
+	mockProvider := &mockprotocol.MockProvider{
+		ProtocolStateStoreProvider: protocolStateStoreProvider,
+		StoreProvider:              storeProvider,
+		ServiceMap: map[string]interface{}{
+			mediator.Coordination: &mockroute.MockMediatorSvc{},
+		},
+	}
+
+	svc, err := legacyconnection.New(mockProvider)
+	if err != nil {
+		panic(err)
+	}
+
+	mockSigningKey, err := mockkms.CreateMockED25519KeyHandle()
+	if err != nil {
+		panic(err)
+	}
+
+	context := &mockprovider.Provider{
+		KMSValue: &mockkms.KeyManager{
+			CreateKeyID:    "signing-key-123",
+			CreateKeyValue: mockSigningKey,
+		},
+		ProtocolStateStorageProviderValue: protocolStateStoreProvider,
+		StorageProviderValue:              storeProvider,
+		ServiceMap: map[string]interface{}{
+			legacyconnection.LegacyConnection: svc,
+			mediator.Coordination:             &mockroute.MockMediatorSvc{},
+		},
+	}
+
+	return context
+}

--- a/pkg/client/legacyconnection/models.go
+++ b/pkg/client/legacyconnection/models.go
@@ -1,0 +1,69 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package legacyconnection
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/legacyconnection"
+	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
+)
+
+// QueryConnectionsParams model
+//
+// Parameters for querying connections.
+//
+type QueryConnectionsParams struct {
+
+	// Alias of connection invitation
+	Alias string `json:"alias,omitempty"`
+
+	// Initiator is Connection invitation initiator
+	Initiator string `json:"initiator,omitempty"`
+
+	// Invitation key
+	InvitationKey string `json:"invitation_key,omitempty"`
+
+	// Invitation ID
+	InvitationID string `json:"invitation_id,omitempty"`
+
+	// Parent threadID
+	ParentThreadID string `json:"parent_thread_id,omitempty"`
+
+	// MyDID is DID of the agent
+	MyDID string `json:"my_did,omitempty"`
+
+	// State of the connection invitation
+	State string `json:"state"`
+
+	// TheirDID is other party's DID
+	TheirDID string `json:"their_did,omitempty"`
+
+	// TheirRole is other party's role
+	TheirRole string `json:"their_role,omitempty"`
+}
+
+// Connection model
+//
+// This is used to represent query connection result.
+//
+type Connection struct {
+	*connection.Record
+}
+
+// Invitation model for connection invitation.
+type Invitation struct {
+	*legacyconnection.Invitation
+}
+
+// DIDInfo model for specifying public DID and associated label.
+type DIDInfo struct {
+
+	// the DID
+	DID string
+
+	// the label associated with DID
+	Label string
+}

--- a/pkg/controller/command/errors.go
+++ b/pkg/controller/command/errors.go
@@ -1,5 +1,6 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
@@ -79,6 +80,9 @@ const (
 
 	// Connection error group for connection management errors.
 	Connection = 15000
+
+	// LegacyConnection error group for legacyconnection command errors.
+	LegacyConnection = 16000
 )
 
 // Error is the  interface for representing an command error condition, with the nil value representing no error.

--- a/pkg/controller/command/legacyconnection/command.go
+++ b/pkg/controller/command/legacyconnection/command.go
@@ -1,0 +1,498 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package legacyconnection
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/hyperledger/aries-framework-go/pkg/client/legacyconnection"
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/internal/cmdutil"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/webnotifier"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	protocol "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/legacyconnection"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/logutil"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+)
+
+var logger = log.New("aries-framework/controller/legacy-connection")
+
+// constants for endpoints of legacy-connection.
+const (
+	CommandName = "legacyconnection"
+
+	// error messages.
+	errEmptyInviterDID = "empty inviter DID"
+	errEmptyConnID     = "empty connection ID"
+
+	AcceptConnectionRequestCommandMethod  = "AcceptConnectionRequest"
+	AcceptInvitationCommandMethod         = "AcceptInvitation"
+	CreateImplicitInvitationCommandMethod = "CreateImplicitInvitation"
+	CreateInvitationCommandMethod         = "CreateInvitation"
+	QueryConnectionByIDCommandMethod      = "QueryConnectionByID"
+	QueryConnectionsCommandMethod         = "QueryConnections"
+	ReceiveInvitationCommandMethod        = "ReceiveInvitation"
+	CreateConnectionCommandMethod         = "CreateConnection"
+	RemoveConnectionCommandMethod         = "RemoveConnection"
+
+	// log constants.
+	connectionIDString = "connectionID"
+	successString      = "success"
+	invitationIDString = "invitationID"
+)
+
+const (
+	// InvalidRequestErrorCode is typically a code for validation errors
+	// for invalid legacy-connection controller requests.
+	InvalidRequestErrorCode = command.Code(iota + command.LegacyConnection)
+
+	// CreateInvitationErrorCode is for failures in create invitation command.
+	CreateInvitationErrorCode
+
+	// CreateImplicitInvitationErrorCode is for failures in create implicit invitation command.
+	CreateImplicitInvitationErrorCode
+
+	// ReceiveInvitationErrorCode is for failures in receive invitation command.
+	ReceiveInvitationErrorCode
+
+	// AcceptInvitationErrorCode is for failures in accept invitation command.
+	AcceptInvitationErrorCode
+
+	// AcceptConnectionRequestErrorCode is for failures in accept connection request command.
+	AcceptConnectionRequestErrorCode
+
+	// QueryConnectionsErrorCode is for failures in query connection command.
+	QueryConnectionsErrorCode
+
+	// RemoveConnectionErrorCode is for failures in remove connection command.
+	RemoveConnectionErrorCode
+
+	// CreateConnectionErrorCode is for failures in create connection command.
+	CreateConnectionErrorCode
+
+	_actions = "_actions"
+	_states  = "_states"
+)
+
+// provider contains dependencies for the legacy-connection command and is typically created by using aries.Context().
+type provider interface {
+	Service(id string) (interface{}, error)
+	KMS() kms.KeyManager
+	ServiceEndpoint() string
+	StorageProvider() storage.Provider
+	ProtocolStateStorageProvider() storage.Provider
+	KeyType() kms.KeyType
+	KeyAgreementType() kms.KeyType
+	MediaTypeProfiles() []string
+}
+
+// New returns new legacy-connection controller command instance.
+func New(ctx provider, notifier command.Notifier, defaultLabel string, autoAccept bool) (*Command, error) {
+	legacyConnection, err := legacyconnection.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// creates action channel
+	actions := make(chan service.DIDCommAction)
+	// registers action channel to listen for events
+	if err := legacyConnection.RegisterActionEvent(actions); err != nil {
+		return nil, fmt.Errorf("register action event: %w", err)
+	}
+
+	// creates state channel
+	states := make(chan service.StateMsg)
+	// registers state channel to listen for events
+	if err := legacyConnection.RegisterMsgEvent(states); err != nil {
+		return nil, fmt.Errorf("register msg event: %w", err)
+	}
+
+	subscribers := []chan service.DIDCommAction{
+		make(chan service.DIDCommAction),
+	}
+
+	if autoAccept {
+		subscribers = append(subscribers, make(chan service.DIDCommAction))
+
+		go service.AutoExecuteActionEvent(subscribers[1])
+	}
+
+	go func() {
+		for action := range actions {
+			for i := range subscribers {
+				action.Message = action.Message.Clone()
+				subscribers[i] <- action
+			}
+		}
+	}()
+
+	obs := webnotifier.NewObserver(notifier)
+	obs.RegisterAction(protocol.LegacyConnection+_actions, subscribers[0])
+	obs.RegisterStateMsg(protocol.LegacyConnection+_states, states)
+
+	cmd := &Command{
+		ctx:          ctx,
+		client:       legacyConnection,
+		msgCh:        make(chan service.StateMsg),
+		defaultLabel: defaultLabel,
+	}
+
+	return cmd, nil
+}
+
+// Command is controller command for legacy-connection.
+type Command struct {
+	ctx          provider
+	client       *legacyconnection.Client
+	msgCh        chan service.StateMsg
+	defaultLabel string
+}
+
+// GetHandlers returns list of all commands supported by this controller command.
+func (c *Command) GetHandlers() []command.Handler {
+	return []command.Handler{
+		cmdutil.NewCommandHandler(CommandName, CreateInvitationCommandMethod, c.CreateInvitation),
+		cmdutil.NewCommandHandler(CommandName, ReceiveInvitationCommandMethod, c.ReceiveInvitation),
+		cmdutil.NewCommandHandler(CommandName, AcceptInvitationCommandMethod, c.AcceptInvitation),
+		cmdutil.NewCommandHandler(CommandName, CreateConnectionCommandMethod, c.CreateConnection),
+		cmdutil.NewCommandHandler(CommandName, RemoveConnectionCommandMethod, c.RemoveConnection),
+		cmdutil.NewCommandHandler(CommandName, QueryConnectionByIDCommandMethod, c.QueryConnectionByID),
+		cmdutil.NewCommandHandler(CommandName, QueryConnectionsCommandMethod, c.QueryConnections),
+		cmdutil.NewCommandHandler(CommandName, AcceptConnectionRequestCommandMethod, c.AcceptConnectionRequest),
+		cmdutil.NewCommandHandler(CommandName, CreateImplicitInvitationCommandMethod, c.CreateImplicitInvitation),
+	}
+}
+
+// CreateInvitation Creates a new connection invitation.
+func (c *Command) CreateInvitation(rw io.Writer, req io.Reader) command.Error {
+	var request CreateInvitationArgs
+
+	err := json.NewDecoder(req).Decode(&request)
+	if err != nil {
+		logutil.LogInfo(logger, CommandName, CreateInvitationCommandMethod, err.Error())
+
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	var invitation *legacyconnection.Invitation
+	// call legacyconnection client
+	if request.Public != "" {
+		invitation, err = c.client.CreateInvitationWithDID(c.defaultLabel, request.Public)
+	} else {
+		invitation, err = c.client.CreateInvitation(c.defaultLabel,
+			legacyconnection.WithRouterConnectionID(request.RouterConnectionID))
+	}
+
+	if err != nil {
+		logutil.LogError(logger, CommandName, CreateInvitationCommandMethod, err.Error())
+
+		return command.NewExecuteError(CreateInvitationErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &CreateInvitationResponse{
+		Invitation: invitation,
+		Alias:      request.Alias,
+	},
+		logger)
+
+	logutil.LogDebug(logger, CommandName, CreateInvitationCommandMethod, successString,
+		logutil.CreateKeyValueString(invitationIDString, invitation.ID))
+
+	return nil
+}
+
+// ReceiveInvitation receives a new connection invitation.
+func (c *Command) ReceiveInvitation(rw io.Writer, req io.Reader) command.Error {
+	var request legacyconnection.Invitation
+
+	err := json.NewDecoder(req).Decode(&request.Invitation)
+	if err != nil {
+		logutil.LogInfo(logger, CommandName, ReceiveInvitationCommandMethod, err.Error())
+
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	connectionID, err := c.client.HandleInvitation(&request)
+	if err != nil {
+		logutil.LogError(logger, CommandName, ReceiveInvitationCommandMethod, err.Error(),
+			logutil.CreateKeyValueString(invitationIDString, request.ID),
+			logutil.CreateKeyValueString("label", request.Label),
+			logutil.CreateKeyValueString(connectionIDString, connectionID))
+
+		return command.NewExecuteError(ReceiveInvitationErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, ReceiveInvitationResponse{
+		ConnectionID: connectionID,
+	}, logger)
+
+	logutil.LogDebug(logger, CommandName, ReceiveInvitationCommandMethod, successString,
+		logutil.CreateKeyValueString(invitationIDString, request.ID),
+		logutil.CreateKeyValueString("label", request.Label),
+		logutil.CreateKeyValueString(connectionIDString, connectionID))
+
+	return nil
+}
+
+// AcceptInvitation accepts a stored connection invitation.
+func (c *Command) AcceptInvitation(rw io.Writer, req io.Reader) command.Error {
+	var request AcceptInvitationArgs
+
+	err := json.NewDecoder(req).Decode(&request)
+	if err != nil {
+		logutil.LogInfo(logger, CommandName, AcceptInvitationCommandMethod, err.Error())
+
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if request.ID == "" {
+		logutil.LogDebug(logger, CommandName, AcceptInvitationCommandMethod, errEmptyConnID)
+
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyConnID))
+	}
+
+	err = c.client.AcceptInvitation(request.ID, request.Public, c.defaultLabel,
+		legacyconnection.WithRouterConnections(strings.Split(request.RouterConnections, ",")...))
+	if err != nil {
+		logutil.LogError(logger, CommandName, AcceptInvitationCommandMethod, err.Error(),
+			logutil.CreateKeyValueString(connectionIDString, request.ID))
+
+		return command.NewExecuteError(AcceptInvitationErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &AcceptInvitationResponse{
+		ConnectionID: request.ID,
+	}, logger)
+
+	logutil.LogDebug(logger, CommandName, AcceptInvitationCommandMethod, successString,
+		logutil.CreateKeyValueString(connectionIDString, request.ID))
+
+	return nil
+}
+
+// CreateImplicitInvitation creates implicit invitation using inviter DID.
+func (c *Command) CreateImplicitInvitation(rw io.Writer, req io.Reader) command.Error {
+	var request ImplicitInvitationArgs
+
+	err := json.NewDecoder(req).Decode(&request)
+	if err != nil {
+		logutil.LogInfo(logger, CommandName, CreateImplicitInvitationCommandMethod, err.Error())
+
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if request.InviterDID == "" {
+		logutil.LogDebug(logger, CommandName, CreateImplicitInvitationCommandMethod, errEmptyInviterDID)
+
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyInviterDID))
+	}
+
+	logger.Debugf("create implicit invitation: inviterDID[%s], inviterLabel[%s], inviteeDID[%s], inviteeLabel[%s]",
+		request.InviterDID, request.InviterLabel, request.InviteeDID, request.InviterLabel)
+
+	inviter := &legacyconnection.DIDInfo{DID: request.InviterDID, Label: request.InviterLabel}
+
+	var id string
+
+	if request.InviteeDID != "" {
+		invitee := &legacyconnection.DIDInfo{DID: request.InviteeDID, Label: request.InviteeLabel}
+		id, err = c.client.CreateImplicitInvitationWithDID(inviter, invitee)
+	} else {
+		id, err = c.client.CreateImplicitInvitation(inviter.Label, inviter.DID,
+			legacyconnection.WithRouterConnections(strings.Split(request.RouterConnections, ",")...))
+	}
+
+	if err != nil {
+		logutil.LogError(logger, CommandName, CreateImplicitInvitationCommandMethod, err.Error())
+
+		return command.NewExecuteError(CreateImplicitInvitationErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &ImplicitInvitationResponse{
+		ConnectionID: id,
+	}, logger)
+
+	logutil.LogDebug(logger, CommandName, CreateImplicitInvitationCommandMethod, successString)
+
+	return nil
+}
+
+// AcceptConnectionRequest accepts a stored connection request.
+func (c *Command) AcceptConnectionRequest(rw io.Writer, req io.Reader) command.Error {
+	var request AcceptConnectionRequestArgs
+
+	err := json.NewDecoder(req).Decode(&request)
+	if err != nil {
+		logutil.LogInfo(logger, CommandName, AcceptConnectionRequestCommandMethod, err.Error())
+
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if request.ID == "" {
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyConnID))
+	}
+
+	err = c.client.AcceptConnectionRequest(request.ID, request.Public,
+		c.defaultLabel, legacyconnection.WithRouterConnections(strings.Split(request.RouterConnections, ",")...))
+	if err != nil {
+		logutil.LogError(logger, CommandName, AcceptConnectionRequestCommandMethod, err.Error(),
+			logutil.CreateKeyValueString(connectionIDString, request.ID))
+
+		return command.NewExecuteError(AcceptConnectionRequestErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &ConnectionResponse{
+		ConnectionID: request.ID,
+	}, logger)
+
+	logutil.LogDebug(logger, CommandName, AcceptConnectionRequestCommandMethod, successString,
+		logutil.CreateKeyValueString(connectionIDString, request.ID))
+
+	return nil
+}
+
+// QueryConnections queries agent to agent connections.
+func (c *Command) QueryConnections(rw io.Writer, req io.Reader) command.Error {
+	var request QueryConnectionsArgs
+
+	err := json.NewDecoder(req).Decode(&request)
+	if err != nil {
+		logutil.LogInfo(logger, CommandName, QueryConnectionsCommandMethod, err.Error())
+
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	results, err := c.client.QueryConnections(&request.QueryConnectionsParams)
+	if err != nil {
+		logutil.LogError(logger, CommandName, QueryConnectionsCommandMethod, err.Error())
+
+		return command.NewExecuteError(QueryConnectionsErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &QueryConnectionsResponse{
+		Results: results,
+	}, logger)
+
+	logutil.LogDebug(logger, CommandName, QueryConnectionsCommandMethod, successString)
+
+	return nil
+}
+
+// QueryConnectionByID fetches a single connection record by connection ID.
+func (c *Command) QueryConnectionByID(rw io.Writer, req io.Reader) command.Error {
+	var request ConnectionIDArg
+
+	err := json.NewDecoder(req).Decode(&request)
+	if err != nil {
+		logutil.LogInfo(logger, CommandName, QueryConnectionByIDCommandMethod, err.Error())
+
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if request.ID == "" {
+		logutil.LogDebug(logger, CommandName, QueryConnectionByIDCommandMethod, errEmptyConnID)
+
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyConnID))
+	}
+
+	result, err := c.client.GetConnection(request.ID)
+	if err != nil {
+		logutil.LogError(logger, CommandName, QueryConnectionByIDCommandMethod, err.Error(),
+			logutil.CreateKeyValueString(connectionIDString, request.ID))
+
+		return command.NewExecuteError(QueryConnectionsErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &QueryConnectionResponse{
+		Result: result,
+	}, logger)
+
+	logutil.LogDebug(logger, CommandName, QueryConnectionByIDCommandMethod, successString,
+		logutil.CreateKeyValueString(connectionIDString, request.ID))
+
+	return nil
+}
+
+// CreateConnection creates a new connection record in completed state and returns the generated connectionID.
+func (c *Command) CreateConnection(rw io.Writer, req io.Reader) command.Error {
+	request := &CreateConnectionRequest{}
+
+	err := json.NewDecoder(req).Decode(request)
+	if err != nil {
+		logutil.LogInfo(logger, CommandName, CreateConnectionCommandMethod, err.Error())
+
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	theirDID, err := did.ParseDocument(request.TheirDID.Contents)
+	if err != nil {
+		logutil.LogInfo(logger, CommandName, CreateConnectionCommandMethod, err.Error())
+
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	id, err := c.client.CreateConnection(request.MyDID, theirDID,
+		legacyconnection.WithImplicit(request.Implicit),
+		legacyconnection.WithTheirLabel(request.TheirLabel),
+		legacyconnection.WithInvitationDID(request.InvitationDID),
+		legacyconnection.WithInvitationID(request.InvitationID),
+		legacyconnection.WithParentThreadID(request.ParentThreadID),
+		legacyconnection.WithThreadID(request.ThreadID))
+	if err != nil {
+		logutil.LogError(logger, CommandName, CreateConnectionCommandMethod, err.Error())
+
+		return command.NewExecuteError(CreateConnectionErrorCode, err)
+	}
+
+	command.WriteNillableResponse(rw, &ConnectionIDArg{
+		ID: id,
+	}, logger)
+
+	logutil.LogDebug(logger, CommandName, CreateConnectionCommandMethod, successString,
+		logutil.CreateKeyValueString(connectionIDString, id))
+
+	return nil
+}
+
+// RemoveConnection removes given connection record.
+func (c *Command) RemoveConnection(_ io.Writer, req io.Reader) command.Error {
+	var request ConnectionIDArg
+
+	err := json.NewDecoder(req).Decode(&request)
+	if err != nil {
+		logutil.LogInfo(logger, CommandName, RemoveConnectionCommandMethod, err.Error())
+
+		return command.NewValidationError(InvalidRequestErrorCode, err)
+	}
+
+	if request.ID == "" {
+		logutil.LogDebug(logger, CommandName, RemoveConnectionCommandMethod, errEmptyConnID)
+
+		return command.NewValidationError(InvalidRequestErrorCode, fmt.Errorf(errEmptyConnID))
+	}
+
+	logger.Debugf("Removing connection record for id [%s]", request.ID)
+
+	err = c.client.RemoveConnection(request.ID)
+	if err != nil {
+		logutil.LogError(logger, CommandName, RemoveConnectionCommandMethod, err.Error(),
+			logutil.CreateKeyValueString(connectionIDString, request.ID))
+
+		return command.NewExecuteError(RemoveConnectionErrorCode, err)
+	}
+
+	logutil.LogDebug(logger, CommandName, RemoveConnectionCommandMethod, successString,
+		logutil.CreateKeyValueString(connectionIDString, request.ID))
+
+	return nil
+}

--- a/pkg/controller/command/legacyconnection/command_test.go
+++ b/pkg/controller/command/legacyconnection/command_test.go
@@ -1,0 +1,1032 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package legacyconnection
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
+	mockwebhook "github.com/hyperledger/aries-framework-go/pkg/controller/internal/mocks/webhook"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/webnotifier"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
+	legacyconnsvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/legacyconnection"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+	"github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol"
+	mocklegacyconn "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/legacyconnection"
+	mockroute "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/mediator"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
+	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
+	mockstore "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	mockvdr "github.com/hyperledger/aries-framework-go/pkg/mock/vdr"
+	"github.com/hyperledger/aries-framework-go/pkg/secretlock/noop"
+	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/peer"
+	spi "github.com/hyperledger/aries-framework-go/spi/storage"
+)
+
+const (
+	mockSvcEndpoint = "endpoint"
+	postState       = "post_state"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("Successfully create new legacy-connection command", func(t *testing.T) {
+		cmd, err := New(mockProvider(), webnotifier.NewHTTPNotifier(nil), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		handlers := cmd.GetHandlers()
+		require.NotEmpty(t, handlers)
+	})
+
+	t.Run("Successfully create new legacy-connection command with auto accept", func(t *testing.T) {
+		cmd, err := New(mockProvider(), webnotifier.NewHTTPNotifier(nil), "", true)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+	})
+
+	t.Run("Test create new legacy-connection command failure", func(t *testing.T) {
+		cmd, err := New(&mockprovider.Provider{ServiceErr: errors.New("test-error")},
+			webnotifier.NewHTTPNotifier(nil), "", false)
+		require.Error(t, err)
+		require.Nil(t, cmd)
+	})
+
+	expectedErr := errors.New("error")
+
+	t.Run("Register action event: error", func(t *testing.T) {
+		prov := mockProvider()
+		prov.ServiceMap[legacyconnsvc.LegacyConnection] = &mocklegacyconn.MockLegacyConnectionSvc{
+			ProtocolName:           "mockProtocolSvc",
+			RegisterActionEventErr: expectedErr,
+			RegisterMsgEventErr:    expectedErr,
+		}
+
+		cmd, err := New(prov, webnotifier.NewHTTPNotifier(nil), "", false)
+		require.EqualError(t, err, "register action event: "+expectedErr.Error())
+		require.Nil(t, cmd)
+	})
+
+	t.Run("Register msg event: error", func(t *testing.T) {
+		prov := mockProvider()
+		prov.ServiceMap[legacyconnsvc.LegacyConnection] = &mocklegacyconn.MockLegacyConnectionSvc{
+			ProtocolName:        "mockProtocolSvc",
+			RegisterMsgEventErr: expectedErr,
+		}
+
+		cmd, err := New(prov, webnotifier.NewHTTPNotifier(nil), "", false)
+		require.EqualError(t, err, "register msg event: "+expectedErr.Error())
+		require.Nil(t, cmd)
+	})
+}
+
+func TestCommand_CreateInvitation(t *testing.T) {
+	t.Run("Successful CreateInvitation with label", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		jsonReq := `{"alias":"myalias"}`
+		var b bytes.Buffer
+		cmdErr := cmd.CreateInvitation(&b, bytes.NewBufferString(jsonReq))
+		require.NoError(t, cmdErr)
+
+		response := CreateInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response.Invitation)
+		require.Equal(t, mockSvcEndpoint, response.Invitation.ServiceEndpoint)
+		require.Empty(t, response.Invitation.Label)
+		require.Equal(t, "myalias", response.Alias)
+		require.NotEmpty(t, response.Invitation.ID)
+		require.Equal(t, "https://didcomm.org/connections/1.0/invitation", response.Invitation.Type)
+	})
+
+	t.Run("Successful CreateInvitation with label and public DID", func(t *testing.T) {
+		const publicDID = "sample-public-did"
+
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		jsonReq := fmt.Sprintf(`{"alias":"myalias", "public":"%s"}`, publicDID)
+
+		var b bytes.Buffer
+		cmdErr := cmd.CreateInvitation(&b, bytes.NewBufferString(jsonReq))
+		require.NoError(t, cmdErr)
+
+		response := CreateInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response.Invitation)
+		require.Empty(t, response.Invitation.ServiceEndpoint)
+		require.Empty(t, response.Invitation.Label)
+		require.NotEmpty(t, response.Alias)
+		require.NotEmpty(t, response.Invitation.DID)
+		require.Equal(t, publicDID, response.Invitation.DID)
+	})
+
+	t.Run("Successful CreateInvitation with default params", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.CreateInvitation(&b, bytes.NewBufferString("{}"))
+		require.NoError(t, cmdErr)
+
+		response := CreateInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response.Invitation)
+		require.Equal(t, mockSvcEndpoint, response.Invitation.ServiceEndpoint)
+		require.Empty(t, response.Invitation.Label)
+		require.Empty(t, response.Alias)
+		require.NotEmpty(t, response.Invitation.ID)
+		require.Equal(t, "https://didcomm.org/connections/1.0/invitation", response.Invitation.Type)
+	})
+
+	t.Run("CreateInvitation failure", func(t *testing.T) {
+		const errMsg = "sample-err-01"
+		provider := mockProvider()
+		provider.StorageProviderValue = mockstore.NewCustomMockStoreProvider(
+			&mockstore.MockStore{
+				ErrPut: fmt.Errorf(errMsg),
+			},
+		)
+
+		cmd, err := New(provider, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.CreateInvitation(&b, bytes.NewBufferString("--"))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+
+		b.Reset()
+		cmdErr = cmd.CreateInvitation(&b, bytes.NewBufferString("{}"))
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errMsg)
+		require.Equal(t, CreateInvitationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+}
+
+func TestCommand_ReceiveInvitation(t *testing.T) {
+	t.Run("Successful ReceiveInvitation", func(t *testing.T) {
+		jsonStr := `{
+		"serviceEndpoint":"http://alice.agent.example.com:8081",
+		"recipientKeys":["FDmegH8upiNquathbHZiGBZKwcudNfNWPeGQFBt8eNNi"],
+		"@id":"a35c0ac6-4fc3-46af-a072-c1036d036057",
+		"label":"agent",
+		"@type":"https://didcomm.org/connections/1.0/invitation"}`
+
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.ReceiveInvitation(&b, bytes.NewBufferString(jsonStr))
+		require.NoError(t, cmdErr)
+
+		response := ReceiveInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.ConnectionID)
+	})
+
+	t.Run("ReceiveInvitation failure", func(t *testing.T) {
+		jsonStr := `{
+    	"@type": "https://didcomm.org/connections/1.0/invitation",
+    	"@id": "4e8650d9-6cc9-491e-b00e-7bf6cb5858fc",
+    	"serviceEndpoint": "http://ip10-0-46-4-blikjbs9psqg8vrg4p10-8020.direct.play-with-von.vonx.io",
+    	"label": "Faber Agent",
+    	"recipientKeys": [
+      		"6LE8yhZB8Xffc5vFgFntE3YLrxq5JVUsoAvUQgUyktGt"
+    		]
+  	}`
+		const errMsg = "sample-err-01"
+
+		prov := mockProvider()
+		prov.ServiceMap[legacyconnsvc.LegacyConnection] = &mocklegacyconn.MockLegacyConnectionSvc{
+			ProtocolName: "mockProtocolSvc",
+			HandleFunc: func(msg service.DIDCommMsg) (string, error) {
+				return uuid.New().String(), fmt.Errorf(errMsg)
+			},
+		}
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.ReceiveInvitation(&b, bytes.NewBufferString(jsonStr))
+		require.Error(t, cmdErr)
+		require.Contains(t, cmdErr.Error(), errMsg)
+		require.Equal(t, ReceiveInvitationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+
+	t.Run("ReceiveInvitation validation error", func(t *testing.T) {
+		jsonStr := `--`
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.ReceiveInvitation(&b, bytes.NewBufferString(jsonStr))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+}
+
+func TestCommand_QueryConnectionByID(t *testing.T) {
+	t.Run("QueryConnectionByID success", func(t *testing.T) {
+		// prepare data
+		const connID = "1234"
+		prov := mockProvider()
+		store := mockstore.MockStore{Store: make(map[string]mockstore.DBEntry)}
+		connRec := &connection.Record{State: "complete", ConnectionID: "1234", ThreadID: "th1234"}
+
+		connBytes, err := json.Marshal(connRec)
+		require.NoError(t, err)
+		require.NoError(t, store.Put("conn_"+connID, connBytes))
+		prov.StorageProviderValue = &mockstore.MockStoreProvider{Store: &store}
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		jsoStr := fmt.Sprintf(`{"id":"%s"}`, connID)
+
+		var b bytes.Buffer
+		cmdErr := cmd.QueryConnectionByID(&b, bytes.NewBufferString(jsoStr))
+		require.NoError(t, cmdErr)
+
+		response := QueryConnectionResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.Result.ConnectionID)
+		require.Equal(t, connID, response.Result.ConnectionID)
+	})
+
+	t.Run("QueryConnectionByID validation error", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.QueryConnectionByID(&b, bytes.NewBufferString("--"))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("QueryConnectionByID validation error", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.QueryConnectionByID(&b, bytes.NewBufferString("{}"))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+		require.Contains(t, cmdErr.Error(), errEmptyConnID)
+	})
+
+	t.Run("QueryConnectionByID store failure", func(t *testing.T) {
+		// prepare data
+		const errMsg = "sample-err-01"
+		prov := mockProvider()
+		store := mockstore.MockStore{ErrGet: fmt.Errorf(errMsg)}
+		prov.StorageProviderValue = &mockstore.MockStoreProvider{Store: &store}
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.QueryConnectionByID(&b, bytes.NewBufferString(`{"id":"xyz"}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, QueryConnectionsErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+		require.Contains(t, cmdErr.Error(), errMsg)
+	})
+}
+
+func TestCommand_QueryConnections(t *testing.T) {
+	t.Run("test query connections with state filter", func(t *testing.T) {
+		// prepare data
+		const connID = "1234"
+		const state = "requested"
+
+		prov := mockProvider()
+
+		memStorageProvider := mem.NewProvider()
+
+		store, err := memStorageProvider.OpenStore("didexchange")
+		require.NoError(t, err)
+
+		connRec := &connection.Record{State: state, ConnectionID: connID, ThreadID: "th1234"}
+
+		connBytes, err := json.Marshal(connRec)
+		require.NoError(t, err)
+		require.NoError(t, store.Put("conn_"+connID, connBytes, spi.Tag{Name: "conn_"}))
+
+		prov.StorageProviderValue = memStorageProvider
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		jsoStr := fmt.Sprintf(`{"state":"%s"}`, state)
+
+		var b bytes.Buffer
+		cmdErr := cmd.QueryConnections(&b, bytes.NewBufferString(jsoStr))
+		require.NoError(t, cmdErr)
+
+		response := QueryConnectionsResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.Results)
+		require.Len(t, response.Results, 1)
+		require.NotEmpty(t, connID, response.Results[0].ConnectionID)
+		require.NotEmpty(t, state, response.Results[0].State)
+
+		// test for record not found
+		b.Reset()
+		cmdErr = cmd.QueryConnections(&b, bytes.NewBufferString(`{"state":"completed"}`))
+		require.NoError(t, cmdErr)
+
+		response = QueryConnectionsResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.Empty(t, response)
+	})
+
+	t.Run("test query connections without state filter", func(t *testing.T) {
+		// prepare data
+		const connID = "1234"
+
+		prov := mockProvider()
+
+		memStorageProvider := mem.NewProvider()
+
+		store, err := memStorageProvider.OpenStore("didexchange")
+		require.NoError(t, err)
+
+		connRec := &connection.Record{State: "completed", ConnectionID: connID, ThreadID: "th1234"}
+
+		connBytes, err := json.Marshal(connRec)
+		require.NoError(t, err)
+		require.NoError(t, store.Put("conn_"+connID, connBytes, spi.Tag{Name: "conn_"}))
+		prov.StorageProviderValue = memStorageProvider
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.QueryConnections(&b, bytes.NewBufferString("{}"))
+		require.NoError(t, cmdErr)
+
+		response := QueryConnectionsResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.Results)
+		require.Len(t, response.Results, 1)
+		require.NotEmpty(t, connID, response.Results[0].ConnectionID)
+	})
+
+	t.Run("test query connections validation error", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.QueryConnections(&b, bytes.NewBufferString("--"))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+}
+
+func TestCommand_AcceptInvitation(t *testing.T) {
+	t.Run("test accept invitation success", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptInvitation(&b, bytes.NewBufferString(`{"id":"1234"}`))
+		require.NoError(t, cmdErr)
+
+		response := AcceptInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+		require.Equal(t, "1234", response.ConnectionID)
+	})
+
+	t.Run("test accept invitation validation error", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptInvitation(&b, bytes.NewBufferString(`{"id":""}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+		require.Contains(t, cmdErr.Error(), errEmptyConnID)
+
+		b.Reset()
+		cmdErr = cmd.AcceptInvitation(&b, bytes.NewBufferString(`--`))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("test accept invitation failures", func(t *testing.T) {
+		const errMsg = "sample-err-01"
+		prov := mockProvider()
+		prov.ServiceMap[legacyconnsvc.LegacyConnection] = &mocklegacyconn.MockLegacyConnectionSvc{
+			ProtocolName: "mockProtocolSvc",
+			HandleFunc: func(msg service.DIDCommMsg) (string, error) {
+				return uuid.New().String(), nil
+			},
+			AcceptError: fmt.Errorf(errMsg),
+		}
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptInvitation(&b, bytes.NewBufferString(`{"id":"1234"}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, AcceptInvitationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+		require.Contains(t, cmdErr.Error(), errMsg)
+	})
+
+	t.Run("test accept invitation complete flow", func(t *testing.T) {
+		store := mockstore.NewMockStoreProvider()
+		km := newKMS(t, store)
+		legacyConnSvc, err := legacyconnsvc.New(&protocol.MockProvider{
+			ProtocolStateStoreProvider: store,
+			ServiceMap: map[string]interface{}{
+				mediator.Coordination: &mockroute.MockMediatorSvc{},
+			},
+			CustomKMS:             km,
+			KeyTypeValue:          kms.ED25519Type,
+			KeyAgreementTypeValue: kms.X25519ECDHKWType,
+		})
+
+		require.NoError(t, err)
+
+		done := make(chan struct{})
+		connID := make(chan string)
+
+		// create the client
+		cmd, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: store,
+			StorageProviderValue:              mockstore.NewMockStoreProvider(),
+			ServiceMap: map[string]interface{}{
+				legacyconnsvc.LegacyConnection: legacyConnSvc,
+				mediator.Coordination:          &mockroute.MockMediatorSvc{},
+			},
+			KMSValue:              km,
+			KeyTypeValue:          kms.ED25519Type,
+			KeyAgreementTypeValue: kms.X25519ECDHKWType,
+		},
+			&mockwebhook.Notifier{
+				NotifyFunc: func(topic string, message []byte) error {
+					if topic == "legacyconnection_actions" {
+						return nil
+					}
+					require.Equal(t, "legacyconnection_states", topic)
+					conn := struct {
+						StateID    string
+						Properties map[string]string
+						Type       string
+					}{}
+					jsonErr := json.Unmarshal(message, &conn)
+					require.NoError(t, jsonErr)
+
+					if conn.StateID == "invited" && conn.Type == postState {
+						connID <- conn.Properties[connectionIDString]
+					}
+
+					if conn.StateID == "requested" && conn.Type == postState {
+						close(done)
+					}
+
+					return nil
+				},
+			},
+			"", false,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		_, pubKey, e := km.CreateAndExportPubKeyBytes(kms.ED25519Type)
+		require.NoError(t, e)
+
+		// send connection invitation message
+		invitation, err := json.Marshal(
+			&legacyconnsvc.Invitation{
+				Type:          legacyconnsvc.InvitationMsgType,
+				ID:            "abc",
+				Label:         "test",
+				RecipientKeys: []string{string(pubKey)},
+			},
+		)
+		require.NoError(t, err)
+
+		msg, err := service.ParseDIDCommMsgMap(invitation)
+		require.NoError(t, err)
+
+		_, err = legacyConnSvc.HandleInbound(msg, service.EmptyDIDCommContext())
+		require.NoError(t, err)
+
+		var cid string
+		select {
+		case cid = <-connID:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "tests are not validated")
+		}
+
+		jsonStr := fmt.Sprintf(`{"id":"%s"}`, cid)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptInvitation(&b, bytes.NewBufferString(jsonStr))
+		require.NoError(t, cmdErr)
+
+		response := AcceptInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		select {
+		case <-done:
+		case <-time.After(1 * time.Second):
+			require.Fail(t, "tests are not validated")
+		}
+	})
+}
+
+func TestCommand_CreateImplicitInvitation(t *testing.T) {
+	t.Run("test create implicit invitation success", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.CreateImplicitInvitation(&b, bytes.NewBufferString(`{"their_did":"samle-public-did"}`))
+		require.NoError(t, cmdErr)
+
+		response := ImplicitInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+		require.NotEmpty(t, response)
+		require.Equal(t, "connection-id", response.ConnectionID)
+	})
+
+	t.Run("test create implicit invitation with DID success", func(t *testing.T) {
+		const jsonStr = `{"their_did":"samle-public-did","my_did":"my-public-did"}`
+
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.CreateImplicitInvitation(&b, bytes.NewBufferString(jsonStr))
+		require.NoError(t, cmdErr)
+
+		response := ImplicitInvitationResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+		require.NotEmpty(t, response)
+		require.Equal(t, "connection-id", response.ConnectionID)
+	})
+
+	t.Run("test create implicit invitation validation error", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.CreateImplicitInvitation(&b, bytes.NewBufferString(`{}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("test handler failure", func(t *testing.T) {
+		const errMsg = "sample-err-01"
+		prov := mockProvider()
+		prov.ServiceMap[legacyconnsvc.LegacyConnection] = &mocklegacyconn.MockLegacyConnectionSvc{
+			ProtocolName: "mockProtocolSvc",
+			HandleFunc: func(msg service.DIDCommMsg) (string, error) {
+				return uuid.New().String(), nil
+			},
+			ImplicitInvitationErr: fmt.Errorf(errMsg),
+		}
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.CreateImplicitInvitation(&b, bytes.NewBufferString(`{"their_did":"samle-public-did"}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, CreateImplicitInvitationErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+	})
+}
+
+func TestCommand_AcceptConnectionRequest(t *testing.T) {
+	t.Run("test accept connection request success", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptConnectionRequest(&b, bytes.NewBufferString(`{"id":"1234"}`))
+		require.NoError(t, cmdErr)
+
+		response := ConnectionResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+		require.Equal(t, "1234", response.ConnectionID)
+	})
+
+	t.Run("test accept connection request validation error", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptConnectionRequest(&b, bytes.NewBufferString(`{"id":""}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+		require.Contains(t, cmdErr.Error(), errEmptyConnID)
+
+		b.Reset()
+		cmdErr = cmd.AcceptConnectionRequest(&b, bytes.NewBufferString(`--`))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+
+	t.Run("test accept connection request failures", func(t *testing.T) {
+		const errMsg = "sample-err-01"
+		prov := mockProvider()
+		prov.ServiceMap[legacyconnsvc.LegacyConnection] = &mocklegacyconn.MockLegacyConnectionSvc{
+			ProtocolName: "mockProtocolSvc",
+			HandleFunc: func(msg service.DIDCommMsg) (string, error) {
+				return uuid.New().String(), nil
+			},
+			AcceptError: fmt.Errorf(errMsg),
+		}
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptConnectionRequest(&b, bytes.NewBufferString(`{"id":"1234"}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, AcceptConnectionRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ExecuteError, cmdErr.Type())
+		require.Contains(t, cmdErr.Error(), errMsg)
+	})
+
+	t.Run("test accept connection request complete flow", func(t *testing.T) {
+		protocolStateStore := mockstore.NewMockStoreProvider()
+		store := mockstore.NewMockStoreProvider()
+		km := newKMS(t, store)
+		legacyConnSvc, err := legacyconnsvc.New(
+			&protocol.MockProvider{
+				ProtocolStateStoreProvider: protocolStateStore, StoreProvider: store,
+				ServiceMap: map[string]interface{}{
+					mediator.Coordination: &mockroute.MockMediatorSvc{},
+				},
+				CustomKMS:             km,
+				KeyTypeValue:          kms.ED25519Type,
+				KeyAgreementTypeValue: kms.X25519ECDHKWType,
+			},
+		)
+
+		require.NoError(t, err)
+
+		done := make(chan struct{})
+		connID := make(chan string)
+
+		// create the client
+		cmd, err := New(&mockprovider.Provider{
+			ProtocolStateStorageProviderValue: protocolStateStore,
+			StorageProviderValue:              store,
+			ServiceMap: map[string]interface{}{
+				legacyconnsvc.LegacyConnection: legacyConnSvc,
+				mediator.Coordination:          &mockroute.MockMediatorSvc{},
+			},
+			KMSValue:              km,
+			KeyTypeValue:          kms.ED25519Type,
+			KeyAgreementTypeValue: kms.X25519ECDHKWType,
+		},
+			&mockwebhook.Notifier{
+				NotifyFunc: func(topic string, message []byte) error {
+					if topic == "legacyconnection_actions" {
+						return nil
+					}
+
+					require.Equal(t, "legacyconnection_states", topic)
+					conn := struct {
+						StateID    string
+						Properties map[string]string
+						Type       string
+					}{}
+					jsonErr := json.Unmarshal(message, &conn)
+					require.NoError(t, jsonErr)
+
+					if conn.StateID == "requested" && conn.Type == postState {
+						connID <- conn.Properties[connectionIDString]
+					}
+
+					if conn.StateID == "responded" && conn.Type == postState {
+						close(done)
+					}
+
+					return nil
+				},
+			},
+			"", false,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		// send connection request message
+		id := "valid-thread-id"
+		didDoc, err := (&mockvdr.MockVDRegistry{}).Create("peer", nil)
+		require.NoError(t, err)
+
+		invitation, err := cmd.client.CreateInvitation("test")
+		require.NoError(t, err)
+
+		request, err := json.Marshal(
+			&legacyconnsvc.Request{
+				Type:  legacyconnsvc.RequestMsgType,
+				ID:    id,
+				Label: "test",
+				Thread: &decorator.Thread{
+					PID: invitation.ID,
+				},
+				Connection: &legacyconnsvc.Connection{
+					DID:    didDoc.DIDDocument.ID,
+					DIDDoc: didDoc.DIDDocument,
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		msg, err := service.ParseDIDCommMsgMap(request)
+		require.NoError(t, err)
+
+		_, err = legacyConnSvc.HandleInbound(msg, service.EmptyDIDCommContext())
+		require.NoError(t, err)
+
+		cid := <-connID
+
+		jsonStr := fmt.Sprintf(`{"id":"%s"}`, cid)
+
+		var b bytes.Buffer
+		cmdErr := cmd.AcceptConnectionRequest(&b, bytes.NewBufferString(jsonStr))
+		require.NoError(t, cmdErr)
+
+		response := ConnectionResponse{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "tests are not validated")
+		}
+	})
+}
+
+func TestCommand_SaveConnection(t *testing.T) {
+	t.Run("test save connection - success", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		theirDID := newPeerDID(t)
+		theirDIDBytes, err := theirDID.JSONBytes()
+		require.NoError(t, err)
+
+		request := &CreateConnectionRequest{
+			MyDID: newPeerDID(t).ID,
+			TheirDID: DIDDocument{
+				ID:       theirDID.ID,
+				Contents: theirDIDBytes,
+			},
+			TheirLabel:     "alice",
+			InvitationID:   uuid.New().String(),
+			InvitationDID:  newPeerDID(t).ID,
+			ParentThreadID: uuid.New().String(),
+			ThreadID:       uuid.New().String(),
+			Implicit:       true,
+		}
+
+		var b bytes.Buffer
+
+		cmdErr := cmd.CreateConnection(&b, bytes.NewBuffer(toBytes(t, request)))
+		require.NoError(t, cmdErr)
+
+		response := ConnectionIDArg{}
+		err = json.NewDecoder(&b).Decode(&response)
+		require.NoError(t, err)
+		require.NotEmpty(t, response.ID)
+	})
+
+	t.Run("test remove connection validation error", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.CreateConnection(&b, bytes.NewBufferString(`--`))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+}
+
+func TestCommand_RemoveConnection(t *testing.T) {
+	t.Run("test remove connection", func(t *testing.T) {
+		// prepare data
+		const connID = "1234"
+		prov := mockProvider()
+		store := mockstore.MockStore{Store: make(map[string]mockstore.DBEntry)}
+		connRec := &connection.Record{State: "complete", ConnectionID: "1234", ThreadID: "th1234"}
+
+		connBytes, err := json.Marshal(connRec)
+		require.NoError(t, err)
+		require.NoError(t, store.Put("conn_"+connID, connBytes))
+		prov.StorageProviderValue = &mockstore.MockStoreProvider{Store: &store}
+
+		cmd, err := New(prov, mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+
+		cmdErr := cmd.QueryConnectionByID(&b, bytes.NewBufferString(`{"id":"1234"}`))
+		require.NoError(t, cmdErr)
+
+		b.Reset()
+
+		cmdErr = cmd.RemoveConnection(&b, bytes.NewBufferString(`{"id":"1234", "myDid": "myDid", "theirDid": "theirDid"}`))
+		require.NoError(t, cmdErr)
+
+		b.Reset()
+
+		cmdErr = cmd.QueryConnectionByID(&b, bytes.NewBufferString(`{"id":"1234"}`))
+		require.Error(t, cmdErr)
+	})
+
+	t.Run("test remove connection validation error", func(t *testing.T) {
+		cmd, err := New(mockProvider(), mockwebhook.NewMockWebhookNotifier(), "", false)
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+
+		var b bytes.Buffer
+		cmdErr := cmd.RemoveConnection(&b, bytes.NewBufferString(`{"id":""}`))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+		require.Contains(t, cmdErr.Error(), errEmptyConnID)
+
+		b.Reset()
+		cmdErr = cmd.RemoveConnection(&b, bytes.NewBufferString(`--`))
+		require.Error(t, cmdErr)
+		require.Equal(t, InvalidRequestErrorCode, cmdErr.Code())
+		require.Equal(t, command.ValidationError, cmdErr.Type())
+	})
+}
+
+func mockProvider() *mockprovider.Provider {
+	return &mockprovider.Provider{
+		ProtocolStateStorageProviderValue: mem.NewProvider(),
+		StorageProviderValue:              mockstore.NewMockStoreProvider(),
+		ServiceMap: map[string]interface{}{
+			legacyconnsvc.LegacyConnection: &mocklegacyconn.MockLegacyConnectionSvc{},
+			mediator.Coordination:          &mockroute.MockMediatorSvc{},
+		},
+		KMSValue:             &mockkms.KeyManager{},
+		ServiceEndpointValue: mockSvcEndpoint,
+	}
+}
+
+func newPeerDID(t *testing.T) *did.Doc {
+	t.Helper()
+
+	a, err := aries.New(
+		aries.WithStoreProvider(mem.NewProvider()),
+		aries.WithProtocolStateStoreProvider(mem.NewProvider()),
+	)
+	require.NoError(t, err)
+
+	ctx, err := a.Context()
+	require.NoError(t, err)
+
+	d, err := ctx.VDRegistry().Create(
+		peer.DIDMethod, &did.Doc{Service: []did.Service{{
+			Type:            vdr.DIDCommServiceType,
+			ServiceEndpoint: model.NewDIDCommV1Endpoint("http://agent.example.com/didcomm"),
+		}}, VerificationMethod: []did.VerificationMethod{getSigningKey()}},
+	)
+	require.NoError(t, err)
+
+	return d.DIDDocument
+}
+
+func getSigningKey() did.VerificationMethod {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+
+	return did.VerificationMethod{Value: pub[:], Type: "Ed25519VerificationKey2018"}
+}
+
+func toBytes(t *testing.T, v interface{}) []byte {
+	t.Helper()
+
+	bits, err := json.Marshal(v)
+	require.NoError(t, err)
+
+	return bits
+}
+
+func newKMS(t *testing.T, store spi.Provider) kms.KeyManager {
+	t.Helper()
+
+	kmsProv := &protocol.MockProvider{
+		StoreProvider: store,
+		CustomLock:    &noop.NoLock{},
+	}
+
+	customKMS, err := localkms.New("local-lock://primary/test/", kmsProv)
+	require.NoError(t, err)
+
+	return customKMS
+}

--- a/pkg/controller/command/legacyconnection/models.go
+++ b/pkg/controller/command/legacyconnection/models.go
@@ -1,0 +1,334 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package legacyconnection
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/hyperledger/aries-framework-go/pkg/client/legacyconnection"
+)
+
+// CreateInvitationArgs model
+//
+// This is used for creating invitation.
+//
+type CreateInvitationArgs struct {
+
+	// The Alias to be used in invitation to be created
+	Alias string `json:"alias"`
+
+	// Optional public DID to be used in invitation
+	Public string `json:"public,omitempty"`
+
+	// Optional specifies router connection id
+	RouterConnectionID string `json:"router_connection_id"`
+}
+
+// CreateInvitationResponse model
+//
+// This is used for returning a create invitation response with a single connection invitation as body.
+//
+type CreateInvitationResponse struct {
+	Invitation *legacyconnection.Invitation `json:"invitation"`
+
+	Alias string `json:"alias"`
+
+	InvitationURL string `json:"invitation_url"`
+}
+
+// ReceiveInvitationResponse model
+//
+// This is used for returning a receive invitation response with a single receive invitation response as body.
+//
+type ReceiveInvitationResponse struct {
+	// State of the connection invitation
+	State string `json:"state"`
+
+	// Created time
+	CreateTime time.Time `json:"created_at,omitempty"`
+
+	// Updated time
+	UpdateTime time.Time `json:"updated_at,omitempty"`
+
+	// the connection ID of the connection invitation
+	ConnectionID string `json:"connection_id"`
+
+	// Routing state of connection invitation
+	RoutingState string `json:"routing_state,omitempty"`
+
+	// Connection invitation initiator
+	Initiator string `json:"initiator,omitempty"`
+
+	// Connection invitation accept mode
+	Accept string `json:"accept,omitempty"`
+
+	// Invitation mode
+	Mode string `json:"invitation_mode,omitempty"`
+
+	// Invitation ID of invitation response
+	RequestID string `json:"request_id"`
+
+	// My DID
+	DID string `json:"my_did"`
+
+	// Invitation key
+	InvitationKey string `json:"invitation_key,omitempty"`
+
+	// Other party's label
+	InviterLabel string `json:"their_label,omitempty"`
+}
+
+// AcceptInvitationArgs model
+//
+// This is used for operation to accept connection invitation.
+//
+type AcceptInvitationArgs struct {
+	// Connection ID
+	ID string `json:"id"`
+
+	// Optional Public DID to be used for this request
+	Public string `json:"public"`
+
+	// Optional specifies router connections (comma-separated values)
+	RouterConnections string `json:"router_connections"`
+}
+
+// AcceptInvitationResponse model
+//
+// This is used for returning a accept invitation response for single invitation.
+//
+type AcceptInvitationResponse struct {
+
+	// State of the connection invitation
+	State string `json:"state,omitempty"`
+
+	// Other party's DID
+	InviterDID string `json:"their_did,omitempty"`
+
+	// Created time
+	CreateTime time.Time `json:"created_at,omitempty"`
+
+	// Connection invitation accept mode
+	Accept string `json:"accept,omitempty"`
+
+	// My DID
+	DID string `json:"my_did,omitempty"`
+
+	// Invitation ID of invitation response
+	RequestID string `json:"request_id,omitempty"`
+
+	// Other party's label
+	InviterLabel string `json:"their_label,omitempty"`
+
+	// Alias
+	Alias string `json:"alias,omitempty"`
+
+	// Other party's role
+	InviterRole string `json:"their_role,omitempty"`
+
+	// Connection invitation initiator
+	Initiator string `json:"initiator,omitempty"`
+
+	// Updated time
+	UpdateTime time.Time `json:"updated_at,omitempty"`
+
+	// Invitation key
+	InvitationKey string `json:"invitation_key,omitempty"`
+
+	// Routing state of connection invitation
+	RoutingState string `json:"routing_state,omitempty"`
+
+	// Inbound Connection ID  of the connection invitation
+	InboundConnectionID string `json:"inbound_connection_id,omitempty"`
+
+	// the connection ID of the connection invitation
+	ConnectionID string `json:"connection_id,omitempty"`
+
+	// Error message
+	Error string `json:"error_msg,omitempty"`
+
+	// Invitation mode
+	Mode string `json:"invitation_mode,omitempty"`
+}
+
+// ImplicitInvitationArgs model
+//
+// This is used by invitee to create implicit invitation.
+//
+type ImplicitInvitationArgs struct {
+	// InviterDID
+	InviterDID string `json:"their_did"`
+
+	// Optional inviter label
+	InviterLabel string `json:"their_label"`
+
+	// Optional invitee did
+	InviteeDID string `json:"my_did"`
+
+	// Optional invitee label
+	InviteeLabel string `json:"my_label"`
+
+	// Optional specifies router connections (comma-separated values)
+	RouterConnections string `json:"router_connections"`
+}
+
+// ImplicitInvitationResponse model
+//
+// This is used for returning create implicit invitation response.
+//
+type ImplicitInvitationResponse struct {
+	// the connection ID of the connection for implicit invitation
+	ConnectionID string `json:"connection_id,omitempty"`
+}
+
+// GetConnectionRequest model
+//
+// This is used for getting specific connection record.
+//
+type GetConnectionRequest struct {
+	// The ID of the connection to get
+	ID string `json:"id"`
+}
+
+// QueryConnectionsArgs model
+//
+// This is used for querying connections.
+//
+type QueryConnectionsArgs struct {
+	// Params for querying connections
+	legacyconnection.QueryConnectionsParams
+}
+
+// QueryConnectionResponse model
+//
+// This is used for returning query connection result for single record search.
+//
+type QueryConnectionResponse struct {
+	Result *legacyconnection.Connection `json:"result,omitempty"`
+}
+
+// QueryConnectionsResponse model
+//
+// This is used for returning query connections results.
+//
+type QueryConnectionsResponse struct {
+	Results []*legacyconnection.Connection `json:"results,omitempty"`
+}
+
+// AcceptConnectionRequestArgs model
+//
+// This is used for accepting connection request.
+//
+type AcceptConnectionRequestArgs struct {
+	// Connection ID
+	ID string `json:"id"`
+
+	// Optional Public DID to be used for this invitation
+	// request
+	Public string `json:"public"`
+
+	// Optional specifies router connections (comma-separated values)
+	RouterConnections string `json:"router_connections"`
+}
+
+// ConnectionResponse model
+//
+// response of accept connection request.
+//
+type ConnectionResponse struct {
+
+	// Routing state of connection invitation
+	RoutingState string `json:"routing_state,omitempty"`
+
+	// the connection ID of the connection invitation
+	InboundConnectionID string `json:"inbound_connection_id,omitempty"`
+
+	// Invitation key
+	InvitationKey string `json:"invitation_key,omitempty"`
+
+	// TheirDID is other party's DID
+	TheirDID string `json:"their_did"`
+
+	// Invitation ID of the connection request
+	RequestID string `json:"request_id"`
+
+	// Invitation mode
+	Mode string `json:"invitation_mode,omitempty"`
+
+	// TheirRole is other party's role
+	TheirRole string `json:"their_role,omitempty"`
+
+	// TheirRole is other party's role
+	TheirLabel string `json:"their_label,omitempty"`
+
+	// the connection ID of the connection invitation
+	ConnectionID string `json:"connection_id,omitempty"`
+
+	// Initiator is Connection invitation initiator
+	Initiator string `json:"initiator,omitempty"`
+
+	// MyDID is DID of the agent
+	MyDID string `json:"my_did,omitempty"`
+
+	// Updated time
+	UpdatedTime time.Time `json:"updated_at,omitempty"`
+
+	// Created time
+	CreatedTime time.Time `json:"created_at,omitempty"`
+
+	// Error message
+	Error string `json:"error_msg,omitempty"`
+
+	// Alias of connection invitation
+	Alias string `json:"alias,omitempty"`
+
+	// State of the connection invitation
+	State string `json:"state"`
+
+	// Connection invitation accept mode
+	Accept string `json:"accept,omitempty"`
+}
+
+// RemoveConnectionRequest model
+//
+// This is used for removing connection request.
+//
+type RemoveConnectionRequest struct {
+	// The ID of the connection record to remove
+	ID string `json:"id"`
+}
+
+// ConnectionIDArg model
+//
+// This is used for querying/removing connection by ID.
+//
+type ConnectionIDArg struct {
+	// Connection ID
+	ID string `json:"id"`
+}
+
+// CreateConnectionRequest model
+//
+// This is used for creating connection request.
+//
+type CreateConnectionRequest struct {
+	MyDID          string      `json:"myDID"`
+	TheirDID       DIDDocument `json:"theirDID"`
+	TheirLabel     string      `json:"theirLabel,omitempty"`
+	InvitationID   string      `json:"invitationID,omitempty"`
+	InvitationDID  string      `json:"invitationDID,omitempty"`
+	ParentThreadID string      `json:"parentThreadID,omitempty"`
+	ThreadID       string      `json:"threadID,omitempty"`
+	Implicit       bool        `json:"implicit,omitempty"`
+}
+
+// DIDDocument model.
+type DIDDocument struct {
+	ID       string          `json:"id"`
+	Contents json.RawMessage `json:"contents"`
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
@@ -18,6 +19,7 @@ import (
 	issuecredentialcmd "github.com/hyperledger/aries-framework-go/pkg/controller/command/issuecredential"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/command/kms"
 	ldcmd "github.com/hyperledger/aries-framework-go/pkg/controller/command/ld"
+	legacyconncmd "github.com/hyperledger/aries-framework-go/pkg/controller/command/legacyconnection"
 	routercmd "github.com/hyperledger/aries-framework-go/pkg/controller/command/mediator"
 	messagingcmd "github.com/hyperledger/aries-framework-go/pkg/controller/command/messaging"
 	outofbandcmd "github.com/hyperledger/aries-framework-go/pkg/controller/command/outofband"
@@ -32,6 +34,7 @@ import (
 	issuecredentialrest "github.com/hyperledger/aries-framework-go/pkg/controller/rest/issuecredential"
 	kmsrest "github.com/hyperledger/aries-framework-go/pkg/controller/rest/kms"
 	ldrest "github.com/hyperledger/aries-framework-go/pkg/controller/rest/ld"
+	legacyconnrest "github.com/hyperledger/aries-framework-go/pkg/controller/rest/legacyconnection"
 	"github.com/hyperledger/aries-framework-go/pkg/controller/rest/mediator"
 	messagingrest "github.com/hyperledger/aries-framework-go/pkg/controller/rest/messaging"
 	outofbandrest "github.com/hyperledger/aries-framework-go/pkg/controller/rest/outofband"
@@ -155,6 +158,13 @@ func GetRESTHandlers(ctx *context.Provider, opts ...Opt) ([]rest.Handler, error)
 		return nil, err
 	}
 
+	// Legacy connection REST operation
+	legacyConnOp, err := legacyconnrest.New(ctx, notifier, restAPIOpts.defaultLabel,
+		restAPIOpts.autoAccept)
+	if err != nil {
+		return nil, err
+	}
+
 	// VDR REST operation
 	vdrOp, err := vdrrest.New(ctx)
 	if err != nil {
@@ -234,6 +244,7 @@ func GetRESTHandlers(ctx *context.Provider, opts ...Opt) ([]rest.Handler, error)
 	// creat handlers from all operations
 	var allHandlers []rest.Handler
 	allHandlers = append(allHandlers, exchangeOp.GetRESTHandlers()...)
+	allHandlers = append(allHandlers, legacyConnOp.GetRESTHandlers()...)
 	allHandlers = append(allHandlers, vdrOp.GetRESTHandlers()...)
 	allHandlers = append(allHandlers, messagingOp.GetRESTHandlers()...)
 	allHandlers = append(allHandlers, routeOp.GetRESTHandlers()...)
@@ -283,6 +294,13 @@ func GetCommandHandlers(ctx *context.Provider, opts ...Opt) ([]command.Handler, 
 		cmdOpts.autoAccept)
 	if err != nil {
 		return nil, fmt.Errorf("failed initialized didexchange command: %w", err)
+	}
+
+	// legacy connection command operation
+	legconncmd, err := legacyconncmd.New(ctx, notifier, cmdOpts.defaultLabel,
+		cmdOpts.autoAccept)
+	if err != nil {
+		return nil, fmt.Errorf("failed initialized legacy-connection command: %w", err)
 	}
 
 	// VDR command operation
@@ -356,6 +374,7 @@ func GetCommandHandlers(ctx *context.Provider, opts ...Opt) ([]command.Handler, 
 
 	var allHandlers []command.Handler
 	allHandlers = append(allHandlers, didexcmd.GetHandlers()...)
+	allHandlers = append(allHandlers, legconncmd.GetHandlers()...)
 	allHandlers = append(allHandlers, vcmd.GetHandlers()...)
 	allHandlers = append(allHandlers, msgcmd.GetHandlers()...)
 	allHandlers = append(allHandlers, routecmd.GetHandlers()...)

--- a/pkg/controller/rest/didexchange/models.go
+++ b/pkg/controller/rest/didexchange/models.go
@@ -1,5 +1,6 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/pkg/controller/rest/legacyconnection/models.go
+++ b/pkg/controller/rest/legacyconnection/models.go
@@ -1,0 +1,262 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package legacyconnection
+
+import (
+	legacyConnSvc "github.com/hyperledger/aries-framework-go/pkg/client/legacyconnection"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/command/legacyconnection"
+)
+
+// legacyCreateInvitationRequest model
+//
+// This is used for operation to create invitation
+//
+// swagger:parameters legacyCreateInvitation
+type legacyCreateInvitationRequest struct { // nolint: unused,deadcode
+	// Params for creating invitation
+	//
+	// in: path
+	legacyconnection.CreateInvitationArgs
+}
+
+// legacyCreateInvitationResponse model
+//
+// This is used for returning a create invitation response with a single connection invitation as body
+//
+// swagger:response legacyCreateInvitationResponse
+type legacyCreateInvitationResponse struct { // nolint: unused,deadcode
+	// in: body
+	Body struct {
+		Invitation    struct{ *legacyConnSvc.Invitation } `json:"invitation"`
+		Alias         string                              `json:"alias"`
+		InvitationURL string                              `json:"invitation_url"`
+	}
+}
+
+// legacyReceiveInvitationRequest model
+//
+// This is used for operation to receive connection invitation
+//
+// swagger:parameters legacyReceiveInvitation
+type legacyReceiveInvitationRequest struct { // nolint: unused,deadcode
+	// The Invitation Invitation to receive
+	//
+	// required: true
+	// in: body
+	Invitation struct {
+		*legacyConnSvc.Invitation
+	}
+}
+
+// legacyReceiveInvitationResponse model
+//
+// This is used for returning a receive invitation response with a single receive invitation response as body
+//
+// swagger:response legacyReceiveInvitationResponse
+type legacyReceiveInvitationResponse struct { // nolint: unused,deadcode
+	// in: body
+	Body struct {
+		legacyconnection.ReceiveInvitationResponse
+	}
+}
+
+// legacyAcceptInvitationRequest model
+//
+// This is used for operation to accept connection invitation
+//
+// swagger:parameters legacyAcceptInvitation
+type legacyAcceptInvitationRequest struct { // nolint: unused,deadcode
+	// Connection ID
+	//
+	// in: path
+	// required: true
+	ID string `json:"id"`
+
+	// Optional Public DID to be used for this request
+	Public string `json:"public"`
+
+	// Optional specifies router connections (comma-separated values)
+	RouterConnections string `json:"router_connections"`
+}
+
+// legacyAcceptInvitationResponse model
+//
+// This is used for returning a accept invitation response for single invitation
+//
+// swagger:response legacyAcceptInvitationResponse
+type legacyAcceptInvitationResponse struct { // nolint: unused,deadcode
+	// in: body
+	Body struct {
+		legacyconnection.AcceptInvitationResponse
+	}
+}
+
+// legacyImplicitInvitationRequest model
+//
+// This is used by invitee to create implicit invitation
+//
+// swagger:parameters legacyImplicitInvitation
+type legacyImplicitInvitationRequest struct { // nolint: unused,deadcode
+	// InviterDID
+	InviterDID string `json:"their_did"`
+
+	// Optional inviter label
+	InviterLabel string `json:"their_label"`
+
+	// Optional invitee did
+	InviteeDID string `json:"my_did"`
+
+	// Optional invitee label
+	InviteeLabel string `json:"my_label"`
+
+	// Optional specifies router connections (comma-separated values)
+	RouterConnections string `json:"router_connections"`
+}
+
+// legacyImplicitInvitationResponse model
+//
+// This is used for returning create implicit invitation response
+//
+// swagger:response legacyImplicitInvitationResponse
+type legacyImplicitInvitationResponse struct { // nolint: unused,deadcode
+	// in: body
+	Body struct {
+		legacyconnection.ImplicitInvitationResponse
+	}
+}
+
+// legacyGetConnectionRequest model
+//
+// This is used for getting specific connection record
+//
+// swagger:parameters legacyGetConnection
+type legacyGetConnectionRequest struct { // nolint: unused,deadcode
+	// The ID of the connection to get
+	//
+	// in: path
+	// required: true
+	ID string `json:"id"`
+}
+
+// legacyQueryConnections model
+//
+// This is used for querying connections
+//
+// swagger:parameters legacyQueryConnections
+type legacyQueryConnections struct { // nolint: unused,deadcode
+	// Params for querying connections
+	//
+	// in: path
+	// required: true
+	legacyConnSvc.QueryConnectionsParams
+}
+
+// legacyQueryConnectionResponse model
+//
+// This is used for returning query connection result for single record search
+//
+// swagger:response legacyQueryConnectionResponse
+type legacyQueryConnectionResponse struct { // nolint: unused,deadcode
+	// in: body
+	Body struct {
+		Result *legacyConnSvc.Connection `json:"result,omitempty"`
+	}
+}
+
+// legacyQueryConnectionsResponse model
+//
+// This is used for returning query connections results
+//
+// swagger:response legacyQueryConnectionsResponse
+type legacyQueryConnectionsResponse struct { // nolint: unused,deadcode
+
+	// in: body
+	Body struct {
+		Results []*legacyConnSvc.Connection `json:"results,omitempty"`
+	}
+}
+
+// legacyAcceptConnectionRequestParams model
+//
+// This is used for accepting connection request
+//
+// swagger:parameters legacyAcceptRequest
+type legacyAcceptConnectionRequestParams struct { // nolint: unused,deadcode
+	// Connection ID
+	//
+	// in: path
+	// required: true
+	ID string `json:"id"`
+
+	// Optional Public DID to be used for this invitation
+	// request
+	Public string `json:"public"`
+
+	// Optional specifies router connections (comma-separated values)
+	RouterConnections string `json:"router_connections"`
+}
+
+// legacyAcceptConnectionResult model
+//
+// This is used for returning response for accept Connection request
+//
+// swagger:response legacyAcceptConnectionResponse
+type legacyAcceptConnectionResult struct { // nolint: unused,deadcode
+
+	// in: body
+	Result legacyconnection.ConnectionResponse
+}
+
+// LegacyRemoveConnectionRequest model
+//
+// This is used for removing connection request
+//
+// swagger:parameters legacyRemoveConnection
+type LegacyRemoveConnectionRequest struct {
+	// The ID of the connection record to remove
+	//
+	// in: path
+	// required: true
+	ID string `json:"id"`
+}
+
+// LegacyRemoveConnectionResponse model
+//
+// response of remove connection action
+//
+// swagger:response legacyRemoveConnectionResponse
+type LegacyRemoveConnectionResponse struct {
+	// in: body
+	Body struct{}
+}
+
+// legacyCreateConnectionResp model
+//
+// This is used as the response model for save connection api.
+//
+// swagger:response legacyCreateConnectionResp
+type legacyCreateConnectionResp struct { // nolint: unused,deadcode
+	// in: body
+	Body struct {
+		// The ID of the connection to get
+		//
+		ID string `json:"id"`
+	}
+}
+
+// legacyCreateConnectionRequest model
+//
+// Request to create a new connection between two DIDs.
+//
+// swagger:parameters legacyCreateConnection
+type legacyCreateConnectionRequest struct { // nolint: unused,deadcode
+	// Params for creating a connection.
+	//
+	// in: body
+	// required: true
+	Request legacyconnection.CreateConnectionRequest
+}

--- a/pkg/controller/rest/legacyconnection/operation.go
+++ b/pkg/controller/rest/legacyconnection/operation.go
@@ -1,0 +1,264 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package legacyconnection
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/gorilla/mux"
+
+	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/command/legacyconnection"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/internal/cmdutil"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/rest"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+)
+
+// constants for endpoints of legacy-connection.
+const (
+	OperationID                  = "/legacy/connections"
+	CreateInvitationPath         = OperationID + "/create-invitation"
+	CreateImplicitInvitationPath = OperationID + "/create-implicit-invitation"
+	ReceiveInvitationPath        = OperationID + "/receive-invitation"
+	AcceptInvitationPath         = OperationID + "/{id}/accept-invitation"
+	Connections                  = OperationID
+	ConnectionsByID              = OperationID + "/{id}"
+	AcceptConnectionRequest      = OperationID + "/{id}/accept-request"
+	CreateConnection             = OperationID + "/create"
+	RemoveConnection             = OperationID + "/{id}/remove"
+)
+
+// provider contains dependencies for the legacy-connection protocol and is typically created by using aries.Context().
+type provider interface {
+	Service(id string) (interface{}, error)
+	KMS() kms.KeyManager
+	ServiceEndpoint() string
+	StorageProvider() storage.Provider
+	ProtocolStateStorageProvider() storage.Provider
+	KeyType() kms.KeyType
+	KeyAgreementType() kms.KeyType
+	MediaTypeProfiles() []string
+}
+
+// New returns new legacy-connection rest client protocol instance.
+func New(ctx provider, notifier command.Notifier, defaultLabel string, autoAccept bool) (*Operation, error) {
+	dxcmd, err := legacyconnection.New(ctx, notifier, defaultLabel, autoAccept)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize legacy-connection command : %w", err)
+	}
+
+	o := &Operation{command: dxcmd}
+	o.registerHandler()
+
+	return o, nil
+}
+
+// Operation is controller REST service controller for legacy-connection.
+type Operation struct {
+	command  *legacyconnection.Command
+	handlers []rest.Handler
+}
+
+// GetRESTHandlers get all controller API handler available for this protocol service.
+func (c *Operation) GetRESTHandlers() []rest.Handler {
+	return c.handlers
+}
+
+// registerHandler register handlers to be exposed from this protocol service as REST API endpoints.
+func (c *Operation) registerHandler() {
+	// Add more protocol endpoints here to expose them as controller API endpoints
+	c.handlers = []rest.Handler{
+		cmdutil.NewHTTPHandler(Connections, http.MethodGet, c.QueryConnections),
+		cmdutil.NewHTTPHandler(ConnectionsByID, http.MethodGet, c.QueryConnectionByID),
+		cmdutil.NewHTTPHandler(CreateInvitationPath, http.MethodPost, c.CreateInvitation),
+		cmdutil.NewHTTPHandler(CreateImplicitInvitationPath, http.MethodPost, c.CreateImplicitInvitation),
+		cmdutil.NewHTTPHandler(ReceiveInvitationPath, http.MethodPost, c.ReceiveInvitation),
+		cmdutil.NewHTTPHandler(AcceptInvitationPath, http.MethodPost, c.AcceptInvitation),
+		cmdutil.NewHTTPHandler(AcceptConnectionRequest, http.MethodPost, c.AcceptConnectionRequest),
+		cmdutil.NewHTTPHandler(CreateConnection, http.MethodPost, c.CreateConnection),
+		cmdutil.NewHTTPHandler(RemoveConnection, http.MethodPost, c.RemoveConnection),
+	}
+}
+
+// CreateInvitation swagger:route POST /legacy/connections/create-invitation legacy-connection legacyCreateInvitation
+//
+// Creates a new connection invitation....
+//
+// Responses:
+//    default: genericError
+//        200: legacyCreateInvitationResponse
+func (c *Operation) CreateInvitation(rw http.ResponseWriter, req *http.Request) {
+	reqBytes, err := queryValuesAsJSON(req.URL.Query())
+	if err != nil {
+		rest.SendHTTPStatusError(rw, http.StatusBadRequest, legacyconnection.InvalidRequestErrorCode, err)
+		return
+	}
+
+	rest.Execute(c.command.CreateInvitation, rw, bytes.NewReader(reqBytes))
+}
+
+// ReceiveInvitation swagger:route POST /legacy/connections/receive-invitation legacy-connection legacyReceiveInvitation
+//
+// Receive a new connection invitation....
+//
+// Responses:
+//    default: genericError
+//        200: legacyReceiveInvitationResponse
+func (c *Operation) ReceiveInvitation(rw http.ResponseWriter, req *http.Request) {
+	rest.Execute(c.command.ReceiveInvitation, rw, req.Body)
+}
+
+// AcceptInvitation swagger:route POST /legacy/connections/{id}/accept-invitation legacy-connection legacyAcceptInvitation
+//
+// Accept a stored connection invitation....
+//
+// Responses:
+//    default: genericError
+//        200: legacyAcceptInvitationResponse
+func (c *Operation) AcceptInvitation(rw http.ResponseWriter, req *http.Request) {
+	id, found := getIDFromRequest(rw, req)
+	if !found {
+		return
+	}
+
+	request := fmt.Sprintf(`{"id":"%s", "public":"%s", "router_connections": "%s"}`,
+		id, req.URL.Query().Get("public"), req.URL.Query().Get("router_connections"))
+
+	rest.Execute(c.command.AcceptInvitation, rw, bytes.NewBufferString(request))
+}
+
+// CreateImplicitInvitation swagger:route POST /legacy/connections/create-implicit-invitation legacy-connection legacyImplicitInvitation
+//
+//  Create implicit invitation using inviter DID.
+//
+// Responses:
+//    default: genericError
+//        200: legacyImplicitInvitationResponse
+func (c *Operation) CreateImplicitInvitation(rw http.ResponseWriter, req *http.Request) {
+	reqBytes, err := queryValuesAsJSON(req.URL.Query())
+	if err != nil {
+		rest.SendHTTPStatusError(rw, http.StatusBadRequest, legacyconnection.InvalidRequestErrorCode, err)
+		return
+	}
+
+	rest.Execute(c.command.CreateImplicitInvitation, rw, bytes.NewReader(reqBytes))
+}
+
+// AcceptConnectionRequest swagger:route POST /legacy/connections/{id}/accept-request legacy-connection legacyAcceptRequest
+//
+// Accepts a stored connection request.
+//
+// Responses:
+//    default: genericError
+//        200: legacyAcceptConnectionResponse
+func (c *Operation) AcceptConnectionRequest(rw http.ResponseWriter, req *http.Request) {
+	id, found := getIDFromRequest(rw, req)
+	if !found {
+		return
+	}
+
+	request := fmt.Sprintf(`{"id":"%s", "public":"%s", "router_connections": "%s"}`,
+		id, req.URL.Query().Get("public"), req.URL.Query().Get("router_connections"))
+
+	rest.Execute(c.command.AcceptConnectionRequest, rw, bytes.NewBufferString(request))
+}
+
+// QueryConnections swagger:route GET /legacy/connections legacy-connection legacyQueryConnections
+//
+// query agent to agent connections.
+//
+// Responses:
+//    default: genericError
+//        200: legacyQueryConnectionsResponse
+func (c *Operation) QueryConnections(rw http.ResponseWriter, req *http.Request) {
+	reqBytes, err := queryValuesAsJSON(req.URL.Query())
+	if err != nil {
+		rest.SendHTTPStatusError(rw, http.StatusBadRequest, legacyconnection.InvalidRequestErrorCode, err)
+		return
+	}
+
+	rest.Execute(c.command.QueryConnections, rw, bytes.NewReader(reqBytes))
+}
+
+// QueryConnectionByID swagger:route GET /legacy/connections/{id} legacy-connection legacyGetConnection
+//
+// Fetch a single connection record.
+//
+// Responses:
+//    default: genericError
+//        200: legacyQueryConnectionResponse
+func (c *Operation) QueryConnectionByID(rw http.ResponseWriter, req *http.Request) {
+	id, found := getIDFromRequest(rw, req)
+	if !found {
+		return
+	}
+
+	request := fmt.Sprintf(`{"id":"%s"}`, id)
+
+	rest.Execute(c.command.QueryConnectionByID, rw, bytes.NewBufferString(request))
+}
+
+// CreateConnection swagger:route POST /legacy/connections/create legacy-connection legacyCreateConnection
+//
+// Saves the connection record.
+//
+// Responses:
+//    default: genericError
+//    200: legacyCreateConnectionResp
+func (c *Operation) CreateConnection(rw http.ResponseWriter, req *http.Request) {
+	rest.Execute(c.command.CreateConnection, rw, req.Body)
+}
+
+// RemoveConnection swagger:route POST /legacy/connections/{id}/remove legacy-connection legacyRemoveConnection
+//
+// Removes given connection record.
+//
+// Responses:
+//    default: genericError
+//    200: legacyRemoveConnectionResponse
+func (c *Operation) RemoveConnection(rw http.ResponseWriter, req *http.Request) {
+	id, found := getIDFromRequest(rw, req)
+	if !found {
+		return
+	}
+
+	request := fmt.Sprintf(`{"id":"%s"}`, id)
+
+	rest.Execute(c.command.RemoveConnection, rw, bytes.NewBufferString(request))
+}
+
+// queryValuesAsJSON converts query strings to `map[string]string`
+// and marshals them to JSON bytes.
+func queryValuesAsJSON(vals url.Values) ([]byte, error) {
+	// normalize all query string key/values
+	args := make(map[string]string)
+
+	for k, v := range vals {
+		if len(v) > 0 {
+			args[k] = v[0]
+		}
+	}
+
+	return json.Marshal(args)
+}
+
+// getIDFromRequest returns ID from request.
+func getIDFromRequest(rw http.ResponseWriter, req *http.Request) (string, bool) {
+	id := mux.Vars(req)["id"]
+	if id == "" {
+		rest.SendHTTPStatusError(rw, http.StatusBadRequest, legacyconnection.InvalidRequestErrorCode,
+			fmt.Errorf("empty connection ID"))
+		return "", false
+	}
+
+	return id, true
+}

--- a/pkg/controller/rest/legacyconnection/operation_test.go
+++ b/pkg/controller/rest/legacyconnection/operation_test.go
@@ -1,0 +1,609 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package legacyconnection
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/command"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/command/legacyconnection"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/rest"
+	"github.com/hyperledger/aries-framework-go/pkg/controller/webnotifier"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	legacyConnSvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/legacyconnection"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
+	mocklegacyconn "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/legacyconnection"
+	mockroute "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/mediator"
+	mockkms "github.com/hyperledger/aries-framework-go/pkg/mock/kms"
+	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
+	mockstore "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/peer"
+	spi "github.com/hyperledger/aries-framework-go/spi/storage"
+)
+
+func TestOperation_GetAPIHandlers(t *testing.T) {
+	svc, err := New(&mockprovider.Provider{
+		ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+		StorageProviderValue:              mockstore.NewMockStoreProvider(),
+		ServiceMap: map[string]interface{}{
+			legacyConnSvc.LegacyConnection: &mocklegacyconn.MockLegacyConnectionSvc{},
+			mediator.Coordination:          &mockroute.MockMediatorSvc{},
+		},
+	},
+		webnotifier.NewHTTPNotifier(nil), "", false)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+
+	handlers := svc.GetRESTHandlers()
+	require.NotEmpty(t, handlers)
+}
+
+func TestNew_Fail(t *testing.T) {
+	svc, err := New(&mockprovider.Provider{ServiceErr: errors.New("test-error")},
+		webnotifier.NewHTTPNotifier(nil), "", false)
+	require.Error(t, err)
+	require.Nil(t, svc)
+}
+
+func TestOperation_CreateInvitation(t *testing.T) {
+	t.Run("Successful CreateInvitation with label", func(t *testing.T) {
+		handler := getHandler(t, CreateInvitationPath)
+		buf, err := getSuccessResponseFromHandler(handler, nil, handler.Path()+"?alias=mylabel")
+		require.NoError(t, err)
+
+		response := legacyconnection.CreateInvitationResponse{}
+		err = json.Unmarshal(buf.Bytes(), &response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response.Invitation)
+		require.Equal(t, "endpoint", response.Invitation.ServiceEndpoint)
+		require.Empty(t, response.Invitation.Label)
+		require.NotEmpty(t, response.Alias)
+	})
+
+	t.Run("Successful CreateInvitation with label and public DID", func(t *testing.T) {
+		const publicDID = "sample-public-did"
+		handler := getHandler(t, CreateInvitationPath)
+		buf, err := getSuccessResponseFromHandler(handler, nil, handler.Path()+"?alias=mylabel&public="+publicDID)
+		require.NoError(t, err)
+
+		response := legacyconnection.CreateInvitationResponse{}
+		err = json.Unmarshal(buf.Bytes(), &response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response.Invitation)
+		require.Empty(t, response.Invitation.ServiceEndpoint)
+		require.Empty(t, response.Invitation.Label)
+		require.NotEmpty(t, response.Alias)
+		require.NotEmpty(t, response.Invitation.DID)
+		require.Equal(t, publicDID, response.Invitation.DID)
+	})
+
+	t.Run("Successful CreateInvitation with default params", func(t *testing.T) {
+		handler := getHandler(t, CreateInvitationPath)
+		buf, err := getSuccessResponseFromHandler(handler, nil, handler.Path())
+		require.NoError(t, err)
+
+		response := legacyconnection.CreateInvitationResponse{}
+		err = json.Unmarshal(buf.Bytes(), &response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response.Invitation)
+		require.Equal(t, "endpoint", response.Invitation.ServiceEndpoint)
+		require.Empty(t, response.Invitation.Label)
+		require.Empty(t, response.Alias)
+	})
+
+	t.Run("CreateInvitation failure", func(t *testing.T) {
+		const errMsg = "sample-err-01"
+		handler := getHandlerWithError(t, CreateInvitationPath, &fails{storePutErr: fmt.Errorf(errMsg)})
+
+		buf, code, err := sendRequestToHandler(handler, nil, handler.Path())
+		require.NoError(t, err)
+		require.Equal(t, http.StatusInternalServerError, code)
+		verifyRESTError(t, legacyconnection.CreateInvitationErrorCode, buf.Bytes())
+	})
+}
+
+func TestOperation_ReceiveInvitation(t *testing.T) {
+	jsonStr := []byte(`{
+		"serviceEndpoint":"http://alice.agent.example.com:8081",
+		"recipientKeys":["FDmegH8upiNquathbHZiGBZKwcudNfNWPeGQFBt8eNNi"],
+		"@id":"a35c0ac6-4fc3-46af-a072-c1036d036057",
+		"label":"agent",
+		"@type":"https://didcomm.org/connections/1.0/invitation"}`)
+
+	handler := getHandler(t, ReceiveInvitationPath)
+	buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
+	require.NoError(t, err)
+
+	response := legacyconnection.ReceiveInvitationResponse{}
+	err = json.Unmarshal(buf.Bytes(), &response)
+	require.NoError(t, err)
+
+	// verify response
+	require.NotEmpty(t, response)
+	require.NotEmpty(t, response.ConnectionID)
+}
+
+func TestOperation_QueryConnectionByID(t *testing.T) {
+	t.Run("connectionsByID success", func(t *testing.T) {
+		handler := getHandler(t, ConnectionsByID)
+		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer([]byte("sample-connection-id")),
+			OperationID+"/1234")
+		require.NoError(t, err)
+
+		response := legacyconnection.QueryConnectionResponse{}
+		err = json.Unmarshal(buf.Bytes(), &response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.Result.ConnectionID)
+	})
+
+	t.Run("connectionsByID failure", func(t *testing.T) {
+		const errMsg = "sample-err-01"
+		handler := getHandlerWithError(t, ConnectionsByID, &fails{storeGetErr: fmt.Errorf(errMsg)})
+
+		buf, code, err := sendRequestToHandler(handler, nil, handler.Path())
+		require.NoError(t, err)
+		require.Equal(t, http.StatusInternalServerError, code)
+		verifyRESTError(t, legacyconnection.QueryConnectionsErrorCode, buf.Bytes())
+	})
+}
+
+func TestOperation_QueryConnectionByParams(t *testing.T) {
+	// perform receive invitation to insert record into store
+	jsonStr := []byte(`{
+		"serviceEndpoint":"http://alice.agent.example.com:8081",
+		"recipientKeys":["FDmegH8upiNquathbHZiGBZKwcudNfNWPeGQFBt8eNNi"],
+		"@id":"a35c0ac6-4fc3-46af-a072-c1036d036057",
+		"label":"agent",
+		"@type":"https://didcomm.org/connections/1.0/invitation"}`)
+
+	handler := getHandler(t, ReceiveInvitationPath)
+	_, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
+	require.NoError(t, err)
+
+	t.Run("test query connections with state filter", func(t *testing.T) {
+		// perform test
+		handler = getHandler(t, Connections)
+		buf, err := getSuccessResponseFromHandler(handler, nil,
+			OperationID+"?state=complete")
+		require.NoError(t, err)
+
+		response := legacyconnection.QueryConnectionsResponse{}
+		err = json.Unmarshal(buf.Bytes(), &response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.Results)
+		for _, result := range response.Results {
+			require.NotNil(t, result)
+			require.NotNil(t, result.ConnectionID)
+		}
+	})
+
+	t.Run("test query connections without state filter", func(t *testing.T) {
+		// perform test
+		handler = getHandler(t, Connections)
+		buf, err := getSuccessResponseFromHandler(handler, nil,
+			OperationID)
+		require.NoError(t, err)
+
+		response := legacyconnection.QueryConnectionsResponse{}
+		err = json.Unmarshal(buf.Bytes(), &response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.Results)
+		for _, result := range response.Results {
+			require.NotNil(t, result)
+			require.NotNil(t, result.ConnectionID)
+		}
+	})
+}
+
+func TestOperation_ReceiveInvitationFailure(t *testing.T) {
+	// Failure in service
+	jsonStr := []byte(`{
+    	"@type": "https://didcomm.org/connections/1.0/invitation",
+    	"@id": "4e8650d9-6cc9-491e-b00e-7bf6cb5858fc",
+    	"serviceEndpoint": "http://ip10-0-46-4-blikjbs9psqg8vrg4p10-8020.direct.play-with-von.vonx.io",
+    	"label": "Faber Agent",
+    	"recipientKeys": [
+      		"6LE8yhZB8Xffc5vFgFntE3YLrxq5JVUsoAvUQgUyktGt"
+    		]
+  	}`)
+
+	handler := getHandlerWithError(t, ReceiveInvitationPath, &fails{handleErr: fmt.Errorf("handle failed")})
+	buf, code, err := sendRequestToHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, code)
+	verifyRESTError(t, legacyconnection.ReceiveInvitationErrorCode, buf.Bytes())
+
+	// Failure due to invalid request body
+	jsonStr = []byte("")
+	handler = getHandler(t, ReceiveInvitationPath)
+	buf, code, err = sendRequestToHandler(handler, bytes.NewBuffer(jsonStr), handler.Path())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, code)
+
+	verifyRESTError(t, legacyconnection.InvalidRequestErrorCode, buf.Bytes())
+}
+
+func TestOperation_AcceptInvitation(t *testing.T) {
+	t.Run("test accept invitation success", func(t *testing.T) {
+		handler := getHandler(t, AcceptInvitationPath)
+		buf, err := getSuccessResponseFromHandler(handler, nil,
+			OperationID+"/1111/accept-invitation?public=sample-public-did")
+		require.NoError(t, err)
+
+		response := legacyconnection.AcceptInvitationResponse{}
+		err = json.Unmarshal(buf.Bytes(), &response)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.ConnectionID)
+	})
+
+	t.Run("test accept invitation failures", func(t *testing.T) {
+		handler := getHandlerWithError(t, AcceptInvitationPath, &fails{acceptErr: fmt.Errorf("fail it")})
+		buf, code, err := sendRequestToHandler(handler, nil,
+			OperationID+"/1111/accept-invitation?publicDID=xyz")
+		require.NoError(t, err)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusInternalServerError, code)
+		verifyRESTError(t, legacyconnection.AcceptInvitationErrorCode, buf.Bytes())
+	})
+}
+
+func TestOperation_CreateImplicitInvitation(t *testing.T) {
+	t.Run("test create implicit invitation success", func(t *testing.T) {
+		handler := getHandler(t, CreateImplicitInvitationPath)
+		buf, err := getSuccessResponseFromHandler(handler, nil,
+			CreateImplicitInvitationPath+"?their_did=sample-public-did")
+		require.NoError(t, err)
+
+		response := legacyconnection.ImplicitInvitationResponse{}
+		err = json.Unmarshal(buf.Bytes(), &response)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.ConnectionID)
+	})
+
+	t.Run("test create implicit invitation with DID success", func(t *testing.T) {
+		handler := getHandler(t, CreateImplicitInvitationPath)
+		buf, err := getSuccessResponseFromHandler(handler, nil,
+			CreateImplicitInvitationPath+"?their_did=their-public-did&my_did=my-public-did")
+		require.NoError(t, err)
+
+		response := legacyconnection.ImplicitInvitationResponse{}
+		err = json.Unmarshal(buf.Bytes(), &response)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.ConnectionID)
+	})
+
+	t.Run("test required parameters", func(t *testing.T) {
+		handler := getHandler(t, CreateImplicitInvitationPath)
+		buf, code, err := sendRequestToHandler(handler, nil,
+			CreateImplicitInvitationPath+"?invalid=xyz")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, code)
+
+		verifyRESTError(t, legacyconnection.InvalidRequestErrorCode, buf.Bytes())
+	})
+
+	t.Run("test handler failure", func(t *testing.T) {
+		handler := getHandlerWithError(t, CreateImplicitInvitationPath, &fails{implicitErr: fmt.Errorf("implicit error")})
+		buf, code, err := sendRequestToHandler(handler, nil,
+			CreateImplicitInvitationPath+"?their_did=xyz")
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusInternalServerError, code)
+		verifyRESTError(t, legacyconnection.CreateImplicitInvitationErrorCode, buf.Bytes())
+	})
+}
+
+func TestOperation_AcceptConnectionRequest(t *testing.T) {
+	t.Run("test accept connection request failures", func(t *testing.T) {
+		handler := getHandler(t, AcceptConnectionRequest)
+		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer([]byte("test-id")),
+			OperationID+"/4444/accept-request?public=sample-public-did")
+		require.NoError(t, err)
+
+		response := legacyconnection.ConnectionResponse{}
+		err = json.Unmarshal(buf.Bytes(), &response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.ConnectionID)
+	})
+
+	t.Run("test accept connection request failures", func(t *testing.T) {
+		handler := getHandlerWithError(t, AcceptConnectionRequest, &fails{acceptErr: fmt.Errorf("fail it")})
+		buf, code, err := sendRequestToHandler(handler, nil,
+			OperationID+"/4444/accept-request?public=sample-public-did")
+		require.NoError(t, err)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusInternalServerError, code)
+		verifyRESTError(t, legacyconnection.AcceptConnectionRequestErrorCode, buf.Bytes())
+	})
+}
+
+func TestOperation_CreateConnection(t *testing.T) {
+	t.Run("test create connection - success", func(t *testing.T) {
+		myDID := newPeerDID(t)
+		theirDID := newPeerDID(t)
+		request, err := json.Marshal(&legacyconnection.CreateConnectionRequest{
+			MyDID: myDID.ID,
+			TheirDID: legacyconnection.DIDDocument{
+				ID:       theirDID.ID,
+				Contents: marshalDoc(t, theirDID),
+			},
+		})
+		require.NoError(t, err)
+		handler := getHandler(t, CreateConnection)
+		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer(request),
+			CreateConnection)
+		require.NoError(t, err)
+
+		response := &legacyconnection.ConnectionIDArg{}
+		err = json.Unmarshal(buf.Bytes(), &response)
+		require.NoError(t, err)
+
+		// verify response
+		require.NotEmpty(t, response)
+		require.NotEmpty(t, response.ID)
+	})
+}
+
+func TestOperation_RemoveConnection(t *testing.T) {
+	t.Run("test remove connection success", func(t *testing.T) {
+		handler := getHandler(t, RemoveConnection)
+		buf, err := getSuccessResponseFromHandler(handler, bytes.NewBuffer([]byte("test-id")),
+			OperationID+"/1234/remove")
+		require.NoError(t, err)
+		require.Empty(t, buf.Bytes())
+	})
+}
+
+func TestGetIDFromRequest(t *testing.T) {
+	id, found := getIDFromRequest(httptest.NewRecorder(), &http.Request{})
+	require.False(t, found)
+	require.Empty(t, id)
+}
+
+func TestEmptyID(t *testing.T) {
+	const response = `{"code":16000,"message":"empty connection ID"}`
+
+	prov := &mockprovider.Provider{
+		ProtocolStateStorageProviderValue: mockstore.NewMockStoreProvider(),
+		StorageProviderValue:              mockstore.NewMockStoreProvider(),
+		ServiceMap: map[string]interface{}{
+			legacyConnSvc.LegacyConnection: &mocklegacyconn.MockLegacyConnectionSvc{},
+			mediator.Coordination:          &mockroute.MockMediatorSvc{},
+		},
+		KMSValue:             &mockkms.KeyManager{},
+		ServiceEndpointValue: "endppint",
+	}
+
+	op, err := New(prov, webnotifier.NewHTTPNotifier(nil), "", false)
+	require.NoError(t, err)
+	require.NotNil(t, op)
+
+	restHandlers := []http.HandlerFunc{
+		op.AcceptInvitation, op.AcceptConnectionRequest, op.QueryConnectionByID, op.RemoveConnection,
+	}
+	for _, handler := range restHandlers {
+		rw := httptest.NewRecorder()
+		handler(rw, &http.Request{})
+		require.Contains(t, rw.Body.String(), response)
+	}
+}
+
+// sendRequestToHandler reads response from given http handle func.
+func sendRequestToHandler(handler rest.Handler, requestBody io.Reader, path string) (*bytes.Buffer, int, error) {
+	// prepare request
+	req, err := http.NewRequest(handler.Method(), path, requestBody)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// prepare router
+	router := mux.NewRouter()
+
+	router.HandleFunc(handler.Path(), handler.Handle()).Methods(handler.Method())
+
+	// create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+
+	// serve http on given response and request
+	router.ServeHTTP(rr, req)
+
+	return rr.Body, rr.Code, nil
+}
+
+// getSuccessResponseFromHandler reads response from given http handle func.
+// expects http status OK.
+func getSuccessResponseFromHandler(handler rest.Handler, requestBody io.Reader,
+	path string) (*bytes.Buffer, error) {
+	response, status, err := sendRequestToHandler(handler, requestBody, path)
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: got %v, want %v",
+			status, http.StatusOK)
+	}
+
+	return response, err
+}
+
+func getHandler(t *testing.T, lookup string) rest.Handler {
+	t.Helper()
+
+	return getHandlerWithError(t, lookup, &fails{})
+}
+
+type fails struct {
+	handleErr, acceptErr, implicitErr, storePutErr, storeGetErr error
+}
+
+func getHandlerWithError(t *testing.T, lookup string, f *fails) rest.Handler {
+	t.Helper()
+
+	protocolStateStore := mockstore.MockStore{Store: make(map[string]mockstore.DBEntry)}
+	store := mockstore.MockStore{Store: make(map[string]mockstore.DBEntry)}
+	connRec := &connection.Record{State: "complete", ConnectionID: "1234", ThreadID: "th1234"}
+
+	connBytes, err := json.Marshal(connRec)
+	require.NoError(t, err)
+	require.NoError(t, store.Put("conn_1234", connBytes, spi.Tag{Name: "conn_"}))
+
+	h := crypto.SHA256.New()
+	hash := h.Sum([]byte(connRec.ConnectionID))
+	key := fmt.Sprintf("%x", hash)
+
+	require.NoError(t, store.Put("my_"+key, []byte(connRec.ConnectionID)))
+
+	if f.storePutErr != nil {
+		store.ErrPut = f.storePutErr
+		store.ErrGet = f.storeGetErr
+	}
+
+	ed25519KH, err := mockkms.CreateMockED25519KeyHandle()
+	require.NoError(t, err)
+
+	svc, err := New(&mockprovider.Provider{
+		ServiceMap: map[string]interface{}{
+			legacyConnSvc.LegacyConnection: &mocklegacyconn.MockLegacyConnectionSvc{
+				ProtocolName: "mockProtocolSvc",
+				HandleFunc: func(msg service.DIDCommMsg) (string, error) {
+					return uuid.New().String(), f.handleErr
+				},
+				AcceptError:           f.acceptErr,
+				ImplicitInvitationErr: f.implicitErr,
+			},
+			mediator.Coordination: &mockroute.MockMediatorSvc{},
+		},
+		KMSValue:                          &mockkms.KeyManager{CreateKeyValue: ed25519KH},
+		ServiceEndpointValue:              "endpoint",
+		ProtocolStateStorageProviderValue: &mockstore.MockStoreProvider{Store: &protocolStateStore},
+		StorageProviderValue:              &mockstore.MockStoreProvider{Store: &store},
+	},
+		webnotifier.NewHTTPNotifier(nil),
+		"", true,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+
+	return handlerLookup(t, svc, lookup)
+}
+
+func handlerLookup(t *testing.T, op *Operation, lookup string) rest.Handler {
+	t.Helper()
+
+	handlers := op.GetRESTHandlers()
+	require.NotEmpty(t, handlers)
+
+	for _, h := range handlers {
+		if h.Path() == lookup {
+			return h
+		}
+	}
+
+	require.Fail(t, "unable to find handler")
+
+	return nil
+}
+
+func verifyRESTError(t *testing.T, code command.Code, data []byte) {
+	t.Helper()
+
+	// Parser generic error response
+	errResponse := struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}{}
+	err := json.Unmarshal(data, &errResponse)
+	require.NoError(t, err)
+
+	// verify response
+	require.EqualValues(t, code, errResponse.Code)
+	require.NotEmpty(t, errResponse.Message)
+}
+
+func newPeerDID(t *testing.T) *did.Doc {
+	t.Helper()
+
+	a, err := aries.New(
+		aries.WithStoreProvider(mem.NewProvider()),
+		aries.WithProtocolStateStoreProvider(mem.NewProvider()),
+	)
+	require.NoError(t, err)
+
+	ctx, err := a.Context()
+	require.NoError(t, err)
+
+	d, err := ctx.VDRegistry().Create(
+		peer.DIDMethod, &did.Doc{Service: []did.Service{{
+			Type:            vdr.DIDCommServiceType,
+			ServiceEndpoint: model.NewDIDCommV1Endpoint("http://agent.example.com/didcomm"),
+		}}, VerificationMethod: []did.VerificationMethod{getSigningKey()}},
+	)
+	require.NoError(t, err)
+
+	return d.DIDDocument
+}
+
+func getSigningKey() did.VerificationMethod {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+
+	return did.VerificationMethod{Value: pub[:], Type: "Ed25519VerificationKey2018"}
+}
+
+func marshalDoc(t *testing.T, d *did.Doc) []byte {
+	t.Helper()
+
+	bits, err := d.JSONBytes()
+	require.NoError(t, err)
+
+	return bits
+}

--- a/pkg/didcomm/common/model/event.go
+++ b/pkg/didcomm/common/model/event.go
@@ -1,15 +1,16 @@
 /*
-Copyright SecureKey Technologies Inc. All Rights Reserved.
 Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
 
-package didexchange
-
-import (
-	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/model"
-)
+package model
 
 // Event properties related api. This can be used to cast Generic event properties to DID Exchange specific props.
-type Event model.Event
+type Event interface {
+	// connection ID
+	ConnectionID() string
+
+	// invitation ID
+	InvitationID() string
+}

--- a/pkg/didcomm/common/service/destination.go
+++ b/pkg/didcomm/common/service/destination.go
@@ -1,5 +1,6 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
@@ -25,10 +26,11 @@ type Destination struct {
 }
 
 const (
-	didCommServiceType      = "did-communication"
-	didCommV2ServiceType    = "DIDCommMessaging"
-	defaultDIDCommProfile   = "didcomm/aip2;env=rfc19"
-	defaultDIDCommV2Profile = "didcomm/v2"
+	didCommServiceType       = "did-communication"
+	didCommV2ServiceType     = "DIDCommMessaging"
+	defaultDIDCommProfile    = "didcomm/aip2;env=rfc19"
+	defaultDIDCommV2Profile  = "didcomm/v2"
+	legacyDIDCommServiceType = "IndyAgent"
 )
 
 // GetDestination constructs a Destination struct based on the given DID and parameters

--- a/pkg/didcomm/common/service/destination_default.go
+++ b/pkg/didcomm/common/service/destination_default.go
@@ -3,6 +3,7 @@
 
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
@@ -15,88 +16,102 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	diddoc "github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/didkeyutil"
 )
 
 // CreateDestination makes a DIDComm Destination object from a DID Doc as per the DIDComm service conventions:
 // https://github.com/hyperledger/aries-rfcs/blob/master/features/0067-didcomm-diddoc-conventions/README.md.
-//nolint:gocyclo,funlen,gocognit
 func CreateDestination(didDoc *diddoc.Doc) (*Destination, error) {
+	// try DIDComm v2 first
+	if didCommService, ok := diddoc.LookupService(didDoc, didCommV2ServiceType); ok {
+		return createDIDCommV2Destination(didDoc, didCommService)
+	}
+	// try DIDComm v1
+	if didCommService, ok := diddoc.LookupService(didDoc, didCommServiceType); ok {
+		return createDIDCommV1Destination(didDoc, didCommService)
+	}
+	// try DIDComm v1 legacy
+	if didCommService, ok := diddoc.LookupService(didDoc, legacyDIDCommServiceType); ok {
+		return createLegacyDestination(didDoc, didCommService)
+	}
+
+	return nil, fmt.Errorf("create destination: missing DID doc service")
+}
+
+func createDIDCommV2Destination(didDoc *diddoc.Doc, didCommService *diddoc.Service) (*Destination, error) {
 	var (
 		sp                  model.Endpoint
 		accept, routingKeys []string
 		uri                 string
 		err                 error
+		recKeys             []string
 	)
 
-	// try DIDComm V2 and use it if found, else use default DIDComm v1 bloc.
-	didCommService, ok := diddoc.LookupService(didDoc, didCommV2ServiceType)
-	if ok { //nolint:nestif
-		var recKeys []string
-
-		for _, ka := range didDoc.KeyAgreement {
-			keyID := ka.VerificationMethod.ID
-			if strings.HasPrefix(keyID, "#") {
-				keyID = didDoc.ID + keyID
-			}
-
-			recKeys = append(recKeys, keyID)
+	for _, ka := range didDoc.KeyAgreement {
+		keyID := ka.VerificationMethod.ID
+		if strings.HasPrefix(keyID, "#") {
+			keyID = didDoc.ID + keyID
 		}
 
-		if len(recKeys) == 0 {
-			return nil, fmt.Errorf("create destination: no keyAgreements in diddoc for didcomm v2 service bloc. "+
-				"DIDDoc: %+v", didDoc)
-		}
-
-		// use keyAgreements as recipientKeys
-		didCommService.RecipientKeys = recKeys
-
-		// if Accept is missing, ensure DIDCommV2 is at least added for packer selection based on MediaTypeProfile.
-		if accept, err = didCommService.ServiceEndpoint.Accept(); len(accept) == 0 || err != nil {
-			accept = []string{defaultDIDCommV2Profile}
-		}
-
-		uri, err = didCommService.ServiceEndpoint.URI()
-		if err != nil { // uri is required.
-			return nil, fmt.Errorf("create destination: service endpoint URI for didcomm v2 service block "+
-				"error: %+v, %w", didDoc, err)
-		}
-
-		routingKeys, err = didCommService.ServiceEndpoint.RoutingKeys()
-		if err != nil { // routingKeys can be optional.
-			routingKeys = nil
-		}
-
-		sp = model.NewDIDCommV2Endpoint([]model.DIDCommV2Endpoint{{URI: uri, Accept: accept, RoutingKeys: routingKeys}})
-	} else { // didcomm v1 service
-		didCommService, ok = diddoc.LookupService(didDoc, didCommServiceType)
-		if !ok {
-			return nil, fmt.Errorf("create destination: missing DID doc service")
-		}
-
-		uri, err = didCommService.ServiceEndpoint.URI()
-		if err != nil { // uri is required.
-			return nil, fmt.Errorf("create destination: service endpoint URI on didcomm v1 service block "+
-				"in diddoc error: %+v, %w", didDoc, err)
-		}
-
-		if len(didCommService.RecipientKeys) == 0 {
-			return nil, fmt.Errorf("create destination: no recipient keys on didcomm service block in diddoc: %+v", didDoc)
-		}
-
-		for i, k := range didCommService.RecipientKeys {
-			if !strings.HasPrefix(k, "did:") {
-				return nil, fmt.Errorf("create destination: recipient key %d:[%v] of didComm '%s' not a did:key", i+1,
-					k, didCommService.ID)
-			}
-		}
-
-		// if Accept is missing, ensure DIDCommV1 is at least added for packer selection based on MediaTypeProfile.
-		if len(didCommService.Accept) == 0 {
-			didCommService.Accept = []string{defaultDIDCommProfile}
-		}
-
-		sp = model.NewDIDCommV1Endpoint(uri)
+		recKeys = append(recKeys, keyID)
 	}
+
+	if len(recKeys) == 0 {
+		return nil, fmt.Errorf("create destination: no keyAgreements in diddoc for didcomm v2 service bloc. "+
+			"DIDDoc: %+v", didDoc)
+	}
+
+	// if Accept is missing, ensure DIDCommV2 is at least added for packer selection based on MediaTypeProfile.
+	if accept, err = didCommService.ServiceEndpoint.Accept(); len(accept) == 0 || err != nil {
+		accept = []string{defaultDIDCommV2Profile}
+	}
+
+	uri, err = didCommService.ServiceEndpoint.URI()
+	if err != nil { // uri is required.
+		return nil, fmt.Errorf("create destination: service endpoint URI for didcomm v2 service block "+
+			"error: %+v, %w", didDoc, err)
+	}
+
+	routingKeys, err = didCommService.ServiceEndpoint.RoutingKeys()
+	if err != nil { // routingKeys can be optional.
+		routingKeys = nil
+	}
+
+	sp = model.NewDIDCommV2Endpoint([]model.DIDCommV2Endpoint{{URI: uri, Accept: accept, RoutingKeys: routingKeys}})
+
+	return &Destination{
+		RecipientKeys:     recKeys,
+		ServiceEndpoint:   sp,
+		RoutingKeys:       didCommService.RoutingKeys,
+		MediaTypeProfiles: didCommService.Accept,
+		DIDDoc:            didDoc,
+	}, nil
+}
+
+func createDIDCommV1Destination(didDoc *diddoc.Doc, didCommService *diddoc.Service) (*Destination, error) {
+	uri, err := didCommService.ServiceEndpoint.URI()
+	if err != nil { // uri is required.
+		return nil, fmt.Errorf("create destination: service endpoint URI on didcomm v1 service block "+
+			"in diddoc error: %+v, %w", didDoc, err)
+	}
+
+	if len(didCommService.RecipientKeys) == 0 {
+		return nil, fmt.Errorf("create destination: no recipient keys on didcomm service block in diddoc: %+v", didDoc)
+	}
+
+	for i, k := range didCommService.RecipientKeys {
+		if !strings.HasPrefix(k, "did:") {
+			return nil, fmt.Errorf("create destination: recipient key %d:[%v] of didComm '%s' not a did:key", i+1,
+				k, didCommService.ID)
+		}
+	}
+
+	// if Accept is missing, ensure DIDCommV1 is at least added for packer selection based on MediaTypeProfile.
+	if len(didCommService.Accept) == 0 {
+		didCommService.Accept = []string{defaultDIDCommProfile}
+	}
+
+	sp := model.NewDIDCommV1Endpoint(uri)
 
 	return &Destination{
 		RecipientKeys:     didCommService.RecipientKeys,
@@ -104,5 +119,28 @@ func CreateDestination(didDoc *diddoc.Doc) (*Destination, error) {
 		RoutingKeys:       didCommService.RoutingKeys,
 		MediaTypeProfiles: didCommService.Accept,
 		DIDDoc:            didDoc,
+	}, nil
+}
+
+func createLegacyDestination(didDoc *diddoc.Doc, didCommService *diddoc.Service) (*Destination, error) {
+	uri, err := didCommService.ServiceEndpoint.URI()
+	if uri == "" || err != nil {
+		return nil, fmt.Errorf("create destination: no service endpoint on didcomm service block in diddoc: %#v", didDoc)
+	}
+
+	if len(didCommService.RecipientKeys) == 0 {
+		return nil, fmt.Errorf("create destination: no recipient keys on didcomm service block in diddoc: %#v", didDoc)
+	}
+
+	// if Accept is missing, ensure IndyAgent is at least added for packer selection based on MediaTypeProfile.
+	if len(didCommService.Accept) == 0 {
+		didCommService.Accept = []string{legacyDIDCommServiceType}
+	}
+
+	return &Destination{
+		RecipientKeys:     didkeyutil.ConvertBase58KeysToDIDKeys(didCommService.RecipientKeys),
+		ServiceEndpoint:   model.NewDIDCommV1Endpoint(uri),
+		RoutingKeys:       didkeyutil.ConvertBase58KeysToDIDKeys(didCommService.RoutingKeys),
+		MediaTypeProfiles: didCommService.Accept,
 	}, nil
 }

--- a/pkg/didcomm/common/service/destination_test.go
+++ b/pkg/didcomm/common/service/destination_test.go
@@ -1,5 +1,7 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
+
 SPDX-License-Identifier: Apache-2.0
 */
 
@@ -122,6 +124,17 @@ func TestPrepareDestination(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uri, "https://localhost:8090")
 		require.EqualValues(t, doc.Service[0].RoutingKeys, dest.RoutingKeys)
+	})
+
+	t.Run("successfully prepared legacy destination", func(t *testing.T) {
+		doc := mockdiddoc.GetMockIndyDoc(t)
+		dest, err := CreateDestination(doc)
+		require.NoError(t, err)
+		require.NotNil(t, dest)
+		uri, err := dest.ServiceEndpoint.URI()
+		require.NoError(t, err)
+		require.Equal(t, uri, "https://localhost:8090")
+		require.Equal(t, doc.Service[0].RoutingKeys, dest.RoutingKeys)
 	})
 
 	t.Run("error with destination having recipientKeys not did:keys", func(t *testing.T) {

--- a/pkg/didcomm/packager/packager.go
+++ b/pkg/didcomm/packager/packager.go
@@ -1,5 +1,6 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
@@ -13,6 +14,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/btcsuite/btcutil/base58"
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	"github.com/hyperledger/aries-framework-go/pkg/crypto"
@@ -153,7 +156,8 @@ func (bp *Packager) prepareSenderAndRecipientKeys(cty string, envelope *transpor
 
 				recipients = append(recipients, marshalledKey)
 			}
-
+		case cty == transport.LegacyDIDCommV1Profile:
+			recipients = append(recipients, base58.Decode(receiverKeyID))
 		default:
 			recipients = append(recipients, []byte(receiverKeyID))
 		}
@@ -392,7 +396,7 @@ func (bp *Packager) getCTYAndPacker(envelope *transport.Envelope) (string, packe
 		packerName := addAuthcryptSuffix(envelope.FromKey, transport.MediaTypeRFC0019EncryptedEnvelope)
 
 		return transport.MediaTypeRFC0019EncryptedEnvelope, bp.packers[packerName], nil
-	case transport.MediaTypeRFC0019EncryptedEnvelope:
+	case transport.MediaTypeRFC0019EncryptedEnvelope, transport.LegacyDIDCommV1Profile:
 		packerName := addAuthcryptSuffix(envelope.FromKey, transport.MediaTypeRFC0019EncryptedEnvelope)
 
 		return envelope.MediaTypeProfile, bp.packers[packerName], nil

--- a/pkg/didcomm/protocol/didexchange/event.go
+++ b/pkg/didcomm/protocol/didexchange/event.go
@@ -1,19 +1,11 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
 
 package didexchange
-
-// Event properties related api. This can be used to cast Generic event properties to DID Exchange specific props.
-type Event interface {
-	// connection ID
-	ConnectionID() string
-
-	// invitation ID
-	InvitationID() string
-}
 
 // didExchangeEvent implements didexchange.Event interface.
 type didExchangeEvent struct {

--- a/pkg/didcomm/protocol/legacyconnection/service.go
+++ b/pkg/didcomm/protocol/legacyconnection/service.go
@@ -36,7 +36,7 @@ var logger = log.New("aries-framework/legacyconnection/service")
 
 const (
 	// LegacyConnection connection protocol.
-	LegacyConnection = "LegacyConnection"
+	LegacyConnection = "legacyconnection"
 	// PIURI is the connection protocol identifier URI.
 	PIURI = "https://didcomm.org/connections/1.0"
 	// InvitationMsgType defines the legacy-connection invite message type.
@@ -179,7 +179,7 @@ func (s *Service) Initialize(p interface{}) error {
 
 	keyAgreementType := kms.X25519ECDHKWType
 
-	mediaTypeProfiles := []string{transport.MediaTypeProfileDIDCommAIP1}
+	mediaTypeProfiles := []string{transport.LegacyDIDCommV1Profile}
 
 	s.ctx = &context{
 		outboundDispatcher: prov.OutboundDispatcher(),

--- a/pkg/didcomm/protocol/outofband/service.go
+++ b/pkg/didcomm/protocol/outofband/service.go
@@ -1,5 +1,6 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
@@ -17,6 +18,7 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
 	"github.com/hyperledger/aries-framework-go/pkg/common/model"
+	didcommModel "github.com/hyperledger/aries-framework-go/pkg/didcomm/common/model"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
@@ -709,7 +711,7 @@ func (s *Service) handleDIDEvent(e service.StateMsg) error {
 		return errIgnoredDidEvent
 	}
 
-	props, ok := e.Properties.(didexchange.Event)
+	props, ok := e.Properties.(didcommModel.Event)
 	if !ok {
 		return fmt.Errorf("handleDIDEvent: failed to cast did state msg properties")
 	}

--- a/pkg/doc/util/kmsdidkey/kmsdidkey.go
+++ b/pkg/doc/util/kmsdidkey/kmsdidkey.go
@@ -1,5 +1,6 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/pkg/doc/util/kmsdidkey/kmsdidkey_test.go
+++ b/pkg/doc/util/kmsdidkey/kmsdidkey_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/pkg/framework/aries/default.go
+++ b/pkg/framework/aries/default.go
@@ -1,5 +1,6 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
@@ -21,6 +22,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/introduce"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/issuecredential"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/legacyconnection"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/messagepickup"
 	mdissuecredential "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/middleware/issuecredential"
@@ -82,7 +84,7 @@ func defFrameworkOpts(frameworkOpts *Aries) error { //nolint:gocyclo
 	// - OutOfBand depends on DIDExchange
 	// - Introduce depends on OutOfBand
 	frameworkOpts.protocolSvcCreators = append(frameworkOpts.protocolSvcCreators,
-		newMessagePickupSvc(), newRouteSvc(), newExchangeSvc(), newOutOfBandSvc(),
+		newMessagePickupSvc(), newRouteSvc(), newExchangeSvc(), newLegacyConnectionSvc(), newOutOfBandSvc(),
 		newIntroduceSvc(), newIssueCredentialSvc(), newPresentProofSvc(), newOutOfBandV2Svc())
 
 	if frameworkOpts.secretLock == nil && frameworkOpts.kmsCreator == nil {
@@ -99,6 +101,14 @@ func newExchangeSvc() api.ProtocolSvcCreator {
 	return api.ProtocolSvcCreator{
 		Create: func(prv api.Provider) (dispatcher.ProtocolService, error) {
 			return &didexchange.Service{}, nil
+		},
+	}
+}
+
+func newLegacyConnectionSvc() api.ProtocolSvcCreator {
+	return api.ProtocolSvcCreator{
+		Create: func(prv api.Provider) (dispatcher.ProtocolService, error) {
+			return &legacyconnection.Service{}, nil
 		},
 	}
 }

--- a/pkg/internal/didkeyutil/util.go
+++ b/pkg/internal/didkeyutil/util.go
@@ -1,0 +1,51 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didkeyutil
+
+import (
+	"strings"
+
+	"github.com/btcsuite/btcutil/base58"
+
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
+)
+
+// ConvertBase58KeysToDIDKeys converts base58 keys array to did:key keys array.
+func ConvertBase58KeysToDIDKeys(keys []string) []string {
+	var didKeys []string
+
+	for _, key := range keys {
+		if key == "" {
+			didKeys = append(didKeys, key)
+			continue
+		}
+
+		// skip if the key is a relative did-url (ie, it starts with ?, /, or #)
+		if strings.Contains("?/#", string(key[0])) { // nolint:gocritic
+			didKeys = append(didKeys, key)
+			continue
+		}
+
+		// skip if the key is already a did
+		if strings.HasPrefix(key, "did:") {
+			didKeys = append(didKeys, key)
+			continue
+		}
+
+		rawKey := base58.Decode(key)
+		if len(rawKey) == 0 {
+			didKeys = append(didKeys, key)
+			continue
+		}
+
+		didKey, _ := fingerprint.CreateDIDKey(rawKey)
+
+		didKeys = append(didKeys, didKey)
+	}
+
+	return didKeys
+}

--- a/pkg/internal/didkeyutil/util_test.go
+++ b/pkg/internal/didkeyutil/util_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didkeyutil
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcutil/base58"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/fingerprint"
+)
+
+func TestConvertBase58KeysToDIDKeys(t *testing.T) {
+	t.Run("no keys given", func(t *testing.T) {
+		recipientKeys := ConvertBase58KeysToDIDKeys(nil)
+		require.Nil(t, recipientKeys)
+	})
+
+	t.Run("some keys are converted", func(t *testing.T) {
+		inKeys := []string{
+			"6SFxbqdqGKtVVmLvXDnq9JP4ziZCG2fJzETpMYHt1VNx",
+			"#key1",
+			"6oDmCnt5w4h2hEQ12hwvD8w5JdvMDPYMzKNv5yPVomFu",
+			"did:key:z6MkjtX1C5tGbsNxcGBdCnkfzPw4pHq3fuufgFNkBpFtviAL",
+			"QEaG6QrDbx7dQ7U5Bm1Bqvx3psrGEqSieZACZ1LyU62",
+			"/path#fragment",
+			"9onu2hZrqtcoiVTkBStZ4N8iLYd24bmuHUvx9w3jb9av",
+			"GTcPhsGS3XdkWL5mS8sxsTLzwPfSBCYVY93QeT95U6NQ",
+			"?query=value",
+			"FFPJcCWHGchhuiE5hV1BTRaiBzXpZfgYdsSPFHu6DSAC",
+			"",
+			"@!~unexpected data~!@",
+		}
+		expectedKeys := []string{
+			"did:key:z6MkjtX1C5tGbsNxcGBdCnkfzPw4pHq3fuufgFNkBpFtviAL",
+			"#key1",
+			"did:key:z6MkkFUoo38XGcBVojEhiGum4EV58DCCdGnigLHqvFMWiz3H",
+			"did:key:z6MkjtX1C5tGbsNxcGBdCnkfzPw4pHq3fuufgFNkBpFtviAL",
+			"did:key:z6MkerVcrLfHZ9SajtxAkkir2wUwsQ9hg85oQfU62pyMtgsQ",
+			"/path#fragment",
+			"did:key:z6MkoG3wcwpJBS7GpzJSs1rPuTgiA7tsUV2FyVqszD1kWNNJ",
+			"did:key:z6MkuusSJ7WsP58DcpvU7hqoiYtzkxwHb5nrE9xLUj76PK9n",
+			"?query=value",
+			"did:key:z6MktheMCSkicACB2D4nP3y2JX8i1ZofyYvuKtMK5Zs78ewa",
+			"",
+			"@!~unexpected data~!@",
+		}
+
+		outKeys := ConvertBase58KeysToDIDKeys(inKeys)
+
+		require.Equal(t, len(expectedKeys), len(outKeys))
+
+		for i := range outKeys {
+			require.Equal(t, expectedKeys[i], outKeys[i])
+
+			// if we expect the key to be converted, check if it's converted correctly
+			if inKeys[i] != expectedKeys[i] {
+				pk, err := fingerprint.PubKeyFromDIDKey(outKeys[i])
+				require.NoError(t, err)
+
+				pkb58 := base58.Encode(pk)
+				require.Equal(t, inKeys[i], pkb58)
+			}
+		}
+	})
+}

--- a/pkg/mock/didcomm/protocol/legacyconnection/mock_legacyconnection.go
+++ b/pkg/mock/didcomm/protocol/legacyconnection/mock_legacyconnection.go
@@ -1,0 +1,239 @@
+/*
+ *
+ * Copyright Avast Software. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * /
+ *
+ */
+
+package didexchange
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/hyperledger/aries-framework-go/pkg/crypto"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/common/service"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/dispatcher"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	vdrapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
+	mockcrypto "github.com/hyperledger/aries-framework-go/pkg/mock/crypto"
+	mockdispatcher "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/dispatcher"
+	mockstore "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	mockvdr "github.com/hyperledger/aries-framework-go/pkg/mock/vdr"
+	"github.com/hyperledger/aries-framework-go/pkg/store/connection"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+)
+
+// MockLegacyConnectionSvc mock legacy connection service.
+type MockLegacyConnectionSvc struct {
+	ProtocolName             string
+	HandleFunc               func(service.DIDCommMsg) (string, error)
+	HandleOutboundFunc       func(msg service.DIDCommMsg, myDID, theirDID string) (string, error)
+	AcceptFunc               func(string) bool
+	RegisterActionEventErr   error
+	UnregisterActionEventErr error
+	RegisterMsgEventHandle   func(chan<- service.StateMsg) error
+	RegisterMsgEventErr      error
+	UnregisterMsgEventHandle func(chan<- service.StateMsg) error
+	UnregisterMsgEventErr    error
+	AcceptError              error
+	ImplicitInvitationErr    error
+	CreateConnRecordFunc     func(*connection.Record, *did.Doc) error
+}
+
+// Initialize service.
+func (m *MockLegacyConnectionSvc) Initialize(interface{}) error {
+	return nil
+}
+
+// HandleInbound msg.
+func (m *MockLegacyConnectionSvc) HandleInbound(msg service.DIDCommMsg, ctx service.DIDCommContext) (string, error) {
+	if m.HandleFunc != nil {
+		return m.HandleFunc(msg)
+	}
+
+	return uuid.New().String(), nil
+}
+
+// HandleOutbound msg.
+func (m *MockLegacyConnectionSvc) HandleOutbound(msg service.DIDCommMsg, myDID, theirDID string) (string, error) {
+	if m.HandleOutboundFunc != nil {
+		return m.HandleOutboundFunc(msg, myDID, theirDID)
+	}
+
+	return "", nil
+}
+
+// Accept msg checks the msg type.
+func (m *MockLegacyConnectionSvc) Accept(msgType string) bool {
+	if m.AcceptFunc != nil {
+		return m.AcceptFunc(msgType)
+	}
+
+	return true
+}
+
+// Name return service name.
+func (m *MockLegacyConnectionSvc) Name() string {
+	if m.ProtocolName != "" {
+		return m.ProtocolName
+	}
+
+	return "legacyconnection"
+}
+
+// RegisterActionEvent register action event.
+func (m *MockLegacyConnectionSvc) RegisterActionEvent(_ chan<- service.DIDCommAction) error {
+	if m.RegisterActionEventErr != nil {
+		return m.RegisterActionEventErr
+	}
+
+	return nil
+}
+
+// UnregisterActionEvent unregister action event.
+func (m *MockLegacyConnectionSvc) UnregisterActionEvent(_ chan<- service.DIDCommAction) error {
+	if m.UnregisterActionEventErr != nil {
+		return m.UnregisterActionEventErr
+	}
+
+	return nil
+}
+
+// RegisterMsgEvent register message event.
+func (m *MockLegacyConnectionSvc) RegisterMsgEvent(ch chan<- service.StateMsg) error {
+	if m.RegisterMsgEventErr != nil {
+		return m.RegisterMsgEventErr
+	}
+
+	if m.RegisterMsgEventHandle != nil {
+		return m.RegisterMsgEventHandle(ch)
+	}
+
+	return nil
+}
+
+// UnregisterMsgEvent unregister message event.
+func (m *MockLegacyConnectionSvc) UnregisterMsgEvent(ch chan<- service.StateMsg) error {
+	if m.UnregisterMsgEventErr != nil {
+		return m.UnregisterMsgEventErr
+	}
+
+	if m.UnregisterMsgEventHandle != nil {
+		return m.UnregisterMsgEventHandle(ch)
+	}
+
+	return nil
+}
+
+// AcceptConnectionRequest accepts/approves exchange request.
+func (m *MockLegacyConnectionSvc) AcceptConnectionRequest(connectionID, publicDID, label string, conns []string) error {
+	if m.AcceptError != nil {
+		return m.AcceptError
+	}
+
+	return nil
+}
+
+// AcceptInvitation accepts/approves exchange invitation.
+func (m *MockLegacyConnectionSvc) AcceptInvitation(connectionID, publicDID, label string, conns []string) error {
+	if m.AcceptError != nil {
+		return m.AcceptError
+	}
+
+	return nil
+}
+
+// CreateImplicitInvitation creates implicit invitation using public DID(s).
+func (m *MockLegacyConnectionSvc) CreateImplicitInvitation(inviterLabel, inviterDID, inviteeLabel, inviteeDID string, conns []string) (string, error) { //nolint: lll
+	if m.ImplicitInvitationErr != nil {
+		return "", m.ImplicitInvitationErr
+	}
+
+	return "connection-id", nil
+}
+
+// CreateConnection saves the connection record.
+func (m *MockLegacyConnectionSvc) CreateConnection(r *connection.Record, theirDID *did.Doc) error {
+	if m.CreateConnRecordFunc != nil {
+		return m.CreateConnRecordFunc(r, theirDID)
+	}
+
+	return nil
+}
+
+// MockProvider is provider for DIDExchange Service.
+type MockProvider struct {
+	StoreProvider              *mockstore.MockStoreProvider
+	ProtocolStateStoreProvider *mockstore.MockStoreProvider
+	CustomVDR                  vdrapi.Registry
+}
+
+// OutboundDispatcher is mock outbound dispatcher for legacy connection service.
+func (p *MockProvider) OutboundDispatcher() dispatcher.Outbound {
+	return &mockdispatcher.MockOutbound{}
+}
+
+// StorageProvider is mock storage provider for legacy connection service.
+func (p *MockProvider) StorageProvider() storage.Provider {
+	if p.StoreProvider != nil {
+		return p.StoreProvider
+	}
+
+	return mockstore.NewMockStoreProvider()
+}
+
+// ProtocolStateStorageProvider is mock protocol state storage provider for legacy connection service.
+func (p *MockProvider) ProtocolStateStorageProvider() storage.Provider {
+	if p.ProtocolStateStoreProvider != nil {
+		return p.ProtocolStateStoreProvider
+	}
+
+	return mockstore.NewMockStoreProvider()
+}
+
+// Crypto is mock crypto service for legacy connection service.
+func (p *MockProvider) Crypto() crypto.Crypto {
+	return &mockcrypto.Crypto{}
+}
+
+// VDRegistry is mock vdr registry.
+func (p *MockProvider) VDRegistry() vdrapi.Registry {
+	if p.CustomVDR != nil {
+		return p.CustomVDR
+	}
+
+	return &mockvdr.MockVDRegistry{}
+}
+
+// MockEventProperties is a didexchange.Event.
+type MockEventProperties struct {
+	ConnID     string
+	InvID      string
+	Properties map[string]interface{}
+}
+
+// ConnectionID returns the connection id.
+func (m *MockEventProperties) ConnectionID() string {
+	return m.ConnID
+}
+
+// InvitationID returns the invitation id.
+func (m *MockEventProperties) InvitationID() string {
+	return m.InvID
+}
+
+// All returns all properties.
+func (m *MockEventProperties) All() map[string]interface{} {
+	p := map[string]interface{}{
+		"connectionID": m.ConnectionID(),
+		"invitationID": m.InvitationID(),
+	}
+
+	for k, v := range m.Properties {
+		p[k] = v
+	}
+
+	return p
+}

--- a/pkg/wallet/didcomm.go
+++ b/pkg/wallet/didcomm.go
@@ -1,5 +1,6 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
+Copyright Avast Software. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
@@ -547,10 +548,10 @@ func waitForConnect(ctx context.Context, didStateMsgs chan service.StateMsg, con
 				continue
 			}
 
-			var event didexchangeSvc.Event
+			var event model.Event
 
 			switch p := msg.Properties.(type) {
-			case didexchangeSvc.Event:
+			case model.Event:
 				event = p
 			default:
 				logger.Warnf("failed to cast didexchange event properties")


### PR DESCRIPTION
**Title:**
Add client, rest and command handlers for legacy-connection protocol

**Summary:**

- Add client for legacy-connection protocol
- Move didexchange.Event to didcomm/common/event.go in order to make it common for didexchange and legacy-connection protocols
- Refactor HandleInboundEnvelope method of inbound message handler in order to handle messages of legacy-connection protocol
- Add rest and command handlers for legacy-connection protocol. Use them inside controller package
- Add creating legacy destination
- Add new LegacyConnection Error group
- Enable handling base58 keys while packing legacy media type envelopes
- Change media type profile while initializing legacy-connection service

Closes #3300 
