### PR TITLE
fix: don't panic on malformed proof properties

### DIFF
--- a/pkg/doc/signature/proof/proof.go
+++ b/pkg/doc/signature/proof/proof.go
@@ -167,7 +167,11 @@ func stringEntry(entry interface{}) string {
 		return ""
 	}
 
-	return entry.(string)
+	if strVal, ok := entry.(string); ok {
+		return strVal
+	}
+
+	return ""
 }
 
 // JSONLdObject returns map that represents JSON LD Object.

--- a/pkg/doc/signature/proof/proof_test.go
+++ b/pkg/doc/signature/proof/proof_test.go
@@ -155,6 +155,183 @@ func TestProof(t *testing.T) {
 	})
 }
 
+func TestInvalidInterfaceTypeShouldNotPanic(t *testing.T) {
+	t.Run("does not panic if type is not a string", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.Nil(t, r)
+		}()
+		_, err := NewProof(map[string]interface{}{
+			"type":               123,
+			"creator":            "didID",
+			"verificationMethod": "did:example:123456#key1",
+			"created":            "2018-03-15T00:00:00Z",
+			"domain":             "abc.com",
+			"nonce":              "",
+			"proofValue":         proofValueBase64,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("does not panic if created is not a string", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.Nil(t, r)
+		}()
+		_, err := NewProof(map[string]interface{}{
+			"type":               "type",
+			"creator":            "didID",
+			"verificationMethod": "did:example:123456#key1",
+			"created":            123,
+			"domain":             "abc.com",
+			"nonce":              "",
+			"proofValue":         proofValueBase64,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parsing time")
+	})
+
+	t.Run("does not panic if creator is not a string", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.Nil(t, r)
+		}()
+		_, err := NewProof(map[string]interface{}{
+			"type":               "type",
+			"creator":            123,
+			"verificationMethod": "did:example:123456#key1",
+			"created":            "2018-03-15T00:00:00Z",
+			"domain":             "abc.com",
+			"nonce":              "",
+			"proofValue":         proofValueBase64,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("does not panic if verificationMethod is not a string", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.Nil(t, r)
+		}()
+		_, err := NewProof(map[string]interface{}{
+			"type":               "type",
+			"creator":            "didID",
+			"verificationMethod": 123,
+			"created":            "2018-03-15T00:00:00Z",
+			"domain":             "abc.com",
+			"nonce":              "",
+			"proofValue":         proofValueBase64,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("does not panic if proofValue is not a string", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.Nil(t, r)
+		}()
+		_, err := NewProof(map[string]interface{}{
+			"type":               "type",
+			"creator":            "didID",
+			"verificationMethod": "did:example:123456#key1",
+			"created":            "2018-03-15T00:00:00Z",
+			"domain":             "abc.com",
+			"nonce":              "",
+			"proofValue":         123,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signature is not defined")
+	})
+
+	t.Run("does not panic if jws is not a string", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.Nil(t, r)
+		}()
+		_, err := NewProof(map[string]interface{}{
+			"type":               "type",
+			"creator":            "didID",
+			"verificationMethod": "did:example:123456#key1",
+			"created":            "2018-03-15T00:00:00Z",
+			"domain":             "abc.com",
+			"nonce":              "",
+			"jws":                123,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signature is not defined")
+	})
+
+	t.Run("does not panic if proofPurpose is not a string", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.Nil(t, r)
+		}()
+		_, err := NewProof(map[string]interface{}{
+			"type":               "type",
+			"creator":            "didID",
+			"verificationMethod": "did:example:123456#key1",
+			"created":            "2018-03-15T00:00:00Z",
+			"domain":             "abc.com",
+			"nonce":              "",
+			"proofValue":         proofValueBase64,
+			"proofPurpose":       123,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("does not panic if domain is not a string", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.Nil(t, r)
+		}()
+		_, err := NewProof(map[string]interface{}{
+			"type":               "type",
+			"creator":            "didID",
+			"verificationMethod": "did:example:123456#key1",
+			"created":            "2018-03-15T00:00:00Z",
+			"domain":             123,
+			"nonce":              "",
+			"proofValue":         proofValueBase64,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("does not panic if nonce is not a string", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.Nil(t, r)
+		}()
+		_, err := NewProof(map[string]interface{}{
+			"type":               "type",
+			"creator":            "didID",
+			"verificationMethod": "did:example:123456#key1",
+			"created":            "2018-03-15T00:00:00Z",
+			"domain":             "abc.com",
+			"nonce":              123,
+			"proofValue":         proofValueBase64,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("does not panic if challenge is not a string", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.Nil(t, r)
+		}()
+		_, err := NewProof(map[string]interface{}{
+			"type":               "type",
+			"creator":            "didID",
+			"verificationMethod": "did:example:123456#key1",
+			"created":            "2018-03-15T00:00:00Z",
+			"domain":             "abc.com",
+			"nonce":              "",
+			"proofValue":         proofValueBase64,
+			"challenge":          123,
+		})
+		require.NoError(t, err)
+	})
+}
+
 func TestInvalidProofValue(t *testing.T) {
 	// invalid proof value
 	p, err := NewProof(map[string]interface{}{


### PR DESCRIPTION
**Title:**
Do not panic when creating new Proof object with string map that contains invalid interfaces

**Description:**
This PR fixes #3384 by guarding the type assertion in `proof.stringEntry()` and returning the empty string if it fails.

**Summary:**
Updated `proof.stringEntry()` so that the empty string is returned if the type assertion for `entry.(string)` fails (precedent from [`did.stringEntry()`](https://github.com/hyperledger/aries-framework-go/blob/main/pkg/doc/did/doc.go#L1039-L1049)). Previously, this function would panic if the provided interface was not either `nil` or a `string`.

Added unit testing to ensure that all options passed through `proof.stringEntry()` by `proof.NewProof()` can handle invalid interfaces without a panic.
