### PR TITLE
refactor: A few refactoring of legacy-connection package

### DIFF
--- a/pkg/didcomm/protocol/legacyconnection/keys.go
+++ b/pkg/didcomm/protocol/legacyconnection/keys.go
@@ -27,9 +27,8 @@ func (ctx *context) createNewKeyAndVM(didDoc *did.Doc) error {
 	}
 
 	didDoc.VerificationMethod = append(didDoc.VerificationMethod, *vm)
-	didDoc.Authentication = append(didDoc.Authentication, *did.NewEmbeddedVerification(vm, did.Authentication))
-	// FIXME is KeyAgreement needed?
-	didDoc.KeyAgreement = append(didDoc.KeyAgreement, *did.NewEmbeddedVerification(kaVM, did.KeyAgreement))
+	didDoc.Authentication = append(didDoc.Authentication, *did.NewReferencedVerification(vm, did.Authentication))
+	didDoc.KeyAgreement = append(didDoc.KeyAgreement, *did.NewReferencedVerification(kaVM, did.KeyAgreement))
 
 	return nil
 }

--- a/pkg/didcomm/protocol/legacyconnection/models.go
+++ b/pkg/didcomm/protocol/legacyconnection/models.go
@@ -7,6 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package legacyconnection
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+
 	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/decorator"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 )
