### PR TITLE
JSON LD Contexts in JWT VCs

### DIFF
--- a/pkg/doc/jsonld/validate_test.go
+++ b/pkg/doc/jsonld/validate_test.go
@@ -341,6 +341,85 @@ func Test_ValidateJSONLD_CornerErrorCases(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "compact JSON-LD document")
 	})
+
+	t.Run("JSON-LD WithStrictContextURIPosition invalid context", func(t *testing.T) {
+		vcJSONTemplate := `
+{
+  "@context": "https://www.w3.org/2018/credentials/v1",
+  "id": "http://example.com/credentials/4643",
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "https://example.com/issuers/14",
+  "issuanceDate": "2018-02-24T05:28:04Z",
+  "credentialSubject": "did:example:abcdef1234567"
+}
+`
+
+		err := ValidateJSONLD(vcJSONTemplate,
+			WithDocumentLoader(createTestDocumentLoader(t)),
+			WithStrictContextURIPosition("https://www.w3.org/2018/credentials/v1"),
+			WithStrictContextURIPosition("https://www.w3.org/2018/credentials/examples/v1"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "doc context URIs amount mismatch")
+	})
+
+	t.Run("JSON-LD WithStrictContextURIPosition invalid context URI amount", func(t *testing.T) {
+		vcJSONTemplate := `
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "id": "http://example.com/credentials/4643",
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "https://example.com/issuers/14",
+  "issuanceDate": "2018-02-24T05:28:04Z",
+  "credentialSubject": "did:example:abcdef1234567"
+}
+`
+
+		err := ValidateJSONLD(vcJSONTemplate,
+			WithDocumentLoader(createTestDocumentLoader(t)),
+			WithStrictContextURIPosition("https://www.w3.org/2018/credentials/v1"),
+			WithStrictContextURIPosition("https://www.w3.org/2018/credentials/examples/v1"),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "doc context URIs amount mismatch")
+	})
+
+	t.Run("JSON-LD WithStrictContextURIPosition validate context URI position", func(t *testing.T) {
+		vcJSONTemplate := `
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+	"https://www.w3.org/2018/credentials/examples/v1"
+  ],
+  "id": "http://example.com/credentials/4643",
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "https://example.com/issuers/14",
+  "issuanceDate": "2018-02-24T05:28:04Z",
+  "credentialSubject": "did:example:abcdef1234567"
+}
+`
+
+		err := ValidateJSONLD(vcJSONTemplate,
+			WithDocumentLoader(createTestDocumentLoader(t)),
+			WithStrictContextURIPosition("https://www.w3.org/2018/credentials/examples/v1"),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid context URI on position")
+
+		err = ValidateJSONLD(vcJSONTemplate,
+			WithDocumentLoader(createTestDocumentLoader(t)),
+			WithStrictContextURIPosition("https://www.w3.org/2018/credentials/v1"),
+			WithStrictContextURIPosition("https://www.w3.org/2018/credentials/examples/v1"),
+		)
+		require.NoError(t, err)
+	})
 }
 
 // nolint:gochecknoglobals // needed to avoid Go compiler perf optimizations for benchmarks.

--- a/pkg/doc/verifiable/credential.go
+++ b/pkg/doc/verifiable/credential.go
@@ -886,6 +886,7 @@ func (vc *Credential) validateJSONLD(vcBytes []byte, vcOpts *credentialOpts) err
 		docjsonld.WithDocumentLoader(vcOpts.jsonldCredentialOpts.jsonldDocumentLoader),
 		docjsonld.WithExternalContext(vcOpts.jsonldCredentialOpts.externalContext),
 		docjsonld.WithStrictValidation(vcOpts.strictValidation),
+		docjsonld.WithStrictContextURIPosition(baseContext),
 	)
 }
 


### PR DESCRIPTION
Signed-off-by: Mykhailo Sizov <mykhailo.sizov@securekey.com>

**Title:**
JSON LD Contexts in JWT VCs

**Description:**
Solves: https://github.com/hyperledger/aries-framework-go/issues/3351

**Summary:**

Added extra option to `ValidateJSONLD` function called `WithStrictContextURIPosition` that sets strict validation of URI position within context property. The index of uri in underlying slice represents the position of given URI in parsed context array.
Also, added this option as a default to `*verifiable.Credential.validateJSONLD(.... docjsonld.WithStrictContextURIPosition(baseContext))` function in order to make base context URI required.

