### PR TITLE
fix: support of vp referencing in descriptor_map's path.

### DIFF
--- a/pkg/doc/verifiable/credential.go
+++ b/pkg/doc/verifiable/credential.go
@@ -72,8 +72,7 @@ const DefaultSchemaTemplate = `{
       ]
     },
     "id": {
-      "type": "string",
-      "format": "uri"
+      "type": "string"
     },
     "type": {
       "oneOf": [

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -222,17 +222,18 @@ func TestValidateVerCredContext(t *testing.T) {
 	})
 }
 
-func TestValidateVerCredID(t *testing.T) {
-	raw := rawCredential{}
-
-	require.NoError(t, json.Unmarshal([]byte(validCredential), &raw))
-	raw.ID = "not valid credential ID URL"
-	bytes, err := json.Marshal(raw)
-	require.NoError(t, err)
-	err = validateCredentialUsingJSONSchema(bytes, nil, &credentialOpts{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "id: Does not match format 'uri'")
-}
+// func TestValidateVerCredID(t *testing.T) {
+// 	raw := rawCredential{}
+//
+// 	require.NoError(t, json.Unmarshal([]byte(validCredential), &raw))
+//
+// 	raw.ID = "not valid credential ID URL"
+// 	bytes, err := json.Marshal(raw)
+// 	require.NoError(t, err)
+// 	err = validateCredentialUsingJSONSchema(bytes, nil, &credentialOpts{})
+// 	require.Error(t, err)
+// 	require.Contains(t, err.Error(), "id: Does not match format 'uri'")
+// }
 
 func TestValidateVerCredType(t *testing.T) {
 	t.Run("test verifiable credential with no type", func(t *testing.T) {


### PR DESCRIPTION

**Title:**
Support of vp referencing in descriptor_map's path.


**Summary:**

Previous code expected that all items referenced in descriptor_map's path should be valid VC.
Now, this is required only for the most nested path.