@@ -75,4 +82,81 @@ type PleaseAck struct {
 type Connection struct {
 	DID    string   `json:"DID,omitempty"`
 	DIDDoc *did.Doc `json:"DIDDoc,omitempty"`
+}
+
+type legacyConnection struct {
+	DID    string     `json:"DID,omitempty"`
+	DIDDoc *legacyDoc `json:"DIDDoc,omitempty"`
+}
+
+type legacyDoc struct {
+	Context              interface{}              `json:"@context,omitempty"`
+	ID                   string                   `json:"id,omitempty"`
+	AlsoKnownAs          []interface{}            `json:"alsoKnownAs,omitempty"`
+	VerificationMethod   []map[string]interface{} `json:"verificationMethod,omitempty"`
+	PublicKey            []map[string]interface{} `json:"publicKey,omitempty"`
+	Service              []map[string]interface{} `json:"service,omitempty"`
+	Authentication       []interface{}            `json:"authentication,omitempty"`
+	AssertionMethod      []interface{}            `json:"assertionMethod,omitempty"`
+	CapabilityDelegation []interface{}            `json:"capabilityDelegation,omitempty"`
+	CapabilityInvocation []interface{}            `json:"capabilityInvocation,omitempty"`
+	KeyAgreement         []interface{}            `json:"keyAgreement,omitempty"`
+	Created              *time.Time               `json:"created,omitempty"`
+	Updated              *time.Time               `json:"updated,omitempty"`
+	Proof                []interface{}            `json:"proof,omitempty"`
+}
+
+// JSONBytes converts Connection to json bytes.
+func (con *Connection) toLegacyJSONBytes() ([]byte, error) {
+	if con.DIDDoc == nil {
+		return nil, fmt.Errorf("DIDDoc field cannot be empty")
+	}
+
+	legDoc, err := con.DIDDoc.ToLegacyRawDoc()
+	if err != nil {
+		return nil, fmt.Errorf("converting to Legacy Raw Doc failed: %w", err)
+	}
+
+	connDoc := &legacyDoc{}
+
+	_ = mapstructure.Decode(legDoc, connDoc) //nolint: errcheck
+
+	conRaw := legacyConnection{
+		DID:    con.DID,
+		DIDDoc: connDoc,
+	}
+
+	byteConn, err := json.Marshal(conRaw)
+	if err != nil {
+		return nil, fmt.Errorf("JSON marshalling of connection raw failed: %w", err)
+	}
+
+	return byteConn, nil
+}
+
+// ParseConnection creates an instance of Connection by reading a JSON connection from bytes.
+func parseLegacyJSONBytes(data []byte) (*Connection, error) {
+	connRaw := &legacyConnection{}
+
+	err := json.Unmarshal(data, &connRaw)
+	if err != nil {
+		return nil, fmt.Errorf("JSON umarshalling of connection data bytes failed: %w", err)
+	} else if connRaw.DIDDoc == nil {
+		return nil, errors.New("connection DIDDoc field is missed")
+	}
+
+	docRaw, err := json.Marshal(connRaw.DIDDoc)
+	if err != nil {
+		return nil, fmt.Errorf("JSON marshaling failed: %w", err)
+	}
+
+	doc, err := did.ParseDocument(docRaw)
+	if err != nil {
+		return nil, fmt.Errorf("parcing did document failed: %w", err)
+	}
+
+	return &Connection{
+		DID:    connRaw.DID,
+		DIDDoc: doc,
+	}, nil
 }

--- a/pkg/didcomm/protocol/legacyconnection/models_test.go
+++ b/pkg/didcomm/protocol/legacyconnection/models_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package legacyconnection
+
+import (
+	_ "embed"
+	"encoding/json"
+	"testing"
+
+	"github.com/btcsuite/btcutil/base58"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+)
+
+//nolint:gochecknoglobals
+var (
+	//go:embed testdata/valid_conn_data.jsonld
+	validConnectionData string
+)
+
+// nolint:lll
+func TestJSONConversion(t *testing.T) {
+	con, err := parseLegacyJSONBytes([]byte(validConnectionData))
+	require.NoError(t, err)
+	require.NotEmpty(t, con)
+
+	require.Equal(t, con.DID, "did:example:21tDAKCERh95uGgKbJNHYp")
+	require.Equal(t, con.DIDDoc.ID, "did:example:21tDAKCERh95uGgKbJNHYp")
+	require.Contains(t, con.DIDDoc.Context, "https://w3id.org/did/v0.11")
+	require.Equal(t, con.DIDDoc.AlsoKnownAs[0], "did:example:123")
+	require.Equal(t, con.DIDDoc.VerificationMethod[0].Type, "Secp256k1VerificationKey2018")
+	require.Equal(t, base58.Encode(con.DIDDoc.VerificationMethod[0].Value), "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV")
+	require.Equal(t, con.DIDDoc.Authentication[0].VerificationMethod.Type, "Secp256k1VerificationKey2018")
+	require.Equal(t, base58.Encode(con.DIDDoc.Authentication[0].VerificationMethod.Value), "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV")
+	require.Equal(t, con.DIDDoc.Service[0].Type, "IndyAgent")
+	uri, err := con.DIDDoc.Service[0].ServiceEndpoint.URI()
+	require.NoError(t, err)
+	require.Contains(t, uri, "https://agent.example.com/")
+	require.Equal(t, con.DIDDoc.Service[0].RecipientKeys, []string{"did:example:123456789abcdefghi#key2"})
+	require.Equal(t, con.DIDDoc.Service[0].RoutingKeys, []string{"did:example:123456789abcdefghi#key2"})
+
+	conBytes, err := con.toLegacyJSONBytes()
+	require.NoError(t, err)
+	require.NotEmpty(t, conBytes)
+
+	rawString := string(conBytes)
+
+	require.Contains(t, rawString, "\"DID\":\"did:example:21tDAKCERh95uGgKbJNHYp\"")
+	require.Contains(t, rawString, "\"@context\":\"https://w3id.org/did/v1\"")
+	require.Contains(t, rawString, "\"controller\":\"did:example:123456789abcdefghi\",\"id\":\"did:example:123456789abcdefghi#keys-1\",\"publicKeyBase58\":\"H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV\",\"type\":\"Secp256k1VerificationKey2018\"")
+	require.Contains(t, rawString, "\"authentication\":[{\"publicKey\":\"did:example:123456789abcdefghi#keys-1\",\"type\":\"Secp256k1VerificationKey2018\"},{\"publicKey\":\"did:example:123456789abcdefghs#key3\",\"type\":\"RsaVerificationKey2018\"}]")
+	require.Contains(t, rawString, "\"service\":[{\"id\":\"did:example:123456789abcdefghi#did-communication\",\"priority\":0,\"recipientKeys\":[\"did:example:123456789abcdefghi#key2\"],\"routingKeys\":[\"did:example:123456789abcdefghi#key2\"],\"serviceEndpoint\":\"https://agent.example.com/\",\"type\":\"IndyAgent\"}]")
+}
+
+func TestToLegacyJSONBytes(t *testing.T) {
+	con := &Connection{
+		DID: "did:example:21tDAKCERh95uGgKbJNHYp",
+	}
+
+	// Empty DIDDoc data
+	legacyDoc, err := con.toLegacyJSONBytes()
+	require.ErrorContains(t, err, "DIDDoc field cannot be empty")
+	require.Empty(t, legacyDoc)
+
+	// Success
+
+	con.DIDDoc = &did.Doc{
+		Context: "https://w3id.org/did/v0.11",
+		ID:      "did:example:21tDAKCERh95uGgKbJNHYp",
+	}
+	legacyDoc, err = con.toLegacyJSONBytes()
+
+	require.NoError(t, err)
+	require.NotEmpty(t, legacyDoc)
+	require.Contains(t, string(legacyDoc), "\"DID\":\"did:example:21tDAKCERh95uGgKbJNHYp\"")
+	require.Contains(t, string(legacyDoc), "\"@context\":\"https://w3id.org/did/v1\"")
+}
+
+func TestParseJSONBytes(t *testing.T) {
+	// Nil payload
+	conRaw, err := parseLegacyJSONBytes(nil)
+	require.ErrorContains(t, err, "JSON umarshalling of connection data bytes failed")
+	require.Empty(t, conRaw)
+
+	// Empty payload
+	conRaw, err = parseLegacyJSONBytes([]byte{})
+	require.ErrorContains(t, err, "JSON umarshalling of connection data bytes failed")
+	require.Empty(t, conRaw)
+
+	// Empty DIDDoc
+	docBytes, err := json.Marshal(Connection{
+		DID: "did:example:21tDAKCERh95uGgKbJNHYp",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, docBytes)
+
+	conRaw, err = parseLegacyJSONBytes(docBytes)
+	require.ErrorContains(t, err, "connection DIDDoc field is missed")
+	require.Empty(t, conRaw)
+
+	// Success
+	con, err := parseLegacyJSONBytes([]byte(validConnectionData))
+	require.NoError(t, err)
+	require.NotEmpty(t, con)
+}

--- a/pkg/didcomm/protocol/legacyconnection/testdata/valid_conn_data.jsonld
+++ b/pkg/didcomm/protocol/legacyconnection/testdata/valid_conn_data.jsonld
@@ -1,0 +1,47 @@
+{
+    "DID": "did:example:21tDAKCERh95uGgKbJNHYp",
+    "DIDDoc": {
+      "@context": "https://w3id.org/did/v1",
+      "id": "did:example:21tDAKCERh95uGgKbJNHYp",
+      "alsoKnownAs": [
+        "did:example:123"
+      ],
+      "publicKey": [
+        {
+          "id": "did:example:123456789abcdefghi#keys-1",
+          "type": "Secp256k1VerificationKey2018",
+          "owner": "did:example:123456789abcdefghi",
+          "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+        },
+        {
+          "id": "did:example:123456789abcdefghw#key2",
+          "type": "RsaVerificationKey2018",
+          "owner": "did:example:123456789abcdefghw",
+          "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAryQICCl6NZ5gDKrnSztO\n3Hy8PEUcuyvg/ikC+VcIo2SFFSf18a3IMYldIugqqqZCs4/4uVW3sbdLs/6PfgdX\n7O9D22ZiFWHPYA2k2N744MNiCD1UE+tJyllUhSblK48bn+v1oZHCM0nYQ2NqUkvS\nj+hwUU3RiWl7x3D2s9wSdNt7XUtW05a/FXehsPSiJfKvHJJnGOX0BgTvkLnkAOTd\nOrUZ/wK69Dzu4IvrN4vs9Nes8vbwPa/ddZEzGR0cQMt0JBkhk9kU/qwqUseP1QRJ\n5I1jR4g8aYPL/ke9K35PxZWuDp3U0UPAZ3PjFAh+5T+fc7gzCs9dPzSHloruU+gl\nFQIDAQAB\n-----END PUBLIC KEY-----"
+        }
+      ],
+      "authentication": [
+        {
+          "type": "Secp256k1VerificationKey2018",
+          "publicKey": "did:example:123456789abcdefghi#keys-1"
+        },
+        {
+          "id": "did:example:123456789abcdefghs#key3",
+          "type": "RsaVerificationKey2018",
+          "owner": "did:example:123456789abcdefghs",
+          "publicKeyHex": "02b97c30de767f084ce3080168ee293053ba33b235d7116a3263d29f1450936b71"
+        }
+      ],
+      "service": [
+        {
+          "id": "did:example:123456789abcdefghi#did-communication",
+          "type": "IndyAgent",
+          "serviceEndpoint": "https://agent.example.com/",
+          "priority" : 0,
+          "recipientKeys" : ["did:example:123456789abcdefghi#key2"],
+          "routingKeys" : ["did:example:123456789abcdefghi#key2"]
+        }
+      ],
+      "created": "2002-10-10T17:00:00Z"
+    }
+}

--- a/pkg/didcomm/transport/http/inbound.go
+++ b/pkg/didcomm/transport/http/inbound.go
@@ -100,7 +100,7 @@ func validateHTTPMethod(w http.ResponseWriter, r *http.Request) bool {
 
 	ct := r.Header.Get("Content-type")
 
-	if ct != commContentType {
+	if ct != commContentType && ct != commContentTypeLegacy {
 		http.Error(w, fmt.Sprintf("Unsupported Content-type \"%s\"", ct), http.StatusUnsupportedMediaType)
 		return false
 	}

--- a/pkg/didcomm/transport/http/outbound.go
+++ b/pkg/didcomm/transport/http/outbound.go
@@ -22,8 +22,9 @@ import (
 //go:generate testdata/scripts/openssl_env.sh testdata/scripts/generate_test_keys.sh
 
 const (
-	commContentType = "application/didcomm-envelope-enc"
-	httpScheme      = "http"
+	commContentType       = "application/didcomm-envelope-enc"
+	commContentTypeLegacy = "application/ssi-agent-wire"
+	httpScheme            = "http"
 )
 
 // outboundCommHTTPOpts holds options for the HTTP transport implementation of CommTransport

--- a/pkg/doc/did/legacy.go
+++ b/pkg/doc/did/legacy.go
@@ -1,0 +1,116 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package did
+
+import (
+	"fmt"
+)
+
+// ToLegacyRawDoc converts document to raw doc.
+func (doc *Doc) ToLegacyRawDoc() (interface{}, error) {
+	context := ContextV1Old
+
+	publicKey, err := populateRawVM(context, doc.ID, doc.processingMeta.baseURI, doc.VerificationMethod)
+	if err != nil {
+		return nil, fmt.Errorf("JSON unmarshalling of Legacy Verification Method failed: %w", err)
+	}
+
+	auths := populateRawVerificationLegacy(doc.processingMeta.baseURI, doc.ID, doc.Authentication)
+
+	assertionMethods := populateRawVerificationLegacy(doc.processingMeta.baseURI, doc.ID,
+		doc.AssertionMethod)
+
+	capabilityDelegations := populateRawVerificationLegacy(doc.processingMeta.baseURI, doc.ID,
+		doc.CapabilityDelegation)
+
+	capabilityInvocations := populateRawVerificationLegacy(doc.processingMeta.baseURI, doc.ID,
+		doc.CapabilityInvocation)
+
+	keyAgreements := populateRawVerificationLegacy(doc.processingMeta.baseURI, doc.ID, doc.KeyAgreement)
+
+	services := populateRawServicesLegacy(doc.Service, doc.ID, doc.processingMeta.baseURI)
+
+	raw := &rawDoc{
+		Context: context, ID: doc.ID, PublicKey: publicKey,
+		Authentication: auths, AssertionMethod: assertionMethods, CapabilityDelegation: capabilityDelegations,
+		CapabilityInvocation: capabilityInvocations, KeyAgreement: keyAgreements,
+		Service: services, Created: doc.Created,
+		Proof: populateRawProofs(context, doc.ID, doc.processingMeta.baseURI, doc.Proof), Updated: doc.Updated,
+	}
+
+	return raw, nil
+}
+
+func populateRawVerificationLegacy(baseURI, didID string, verifications []Verification) []interface{} {
+	var rawVerifications []interface{}
+
+	for _, v := range verifications {
+		keyRef := map[string]string{}
+
+		if v.VerificationMethod.relativeURL {
+			keyRef["publicKey"] = makeRelativeDIDURL(v.VerificationMethod.ID, baseURI, didID)
+		} else {
+			keyRef["publicKey"] = v.VerificationMethod.ID
+		}
+
+		keyRef["type"] = v.VerificationMethod.Type
+
+		rawVerifications = append(rawVerifications, keyRef)
+	}
+
+	return rawVerifications
+}
+
+func populateRawServicesLegacy(services []Service, didID, baseURI string) []map[string]interface{} {
+	var rawServices []map[string]interface{}
+
+	for i := range services {
+		rawService := make(map[string]interface{})
+
+		for k, v := range services[i].Properties {
+			rawService[k] = v
+		}
+
+		routingKeys := make([]string, 0)
+
+		for _, v := range services[i].RoutingKeys {
+			if services[i].routingKeysRelativeURL[v] {
+				routingKeys = append(routingKeys, makeRelativeDIDURL(v, baseURI, didID))
+				continue
+			}
+
+			routingKeys = append(routingKeys, v)
+		}
+
+		recipientKeys := make([]string, 0)
+
+		for _, v := range services[i].RecipientKeys {
+			if services[i].recipientKeysRelativeURL[v] {
+				recipientKeys = append(recipientKeys, makeRelativeDIDURL(v, baseURI, didID))
+				continue
+			}
+
+			recipientKeys = append(recipientKeys, v)
+		}
+
+		rawService[jsonldID] = services[i].ID
+		if services[i].relativeURL {
+			rawService[jsonldID] = makeRelativeDIDURL(services[i].ID, baseURI, didID)
+		}
+
+		uri, _ := services[i].ServiceEndpoint.URI() //nolint: errcheck
+
+		rawService[jsonldType] = services[i].Type
+		rawService[jsonldServicePoint] = uri
+		rawService[jsonldRecipientKeys] = recipientKeys
+		rawService[jsonldRoutingKeys] = routingKeys
+		rawService[jsonldPriority] = services[i].Priority
+
+		rawServices = append(rawServices, rawService)
+	}
+
+	return rawServices
+}

--- a/pkg/doc/did/legacy_test.go
+++ b/pkg/doc/did/legacy_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package did
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcutil/base58"
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/model"
+)
+
+func TestToLegacyRawDoc(t *testing.T) {
+	doc, err := ParseDocument([]byte(validDocV011))
+	require.NoError(t, err)
+	require.NotEmpty(t, doc)
+
+	legacyRawDoc, err := doc.ToLegacyRawDoc()
+	require.NoError(t, err)
+
+	rawDoc := &rawDoc{}
+	err = mapstructure.Decode(legacyRawDoc, rawDoc)
+	require.NoError(t, err)
+	require.NotEmpty(t, rawDoc)
+
+	require.Equal(t, rawDoc.ID, doc.ID)
+
+	require.Equal(t, rawDoc.Context, ContextV1Old)
+
+	require.Equal(t, rawDoc.PublicKey[0]["type"], doc.VerificationMethod[0].Type)
+	require.Equal(t, rawDoc.PublicKey[0]["publicKeyBase58"], base58.Encode(doc.VerificationMethod[0].Value))
+	require.Equal(t, rawDoc.PublicKey[1]["type"], doc.VerificationMethod[1].Type)
+	require.Equal(t, rawDoc.PublicKey[1]["publicKeyBase58"], base58.Encode(doc.VerificationMethod[1].Value))
+
+	require.Equal(t, rawDoc.Authentication[0].(map[string]string)["publicKey"], doc.Authentication[0].VerificationMethod.ID) //nolint: lll
+	require.Equal(t, rawDoc.Authentication[0].(map[string]string)["type"], doc.Authentication[0].VerificationMethod.Type)
+	require.Equal(t, rawDoc.Authentication[1].(map[string]string)["publicKey"], doc.Authentication[1].VerificationMethod.ID) //nolint: lll
+	require.Equal(t, rawDoc.Authentication[1].(map[string]string)["type"], doc.Authentication[1].VerificationMethod.Type)
+
+	require.Equal(t, rawDoc.PublicKey[0]["id"], doc.VerificationMethod[0].ID)
+	require.Equal(t, rawDoc.Service[0]["id"], doc.Service[0].ID)
+	uri, err := doc.Service[0].ServiceEndpoint.URI()
+	require.NoError(t, err)
+	require.Equal(t, rawDoc.Service[0]["serviceEndpoint"], uri)
+}
+
+func TestPopulateRawServicesLegacy(t *testing.T) {
+	services := []Service{
+		{
+			ID:              "did:example:123456789abcdefghi",
+			Type:            "IndyAgent",
+			Priority:        0,
+			RecipientKeys:   []string{"key1"},
+			RoutingKeys:     []string{"key2"},
+			ServiceEndpoint: model.NewDIDCommV1Endpoint("https://agent.example.com/"),
+			Properties:      map[string]interface{}{},
+		},
+		{
+			ID:                       "did:example:123456789abcdefghi#indy",
+			Type:                     "IndyAgent",
+			Priority:                 0,
+			relativeURL:              true,
+			RecipientKeys:            []string{"did:example:123456789abcdefghi#key1"},
+			RoutingKeys:              []string{"did:example:123456789abcdefghi#key2"},
+			ServiceEndpoint:          model.NewDIDCommV1Endpoint("https://agent.example.com/"),
+			Properties:               map[string]interface{}{},
+			recipientKeysRelativeURL: map[string]bool{"did:example:123456789abcdefghi#key1": true},
+			routingKeysRelativeURL:   map[string]bool{"did:example:123456789abcdefghi#key2": true},
+		},
+	}
+
+	rMap := populateRawServicesLegacy(services, "did:example:123456789abcdefghi", "")
+	require.NotEmpty(t, rMap)
+
+	// check without relative URI
+	require.Equal(t, rMap[0]["id"], "did:example:123456789abcdefghi")
+	require.Equal(t, rMap[0]["type"], "IndyAgent")
+	require.Equal(t, rMap[0]["recipientKeys"], []string{"key1"})
+	require.Equal(t, rMap[0]["routingKeys"], []string{"key2"})
+	require.Equal(t, rMap[0]["serviceEndpoint"], "https://agent.example.com/")
+
+	// check with relative URI
+	require.Equal(t, rMap[1]["id"], "#indy")
+	require.Equal(t, rMap[1]["type"], "IndyAgent")
+	require.Equal(t, rMap[1]["recipientKeys"], []string{"#key1"})
+	require.Equal(t, rMap[1]["routingKeys"], []string{"#key2"})
+	require.Equal(t, rMap[1]["serviceEndpoint"], "https://agent.example.com/")
+}

--- a/pkg/internal/didkeyutil/util.go
+++ b/pkg/internal/didkeyutil/util.go
@@ -49,3 +49,20 @@ func ConvertBase58KeysToDIDKeys(keys []string) []string {
 
 	return didKeys
 }
+
+// ConvertDIDKeysToBase58Keys converts base58 keys array to did:key keys array.
+func ConvertDIDKeysToBase58Keys(keys []string) []string {
+	var base58Keys []string
+
+	for _, key := range keys {
+		if strings.HasPrefix(key, "did:key:") {
+			rawKey, _ := fingerprint.PubKeyFromDIDKey(key) //nolint: errcheck
+
+			base58Keys = append(base58Keys, base58.Encode(rawKey))
+		} else {
+			base58Keys = append(base58Keys, key)
+		}
+	}
+
+	return base58Keys
+}

--- a/pkg/internal/didkeyutil/util_test.go
+++ b/pkg/internal/didkeyutil/util_test.go
@@ -69,3 +69,48 @@ func TestConvertBase58KeysToDIDKeys(t *testing.T) {
 		}
 	})
 }
+
+func TestConvertDIDKeysToBase58Keys(t *testing.T) {
+	t.Run("no keys given", func(t *testing.T) {
+		recipientKeys := ConvertDIDKeysToBase58Keys(nil)
+		require.Nil(t, recipientKeys)
+	})
+
+	t.Run("some keys are converted", func(t *testing.T) {
+		inKeys := []string{
+			"did:key:z6MkjtX1C5tGbsNxcGBdCnkfzPw4pHq3fuufgFNkBpFtviAL",
+			"#key1",
+			"did:key:z6MkkFUoo38XGcBVojEhiGum4EV58DCCdGnigLHqvFMWiz3H",
+			"did:key:z6MkerVcrLfHZ9SajtxAkkir2wUwsQ9hg85oQfU62pyMtgsQ",
+			"/path#fragment",
+			"did:key:z6MkoG3wcwpJBS7GpzJSs1rPuTgiA7tsUV2FyVqszD1kWNNJ",
+			"did:key:z6MkuusSJ7WsP58DcpvU7hqoiYtzkxwHb5nrE9xLUj76PK9n",
+			"?query=value",
+			"did:key:z6MktheMCSkicACB2D4nP3y2JX8i1ZofyYvuKtMK5Zs78ewa",
+			"",
+			"@!~unexpected data~!@",
+		}
+
+		expectedKeys := []string{
+			"6SFxbqdqGKtVVmLvXDnq9JP4ziZCG2fJzETpMYHt1VNx",
+			"#key1",
+			"6oDmCnt5w4h2hEQ12hwvD8w5JdvMDPYMzKNv5yPVomFu",
+			"QEaG6QrDbx7dQ7U5Bm1Bqvx3psrGEqSieZACZ1LyU62",
+			"/path#fragment",
+			"9onu2hZrqtcoiVTkBStZ4N8iLYd24bmuHUvx9w3jb9av",
+			"GTcPhsGS3XdkWL5mS8sxsTLzwPfSBCYVY93QeT95U6NQ",
+			"?query=value",
+			"FFPJcCWHGchhuiE5hV1BTRaiBzXpZfgYdsSPFHu6DSAC",
+			"",
+			"@!~unexpected data~!@",
+		}
+
+		outKeys := ConvertDIDKeysToBase58Keys(inKeys)
+
+		require.Equal(t, len(expectedKeys), len(outKeys))
+
+		for i := range outKeys {
+			require.Equal(t, expectedKeys[i], outKeys[i])
+		}
+	})
+}

--- a/pkg/store/connection/connection_lookup.go
+++ b/pkg/store/connection/connection_lookup.go
@@ -54,25 +54,27 @@ type DIDRotationRecord struct {
 }
 
 // Record contain info about did exchange connection.
+// nolint:lll
 type Record struct {
-	ConnectionID        string
-	State               string
-	ThreadID            string
-	ParentThreadID      string
-	TheirLabel          string
-	TheirDID            string
-	MyDID               string
-	ServiceEndPoint     model.Endpoint // ServiceEndPoint is 'their' DIDComm service endpoint.
-	RecipientKeys       []string       // RecipientKeys holds 'their' DIDComm recipient keys.
-	RoutingKeys         []string       // RoutingKeys holds 'their' DIDComm routing keys.
-	InvitationID        string
-	InvitationDID       string
-	Implicit            bool
-	Namespace           string
-	MediaTypeProfiles   []string
-	DIDCommVersion      didcomm.Version
-	PeerDIDInitialState string
-	MyDIDRotation       *DIDRotationRecord `json:"myDIDRotation,omitempty"`
+	ConnectionID            string
+	State                   string
+	ThreadID                string
+	ParentThreadID          string
+	TheirLabel              string
+	TheirDID                string
+	MyDID                   string
+	ServiceEndPoint         model.Endpoint // ServiceEndPoint is 'their' DIDComm service endpoint.
+	RecipientKeys           []string       // RecipientKeys holds 'their' DIDComm recipient keys.
+	RoutingKeys             []string       // RoutingKeys holds 'their' DIDComm routing keys.
+	InvitationID            string
+	InvitationDID           string
+	InvitationRecipientKeys []string `json:"invitationRecipientKeys,omitempty"` // InvitationRecipientKeys holds keys generated for invitation
+	Implicit                bool
+	Namespace               string
+	MediaTypeProfiles       []string
+	DIDCommVersion          didcomm.Version
+	PeerDIDInitialState     string
+	MyDIDRotation           *DIDRotationRecord `json:"myDIDRotation,omitempty"`
 }
 
 // NewLookup returns new connection lookup instance.


### PR DESCRIPTION
**Title:**
Refactor legacy-connection package due to interoperability issues

**Summary:**

- Add new legacy http header to handle legacy requests. Cover with unit tests
- Encode invitation Recipient key to base58
- Change embedded verification to referenced while creating verification methods
- Add legacy file into doc package to convert DIDdoc to raw doc. Cover with unit test
- Add handling DID id's where did method is not specified
- Add JSONBytes and ParseConnection methods to use them while handling connection data
- Change AckMsgType content to proper one
- Add method to convert array of did-keys to base58 keys
- Enable saving decryption key while handling envelope at connection-request state
- Add new InvitationRecipientKeys into connection.Record model
- Refactor requestMsgRecord, handleInboundRequest and prepareConnectionSignature methods and their unit-tests
- Save Recipient keys while handling connection request
- Use SaveDID instead SaveDIDByResolving

