### PR TITLE
feat: CL Anoncreds Remote KMS/Crypto

### DIFF
--- a/pkg/crypto/tinkcrypto/cl_crypto.go
+++ b/pkg/crypto/tinkcrypto/cl_crypto.go
@@ -44,18 +44,22 @@ func (t *Crypto) Blind(kh interface{}, values ...map[string]interface{}) ([][]by
 		return [][]byte{blinded}, nil
 	}
 
-	blindedList := make([][]byte, len(values))
+	var blindeds [][]byte
 
-	for i, val := range values {
+	if len(values) == 0 {
+		values = []map[string]interface{}{}
+	}
+
+	for _, val := range values {
 		blinded, err := blinder.Blind(val)
 		if err != nil {
 			return nil, err
 		}
 
-		blindedList[i] = blinded
+		blindeds = append(blindeds, blinded)
 	}
 
-	return blindedList, nil
+	return blindeds, nil
 }
 
 // GetCorrectnessProof will return correctness proof for a public key handle

--- a/pkg/crypto/tinkcrypto/cl_crypto_test.go
+++ b/pkg/crypto/tinkcrypto/cl_crypto_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/google/tink/go/keyset"
 	"github.com/hyperledger/ursa-wrapper-go/pkg/libursa/ursa"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	bld "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/cl/blinder"
