### PR TITLE
feat: Add options to VDR Accept

### DIFF
--- a/pkg/framework/aries/api/vdr/vdr.go
+++ b/pkg/framework/aries/api/vdr/vdr.go
@@ -40,7 +40,7 @@ type Registry interface {
 type VDR interface {
 	Read(did string, opts ...DIDMethodOption) (*did.DocResolution, error)
 	Create(did *did.Doc, opts ...DIDMethodOption) (*did.DocResolution, error)
-	Accept(method string) bool
+	Accept(method string, opts ...DIDMethodOption) bool
 	Update(did *did.Doc, opts ...DIDMethodOption) error
 	Deactivate(did string, opts ...DIDMethodOption) error
 	Close() error

--- a/pkg/mock/vdr/mock_vdr.go
+++ b/pkg/mock/vdr/mock_vdr.go
@@ -16,6 +16,7 @@ import (
 type MockVDR struct {
 	AcceptValue    bool
 	StoreErr       error
+	AcceptFunc     func(method string, opts ...vdrapi.DIDMethodOption) bool
 	ReadFunc       func(didID string, opts ...vdrapi.DIDMethodOption) (*did.DocResolution, error)
 	CreateFunc     func(did *did.Doc, opts ...vdrapi.DIDMethodOption) (*did.DocResolution, error)
 	UpdateFunc     func(didDoc *did.Doc, opts ...vdrapi.DIDMethodOption) error
@@ -60,7 +61,11 @@ func (m *MockVDR) Deactivate(didID string, opts ...vdrapi.DIDMethodOption) error
 }
 
 // Accept did.
-func (m *MockVDR) Accept(method string) bool {
+func (m *MockVDR) Accept(method string, opts ...vdrapi.DIDMethodOption) bool {
+	if m.AcceptFunc != nil {
+		return m.AcceptFunc(method, opts...)
+	}
+
 	return m.AcceptValue
 }
 

--- a/pkg/vdr/httpbinding/vdr.go
+++ b/pkg/vdr/httpbinding/vdr.go
@@ -56,7 +56,7 @@ func New(endpointURL string, opts ...Option) (*VDR, error) {
 }
 
 // Accept did method - attempt to resolve any method.
-func (v *VDR) Accept(method string) bool {
+func (v *VDR) Accept(method string, opts ...vdrapi.DIDMethodOption) bool {
 	return v.accept(method)
 }
 

--- a/pkg/vdr/key/vdr.go
+++ b/pkg/vdr/key/vdr.go
@@ -31,7 +31,7 @@ func New() *VDR {
 }
 
 // Accept accepts did:key method.
-func (v *VDR) Accept(method string) bool {
+func (v *VDR) Accept(method string, opts ...vdrapi.DIDMethodOption) bool {
 	return method == DIDMethod
 }
 

--- a/pkg/vdr/peer/vdr.go
+++ b/pkg/vdr/peer/vdr.go
@@ -49,6 +49,6 @@ func (v *VDR) Deactivate(did string, opts ...vdrapi.DIDMethodOption) error {
 }
 
 // Accept did method.
-func (v *VDR) Accept(method string) bool {
+func (v *VDR) Accept(method string, opts ...vdrapi.DIDMethodOption) bool {
 	return method == DIDMethod
 }

--- a/pkg/vdr/registry.go
+++ b/pkg/vdr/registry.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/vdr/peer"
 )
 
+const didAcceptOpt = "didAcceptOpt"
+
 // Option is a vdr instance option.
 type Option func(opts *Registry)
 
@@ -45,8 +47,12 @@ func (r *Registry) Resolve(did string, opts ...vdrapi.DIDMethodOption) (*diddoc.
 		return nil, err
 	}
 
+	// create accept options with did and add existing options
+	acceptOpts := []vdrapi.DIDMethodOption{vdrapi.WithOption(didAcceptOpt, did)}
+	acceptOpts = append(acceptOpts, opts...)
+
 	// resolve did method
-	method, err := r.resolveVDR(didMethod)
+	method, err := r.resolveVDR(didMethod, acceptOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -71,8 +77,12 @@ func (r *Registry) Update(didDoc *diddoc.Doc, opts ...vdrapi.DIDMethodOption) er
 		return err
 	}
 
+	// create accept options with did and add existing options
+	acceptOpts := []vdrapi.DIDMethodOption{vdrapi.WithOption(didAcceptOpt, didDoc.ID)}
+	acceptOpts = append(acceptOpts, opts...)
+
 	// resolve did method
-	method, err := r.resolveVDR(didMethod)
+	method, err := r.resolveVDR(didMethod, acceptOpts...)
 	if err != nil {
 		return err
 	}
@@ -87,8 +97,12 @@ func (r *Registry) Deactivate(did string, opts ...vdrapi.DIDMethodOption) error 
 		return err
 	}
 
+	// create accept options with did and add existing options
+	acceptOpts := []vdrapi.DIDMethodOption{vdrapi.WithOption(didAcceptOpt, did)}
+	acceptOpts = append(acceptOpts, opts...)
+
 	// resolve did method
-	method, err := r.resolveVDR(didMethod)
+	method, err := r.resolveVDR(didMethod, acceptOpts...)
 	if err != nil {
 		return err
 	}
@@ -105,7 +119,7 @@ func (r *Registry) Create(didMethod string, did *diddoc.Doc,
 		opt(docOpts)
 	}
 
-	method, err := r.resolveVDR(didMethod)
+	method, err := r.resolveVDR(didMethod, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -143,9 +157,9 @@ func (r *Registry) Close() error {
 	return nil
 }
 
-func (r *Registry) resolveVDR(method string) (vdrapi.VDR, error) {
+func (r *Registry) resolveVDR(method string, opts ...vdrapi.DIDMethodOption) (vdrapi.VDR, error) {
 	for _, v := range r.vdr {
-		if v.Accept(method) {
+		if v.Accept(method, opts...) {
 			return v, nil
 		}
 	}

--- a/pkg/vdr/registry_test.go
+++ b/pkg/vdr/registry_test.go
@@ -103,6 +103,24 @@ func TestRegistry_Resolve(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("test opts passed to accept", func(t *testing.T) {
+		registry := New(WithVDR(&mockvdr.MockVDR{
+			AcceptFunc: func(method string, opts ...vdrapi.DIDMethodOption) bool {
+				acceptOpts := &vdrapi.DIDMethodOpts{Values: make(map[string]interface{})}
+				// Apply options
+				for _, opt := range opts {
+					opt(acceptOpts)
+				}
+
+				require.NotNil(t, acceptOpts.Values["k1"])
+				require.NotNil(t, acceptOpts.Values[didAcceptOpt])
+				return true
+			},
+		}))
+		_, err := registry.Resolve("1:id:123", vdrapi.WithOption("k1", "v1"))
+		require.NoError(t, err)
+	})
+
 	t.Run("test success", func(t *testing.T) {
 		registry := New(WithVDR(&mockvdr.MockVDR{AcceptValue: true}))
 		_, err := registry.Resolve("1:id:123")
@@ -147,6 +165,25 @@ func TestRegistry_Update(t *testing.T) {
 
 				require.NotNil(t, didOpts.Values["k1"])
 				return nil
+			},
+		}))
+
+		err := registry.Update(&did.Doc{ID: "1:id:123"}, vdrapi.WithOption("k1", "v1"))
+		require.NoError(t, err)
+	})
+
+	t.Run("test opts passed to accept", func(t *testing.T) {
+		registry := New(WithVDR(&mockvdr.MockVDR{
+			AcceptFunc: func(method string, opts ...vdrapi.DIDMethodOption) bool {
+				acceptOpts := &vdrapi.DIDMethodOpts{Values: make(map[string]interface{})}
+				// Apply options
+				for _, opt := range opts {
+					opt(acceptOpts)
+				}
+
+				require.NotNil(t, acceptOpts.Values["k1"])
+				require.NotNil(t, acceptOpts.Values[didAcceptOpt])
+				return true
 			},
 		}))
 
@@ -205,6 +242,25 @@ func TestRegistry_Deactivate(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("test opts passed to accept", func(t *testing.T) {
+		registry := New(WithVDR(&mockvdr.MockVDR{
+			AcceptFunc: func(method string, opts ...vdrapi.DIDMethodOption) bool {
+				acceptOpts := &vdrapi.DIDMethodOpts{Values: make(map[string]interface{})}
+				// Apply options
+				for _, opt := range opts {
+					opt(acceptOpts)
+				}
+
+				require.NotNil(t, acceptOpts.Values["k1"])
+				require.NotNil(t, acceptOpts.Values[didAcceptOpt])
+				return true
+			},
+		}))
+
+		err := registry.Deactivate("1:id:123", vdrapi.WithOption("k1", "v1"))
+		require.NoError(t, err)
+	})
+
 	t.Run("test success", func(t *testing.T) {
 		registry := New(WithVDR(&mockvdr.MockVDR{AcceptValue: true}))
 		err := registry.Deactivate("1:id:123")
@@ -232,6 +288,27 @@ func TestRegistry_Create(t *testing.T) {
 		_, err := registry.Create("id", &did.Doc{VerificationMethod: []did.VerificationMethod{{ID: "key1"}}})
 		require.NoError(t, err)
 	})
+
+	t.Run("test opts passed to accept", func(t *testing.T) {
+		registry := New(WithVDR(&mockvdr.MockVDR{
+			AcceptFunc: func(method string, opts ...vdrapi.DIDMethodOption) bool {
+				acceptOpts := &vdrapi.DIDMethodOpts{Values: make(map[string]interface{})}
+				// Apply options
+				for _, opt := range opts {
+					opt(acceptOpts)
+				}
+
+				require.NotNil(t, acceptOpts.Values["k1"])
+				return true
+			},
+		}))
+
+		_, err := registry.Create("id",
+			&did.Doc{VerificationMethod: []did.VerificationMethod{{ID: "key1"}}},
+			vdrapi.WithOption("k1", "v1"))
+		require.NoError(t, err)
+	})
+
 	t.Run("with KMS opts - test opts is passed ", func(t *testing.T) {
 		registry := New(WithVDR(&mockvdr.MockVDR{
 			AcceptValue: true,

--- a/pkg/vdr/web/vdr.go
+++ b/pkg/vdr/web/vdr.go
@@ -26,7 +26,7 @@ func New() *VDR {
 }
 
 // Accept method of the VDR interface.
-func (v *VDR) Accept(method string) bool {
+func (v *VDR) Accept(method string, opts ...vdrapi.DIDMethodOption) bool {
 	return method == namespace
 }
 


### PR DESCRIPTION
Currently VDR makes decision on whether to accept or reject request based on method only. Add options to VDR Accept function so VDR can make more complex decisions.

Closes #3438

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>

