### PR TITLE
refactor: Minimize VDResolver interface needed for did config validate

### DIFF
--- a/pkg/client/didconfig/didconfig.go
+++ b/pkg/client/didconfig/didconfig.go
@@ -17,6 +17,7 @@ import (
 	jsonld "github.com/piprate/json-gold/ld"
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/didconfig"
 	vdrapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
 )
@@ -66,10 +67,14 @@ func WithJSONLDDocumentLoader(documentLoader jsonld.DocumentLoader) Option {
 	}
 }
 
+type didResolver interface {
+	Resolve(did string, opts ...vdrapi.DIDMethodOption) (*did.DocResolution, error)
+}
+
 // WithVDRegistry defines a vdr service.
-func WithVDRegistry(vdrRegistry vdrapi.Registry) Option {
+func WithVDRegistry(didResolver didResolver) Option {
 	return func(opts *Client) {
-		opts.didConfigOpts = append(opts.didConfigOpts, didconfig.WithVDRegistry(vdrRegistry))
+		opts.didConfigOpts = append(opts.didConfigOpts, didconfig.WithVDRegistry(didResolver))
 	}
 }
 


### PR DESCRIPTION
Currently, the DID config validate functionality has an option for injecting in a VDR, however most of the methods in the interface are not actually used.

This change switches the option to use a minimal version of that interface that is itself a subset of the full VDR interface. With this change, a caller can now use the VDR option with a more minimal implementation that only has a Resolve method. The minimal interface still lines up with the larger VDR interface, so another caller can still use a full VDR interface implementation without making any changes.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>