### PR TITLE
test: BDD tests for universal wallet JSON-LD support

### DIFF
--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/vdr"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/verifiable"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/waci"
+	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/walletjsonld"
 	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/webkms"
 )
 
@@ -217,5 +218,6 @@ func features() []feature {
 		webkms.NewCryptoSDKSteps(),
 		waci.NewIssuanceDIDCommV1SDKSteps(),
 		waci.NewIssuanceDIDCommV2SDKSteps(),
+		walletjsonld.NewSDKSteps(),
 	}
 }

--- a/test/bdd/features/wallet_jsonld.feature
+++ b/test/bdd/features/wallet_jsonld.feature
@@ -1,0 +1,70 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+@wallet_jsonld
+Feature: Support for JSON-LD in universal wallet
+
+  Scenario Outline: Issue credentials, add to wallet, query presentation, verify presentation and credentials
+    Given credentials crypto algorithm "<crypto>"
+    And  "Berkley" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+    And  "Alice" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+    When "Alice" creates wallet profile
+    And "Alice" opens wallet
+    And "Berkley" issues credentials at "2022-04-12" regarding "Master Degree" to "Alice"
+    Then "Alice" adds credentials to the wallet issued by "Berkley"
+    When "Vanna" queries credentials issued by "Berkley" using "QueryByExample" query type
+    Then "Alice" resolves query
+    And "Alice" adds presentations proof
+    And "Alice" closes wallet
+    Then "Vanna" receives presentations signed by "Alice" and verifies it
+    And "Vanna" receives credentials from presentation signed by "Berkley" and verifies it
+    Examples:
+      | crypto            |
+      | "Ed25519"         |
+      | "ECDSA Secp256r1" |
+      | "ECDSA Secp384r1" |
+
+  Scenario Outline: Issue credentials using the wallet, add to wallet, query presentation, verify presentation and credentials
+    Given credentials crypto algorithm "<crypto>"
+    And  "Alice" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+    When "Alice" creates wallet profile
+    And "Alice" opens wallet
+    And "Alice" creates credentials at "2022-04-12" regarding "Master Degree" without proof
+    And "Alice" issues credentials using the wallet
+    Then "Alice" adds credentials to the wallet issued by "Alice"
+    When "Vanna" queries credentials issued by "Alice" using "PresentationExchange" query type
+    And "Alice" resolves query
+    And "Alice" adds presentations proof
+    And "Alice" closes wallet
+    Then "Vanna" receives presentations signed by "Alice" and verifies it
+    And "Vanna" receives credentials from presentation signed by "Alice" and verifies it
+    Examples:
+      | crypto            |
+      | "Ed25519"         |
+      | "ECDSA Secp256r1" |
+      | "ECDSA Secp384r1" |
+
+  Scenario Outline: Issue multiple credentials, add to wallet, query all, verify credentials
+    Given credentials crypto algorithm "<crypto>"
+    And  "Berkley" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+    And  "MIT" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+    And  "Alice" agent is running on "localhost" port "random" with http-binding did resolver url "${SIDETREE_URL}" which accepts did method "sidetree"
+    When "Alice" creates wallet profile
+    And "Alice" opens wallet
+    And "Berkley" issues credentials at "2022-04-12" regarding "Master Degree" to "Alice"
+    And "MIT" issues credentials at "2022-04-12" regarding "Bachelor Degree" to "Alice"
+    Then "Alice" adds credentials to the wallet issued by "Berkley"
+    And "Alice" adds credentials to the wallet issued by "MIT"
+    When "Vanna" queries all credentials from "Alice"
+    Then "Vanna" receives "2" credentials
+    And "Alice" closes wallet
+    And "Vanna" verifies credentials issued by "Berkley"
+    And "Vanna" verifies credentials issued by "MIT"
+    Examples:
+      | crypto            |
+      | "Ed25519"         |
+      | "ECDSA Secp256r1" |
+      | "ECDSA Secp384r1" |

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -48,7 +48,8 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/tink/go v1.6.1 // indirect
-	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220428211718-66cc046674a1 // indirect
+	github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20220606124520-53422361c38c // indirect
+	github.com/hyperledger/ursa-wrapper-go v0.3.1 // indirect
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a // indirect
 	github.com/kawamuray/jsonpath v0.0.0-20201211160320-7483bafabd7e // indirect
 	github.com/kilic/bls12-381 v0.1.1-0.20210503002446-7b7597926c69 // indirect
