### PR TITLE
feat: SD-JWT Holder/Verifier - Process Disclosures

### DIFF
--- a/pkg/doc/sdjwt/issuer/issuer.go
+++ b/pkg/doc/sdjwt/issuer/issuer.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	defaultHash     = crypto.SHA256
-	defaultSaltSize = 28
+	defaultSaltSize = 128 / 8
 
 	year = 365 * 24 * 60 * time.Minute
 )
@@ -241,5 +241,6 @@ func generateSalt() (string, error) {
 		return "", err
 	}
 
-	return string(salt), nil
+	// it is RECOMMENDED to base64url-encode the salt value, producing a string.
+	return base64.RawURLEncoding.EncodeToString(salt), nil
 }

--- a/pkg/doc/sdjwt/issuer/issuer_test.go
+++ b/pkg/doc/sdjwt/issuer/issuer_test.go
@@ -465,7 +465,7 @@ func verifyRS256(jws string, pubKey *rsa.PublicKey) error {
 }
 
 func existsInDisclosures(claims map[string]interface{}, val string) bool {
-	disclosuresObj, ok := claims["_sd"]
+	disclosuresObj, ok := claims[common.SDKey]
 	if !ok {
 		return false
 	}


### PR DESCRIPTION
Added utility function to decode disclosures (used by both holder and verifier) Created disclose claims function for holder that re-creates SD-JWT with disclosures for selected claims only.

Created get verified payload function for verifier (removes _sd and _sd_alg from claims and inserts into payload disclosed claims).

Closes #3459

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>
