### PR TITLE
fix: change validate->Validate

### DIFF
--- a/pkg/doc/cm/credentialmanifest.go
+++ b/pkg/doc/cm/credentialmanifest.go
@@ -126,7 +126,7 @@ func (cm *CredentialManifest) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	err = cm.validate()
+	err = cm.Validate()
 	if err != nil {
 		return fmt.Errorf("invalid credential manifest: %w", err)
 	}
@@ -136,7 +136,7 @@ func (cm *CredentialManifest) UnmarshalJSON(data []byte) error {
 
 // Validate ensures that this CredentialManifest is valid as per the spec.
 // Note that this function is automatically called when unmarshalling a []byte into a CredentialManifest.
-func (cm *CredentialManifest) validate() error {
+func (cm *CredentialManifest) Validate() error {
 	if cm.Issuer.ID == "" {
 		return errors.New("issuer ID missing")
 	}


### PR DESCRIPTION
Changed credentialManifest's `validate()` back to `Validate() `as it needs to be exported
Signed-off-by: heidihan0000 <daeun.han@avast.com>