@@ -74,7 +75,6 @@ require (
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693 // indirect
-	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/stretchr/testify v1.7.2 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/tidwall/gjson v1.6.7 // indirect

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -279,6 +279,7 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20220606124520-53422361c38c h1:8yL/HlgZmfsyXdLJjdE0gBAUjAuW9ZU4I+OiVkil22w=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20220606124520-53422361c38c/go.mod h1:JrwivOOQmuXbV1mFWgBGWnfCorOFdfGkpBsYK8dYrfM=
 github.com/hyperledger/ursa-wrapper-go v0.3.1 h1:Do+QrVNniY77YK2jTIcyWqj9rm/Yb5SScN0bqCjiibA=
 github.com/hyperledger/ursa-wrapper-go v0.3.1/go.mod h1:nPSAuMasIzSVciQo22PedBk4Opph6bJ6ia3ms7BH/mk=

--- a/test/bdd/pkg/walletjsonld/agent.go
+++ b/test/bdd/pkg/walletjsonld/agent.go
@@ -1,0 +1,24 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package walletjsonld
+
+import (
+	bddagent "github.com/hyperledger/aries-framework-go/test/bdd/agent"
+)
+
+func (s *SDKSteps) createAgent(agent, inboundHost, inboundPort, endpointURL, acceptDidMethod string) error {
+	agentSDK := bddagent.NewSDKSteps()
+	agentSDK.SetContext(s.bddContext)
+
+	return agentSDK.CreateAgentWithHTTPDIDResolver(
+		agent,
+		inboundHost,
+		inboundPort,
+		endpointURL,
+		acceptDidMethod,
+	)
+}

--- a/test/bdd/pkg/walletjsonld/credential.go
+++ b/test/bdd/pkg/walletjsonld/credential.go
@@ -1,0 +1,264 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package walletjsonld
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"time"
+
+	jsonldsig "github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/jsonwebsignature2020"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/hyperledger/aries-framework-go/pkg/wallet"
+)
+
+func (s *SDKSteps) issueCredential(issuer, issuedAt, subject, holder string) error {
+	err := s.createKeyPairLocalKMS(issuer, s.crypto)
+	if err != nil {
+		return err
+	}
+
+	err = s.createDid(issuer)
+	if err != nil {
+		return err
+	}
+
+	vcToIssue, err := s.createRawCredential(issuedAt, subject, issuer)
+	if err != nil {
+		return err
+	}
+
+	vcBytes, err := s.addCredentialProof(vcToIssue, issuer)
+	if err != nil {
+		return err
+	}
+
+	s.vcBytes[issuer] = vcBytes
+
+	return nil
+}
+
+func (s *SDKSteps) createUnsecuredCredential(holder, issuedAt, subject string) error {
+	err := s.createKeyPairWallet(holder, s.crypto)
+	if err != nil {
+		return err
+	}
+
+	err = s.createDid(holder)
+	if err != nil {
+		return err
+	}
+
+	vc, err := s.createRawCredential(issuedAt, subject, holder)
+	if err != nil {
+		return err
+	}
+
+	vcBytes, err := vc.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	s.vcBytes[holder] = vcBytes
+
+	return nil
+}
+
+func (s *SDKSteps) resolveCredentialsQuery(holder string) error {
+	walletInstance := s.wallet
+	if walletInstance == nil {
+		return fmt.Errorf("empty wallet")
+	}
+
+	vpUnsigned, err := walletInstance.Query(s.token,
+		&wallet.QueryParams{Type: s.query.queryType.Name(), Query: []json.RawMessage{s.query.raw}})
+	if err != nil {
+		return err
+	}
+
+	if vpUnsigned == nil {
+		return fmt.Errorf("empty presentation list")
+	}
+
+	s.query.resolved = vpUnsigned
+
+	return nil
+}
+
+func (s *SDKSteps) issueCredentialsUsingWallet(holder string) error {
+	walletInstance := s.wallet
+	if walletInstance == nil {
+		return fmt.Errorf("empty wallet")
+	}
+
+	vcBytes, err := s.issueCredentialsWallet(holder, s.vcBytes[holder], walletInstance)
+	if err != nil {
+		return err
+	}
+
+	s.vcBytes[holder] = vcBytes
+
+	return nil
+}
+
+func (s *SDKSteps) issueCredentialsWallet(agent string, vcUnsecured []byte, walletInstance *wallet.Wallet) ([]byte, error) { //nolint:lll
+	vc, err := walletInstance.Issue(s.token, vcUnsecured, &wallet.ProofOptions{
+		Controller: s.getPublicDID(agent).ID,
+		ProofType:  wallet.JSONWebSignature2020,
+		ProofRepresentation: func() *verifiable.SignatureRepresentation {
+			r := verifiable.SignatureJWS
+			return &r
+		}(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return vc.MarshalJSON()
+}
+
+func (s *SDKSteps) receiveCredentialsAndVerify(verifier, issuer string) error {
+	for _, vp := range s.query.resolved {
+		for _, rawVc := range vp.Credentials() {
+			vc, ok := rawVc.(*verifiable.Credential)
+			if !ok {
+				return fmt.Errorf("invalid resolved credentials type %s", reflect.TypeOf(vc).String())
+			}
+
+			b, err := vc.MarshalJSON()
+			if err != nil {
+				return err
+			}
+
+			err = s.verifyCredential(issuer, b)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *SDKSteps) verifyCredential(issuer string, vcBytes []byte) error {
+	vdr := s.bddContext.AgentCtx[issuer].VDRegistry()
+	pKeyFetcher := verifiable.NewVDRKeyResolver(vdr).PublicKeyFetcher()
+	loader := s.bddContext.AgentCtx[issuer].JSONLDDocumentLoader()
+
+	credentials, err := verifiable.ParseCredential(vcBytes,
+		verifiable.WithPublicKeyFetcher(pKeyFetcher),
+		verifiable.WithJSONLDDocumentLoader(loader))
+	if err != nil {
+		return err
+	}
+
+	if credentials == nil {
+		return errors.New("received nil credential")
+	}
+
+	return nil
+}
+
+func (s *SDKSteps) verifyGetAllCredential(verifier, issuer string) error {
+	vcBytes := s.getAllCredentialsResult[s.getCredentialID(issuer)]
+
+	return s.verifyCredential(issuer, vcBytes)
+}
+
+func (s *SDKSteps) createRawCredential(issuedAt, subject, issuer string) (*verifiable.Credential, error) {
+	const dateLayout = "2006-01-02"
+
+	issued, err := time.Parse(dateLayout, issuedAt)
+	if err != nil {
+		return nil, err
+	}
+
+	vcToIssue := &verifiable.Credential{
+		Context: []string{
+			"https://www.w3.org/2018/credentials/v1",
+			"https://www.w3.org/2018/credentials/examples/v1",
+		},
+		ID: s.getCredentialID(issuer),
+		Types: []string{
+			"VerifiableCredential",
+			"UniversityDegreeCredential",
+		},
+		Subject: subject,
+		Issuer: verifiable.Issuer{
+			ID:           s.getPublicDID(issuer).ID,
+			CustomFields: verifiable.CustomFields{"name": issuer},
+		},
+		Issued: util.NewTime(issued),
+	}
+
+	return vcToIssue, nil
+}
+
+func (s *SDKSteps) getCredentialID(issuer string) string {
+	return fmt.Sprintf("%s-%s", issuer, s.getPublicDID(issuer).ID)
+}
+
+func (s *SDKSteps) addCredentialProof(vc *verifiable.Credential, issuer string) ([]byte, error) {
+	doc := s.getPublicDID(issuer)
+	cr := s.bddContext.AgentCtx[issuer].Crypto()
+	kh := s.bddContext.KeyHandles[issuer]
+	signer := newCryptoSigner(cr, kh)
+	loader := s.bddContext.AgentCtx[issuer].JSONLDDocumentLoader()
+
+	err := vc.AddLinkedDataProof(&verifiable.LinkedDataProofContext{
+		SignatureType:           "JsonWebSignature2020",
+		Suite:                   jsonwebsignature2020.New(suite.WithSigner(signer)),
+		SignatureRepresentation: verifiable.SignatureJWS,
+		Created:                 &vc.Issued.Time,
+		VerificationMethod:      doc.ID + doc.VerificationMethod[0].ID,
+	}, jsonldsig.WithDocumentLoader(loader))
+	if err != nil {
+		return nil, err
+	}
+
+	return vc.MarshalJSON()
+}
+
+func (s *SDKSteps) addCredentialsToWallet(holder, issuer string) error {
+	walletInstance := s.wallet
+	if walletInstance == nil {
+		return fmt.Errorf("empty wallet")
+	}
+
+	return walletInstance.Add(s.token, wallet.Credential, s.vcBytes[issuer])
+}
+
+func (s *SDKSteps) queryAllCredentials(verifier, holder string) error {
+	walletInstance := s.wallet
+	if walletInstance == nil {
+		return fmt.Errorf("empty wallet")
+	}
+
+	queryResult, err := walletInstance.GetAll(s.token, wallet.Credential)
+	if err != nil {
+		return err
+	}
+
+	s.getAllCredentialsResult = queryResult
+
+	return nil
+}
+
+func (s *SDKSteps) checkGetAllAmount(verifier, amount string) error {
+	receivedAmount := len(s.getAllCredentialsResult)
+	if strconv.Itoa(receivedAmount) != amount {
+		return fmt.Errorf("received invalid credentials amount, expected: %s, got: %d", amount, receivedAmount)
+	}
+
+	return nil
+}

--- a/test/bdd/pkg/walletjsonld/did.go
+++ b/test/bdd/pkg/walletjsonld/did.go
@@ -1,0 +1,98 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package walletjsonld
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/jwk"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/jwk/jwksupport"
+	vdrapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/peer"
+)
+
+const (
+	jsonWebKey2020 = "JsonWebKey2020"
+)
+
+type creator struct {
+	vdrRegistry vdrapi.Registry
+}
+
+func newCreator(vdr vdrapi.Registry) *creator {
+	return &creator{
+		vdrRegistry: vdr,
+	}
+}
+
+func (s *SDKSteps) createDid(agent string) error {
+	kid := s.keyIds[agent]
+	vdr := s.bddContext.AgentCtx[agent].VDRegistry()
+
+	didDoc, err := newCreator(vdr).CreatePeerDIDV2(kid, s.bddContext.PublicKeys[agent])
+	if err != nil {
+		return err
+	}
+
+	s.bddContext.PublicDIDDocs[agent] = didDoc
+	s.bddContext.PublicDIDs[agent] = didDoc.ID
+
+	return nil
+}
+
+func (s *SDKSteps) getPublicDID(agentName string) *did.Doc {
+	return s.bddContext.PublicDIDDocs[agentName]
+}
+
+func (c *creator) CreatePeerDIDV2(kid string, jsonWebKey *jwk.JWK) (*did.Doc, error) {
+	newDID := &did.Doc{Service: []did.Service{{Type: vdrapi.DIDCommV2ServiceType}}}
+
+	err := c.createNewKeyAndVM(newDID, kid, jsonWebKey)
+	if err != nil {
+		return nil, fmt.Errorf("creating new keys and VMS for DID document failed: %w", err)
+	}
+
+	myDID, err := c.vdrRegistry.Create(peer.DIDMethod, newDID)
+	if err != nil {
+		return nil, fmt.Errorf("creating new peer DID via VDR failed: %w", err)
+	}
+
+	return myDID.DIDDocument, nil
+}
+
+func (c *creator) createNewKeyAndVM(didDoc *did.Doc, kid string, jsonWebKey *jwk.JWK) error {
+	vm, err := c.createSigningVM(kid, jsonWebKey)
+	if err != nil {
+		return err
+	}
+
+	didDoc.VerificationMethod = append(didDoc.VerificationMethod, *vm)
+	didDoc.Authentication = append(didDoc.Authentication, *did.NewReferencedVerification(vm, did.Authentication))
+	didDoc.AssertionMethod = append(didDoc.AssertionMethod, *did.NewReferencedVerification(vm, did.AssertionMethod))
+
+	return nil
+}
+
+func (c *creator) createSigningVM(kid string, jsonWebKey *jwk.JWK) (*did.VerificationMethod, error) {
+	pubKeyBytes, err := jsonWebKey.PublicKeyBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	kt, err := jsonWebKey.KeyType()
+	if err != nil {
+		return nil, err
+	}
+
+	j, err := jwksupport.PubKeyBytesToJWK(pubKeyBytes, kt)
+	if err != nil {
+		return nil, fmt.Errorf("createSigningVM: failed to convert public key to JWK for VM: %w", err)
+	}
+
+	return did.NewVerificationMethodFromJWK("#"+kid, jsonWebKey2020, "", j)
+}

--- a/test/bdd/pkg/walletjsonld/presentation.go
+++ b/test/bdd/pkg/walletjsonld/presentation.go
@@ -1,0 +1,121 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package walletjsonld
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/hyperledger/aries-framework-go/pkg/wallet"
+)
+
+func (s *SDKSteps) queryPresentations(verifier, issuer, rawQueryType string) error {
+	queryType, err := wallet.GetQueryType(rawQueryType)
+	if err != nil {
+		return err
+	}
+
+	query, err := s.getQuery(queryType, s.getPublicDID(issuer).ID)
+	if err != nil {
+		return err
+	}
+
+	s.query = credentialsQuery{
+		queryType: queryType,
+		raw:       query,
+	}
+
+	return nil
+}
+
+func (s *SDKSteps) addResolvedPresentationProof(holder string) error {
+	err := s.createKeyPairWallet(holder, s.crypto)
+	if err != nil {
+		return err
+	}
+
+	err = s.createDid(holder)
+	if err != nil {
+		return err
+	}
+
+	walletInstance := s.wallet
+	if walletInstance == nil {
+		return fmt.Errorf("empty wallet")
+	}
+
+	err = s.signPresentations(holder, walletInstance)
+
+	return err
+}
+
+func (s *SDKSteps) signPresentations(
+	agent string,
+	walletInstance *wallet.Wallet) error {
+	presentations := make([]*verifiable.Presentation, 0, len(s.query.resolved))
+
+	for _, vp := range s.query.resolved {
+		vp.Context = append(vp.Context, "https://w3id.org/security/suites/jws-2020/v1")
+
+		vpSigned, err := walletInstance.Prove(s.token,
+			&wallet.ProofOptions{
+				Controller: s.getPublicDID(agent).ID,
+				ProofType:  wallet.JSONWebSignature2020,
+				ProofRepresentation: func() *verifiable.SignatureRepresentation {
+					r := verifiable.SignatureJWS
+					return &r
+				}(),
+			},
+			wallet.WithPresentationToProve(vp),
+		)
+		if err != nil {
+			return err
+		}
+
+		presentations = append(presentations, vpSigned)
+	}
+
+	s.query.resolved = presentations
+
+	return nil
+}
+
+func (s *SDKSteps) receivePresentationsAndVerify(verifier, issuer string) error {
+	for _, vp := range s.query.resolved {
+		b, err := vp.MarshalJSON()
+		if err != nil {
+			return err
+		}
+
+		_, err = s.verifyPresentation(issuer, b)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *SDKSteps) verifyPresentation(agent string, vp []byte) (*verifiable.Presentation, error) {
+	vdr := s.bddContext.AgentCtx[agent].VDRegistry()
+	pKeyFetcher := verifiable.NewVDRKeyResolver(vdr).PublicKeyFetcher()
+	loader := s.bddContext.AgentCtx[agent].JSONLDDocumentLoader()
+
+	presentation, err := verifiable.ParsePresentation(vp,
+		verifiable.WithPresPublicKeyFetcher(pKeyFetcher),
+		verifiable.WithPresJSONLDDocumentLoader(loader))
+	if err != nil {
+		return nil, err
+	}
+
+	if presentation == nil {
+		return nil, errors.New("received nil presentation")
+	}
+
+	return presentation, nil
+}

--- a/test/bdd/pkg/walletjsonld/query.go
+++ b/test/bdd/pkg/walletjsonld/query.go
@@ -1,0 +1,32 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package walletjsonld
+
+import (
+	_ "embed" //nolint:gci // required for go:embed
+	"encoding/json"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/wallet"
+)
+
+//go:embed testdata/query_by_example_fmt.json
+var sampleQueryByExFmt string //nolint:gochecknoglobals
+
+//go:embed testdata/presentation_definition_fmt.json
+var presentationDefinitionFmt string //nolint:gochecknoglobals
+
+func (s *SDKSteps) getQuery(queryType wallet.QueryType, didID string) (json.RawMessage, error) {
+	switch queryType {
+	case wallet.QueryByExample:
+		return []byte(fmt.Sprintf(sampleQueryByExFmt, didID)), nil
+	case wallet.PresentationExchange:
+		return []byte(fmt.Sprintf(presentationDefinitionFmt, didID)), nil
+	}
+
+	return nil, fmt.Errorf("invalid queryType %v", queryType)
+}

--- a/test/bdd/pkg/walletjsonld/signer.go
+++ b/test/bdd/pkg/walletjsonld/signer.go
@@ -1,0 +1,28 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package walletjsonld
+
+import (
+	ariescrypto "github.com/hyperledger/aries-framework-go/pkg/crypto"
+)
+
+type cryptoSigner struct {
+	cr ariescrypto.Crypto
+	kh interface{}
+}
+
+func newCryptoSigner(cr ariescrypto.Crypto, keyHandle interface{}) *cryptoSigner {
+	return &cryptoSigner{cr: cr, kh: keyHandle}
+}
+
+func (s *cryptoSigner) Sign(data []byte) ([]byte, error) {
+	return s.cr.Sign(data, s.kh)
+}
+
+func (s *cryptoSigner) Alg() string {
+	return ""
+}

--- a/test/bdd/pkg/walletjsonld/testdata/presentation_definition_fmt.json
+++ b/test/bdd/pkg/walletjsonld/testdata/presentation_definition_fmt.json
@@ -1,0 +1,26 @@
+{
+  "id": "ec2f83c5-eac4-4d04-b41e-6636d6670a2e",
+  "input_descriptors": [
+    {
+      "id": "105b1d58-71f8-4d1e-be71-36c9c6f600c9",
+      "schema": [
+        {
+          "uri": "https://www.w3.org/2018/credentials#VerifiableCredential"
+        }
+      ],
+      "constraints": {
+        "fields": [
+          {
+            "path": [
+              "$.issuer.id"
+            ],
+            "filter": {
+              "type": "string",
+              "const": "%s"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/bdd/pkg/walletjsonld/testdata/query_by_example_fmt.json
+++ b/test/bdd/pkg/walletjsonld/testdata/query_by_example_fmt.json
@@ -1,0 +1,16 @@
+{
+  "reason": "Please present your identity document.",
+  "example": {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/examples/v1"
+    ],
+    "type": ["VerifiableCredential","UniversityDegreeCredential"],
+    "trustedIssuer": [
+      {
+        "required": true,
+        "issuer": "%s"
+      }
+    ]
+  }
+}

--- a/test/bdd/pkg/walletjsonld/wallet.go
+++ b/test/bdd/pkg/walletjsonld/wallet.go
@@ -1,0 +1,100 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package walletjsonld
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/jwk/jwksupport"
+	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+	"github.com/hyperledger/aries-framework-go/pkg/wallet"
+)
+
+const (
+	samplePassPhrase = "youshallnotpass"
+	sampleUser       = "sampleUser"
+)
+
+func (s *SDKSteps) createWalletProfile(holder string) error {
+	provider := &mockprovider.Provider{
+		DocumentLoaderValue:               s.bddContext.AgentCtx[holder].JSONLDDocumentLoader(),
+		StorageProviderValue:              mockstorage.NewMockStoreProvider(),
+		ProtocolStateStorageProviderValue: mockstorage.NewMockStoreProvider(),
+		CryptoValue:                       s.bddContext.AgentCtx[holder].Crypto(),
+		VDRegistryValue:                   s.bddContext.AgentCtx[holder].VDRegistry(),
+	}
+
+	err := wallet.CreateProfile(sampleUser, provider, wallet.WithPassphrase(samplePassPhrase))
+	if err != nil {
+		return err
+	}
+
+	s.walletProvider = provider
+
+	return nil
+}
+
+func (s *SDKSteps) openWallet(holder string) error {
+	walletInstance, err := wallet.New(sampleUser, s.walletProvider)
+	if err != nil {
+		return err
+	}
+
+	token, err := walletInstance.Open(wallet.WithUnlockByPassphrase(samplePassPhrase))
+	if err != nil {
+		return err
+	}
+
+	s.wallet = walletInstance
+	s.token = token
+
+	return nil
+}
+
+func (s *SDKSteps) closeWallet(holder string) error {
+	walletInstance := s.wallet
+	if walletInstance == nil {
+		return fmt.Errorf("empty wallet")
+	}
+
+	walletInstance.Close()
+
+	return nil
+}
+
+func (s *SDKSteps) createKeyPairWallet(agent, crypto string) error {
+	walletInstance := s.wallet
+	if walletInstance == nil {
+		return fmt.Errorf("empty wallet")
+	}
+
+	keyType := mapCryptoKeyType(crypto)
+
+	keyPair, err := walletInstance.CreateKeyPair(s.token, keyType)
+	if err != nil {
+		return err
+	}
+
+	kid := keyPair.KeyID
+
+	pubKeyBytes, err := base64.RawURLEncoding.DecodeString(keyPair.PublicKey)
+	if err != nil {
+		return err
+	}
+
+	pubKeyJWK, err := jwksupport.PubKeyBytesToJWK(pubKeyBytes, keyType)
+	if err != nil {
+		return err
+	}
+
+	s.bddContext.PublicKeys[agent] = pubKeyJWK
+	s.keyIds[agent] = kid
+
+	return nil
+}

--- a/test/bdd/pkg/walletjsonld/wallet_steps.go
+++ b/test/bdd/pkg/walletjsonld/wallet_steps.go
@@ -1,0 +1,136 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package walletjsonld
+
+import (
+	_ "embed" //nolint:gci // required for go:embed
+	"encoding/json"
+	"errors"
+
+	"github.com/cucumber/godog"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/jwk/jwksupport"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/kms/localkms"
+	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
+	"github.com/hyperledger/aries-framework-go/pkg/wallet"
+	"github.com/hyperledger/aries-framework-go/test/bdd/pkg/context"
+)
+
+type credentialsQuery struct {
+	raw       json.RawMessage
+	queryType wallet.QueryType
+	resolved  []*verifiable.Presentation
+}
+
+// SDKSteps is steps for universal wallet JSON-LD support.
+type SDKSteps struct {
+	bddContext              *context.BDDContext
+	crypto                  string
+	vcBytes                 map[string][]byte
+	keyIds                  map[string]string
+	query                   credentialsQuery
+	token                   string
+	wallet                  *wallet.Wallet
+	walletProvider          *mockprovider.Provider
+	getAllCredentialsResult map[string]json.RawMessage
+}
+
+// NewSDKSteps creates steps for universal wallet JSON-LD support.
+func NewSDKSteps() *SDKSteps {
+	return &SDKSteps{
+		vcBytes:                 map[string][]byte{},
+		keyIds:                  map[string]string{},
+		getAllCredentialsResult: map[string]json.RawMessage{},
+	}
+}
+
+const (
+	ed25519Crypto   = "Ed25519"
+	secp256r1Crypto = "ECDSA Secp256r1"
+	secp384r1Crypto = "ECDSA Secp384r1"
+)
+
+// SetContext is called before every scenario is run with a fresh new context.
+func (s *SDKSteps) SetContext(ctx *context.BDDContext) {
+	s.bddContext = ctx
+}
+
+// RegisterSteps registers steps for VC and VP in JSON-LD format.
+func (s *SDKSteps) RegisterSteps(gs *godog.Suite) {
+	gs.Step(`^credentials crypto algorithm ""([^"]*)""$`, s.setCryptoAlgorithm)
+	gs.Step(`^"([^"]*)" agent is running on "([^"]*)" port "([^"]*)" `+
+		`with http-binding did resolver url "([^"]*)" which accepts did method "([^"]*)"$`, s.createAgent)
+	gs.Step(`^"([^"]*)" creates wallet profile$`, s.createWalletProfile)
+	gs.Step(`^"([^"]*)" opens wallet$`, s.openWallet)
+	gs.Step(`^"([^"]*)" closes wallet$`, s.closeWallet)
+	gs.Step(`^"([^"]*)" issues credentials at "([^"]*)" regarding "([^"]*)" to "([^"]*)"$`, s.issueCredential)
+	gs.Step(`^"([^"]*)" adds credentials to the wallet issued by "([^"]*)"$`, s.addCredentialsToWallet)
+	gs.Step(`^"([^"]*)" queries credentials issued by "([^"]*)" using "([^"]*)" query type$`, s.queryPresentations)
+	gs.Step(`^"([^"]*)" resolves query$`, s.resolveCredentialsQuery)
+	gs.Step(`^"([^"]*)" adds presentations proof$`, s.addResolvedPresentationProof)
+	gs.Step(`^"([^"]*)" receives presentations `+
+		`signed by "([^"]*)" and verifies it$`, s.receivePresentationsAndVerify)
+	gs.Step(`^"([^"]*)" receives credentials from presentation `+
+		`signed by "([^"]*)" and verifies it$`, s.receiveCredentialsAndVerify)
+	gs.Step(`^"([^"]*)" creates credentials at "([^"]*)" `+
+		`regarding "([^"]*)" without proof$`, s.createUnsecuredCredential)
+	gs.Step(`^"([^"]*)" issues credentials using the wallet$`, s.issueCredentialsUsingWallet)
+	gs.Step(`^"([^"]*)" queries all credentials from "([^"]*)"$`, s.queryAllCredentials)
+	gs.Step(`^"([^"]*)" receives "([^"]*)" credentials$`, s.checkGetAllAmount)
+	gs.Step(`^"([^"]*)" verifies credentials issued by "([^"]*)"$`, s.verifyGetAllCredential)
+}
+
+func (s *SDKSteps) setCryptoAlgorithm(crypto string) error {
+	s.crypto = crypto
+
+	return nil
+}
+
+func (s *SDKSteps) createKeyPairLocalKMS(agent, crypto string) error {
+	localKMS, ok := s.bddContext.AgentCtx[agent].KMS().(*localkms.LocalKMS)
+	if !ok {
+		return errors.New("expected LocalKMS type of KMS")
+	}
+
+	keyType := mapCryptoKeyType(crypto)
+
+	kid, kh, err := localKMS.Create(keyType)
+	if err != nil {
+		return err
+	}
+
+	pubKeyBytes, _, err := localKMS.ExportPubKeyBytes(kid)
+	if err != nil {
+		return err
+	}
+
+	pubKeyJWK, err := jwksupport.PubKeyBytesToJWK(pubKeyBytes, keyType)
+	if err != nil {
+		return err
+	}
+
+	s.bddContext.PublicKeys[agent] = pubKeyJWK
+	s.bddContext.KeyHandles[agent] = kh
+	s.keyIds[agent] = kid
+
+	return nil
+}
+
+func mapCryptoKeyType(crypto string) kms.KeyType {
+	switch crypto {
+	case ed25519Crypto:
+		return kms.ED25519Type
+	case secp256r1Crypto:
+		return kms.ECDSAP256IEEEP1363
+	case secp384r1Crypto:
+		return kms.ECDSAP384IEEEP1363
+	default:
+		panic("unsupported crypto type: " + crypto)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Mykhailo Sizov <mykhailo.sizov@securekey.com>

**Title:**
Support for JSON-LD in universal wallet implementation.

**Description:**
Solves: https://github.com/hyperledger/aries-framework-go/issues/3344

**Summary:**
Added BDD tests for universal wallet JSON-LD support.

Included the next actions:
- Sign JSON-LD Credential - Add it to wallet - get from wallet - verify Credential.
- Get JSON-LD Credential (without proof) - Call wallet.Issue() - get signed credential back - verify credential.
- Use signed credentials from previous steps - call wallet.Prove() - get presentation back - verify presentation.
- Add all the credentials from previous steps to holder's wallet - call wallet.Add(json-ld Credential) - wallet.Query() - get query result as json-ld presentation. (Included `wallet.QueryByExample` and `wallet.PresentationExchange` query types).
- Call wallet.GetAll() credential - get json-ld credentials back - check expected amount.