@@ -161,7 +160,7 @@ func generateBlindedSecretsWithNonces(
 	_offerNonce, err := ursa.NewNonce()
 	require.NoError(t, err)
 	_blindedSecrets, err := ursa.BlindCredentialSecrets(_pubKey, _correctnessProof, _offerNonce, _blindedVals)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_requestNonce, err := ursa.NewNonce()
 	require.NoError(t, err)
 

--- a/pkg/crypto/webkms/cl_remotecrypto_test.go
+++ b/pkg/crypto/webkms/cl_remotecrypto_test.go
@@ -1,0 +1,345 @@
+//go:build ursa
+// +build ursa
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package webkms
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/tink/go/keyset"
+	"github.com/hyperledger/ursa-wrapper-go/pkg/libursa/ursa"
+	"github.com/stretchr/testify/require"
+
+	bld "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/cl/blinder"
+	sgn "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto/primitive/cl/signer"
+	webkmsimpl "github.com/hyperledger/aries-framework-go/pkg/kms/webkms"
+)
+
+func TestClMethods(t *testing.T) {
+	sgnKh, err := keyset.NewHandle(sgn.CredDefKeyTemplate([]string{"attr1", "attr2"}))
+	require.NoError(t, err)
+
+	bldKh, err := keyset.NewHandle(bld.MasterSecretKeyTemplate())
+	require.NoError(t, err)
+
+	pubKh, err := sgnKh.Public()
+	require.NoError(t, err)
+
+	pubKey, err := sgn.ExportCredDefPubKey(pubKh)
+	require.NoError(t, err)
+
+	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err = processClRequest(w, r, sgnKh, bldKh)
+		require.NoError(t, err)
+	})
+
+	server, url, client := CreateMockHTTPServerAndClient(t, hf)
+
+	defer func() {
+		e := server.Close()
+		require.NoError(t, e)
+	}()
+
+	defaultKeystoreURL := fmt.Sprintf("%s/%s", strings.ReplaceAll(webkmsimpl.KeystoreEndpoint,
+		"{serverEndpoint}", url), defaultKeyStoreID)
+	sgnKeyURL := defaultKeystoreURL + "/keys/SGN"
+	bldKeyURL := defaultKeystoreURL + "/keys/BLD"
+	rCrypto := New(defaultKeystoreURL, client)
+
+	// test successful CL methods usage
+	blinded, err := rCrypto.Blind(bldKeyURL, map[string]interface{}{"attr1": 1, "attr2": "aaa"})
+	require.NoError(t, err)
+	require.NotEmpty(t, blinded)
+
+	// blind should work with no parameters
+	_, err = rCrypto.Blind(bldKeyURL)
+	require.NoError(t, err)
+
+	correctnessProof, err := rCrypto.GetCorrectnessProof(sgnKeyURL)
+	require.NoError(t, err)
+	require.NotEmpty(t, correctnessProof)
+
+	secrets, secretsProof, offerNonce, requestNonce := generateBlindedSecretsWithNonces(t,
+		pubKey,
+		correctnessProof,
+		blinded[0],
+	)
+
+	sig, sigProof, err := rCrypto.SignWithSecrets(sgnKeyURL,
+		map[string]interface{}{"attr1": 1, "attr2": "aaa"},
+		secrets,
+		secretsProof,
+		[][]byte{offerNonce, requestNonce},
+		"did:example:id",
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, sig)
+	require.NotEmpty(t, sigProof)
+
+	t.Run("CL request failure", func(t *testing.T) {
+		blankClient := &http.Client{}
+		tmpCrypto := New(defaultKeystoreURL, blankClient)
+
+		var err error
+
+		_, err = tmpCrypto.Blind(bldKeyURL)
+		require.Error(t, err)
+
+		_, err = tmpCrypto.GetCorrectnessProof(sgnKeyURL)
+		require.Error(t, err)
+
+		_, _, err = tmpCrypto.SignWithSecrets(sgnKeyURL,
+			map[string]interface{}{},
+			nil,
+			nil,
+			nil,
+			"",
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("CL json marshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.marshalFunc = failingMarshal
+
+		var err error
+		_, err = remoteCrypto2.Blind(bldKeyURL, map[string]interface{}{"attr1": 1, "attr2": "aaa"})
+		require.Error(t, err)
+
+		_, _, err = remoteCrypto2.SignWithSecrets(sgnKeyURL,
+			map[string]interface{}{"attr1": 1, "attr2": "aaa"},
+			secrets,
+			secretsProof,
+			[][]byte{offerNonce, requestNonce},
+			"did:example:id",
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("CL json unmarshal failure", func(t *testing.T) {
+		remoteCrypto2 := New(defaultKeystoreURL, client)
+
+		remoteCrypto2.unmarshalFunc = failingUnmarshal
+
+		var err error
+		_, err = remoteCrypto2.Blind(bldKeyURL, map[string]interface{}{"attr1": 1, "attr2": "aaa"})
+		require.Error(t, err)
+
+		_, err = remoteCrypto2.GetCorrectnessProof(sgnKeyURL)
+		require.Error(t, err)
+
+		_, _, err = remoteCrypto2.SignWithSecrets(sgnKeyURL,
+			map[string]interface{}{"attr1": 1, "attr2": "aaa"},
+			secrets,
+			secretsProof,
+			[][]byte{offerNonce, requestNonce},
+			"did:example:id",
+		)
+		require.Error(t, err)
+	})
+}
+
+func processClRequest(w http.ResponseWriter, r *http.Request, sgnKh, bldKh *keyset.Handle) error {
+	if valid := validateHTTPMethod(w, r); !valid {
+		return errors.New("http method invalid")
+	}
+
+	if valid := validatePostPayload(r, w); !valid {
+		return errors.New("http request body invalid")
+	}
+
+	reqBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+
+	if matchPath(r, blindURI) {
+		err = clBlindPOSTHandle(w, reqBody, bldKh)
+		if err != nil {
+			return err
+		}
+	}
+
+	if matchPath(r, correctnessProofURI) {
+		err = clCorrectnessProofGETHandle(w, sgnKh)
+		if err != nil {
+			return err
+		}
+	}
+
+	if matchPath(r, signWithSecretsURI) {
+		err = clSignWithSecretsPOSTHandle(w, reqBody, sgnKh)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func clBlindPOSTHandle(w http.ResponseWriter, reqBody []byte, kh *keyset.Handle) error {
+	req := &blindReq{}
+
+	err := json.Unmarshal(reqBody, req)
+	if err != nil {
+		return err
+	}
+
+	blinder, err := bld.NewBlinder(kh)
+	if err != nil {
+		return fmt.Errorf("create new CL blinder: %w", err)
+	}
+
+	defer blinder.Free() // nolint: errcheck
+
+	vals := req.Values
+	if len(vals) == 0 {
+		vals = []map[string]interface{}{}
+	}
+
+	var blindeds [][]byte
+
+	for _, val := range vals {
+		blinded, e := blinder.Blind(val)
+		if e != nil {
+			return e
+		}
+
+		blindeds = append(blindeds, blinded)
+	}
+
+	resp := &blindResp{
+		Blinded: blindeds,
+	}
+
+	mResp, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(mResp)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func clCorrectnessProofGETHandle(w http.ResponseWriter, kh *keyset.Handle) error {
+	signer, err := sgn.NewSigner(kh)
+	if err != nil {
+		return fmt.Errorf("create new CL signer: %w", err)
+	}
+
+	defer signer.Free() // nolint: errcheck
+
+	correctnessProof, err := signer.GetCorrectnessProof()
+	if err != nil {
+		return fmt.Errorf("CL correctness proof msg: %w", err)
+	}
+
+	resp := &correctnessProofResp{
+		CorrectnessProof: correctnessProof,
+	}
+
+	mResp, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(mResp)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func clSignWithSecretsPOSTHandle(w http.ResponseWriter, reqBody []byte, kh *keyset.Handle) error {
+	req := &signWithSecretsReq{}
+
+	err := json.Unmarshal(reqBody, req)
+	if err != nil {
+		return err
+	}
+
+	signer, err := sgn.NewSigner(kh)
+	if err != nil {
+		return fmt.Errorf("create new CL signer: %w", err)
+	}
+
+	defer signer.Free() // nolint: errcheck
+
+	signature, correctnessProof, err := signer.Sign(
+		req.Values,
+		req.Secrets,
+		req.CorrectnessProof,
+		req.Nonces,
+		req.DID,
+	)
+	if err != nil {
+		return fmt.Errorf("CL sign msg: %w", err)
+	}
+
+	resp := &signWithSecretsResp{
+		Signature:        signature,
+		CorrectnessProof: correctnessProof,
+	}
+
+	mResp, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(mResp)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func generateBlindedSecretsWithNonces(
+	t *testing.T,
+	pubKey []byte,
+	correctnessProof []byte,
+	blindedVals []byte,
+) ([]byte, []byte, []byte, []byte) {
+	_pubKey, err := ursa.CredentialPublicKeyFromJSON(pubKey)
+	require.NoError(t, err)
+	_correctnessProof, err := ursa.CredentialKeyCorrectnessProofFromJSON(correctnessProof)
+	require.NoError(t, err)
+	_blindedVals, err := ursa.CredentialValuesFromJSON(blindedVals)
+	require.NoError(t, err)
+
+	_offerNonce, err := ursa.NewNonce()
+	require.NoError(t, err)
+	_blindedSecrets, err := ursa.BlindCredentialSecrets(_pubKey, _correctnessProof, _offerNonce, _blindedVals)
+	require.NoError(t, err)
+	_requestNonce, err := ursa.NewNonce()
+	require.NoError(t, err)
+
+	secrets, err := _blindedSecrets.Handle.ToJSON()
+	require.NoError(t, err)
+	secretsProof, err := _blindedSecrets.CorrectnessProof.ToJSON()
+	require.NoError(t, err)
+	offerNonce, err := _offerNonce.ToJSON()
+	require.NoError(t, err)
+	requestNonce, err := _requestNonce.ToJSON()
+	require.NoError(t, err)
+
+	return secrets, secretsProof, offerNonce, requestNonce
+}

--- a/pkg/kms/localkms/localkms_ursa_test.go
+++ b/pkg/kms/localkms/localkms_ursa_test.go
@@ -49,6 +49,12 @@ func TestLocalKMS_Ursa_Success(t *testing.T) {
 	opts[kms.CLCredDefType] = kms.WithAttrs([]string{"attr1", "attr2"})
 
 	for _, v := range keyTemplates {
+		// test Create() w/o the opts where they're mandatory
+		if opts[v] != nil {
+			_, _, e := kmsService.Create(v)
+			require.Error(t, e)
+		}
+
 		// test Create() a new key
 		keyID, newKeyHandle, e := kmsService.Create(v, opts[v])
 		require.NoError(t, e, "failed on template %v", v)
@@ -82,6 +88,12 @@ func TestLocalKMS_Ursa_Success(t *testing.T) {
 		require.Empty(t, rotatedKeyHandle)
 		require.Empty(t, newKeyID)
 
+		// with no parameters if they're mandatory - should fail
+		if opts[v] != nil {
+			_, _, e = kmsService.Rotate(v, keyID)
+			require.Error(t, e)
+		}
+
 		// with valid key type - should succeed
 		newKeyID, rotatedKeyHandle, e = kmsService.Rotate(v, keyID, opts[v])
 		require.NoError(t, e)
@@ -112,6 +124,10 @@ func TestLocalKMS_Ursa_Success(t *testing.T) {
 			// test create and export key in one function
 			_, _, e = kmsService.CreateAndExportPubKeyBytes(v, opts[v])
 			require.NoError(t, e)
+
+			// if no parameters passed - CreateAndExport should fail
+			_, _, e = kmsService.CreateAndExportPubKeyBytes(v)
+			require.Error(t, e)
 		}
 	}
 }

--- a/pkg/kms/webkms/remotekms.go
+++ b/pkg/kms/webkms/remotekms.go
@@ -60,6 +60,7 @@ type createKeyStoreResp struct {
 
 type createKeyReq struct {
 	KeyType kms.KeyType `json:"key_type"`
+	Attrs   []string    `json:"attrs,omitempty"`
 }
 
 type createKeyResp struct {
@@ -276,11 +277,18 @@ func (r *RemoteKMS) Create(kt kms.KeyType, opts ...kms.KeyOpts) (string, interfa
 	return kid, keyURL, nil
 }
 
-func (r *RemoteKMS) createKey(kt kms.KeyType, _ ...kms.KeyOpts) (string, []byte, error) {
+func (r *RemoteKMS) createKey(kt kms.KeyType, opts ...kms.KeyOpts) (string, []byte, error) {
 	destination := r.keystoreURL + "/keys"
+
+	keyOpts := kms.NewKeyOpt()
+
+	for _, opt := range opts {
+		opt(keyOpts)
+	}
 
 	httpReqJSON := &createKeyReq{
 		KeyType: kt,
+		Attrs:   keyOpts.Attrs(),
 	}
 
 	marshaledReq, err := r.marshalFunc(httpReqJSON)

--- a/pkg/kms/webkms/remotekms_test.go
+++ b/pkg/kms/webkms/remotekms_test.go
@@ -266,6 +266,12 @@ func TestCreateKeyWithLocationInResponseBody(t *testing.T) {
 	require.Equal(t, defaultKID, kid1)
 	require.Contains(t, keyURL1, fmt.Sprintf("%s/keys/%s", defaultKeystoreURL, defaultKID))
 
+	// no error if options passed
+	_, _, err = remoteKMS.Create(kms.ED25519Type, kms.WithAttrs([]string{"attr1"}))
+	require.NoError(t, err)
+	_, _, err = remoteKMS.CreateAndExportPubKeyBytes(kms.ED25519Type, kms.WithAttrs([]string{"attr2"}))
+	require.NoError(t, err)
+
 	remoteKMS.unmarshalFunc = failingUnmarshal
 	_, _, err = remoteKMS.Create(kms.ED25519Type)
 	require.Contains(t, err.Error(), "unmarshal failed")


### PR DESCRIPTION
**Title:**
CL Anoncreds Remote KMS/Crypto

**Description:**
* Fifth PR to support CL in `af-go` [#180](https://github.com/hyperledger/aries-framework-go/issues/180)
* This PR implements/supports CL methods in remote Crypto
* This PR adds support for KMS extension for remote KMS 
* "server"-side changes will be implemented in the separate PR in both `trustbloc/kms`

**Summary:**
* added client calls to CL methods in remote crypto
* added attrs propagation for remote kms
* added unit tests for remote kms/crypto
* added more failed cases for localkms ursa tests