### PR TITLE
refactor: Minimize interfaces required by didsignjwt.SignJWT

### DIFF
--- a/pkg/internal/kmssigner/kmssigner.go
+++ b/pkg/internal/kmssigner/kmssigner.go
@@ -44,18 +44,7 @@ func (s *KMSSigner) Sign(data []byte) ([]byte, error) {
 
 // Alg provides the JWA corresponding to the KMSSigner's KeyType.
 func (s *KMSSigner) Alg() string {
-	switch s.KeyType {
-	case kms.ECDSAP256IEEEP1363, kms.ECDSAP256DER:
-		return p256Alg
-	case kms.ECDSAP384IEEEP1363, kms.ECDSAP384DER:
-		return p384Alg
-	case kms.ECDSAP521IEEEP1363, kms.ECDSAP521DER:
-		return p521Alg
-	case kms.ED25519:
-		return edAlg
-	}
-
-	return ""
+	return KeyTypeToJWA(s.KeyType)
 }
 
 func (s *KMSSigner) textToLines(txt string) [][]byte {
@@ -69,4 +58,20 @@ func (s *KMSSigner) textToLines(txt string) [][]byte {
 	}
 
 	return linesBytes
+}
+
+// KeyTypeToJWA provides the JWA corresponding to keyType.
+func KeyTypeToJWA(keyType kms.KeyType) string {
+	switch keyType {
+	case kms.ECDSAP256IEEEP1363, kms.ECDSAP256DER:
+		return p256Alg
+	case kms.ECDSAP384IEEEP1363, kms.ECDSAP384DER:
+		return p384Alg
+	case kms.ECDSAP521IEEEP1363, kms.ECDSAP521DER:
+		return p521Alg
+	case kms.ED25519:
+		return edAlg
+	}
+
+	return ""
 }


### PR DESCRIPTION
Minimized the interfaces required by the didsignjwt.SignJWT method by replacing the usage of the kms.KeyManager, crypto.Crypto, and vdr.Registry interfaces with minimized interfaces that define only the functionality needed for the SignJWT function. This makes it easier for consumers to inject in their own implementations. The method signatures of the new minimized interfaces still line up with the method signatures of the kms.KeyManager, crypto.Crypto, and vdr.Registry interfaces, so implementations of those interfaces can still be used without making any changes.