### PR TITLE
fix: credential manifest omit optional properties

### DIFF
--- a/pkg/doc/cm/credentialapplication.go
+++ b/pkg/doc/cm/credentialapplication.go
@@ -41,11 +41,11 @@ const (
 // See https://github.com/decentralized-identity/credential-manifest/issues/73 for more information about this name
 // overloading.
 type CredentialApplication struct {
-	ID string `json:"id,omitempty"`
+	ID string `json:"id,omitempty"` // mandatory property
 	// The value of this property MUST be the ID of a valid Credential Manifest.
-	ManifestID string `json:"manifest_id,omitempty"`
+	ManifestID string `json:"manifest_id,omitempty"` // mandatory property
 	// Must be a subset of the format property of the CredentialManifest that this CredentialApplication is related to
-	Format presexch.Format `json:"format,omitempty"`
+	Format presexch.Format `json:"format,omitempty"` // mandatory property
 }
 
 // UnmarshalAndValidateAgainstCredentialManifest unmarshals the credentialApplicationBytes into a CredentialApplication
@@ -187,7 +187,7 @@ func (ca *CredentialApplication) validateFormatAgainstCredManifestFormat(cm *Cre
 		return errors.New("the Credential Manifest specifies a format but the Credential Application does not")
 	}
 
-	err := ca.ensureFormatIsSubsetOfCredManifestFormat(cm.Format)
+	err := ca.ensureFormatIsSubsetOfCredManifestFormat(*cm.Format)
 	if err != nil {
 		return fmt.Errorf("invalid format request: %w", err)
 	}
@@ -328,10 +328,15 @@ func setCredentialApplicationContext(presentation *verifiable.Presentation) {
 }
 
 func setCustomFields(presentation *verifiable.Presentation, credentialManifest *CredentialManifest) {
+	format := presexch.Format{}
+	if credentialManifest.Format != nil {
+		format = *credentialManifest.Format
+	}
+
 	application := CredentialApplication{
 		ID:         uuid.New().String(),
 		ManifestID: credentialManifest.ID,
-		Format:     credentialManifest.Format,
+		Format:     format,
 	}
 
 	if presentation.CustomFields == nil {

--- a/pkg/doc/cm/credentialfulfillment.go
+++ b/pkg/doc/cm/credentialfulfillment.go
@@ -32,10 +32,10 @@ const (
 // CredentialFulfillment represents a Credential Fulfillment object as defined in
 // https://identity.foundation/credential-manifest/#credential-fulfillment.
 type CredentialFulfillment struct {
-	ID                             string                `json:"id,omitempty"`
-	ManifestID                     string                `json:"manifest_id,omitempty"`
+	ID                             string                `json:"id,omitempty"`          // mandatory property
+	ManifestID                     string                `json:"manifest_id,omitempty"` // mandatory property
 	ApplicationID                  string                `json:"application_id,omitempty"`
-	OutputDescriptorMappingObjects []OutputDescriptorMap `json:"descriptor_map,omitempty"`
+	OutputDescriptorMappingObjects []OutputDescriptorMap `json:"descriptor_map,omitempty"` // mandatory property
 }
 
 // OutputDescriptorMap represents an Output Descriptor Mapping Object as defined in

--- a/pkg/doc/cm/credentialmanifest.go
+++ b/pkg/doc/cm/credentialmanifest.go
@@ -27,28 +27,27 @@ const CredentialManifestAttachmentFormat = "dif/credential-manifest/manifest@v1.
 // CredentialManifest represents a Credential Manifest object as defined in
 // https://identity.foundation/credential-manifest/#credential-manifest-2.
 type CredentialManifest struct {
-	ID                     string                           `json:"id,omitempty"`
-	Version                string                           `json:"version,omitempty"`
-	Issuer                 Issuer                           `json:"issuer,omitempty"`
-	OutputDescriptors      []*OutputDescriptor              `json:"output_descriptors,omitempty"`
-	Format                 presexch.Format                  `json:"format,omitempty"`
+	ID                     string                           `json:"id,omitempty"`                 // mandatory property
+	Issuer                 Issuer                           `json:"issuer,omitempty"`             // mandatory property
+	OutputDescriptors      []*OutputDescriptor              `json:"output_descriptors,omitempty"` // mandatory property
+	Format                 *presexch.Format                 `json:"format,omitempty"`
 	PresentationDefinition *presexch.PresentationDefinition `json:"presentation_definition,omitempty"`
 }
 
 // Issuer represents the issuer object defined in https://identity.foundation/credential-manifest/#general-composition.
 type Issuer struct {
-	ID     string `json:"id,omitempty"` // Must be a valid URI
-	Name   string `json:"name,omitempty"`
-	Styles Styles `json:"styles,omitempty"`
+	ID     string  `json:"id,omitempty"` // mandatory, must be a valid URI
+	Name   string  `json:"name,omitempty"`
+	Styles *Styles `json:"styles,omitempty"`
 }
 
 // Styles represents an Entity Styles object as defined in
-// https://identity.foundation/credential-manifest/wallet-rendering/#entity-styles.
+// https://identity.foundation/wallet-rendering/#entity-styles.
 type Styles struct {
-	Thumbnail  ImageURIWithAltText `json:"thumbnail,omitempty"`
-	Hero       ImageURIWithAltText `json:"hero,omitempty"`
-	Background Color               `json:"background,omitempty"`
-	Text       Color               `json:"text,omitempty"`
+	Thumbnail  *ImageURIWithAltText `json:"thumbnail,omitempty"`
+	Hero       *ImageURIWithAltText `json:"hero,omitempty"`
+	Background *Color               `json:"background,omitempty"`
+	Text       *Color               `json:"text,omitempty"`
 }
 
 // Color represents a single color in RGB hex code format.
@@ -59,31 +58,31 @@ type Color struct {
 // OutputDescriptor represents an Output Descriptor object as defined in
 // https://identity.foundation/credential-manifest/#output-descriptor.
 type OutputDescriptor struct {
-	ID          string                `json:"id,omitempty"`
-	Schema      string                `json:"schema,omitempty"`
-	Name        string                `json:"name,omitempty"`
-	Description string                `json:"description,omitempty"`
-	Display     DataDisplayDescriptor `json:"display,omitempty"`
-	Styles      Styles                `json:"styles,omitempty"`
+	ID          string                 `json:"id,omitempty"`     // mandatory property
+	Schema      string                 `json:"schema,omitempty"` // mandatory property
+	Name        string                 `json:"name,omitempty"`
+	Description string                 `json:"description,omitempty"`
+	Display     *DataDisplayDescriptor `json:"display,omitempty"`
+	Styles      *Styles                `json:"styles,omitempty"`
 }
 
 // ImageURIWithAltText represents a URI that points to an image along with the alt text for it.
 type ImageURIWithAltText struct {
-	URI string `json:"uri,omitempty"`
+	URI string `json:"uri,omitempty"` // mandatory property
 	Alt string `json:"alt,omitempty"`
 }
 
 // DataDisplayDescriptor represents a Data Display Descriptor as defined in
 // https://identity.foundation/credential-manifest/wallet-rendering/#data-display.
 type DataDisplayDescriptor struct {
-	Title       DisplayMappingObject          `json:"title,omitempty"`
-	Subtitle    DisplayMappingObject          `json:"subtitle,omitempty"`
-	Description DisplayMappingObject          `json:"description,omitempty"`
-	Properties  []LabeledDisplayMappingObject `json:"properties,omitempty"`
+	Title       *DisplayMappingObject          `json:"title,omitempty"`
+	Subtitle    *DisplayMappingObject          `json:"subtitle,omitempty"`
+	Description *DisplayMappingObject          `json:"description,omitempty"`
+	Properties  []*LabeledDisplayMappingObject `json:"properties,omitempty"`
 }
 
 // DisplayMappingObject represents a Display Mapping Object as defined in
-// https://identity.foundation/credential-manifest/wallet-rendering/#display-mapping-object
+// https://identity.foundation/wallet-rendering/#display-mapping-object
 // There are two possibilities here:
 // 1. If the text field is used, schema is not required. The text field will contain display
 // information about the target Claim.
@@ -100,13 +99,13 @@ type DisplayMappingObject struct {
 // They are used for the dynamic Properties array in a DataDisplayDescriptor.
 type LabeledDisplayMappingObject struct {
 	DisplayMappingObject
-	Label string `json:"label,omitempty"`
+	Label string `json:"label,omitempty"` // mandatory property
 }
 
 // Schema represents Type and (optional) Format information for a DisplayMappingObject that uses the Paths field,
-// as defined in https://identity.foundation/credential-manifest/wallet-rendering/#using-path.
+// as defined in https://identity.foundation/wallet-rendering/#using-path.
 type Schema struct {
-	Type             string `json:"type,omitempty"`             // MUST be here
+	Type             string `json:"type"`                       // MUST be here
 	Format           string `json:"format,omitempty"`           // MAY be here if the Type is "string".
 	ContentMediaType string `json:"contentMediaType,omitempty"` // MAY be here if the Type is "string".
 	ContentEncoding  string `json:"contentEncoding,omitempty"`  // MAY be here if the Type is "string".
@@ -137,17 +136,54 @@ func (cm *CredentialManifest) UnmarshalJSON(data []byte) error {
 // Validate ensures that this CredentialManifest is valid as per the spec.
 // Note that this function is automatically called when unmarshalling a []byte into a CredentialManifest.
 func (cm *CredentialManifest) Validate() error {
-	if cm.Issuer.ID == "" {
-		return errors.New("issuer ID missing")
+	if cm.ID == "" {
+		return errors.New("ID missing")
+	}
+
+	err := validateIssuer(cm.Issuer)
+	if err != nil {
+		return err
 	}
 
 	if len(cm.OutputDescriptors) == 0 {
 		return errors.New("no output descriptors found")
 	}
 
-	err := ValidateOutputDescriptors(cm.OutputDescriptors)
+	err = ValidateOutputDescriptors(cm.OutputDescriptors)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func validateIssuer(issuer Issuer) error {
+	if issuer.ID == "" {
+		return errors.New("issuer ID missing")
+	}
+
+	if issuer.Styles != nil {
+		return validateStyles(*issuer.Styles)
+	}
+
+	return nil
+}
+
+func validateStyles(styles Styles) error {
+	if styles.Thumbnail != nil {
+		return validateImage(*styles.Thumbnail)
+	}
+
+	if styles.Hero != nil {
+		return validateImage(*styles.Hero)
+	}
+
+	return nil
+}
+
+func validateImage(image ImageURIWithAltText) error {
+	if image.URI == "" {
+		return errors.New("uri missing for image")
 	}
 
 	return nil
@@ -157,7 +193,7 @@ func (cm *CredentialManifest) Validate() error {
 // when placed together within a single Credential Manifest.
 // To pass validation, the following two conditions must be satisfied:
 // 1. Each OutputDescriptor must have a unique ID.
-// 2. Each OutputDescriptor must also have valid contents. See the validateOutputDescriptor function for details.
+// 2. Each OutputDescriptor must also have valid contents. See the validateOutputDescriptorDisplay function for details.
 func ValidateOutputDescriptors(descriptors []*OutputDescriptor) error {
 	allOutputDescriptorIDs := make(map[string]struct{})
 
@@ -177,9 +213,16 @@ func ValidateOutputDescriptors(descriptors []*OutputDescriptor) error {
 			return fmt.Errorf("missing schema for output descriptor at index %d", i)
 		}
 
-		err := validateOutputDescriptor(descriptors[i], i)
+		err := validateOutputDescriptorDisplay(descriptors[i], i)
 		if err != nil {
 			return err
+		}
+
+		if descriptors[i].Styles != nil {
+			err = validateStyles(*descriptors[i].Styles)
+			if err != nil {
+				return fmt.Errorf("%w at index %d", err, i)
+			}
 		}
 	}
 
@@ -187,7 +230,11 @@ func ValidateOutputDescriptors(descriptors []*OutputDescriptor) error {
 }
 
 func (cm *CredentialManifest) hasFormat() bool {
-	return hasAnyAlgorithmsOrProofTypes(cm.Format)
+	if cm.Format == nil {
+		return false
+	}
+
+	return hasAnyAlgorithmsOrProofTypes(*cm.Format)
 }
 
 func (cm *CredentialManifest) standardUnmarshal(data []byte) error {
@@ -203,23 +250,33 @@ func (cm *CredentialManifest) standardUnmarshal(data []byte) error {
 	return nil
 }
 
-func validateOutputDescriptor(outputDescriptor *OutputDescriptor, outputDescriptorIndex int) error {
-	err := validateDisplayMappingObject(&outputDescriptor.Display.Title)
-	if err != nil {
-		return fmt.Errorf("display title for output descriptor at index %d is invalid: %w",
-			outputDescriptorIndex, err)
+func validateOutputDescriptorDisplay(outputDescriptor *OutputDescriptor, outputDescriptorIndex int) error {
+	if outputDescriptor.Display == nil {
+		return nil
 	}
 
-	err = validateDisplayMappingObject(&outputDescriptor.Display.Subtitle)
-	if err != nil {
-		return fmt.Errorf("display subtitle for output descriptor at index %d is invalid: %w",
-			outputDescriptorIndex, err)
+	if outputDescriptor.Display.Title != nil {
+		err := validateDisplayMappingObject(outputDescriptor.Display.Title)
+		if err != nil {
+			return fmt.Errorf("display title for output descriptor at index %d is invalid: %w",
+				outputDescriptorIndex, err)
+		}
 	}
 
-	err = validateDisplayMappingObject(&outputDescriptor.Display.Description)
-	if err != nil {
-		return fmt.Errorf("display description for output descriptor at index %d is invalid: %w",
-			outputDescriptorIndex, err)
+	if outputDescriptor.Display.Subtitle != nil {
+		err := validateDisplayMappingObject(outputDescriptor.Display.Subtitle)
+		if err != nil {
+			return fmt.Errorf("display subtitle for output descriptor at index %d is invalid: %w",
+				outputDescriptorIndex, err)
+		}
+	}
+
+	if outputDescriptor.Display.Description != nil {
+		err := validateDisplayMappingObject(outputDescriptor.Display.Description)
+		if err != nil {
+			return fmt.Errorf("display description for output descriptor at index %d is invalid: %w",
+				outputDescriptorIndex, err)
+		}
 	}
 
 	for i := range outputDescriptor.Display.Properties {

--- a/pkg/doc/cm/credentialmanifest_test.go
+++ b/pkg/doc/cm/credentialmanifest_test.go
@@ -37,6 +37,8 @@ var (
 	credentialManifestDriversLicenseWithPresentationDefinition []byte //nolint:gochecknoglobals
 	//go:embed testdata/credential_manifest_drivers_license_with_presentation_definition_and_format.json
 	credentialManifestDriversLicenseWithPresentationDefinitionAndFormat []byte //nolint:gochecknoglobals
+	//go:embed testdata/credential_manifest_drivers_license_with_no_display_or_styles.json
+	credentialManifestDriversLicenseWithNoDisplayOrStyles []byte //nolint:gochecknoglobals
 )
 
 // Sample verifiable credential for a university degree.
@@ -64,120 +66,167 @@ func TestCredentialManifest_Unmarshal(t *testing.T) {
 		t.Run("With Presentation Submission", func(t *testing.T) {
 			makeCredentialManifestFromBytes(t, credentialManifestUniversityDegreeWithPresentationDefinition)
 		})
-	})
-	t.Run("Missing issuer ID", func(t *testing.T) {
-		credentialManifest := makeCredentialManifestFromBytes(t, credentialManifestUniversityDegree)
-
-		credentialManifest.Issuer.ID = ""
-
-		invalidCredentialManifest, err := json.Marshal(credentialManifest)
-		require.NoError(t, err)
-
-		err = json.Unmarshal(invalidCredentialManifest, &credentialManifest)
-		require.EqualError(t, err, "invalid credential manifest: issuer ID missing")
-	})
-	t.Run("No output descriptors", func(t *testing.T) {
-		credentialManifest := makeCredentialManifestFromBytes(t, credentialManifestUniversityDegree)
-
-		credentialManifest.OutputDescriptors = nil
-
-		invalidCredentialManifest, err := json.Marshal(credentialManifest)
-		require.NoError(t, err)
-
-		err = json.Unmarshal(invalidCredentialManifest, &credentialManifest)
-		require.EqualError(t, err, "invalid credential manifest: no output descriptors found")
-	})
-	t.Run("Output descriptor missing ID", func(t *testing.T) {
-		credentialManifest := makeCredentialManifestFromBytes(t, credentialManifestUniversityDegree)
-
-		credentialManifest.OutputDescriptors[0].ID = ""
-
-		invalidCredentialManifest, err := json.Marshal(credentialManifest)
-		require.NoError(t, err)
-
-		err = json.Unmarshal(invalidCredentialManifest, &credentialManifest)
-		require.EqualError(t, err, "invalid credential manifest: missing ID for output descriptor at index 0")
-	})
-	t.Run("Duplicate output descriptor IDs", func(t *testing.T) {
-		credentialManifest := makeCredentialManifestFromBytes(t, credentialManifestUniversityDegree)
-
-		credentialManifest.OutputDescriptors =
-			append(credentialManifest.OutputDescriptors,
-				&cm.OutputDescriptor{ID: credentialManifest.OutputDescriptors[0].ID})
-
-		invalidCredentialManifest, err := json.Marshal(credentialManifest)
-		require.NoError(t, err)
-
-		err = json.Unmarshal(invalidCredentialManifest, &credentialManifest)
-		require.EqualError(t, err, "invalid credential manifest: the ID bachelors_degree appears "+
-			"in multiple output descriptors")
-	})
-	t.Run("Missing schema for output descriptor", func(t *testing.T) {
-		credentialManifest := makeCredentialManifestFromBytes(t, credentialManifestUniversityDegree)
-
-		credentialManifest.OutputDescriptors[0].Schema = ""
-
-		invalidCredentialManifest, err := json.Marshal(credentialManifest)
-		require.NoError(t, err)
-
-		err = json.Unmarshal(invalidCredentialManifest, &credentialManifest)
-		require.EqualError(t, err, "invalid credential manifest: missing schema for "+
-			"output descriptor at index 0")
-	})
-	t.Run("Invalid JSONPath", func(t *testing.T) {
-		t.Run("Display title", func(t *testing.T) {
-			var credentialManifest cm.CredentialManifest
-
-			err := json.Unmarshal(createMarshalledCredentialManifestWithInvalidTitleJSONPath(t), &credentialManifest)
-			require.EqualError(t, err, "invalid credential manifest: display title for output descriptor "+
-				`at index 0 is invalid: path "%InvalidJSONPath" at index 0 is not a valid JSONPath: parsing error: `+
-				`%InvalidJSONPath	:1:1 - 1:2 unexpected "%" while scanning extensions`)
+		t.Run("Without output descriptor display", func(t *testing.T) {
+			makeCredentialManifestFromBytes(t, credentialManifestDriversLicenseWithNoDisplayOrStyles)
 		})
-		t.Run("Display subtitle", func(t *testing.T) {
-			var credentialManifest cm.CredentialManifest
+		t.Run("Without issuer optional properties", func(t *testing.T) {
+			credentialManifest := makeCredentialManifestFromBytes(t, credentialManifestUniversityDegree)
 
-			err := json.Unmarshal(createMarshalledCredentialManifestWithInvalidSubtitleJSONPath(t), &credentialManifest)
-			require.EqualError(t, err, "invalid credential manifest: display subtitle for output descriptor "+
-				`at index 0 is invalid: path "%InvalidJSONPath" at index 0 is not a valid JSONPath: parsing error: `+
-				`%InvalidJSONPath	:1:1 - 1:2 unexpected "%" while scanning extensions`)
-		})
-		t.Run("Display description", func(t *testing.T) {
-			var credentialManifest cm.CredentialManifest
+			credentialManifest.Issuer = cm.Issuer{ID: "valid ID"}
 
-			err := json.Unmarshal(createMarshalledCredentialManifestWithInvalidDescriptionJSONPath(t), &credentialManifest)
-			require.EqualError(t, err, "invalid credential manifest: display description for output "+
-				`descriptor at index 0 is invalid: path "%InvalidJSONPath" at index 0 is not a valid JSONPath: `+
-				`parsing error: %InvalidJSONPath	:1:1 - 1:2 unexpected "%" while scanning extensions`)
-		})
-		t.Run("Display property", func(t *testing.T) {
-			var credentialManifest cm.CredentialManifest
+			invalidCredentialManifest, err := json.Marshal(credentialManifest)
+			require.NoError(t, err)
 
-			err := json.Unmarshal(createMarshalledCredentialManifestWithInvalidPropertyJSONPath(t), &credentialManifest)
-			require.EqualError(t, err, "invalid credential manifest: display property at index 0 for output "+
-				`descriptor at index 0 is invalid: path "%InvalidJSONPath" at index 0 is not a valid JSONPath: `+
-				`parsing error: %InvalidJSONPath	:1:1 - 1:2 unexpected "%" while scanning extensions`)
+			err = json.Unmarshal(invalidCredentialManifest, &credentialManifest)
+			require.NoError(t, err)
 		})
 	})
-	t.Run("Invalid schema type", func(t *testing.T) {
-		var credentialManifest cm.CredentialManifest
+	t.Run("Invalid Credential Manifest", func(t *testing.T) {
+		t.Run("Missing ID", func(t *testing.T) {
+			credentialManifest := makeCredentialManifestFromBytes(t, credentialManifestUniversityDegree)
 
-		err := json.Unmarshal(createMarshalledCredentialManifestWithInvalidSchemaType(t), &credentialManifest)
-		require.EqualError(t, err, "invalid credential manifest: display title for output descriptor at "+
-			"index 0 is invalid: InvalidSchemaType is not a valid schema type")
-	})
-	t.Run("Invalid schema format", func(t *testing.T) {
-		var credentialManifest cm.CredentialManifest
+			credentialManifest.ID = ""
 
-		err := json.Unmarshal(createMarshalledCredentialManifestWithInvalidSchemaFormat(t), &credentialManifest)
-		require.EqualError(t, err, "invalid credential manifest: display title for output descriptor at "+
-			"index 0 is invalid: UnknownFormat is not a valid string schema format")
-	})
-	t.Run("Missing paths and text", func(t *testing.T) {
-		var credentialManifest cm.CredentialManifest
+			invalidCredentialManifest, err := json.Marshal(credentialManifest)
+			require.NoError(t, err)
 
-		err := json.Unmarshal(createMarshalledCredentialManifestWithMissingPropertyJSONPathAndText(t), &credentialManifest)
-		require.EqualError(t, err, "invalid credential manifest: display property at index 0 for output descriptor at "+
-			"index 0 is invalid: display mapping object must contain either a paths or a text property")
+			err = json.Unmarshal(invalidCredentialManifest, &credentialManifest)
+			require.EqualError(t, err, "invalid credential manifest: ID missing")
+		})
+		t.Run("Missing issuer", func(t *testing.T) {
+			credentialManifest := makeCredentialManifestFromBytes(t, credentialManifestUniversityDegree)
+
+			credentialManifest.Issuer = cm.Issuer{}
+
+			invalidCredentialManifest, err := json.Marshal(credentialManifest)
+			require.NoError(t, err)
+
+			err = json.Unmarshal(invalidCredentialManifest, &credentialManifest)
+			require.EqualError(t, err, "invalid credential manifest: issuer ID missing")
+		})
+		t.Run("Missing issuer ID", func(t *testing.T) {
+			credentialManifest := makeCredentialManifestFromBytes(t, credentialManifestUniversityDegree)
+
+			credentialManifest.Issuer.ID = ""
+
+			invalidCredentialManifest, err := json.Marshal(credentialManifest)
+			require.NoError(t, err)
+
+			err = json.Unmarshal(invalidCredentialManifest, &credentialManifest)
+			require.EqualError(t, err, "invalid credential manifest: issuer ID missing")
+		})
+		t.Run("No output descriptors", func(t *testing.T) {
+			credentialManifest := makeCredentialManifestFromBytes(t, credentialManifestUniversityDegree)
+
+			credentialManifest.OutputDescriptors = nil
+
+			invalidCredentialManifest, err := json.Marshal(credentialManifest)
+			require.NoError(t, err)
+
+			err = json.Unmarshal(invalidCredentialManifest, &credentialManifest)
+			require.EqualError(t, err, "invalid credential manifest: no output descriptors found")
+		})
+		t.Run("Output descriptor missing ID", func(t *testing.T) {
+			credentialManifest := makeCredentialManifestFromBytes(t, credentialManifestUniversityDegree)
+
+			credentialManifest.OutputDescriptors[0].ID = ""
+
+			invalidCredentialManifest, err := json.Marshal(credentialManifest)
+			require.NoError(t, err)
+
+			err = json.Unmarshal(invalidCredentialManifest, &credentialManifest)
+			require.EqualError(t, err, "invalid credential manifest: missing ID for output descriptor at index 0")
+		})
+		t.Run("Duplicate output descriptor IDs", func(t *testing.T) {
+			credentialManifest := makeCredentialManifestFromBytes(t, credentialManifestUniversityDegree)
+
+			credentialManifest.OutputDescriptors =
+				append(credentialManifest.OutputDescriptors,
+					&cm.OutputDescriptor{ID: credentialManifest.OutputDescriptors[0].ID})
+
+			invalidCredentialManifest, err := json.Marshal(credentialManifest)
+			require.NoError(t, err)
+
+			err = json.Unmarshal(invalidCredentialManifest, &credentialManifest)
+			require.EqualError(t, err, "invalid credential manifest: the ID bachelors_degree appears "+
+				"in multiple output descriptors")
+		})
+		t.Run("Missing schema for output descriptor", func(t *testing.T) {
+			credentialManifest := makeCredentialManifestFromBytes(t, credentialManifestUniversityDegree)
+
+			credentialManifest.OutputDescriptors[0].Schema = ""
+
+			invalidCredentialManifest, err := json.Marshal(credentialManifest)
+			require.NoError(t, err)
+
+			err = json.Unmarshal(invalidCredentialManifest, &credentialManifest)
+			require.EqualError(t, err, "invalid credential manifest: missing schema for "+
+				"output descriptor at index 0")
+		})
+		t.Run("Invalid JSONPath", func(t *testing.T) {
+			t.Run("Display title", func(t *testing.T) {
+				var credentialManifest cm.CredentialManifest
+
+				err := json.Unmarshal(createMarshalledCredentialManifestWithInvalidTitleJSONPath(t), &credentialManifest)
+				require.EqualError(t, err, "invalid credential manifest: display title for output descriptor "+
+					`at index 0 is invalid: path "%InvalidJSONPath" at index 0 is not a valid JSONPath: parsing error: `+
+					`%InvalidJSONPath	:1:1 - 1:2 unexpected "%" while scanning extensions`)
+			})
+			t.Run("Display subtitle", func(t *testing.T) {
+				var credentialManifest cm.CredentialManifest
+
+				err := json.Unmarshal(createMarshalledCredentialManifestWithInvalidSubtitleJSONPath(t), &credentialManifest)
+				require.EqualError(t, err, "invalid credential manifest: display subtitle for output descriptor "+
+					`at index 0 is invalid: path "%InvalidJSONPath" at index 0 is not a valid JSONPath: parsing error: `+
+					`%InvalidJSONPath	:1:1 - 1:2 unexpected "%" while scanning extensions`)
+			})
+			t.Run("Display description", func(t *testing.T) {
+				var credentialManifest cm.CredentialManifest
+
+				err := json.Unmarshal(createMarshalledCredentialManifestWithInvalidDescriptionJSONPath(t), &credentialManifest)
+				require.EqualError(t, err, "invalid credential manifest: display description for output "+
+					`descriptor at index 0 is invalid: path "%InvalidJSONPath" at index 0 is not a valid JSONPath: `+
+					`parsing error: %InvalidJSONPath	:1:1 - 1:2 unexpected "%" while scanning extensions`)
+			})
+			t.Run("Display property", func(t *testing.T) {
+				var credentialManifest cm.CredentialManifest
+
+				err := json.Unmarshal(createMarshalledCredentialManifestWithInvalidPropertyJSONPath(t), &credentialManifest)
+				require.EqualError(t, err, "invalid credential manifest: display property at index 0 for output "+
+					`descriptor at index 0 is invalid: path "%InvalidJSONPath" at index 0 is not a valid JSONPath: `+
+					`parsing error: %InvalidJSONPath	:1:1 - 1:2 unexpected "%" while scanning extensions`)
+			})
+		})
+		t.Run("Invalid schema type", func(t *testing.T) {
+			var credentialManifest cm.CredentialManifest
+
+			err := json.Unmarshal(createMarshalledCredentialManifestWithInvalidSchemaType(t), &credentialManifest)
+			require.EqualError(t, err, "invalid credential manifest: display title for output descriptor at "+
+				"index 0 is invalid: InvalidSchemaType is not a valid schema type")
+		})
+		t.Run("Invalid schema format", func(t *testing.T) {
+			var credentialManifest cm.CredentialManifest
+
+			err := json.Unmarshal(createMarshalledCredentialManifestWithInvalidSchemaFormat(t), &credentialManifest)
+			require.EqualError(t, err, "invalid credential manifest: display title for output descriptor at "+
+				"index 0 is invalid: UnknownFormat is not a valid string schema format")
+		})
+		t.Run("Missing paths and text", func(t *testing.T) {
+			var credentialManifest cm.CredentialManifest
+
+			err := json.Unmarshal(createMarshalledCredentialManifestWithMissingPropertyJSONPathAndText(t), &credentialManifest)
+			require.EqualError(t, err, "invalid credential manifest: display property at index 0 for output descriptor at "+
+				"index 0 is invalid: display mapping object must contain either a paths or a text property")
+		})
+		t.Run("Missing image URI", func(t *testing.T) {
+			credentialManifest := createCredentialManifestWithNoImageURI(t)
+
+			invalidCredentialManifest, err := json.Marshal(credentialManifest)
+			require.NoError(t, err)
+
+			err = json.Unmarshal(invalidCredentialManifest, &credentialManifest)
+			require.EqualError(t, err, "invalid credential manifest: uri missing for image at index 0")
+		})
 	})
 }
 
@@ -736,6 +785,17 @@ func createCredentialManifestWithNilLDPFormat(t *testing.T) cm.CredentialManifes
 	credentialManifest := makeCredentialManifestFromBytes(t, credentialManifestUniversityDegreeWithFormat)
 
 	credentialManifest.Format.Ldp = nil
+
+	return credentialManifest
+}
+
+func createCredentialManifestWithNoImageURI(t *testing.T) cm.CredentialManifest {
+	credentialManifest := makeCredentialManifestFromBytes(t, credentialManifestUniversityDegree)
+
+	credentialManifest.OutputDescriptors[0].Styles.Thumbnail = &cm.ImageURIWithAltText{
+		Alt: "valid alt",
+	}
+	require.Empty(t, credentialManifest.OutputDescriptors[0].Styles.Thumbnail.URI)
 
 	return credentialManifest
 }

--- a/pkg/doc/cm/resolve.go
+++ b/pkg/doc/cm/resolve.go
@@ -20,20 +20,20 @@ import (
 
 // ResolvedProperty contains resolved result for each resolved property.
 type ResolvedProperty struct {
-	Schema Schema      `json:"schema,omitempty"`
-	Label  string      `json:"label,omitempty"`
-	Value  interface{} `json:"value,omitempty"`
+	Schema Schema      `json:"schema"`
+	Label  string      `json:"label"`
+	Value  interface{} `json:"value"`
 }
 
 // ResolvedDescriptor typically represents results of resolving manifests by credential fulfillment.
 // Typically represents a DataDisplayDescriptor that's had its various "template" fields resolved
 // into concrete values based on a Verifiable Credential.
 type ResolvedDescriptor struct {
-	DescriptorID string              `json:"descriptor_id,omitempty"`
+	DescriptorID string              `json:"descriptor_id"`
 	Title        string              `json:"title,omitempty"`
 	Subtitle     string              `json:"subtitle,omitempty"`
 	Description  string              `json:"description,omitempty"`
-	Styles       Styles              `json:"styles,omitempty"`
+	Styles       *Styles             `json:"styles,omitempty"`
 	Properties   []*ResolvedProperty `json:"properties,omitempty"`
 }
 
@@ -206,17 +206,17 @@ func resolveOutputDescriptor(outputDescriptor *OutputDescriptor,
 
 func resolveStaticDisplayMappingObjects(outputDescriptor *OutputDescriptor,
 	vc map[string]interface{}) (staticDisplayMappingObjects, error) {
-	title, err := resolveDisplayMappingObject(&outputDescriptor.Display.Title, vc)
+	title, err := resolveDisplayMappingObject(outputDescriptor.Display.Title, vc)
 	if err != nil {
 		return staticDisplayMappingObjects{}, fmt.Errorf("failed to resolve title display mapping object: %w", err)
 	}
 
-	subtitle, err := resolveDisplayMappingObject(&outputDescriptor.Display.Subtitle, vc)
+	subtitle, err := resolveDisplayMappingObject(outputDescriptor.Display.Subtitle, vc)
 	if err != nil {
 		return staticDisplayMappingObjects{}, fmt.Errorf("failed to resolve subtitle display mapping object: %w", err)
 	}
 
-	description, err := resolveDisplayMappingObject(&outputDescriptor.Display.Description, vc)
+	description, err := resolveDisplayMappingObject(outputDescriptor.Display.Description, vc)
 	if err != nil {
 		return staticDisplayMappingObjects{}, fmt.Errorf("failed to resolve description display mapping object: %w", err)
 	}
@@ -228,7 +228,7 @@ func resolveStaticDisplayMappingObjects(outputDescriptor *OutputDescriptor,
 	}, nil
 }
 
-func resolveDescriptorProperties(properties []LabeledDisplayMappingObject,
+func resolveDescriptorProperties(properties []*LabeledDisplayMappingObject,
 	vc map[string]interface{}) ([]*ResolvedProperty, error) {
 	var resolvedProperties []*ResolvedProperty
 

--- a/pkg/doc/cm/testdata/credential_manifest_drivers_license_with_no_display_or_styles.json
+++ b/pkg/doc/cm/testdata/credential_manifest_drivers_license_with_no_display_or_styles.json
@@ -1,0 +1,17 @@
+{
+  "id":"dcc75a16-19f5-4273-84ce-4da69ee2b7fe",
+  "version":"0.1.0",
+  "issuer":{
+    "id":"did:example:123?linked-domains=3",
+    "name":"Washington State Government",
+    "styles":{
+
+    }
+  },
+  "output_descriptors":[
+    {
+      "id":"driver_license_output",
+      "schema":"https://schema.org/EducationalOccupationalCredentialfffff"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #3335 

**Summary:**

- `omitempty` tag for mandatory properties were removed
- optional properties (with the `omitempty` tag) of custom types were changed to pointers so they can be omitted with the `omitempty` tag
- additional validation checks which were missing and more unit tests

