### PR TITLE
chore: Controller should be filled in even with relative URL(@base)

### DIFF
--- a/pkg/doc/did/doc.go
+++ b/pkg/doc/did/doc.go
@@ -1467,9 +1467,6 @@ func populateRawVerificationMethod(context, didID, baseURI string,
 		rawVM[jsonldOwner] = vm.Controller
 	} else {
 		rawVM[jsonldController] = vm.Controller
-		if vm.relativeURL {
-			rawVM[jsonldController] = ""
-		}
 	}
 
 	if vm.jsonWebKey != nil { //nolint: gocritic


### PR DESCRIPTION
Controller information should be filled in even if relative URL (@base) is present.

Closes #3424

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>


