### PR TITLE
feat: add did core support in resolving service endpoints function

### DIFF
--- a/pkg/doc/did/doc.go
+++ b/pkg/doc/did/doc.go
@@ -686,8 +686,8 @@ func populateServices(didID, baseURI string, rawServices []map[string]interface{
 			} else if epEntry != nil { // DIDComm V2 format (first valid entry for now).
 				entries, ok := epEntry.([]interface{})
 				if ok && len(entries) > 0 {
-					firstEntry, ok := entries[0].(map[string]interface{})
-					if ok {
+					firstEntry, is := entries[0].(map[string]interface{})
+					if is {
 						epURI := stringEntry(firstEntry["uri"])
 						epAccept := stringArray(firstEntry["accept"])
 						epRoutingKeys := stringArray(firstEntry["routingKeys"])
@@ -695,6 +695,12 @@ func populateServices(didID, baseURI string, rawServices []map[string]interface{
 							{URI: epURI, Accept: epAccept, RoutingKeys: epRoutingKeys},
 						})
 					}
+				}
+				coreServices, ok := epEntry.(map[string]interface{}) // DID Core
+				if ok && len(coreServices) > 0 {
+					instances := stringArray(coreServices["instances"])
+					origins := stringArray(coreServices["origins"])
+					sp = model.NewDIDCoreEndpoint(append(instances, origins...))
 				}
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Mykhailo Sizov <mykhailo.sizov@securekey.com>

**Title:**
Add did core support in resolving service endpoints function

**Description:**
Solves: https://github.com/hyperledger/aries-framework-go/issues/3428

**Summary:**
Added support of the next structure of service in DID:
```
"service": [
    {
      "id": "#linkeddomains",
      "type": "LinkedDomains",
      "serviceEndpoint": {
        "origins": [
          "https://did.rohitgulati.com/"
        ]
      }
    },
    {
      "id": "#hub",
      "type": "IdentityHub",
      "serviceEndpoint": {
        "instances": [
          "https://hub.did.msidentity.com/v1.0/a492cff2-d733-4057-95a5-a71fc3695bc8"
        ],
        "origins": []
      }
    }
  ]
```

Covered in unit test here: https://github.com/hyperledger/aries-framework-go/blob/main/pkg/doc/didconfig/interop_test.go#L37

