### PR TITLE
fix: Presentation Without Holder Binding should end with ~

### DIFF
--- a/pkg/doc/sdjwt/common/common_test.go
+++ b/pkg/doc/sdjwt/common/common_test.go
@@ -42,14 +42,79 @@ func TestGetHash(t *testing.T) {
 	})
 }
 
-func TestParseSDJWT(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		sdJWT := ParseSDJWT(sdJWT)
-		require.Equal(t, 1, len(sdJWT.Disclosures))
+func TestParseCombinedFormatForIssuance(t *testing.T) {
+	t.Run("success - SD-JWT only", func(t *testing.T) {
+		cfi := ParseCombinedFormatForIssuance(testCombinedFormatForIssuance)
+		require.Equal(t, testSDJWT, cfi.SDJWT)
+		require.Equal(t, 1, len(cfi.Disclosures))
+
+		require.Equal(t, testCombinedFormatForIssuance, cfi.Serialize())
 	})
-	t.Run("success", func(t *testing.T) {
-		sdJWT := ParseSDJWT(specSDJWT)
-		require.Equal(t, 7, len(sdJWT.Disclosures))
+	t.Run("success - spec example", func(t *testing.T) {
+		cfi := ParseCombinedFormatForIssuance(specCombinedFormatForIssuance)
+		require.Equal(t, 7, len(cfi.Disclosures))
+
+		require.Equal(t, specCombinedFormatForIssuance, cfi.Serialize())
+	})
+	t.Run("success - AFG generated", func(t *testing.T) {
+		cfi := ParseCombinedFormatForIssuance(testSDJWT)
+		require.Equal(t, testSDJWT, cfi.SDJWT)
+		require.Equal(t, 0, len(cfi.Disclosures))
+
+		require.Equal(t, testSDJWT, cfi.Serialize())
+	})
+}
+
+func TestParseCombinedFormatForPresentation(t *testing.T) {
+	const testHolderBinding = "holder.binding.jwt"
+
+	testCombinedFormatForPresentation := testCombinedFormatForIssuance + DisclosureSeparator
+
+	t.Run("success - AFG example", func(t *testing.T) {
+		cfp := ParseCombinedFormatForPresentation(testCombinedFormatForPresentation)
+		require.Equal(t, testSDJWT, cfp.SDJWT)
+		require.Equal(t, 1, len(cfp.Disclosures))
+		require.Empty(t, cfp.HolderBinding)
+
+		require.Equal(t, testCombinedFormatForPresentation, cfp.Serialize())
+	})
+
+	t.Run("success - spec example", func(t *testing.T) {
+		cfp := ParseCombinedFormatForPresentation(specCombinedFormatForIssuance + DisclosureSeparator)
+		require.Equal(t, 7, len(cfp.Disclosures))
+		require.Empty(t, cfp.HolderBinding)
+
+		require.Equal(t, specCombinedFormatForIssuance+DisclosureSeparator, cfp.Serialize())
+	})
+
+	t.Run("success - AFG test with holder binding", func(t *testing.T) {
+		testCFI := testCombinedFormatForPresentation + testHolderBinding
+		cfp := ParseCombinedFormatForPresentation(testCFI)
+		require.Equal(t, testSDJWT, cfp.SDJWT)
+		require.Equal(t, 1, len(cfp.Disclosures))
+		require.Equal(t, testHolderBinding, cfp.HolderBinding)
+
+		require.Equal(t, testCFI, cfp.Serialize())
+	})
+
+	t.Run("success - SD-JWT only", func(t *testing.T) {
+		cfp := ParseCombinedFormatForPresentation(testSDJWT)
+		require.Equal(t, testSDJWT, cfp.SDJWT)
+		require.Equal(t, 0, len(cfp.Disclosures))
+		require.Empty(t, cfp.HolderBinding)
+
+		require.Equal(t, testSDJWT, cfp.Serialize())
+	})
+
+	t.Run("success - SD-JWT + holder binding", func(t *testing.T) {
+		testCFI := testSDJWT + DisclosureSeparator + testHolderBinding
+
+		cfp := ParseCombinedFormatForPresentation(testCFI)
+		require.Equal(t, testSDJWT, cfp.SDJWT)
+		require.Equal(t, 0, len(cfp.Disclosures))
+		require.Equal(t, testHolderBinding, cfp.HolderBinding)
+
+		require.Equal(t, testCFI, cfp.Serialize())
 	})
 }
 
@@ -62,10 +127,10 @@ func TestVerifyDisclosuresInSDJWT(t *testing.T) {
 	signer := afjwt.NewEd25519Signer(privKey)
 
 	t.Run("success", func(t *testing.T) {
-		sdJWT := ParseSDJWT(sdJWT)
+		sdJWT := ParseCombinedFormatForIssuance(testCombinedFormatForIssuance)
 		require.Equal(t, 1, len(sdJWT.Disclosures))
 
-		signedJWT, err := afjwt.Parse(sdJWT.JWTSerialized, afjwt.WithSignatureVerifier(&NoopSignatureVerifier{}))
+		signedJWT, err := afjwt.Parse(sdJWT.SDJWT, afjwt.WithSignatureVerifier(&NoopSignatureVerifier{}))
 		require.NoError(t, err)
 
 		err = VerifyDisclosuresInSDJWT(sdJWT.Disclosures, signedJWT)
@@ -98,10 +163,10 @@ func TestVerifyDisclosuresInSDJWT(t *testing.T) {
 	})
 
 	t.Run("error - disclosure not present in SD-JWT", func(t *testing.T) {
-		sdJWT := ParseSDJWT(sdJWT)
+		sdJWT := ParseCombinedFormatForIssuance(testCombinedFormatForIssuance)
 		require.Equal(t, 1, len(sdJWT.Disclosures))
 
-		signedJWT, err := afjwt.Parse(sdJWT.JWTSerialized, afjwt.WithSignatureVerifier(&NoopSignatureVerifier{}))
+		signedJWT, err := afjwt.Parse(sdJWT.SDJWT, afjwt.WithSignatureVerifier(&NoopSignatureVerifier{}))
 		require.NoError(t, err)
 
 		err = VerifyDisclosuresInSDJWT(append(sdJWT.Disclosures, additionalDisclosure), signedJWT)
@@ -195,7 +260,7 @@ func TestGetDisclosureClaims(t *testing.T) {
 	r := require.New(t)
 
 	t.Run("success", func(t *testing.T) {
-		sdJWT := ParseSDJWT(sdJWT)
+		sdJWT := ParseCombinedFormatForIssuance(testCombinedFormatForIssuance)
 		require.Equal(t, 1, len(sdJWT.Disclosures))
 
 		disclosureClaims, err := GetDisclosureClaims(sdJWT.Disclosures)
@@ -207,7 +272,7 @@ func TestGetDisclosureClaims(t *testing.T) {
 	})
 
 	t.Run("error - invalid disclosure format (not encoded)", func(t *testing.T) {
-		sdJWT := ParseSDJWT("jws~xyz")
+		sdJWT := ParseCombinedFormatForIssuance("jws~xyz")
 		require.Equal(t, 1, len(sdJWT.Disclosures))
 
 		disclosureClaims, err := GetDisclosureClaims(sdJWT.Disclosures)
@@ -221,7 +286,7 @@ func TestGetDisclosureClaims(t *testing.T) {
 		disclosureJSON, err := json.Marshal(disclosureArr)
 		require.NoError(t, err)
 
-		sdJWT := ParseSDJWT(fmt.Sprintf("jws~%s", base64.RawURLEncoding.EncodeToString(disclosureJSON)))
+		sdJWT := ParseCombinedFormatForIssuance(fmt.Sprintf("jws~%s", base64.RawURLEncoding.EncodeToString(disclosureJSON)))
 		require.Equal(t, 1, len(sdJWT.Disclosures))
 
 		disclosureClaims, err := GetDisclosureClaims(sdJWT.Disclosures)
@@ -235,7 +300,7 @@ func TestGetDisclosureClaims(t *testing.T) {
 		disclosureJSON, err := json.Marshal(disclosureArr)
 		require.NoError(t, err)
 
-		sdJWT := ParseSDJWT(fmt.Sprintf("jws~%s", base64.RawURLEncoding.EncodeToString(disclosureJSON)))
+		sdJWT := ParseCombinedFormatForIssuance(fmt.Sprintf("jws~%s", base64.RawURLEncoding.EncodeToString(disclosureJSON)))
 		require.Equal(t, 1, len(sdJWT.Disclosures))
 
 		disclosureClaims, err := GetDisclosureClaims(sdJWT.Disclosures)
@@ -255,7 +320,10 @@ func (sv *NoopSignatureVerifier) Verify(joseHeaders jose.Headers, payload, signi
 const additionalDisclosure = `WyJfMjZiYzRMVC1hYzZxMktJNmNCVzVlcyIsICJmYW1pbHlfbmFtZSIsICJNw7ZiaXVzIl0`
 
 // nolint: lll
-const sdJWT = `eyJhbGciOiJFZERTQSJ9.eyJfc2QiOlsicXF2Y3FuY3pBTWdZeDdFeWtJNnd3dHNweXZ5dks3OTBnZTdNQmJRLU51cyJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImV4cCI6MTcwMzAyMzg1NSwiaWF0IjoxNjcxNDg3ODU1LCJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tL2lzc3VlciIsIm5iZiI6MTY3MTQ4Nzg1NX0.vscuzfwcHGi04pWtJCadc4iDELug6NH6YK-qxhY1qacsciIHuoLELAfon1tGamHtuu8TSs6OjtLk3lHE16jqAQ~WyIzanFjYjY3ejl3a3MwOHp3aUs3RXlRIiwgImdpdmVuX25hbWUiLCAiSm9obiJd`
+const testCombinedFormatForIssuance = `eyJhbGciOiJFZERTQSJ9.eyJfc2QiOlsicXF2Y3FuY3pBTWdZeDdFeWtJNnd3dHNweXZ5dks3OTBnZTdNQmJRLU51cyJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImV4cCI6MTcwMzAyMzg1NSwiaWF0IjoxNjcxNDg3ODU1LCJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tL2lzc3VlciIsIm5iZiI6MTY3MTQ4Nzg1NX0.vscuzfwcHGi04pWtJCadc4iDELug6NH6YK-qxhY1qacsciIHuoLELAfon1tGamHtuu8TSs6OjtLk3lHE16jqAQ~WyIzanFjYjY3ejl3a3MwOHp3aUs3RXlRIiwgImdpdmVuX25hbWUiLCAiSm9obiJd`
 
 // nolint: lll
-const specSDJWT = `eyJhbGciOiAiUlMyNTYiLCAia2lkIjogImNBRUlVcUowY21MekQxa3pHemhlaUJhZzBZUkF6VmRsZnhOMjgwTmdIYUEifQ.eyJfc2QiOiBbIk5ZQ29TUktFWXdYZHBlNXlkdUpYQ3h4aHluRVU4ei1iNFR5TmlhcDc3VVkiLCAiU1k4bjJCYmtYOWxyWTNleEhsU3dQUkZYb0QwOUdGOGE5Q1BPLUc4ajIwOCIsICJUUHNHTlBZQTQ2d21CeGZ2MnpuT0poZmRvTjVZMUdrZXpicGFHWkNUMWFjIiwgIlprU0p4eGVHbHVJZFlCYjdDcWtaYkpWbTB3MlY1VXJSZU5UekFRQ1lCanciLCAibDlxSUo5SlRRd0xHN09MRUlDVEZCVnhtQXJ3OFBqeTY1ZEQ2bXRRVkc1YyIsICJvMVNBc0ozM1lNaW9POXBYNVZlQU0xbHh1SEY2aFpXMmtHZGtLS0JuVmxvIiwgInFxdmNxbmN6QU1nWXg3RXlrSTZ3d3RzcHl2eXZLNzkwZ2U3TUJiUS1OdXMiXSwgImlzcyI6ICJodHRwczovL2V4YW1wbGUuY29tL2lzc3VlciIsICJpYXQiOiAxNTE2MjM5MDIyLCAiZXhwIjogMTUxNjI0NzAyMiwgIl9zZF9hbGciOiAic2hhLTI1NiIsICJjbmYiOiB7Imp3ayI6IHsia3R5IjogIlJTQSIsICJuIjogInBtNGJPSEJnLW9ZaEF5UFd6UjU2QVdYM3JVSVhwMTFfSUNEa0dnUzZXM1pXTHRzLWh6d0kzeDY1NjU5a2c0aFZvOWRiR29DSkUzWkdGX2VhZXRFMzBVaEJVRWdwR3dyRHJRaUo5enFwcm1jRmZyM3F2dmtHanR0aDhaZ2wxZU0yYkpjT3dFN1BDQkhXVEtXWXMxNTJSN2c2SmcyT1ZwaC1hOHJxLXE3OU1oS0c1UW9XX21UejEwUVRfNkg0YzdQaldHMWZqaDhocFdObmJQX3B2NmQxelN3WmZjNWZsNnlWUkwwRFYwVjNsR0hLZTJXcWZfZU5HakJyQkxWa2xEVGs4LXN0WF9NV0xjUi1FR21YQU92MFVCV2l0U19kWEpLSnUtdlhKeXcxNG5IU0d1eFRJSzJoeDFwdHRNZnQ5Q3N2cWltWEtlRFRVMTRxUUwxZUU3aWhjdyIsICJlIjogIkFRQUIifX19.xqgKrDO6dK_oBL3fiqdcq_elaIGxM6Z-RyuysglGyddR1O1IiE3mIk8kCpoqcRLR88opkVWN2392K_XYfAuAmeT9kJVisD8ZcgNcv-MQlWW9s8WaViXxBRe7EZWkWRQcQVR6jf95XZ5H2-_KA54POq3L42xjk0y5vDr8yc08Reak6vvJVvjXpp-Wk6uxsdEEAKFspt_EYIvISFJhfTuQqyhCjnaW13X312MSQBPwjbHn74ylUqVLljDvqcemxeqjh42KWJq4C3RqNJ7anA2i3FU1kB4-KNZWsijY7-op49iL7BrnIBxdlAMrbHEkoGTbFWdl7Ki17GHtDxxa1jaxQg~WyJkcVR2WE14UzBHYTNEb2FHbmU5eDBRIiwgInN1YiIsICJqb2huX2RvZV80MiJd~WyIzanFjYjY3ejl3a3MwOHp3aUs3RXlRIiwgImdpdmVuX25hbWUiLCAiSm9obiJd~WyJxUVdtakpsMXMxUjRscWhFTkxScnJ3IiwgImZhbWlseV9uYW1lIiwgIkRvZSJd~WyJLVXhTNWhFX1hiVmFjckdBYzdFRnd3IiwgImVtYWlsIiwgImpvaG5kb2VAZXhhbXBsZS5jb20iXQ~WyIzcXZWSjFCQURwSERTUzkzOVEtUml3IiwgInBob25lX251bWJlciIsICIrMS0yMDItNTU1LTAxMDEiXQ~WyIweEd6bjNNaXFzY3RaSV9PcERsQWJRIiwgImFkZHJlc3MiLCB7InN0cmVldF9hZGRyZXNzIjogIjEyMyBNYWluIFN0IiwgImxvY2FsaXR5IjogIkFueXRvd24iLCAicmVnaW9uIjogIkFueXN0YXRlIiwgImNvdW50cnkiOiAiVVMifV0~WyJFUktNMENOZUZKa2FENW1UWFZfWDh3IiwgImJpcnRoZGF0ZSIsICIxOTQwLTAxLTAxIl0`
+const testSDJWT = `eyJhbGciOiJFZERTQSJ9.eyJfc2QiOlsicXF2Y3FuY3pBTWdZeDdFeWtJNnd3dHNweXZ5dks3OTBnZTdNQmJRLU51cyJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImV4cCI6MTcwMzAyMzg1NSwiaWF0IjoxNjcxNDg3ODU1LCJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tL2lzc3VlciIsIm5iZiI6MTY3MTQ4Nzg1NX0.vscuzfwcHGi04pWtJCadc4iDELug6NH6YK-qxhY1qacsciIHuoLELAfon1tGamHtuu8TSs6OjtLk3lHE16jqAQ`
+
+// nolint: lll
+const specCombinedFormatForIssuance = `eyJhbGciOiAiUlMyNTYiLCAia2lkIjogImNBRUlVcUowY21MekQxa3pHemhlaUJhZzBZUkF6VmRsZnhOMjgwTmdIYUEifQ.eyJfc2QiOiBbIk5ZQ29TUktFWXdYZHBlNXlkdUpYQ3h4aHluRVU4ei1iNFR5TmlhcDc3VVkiLCAiU1k4bjJCYmtYOWxyWTNleEhsU3dQUkZYb0QwOUdGOGE5Q1BPLUc4ajIwOCIsICJUUHNHTlBZQTQ2d21CeGZ2MnpuT0poZmRvTjVZMUdrZXpicGFHWkNUMWFjIiwgIlprU0p4eGVHbHVJZFlCYjdDcWtaYkpWbTB3MlY1VXJSZU5UekFRQ1lCanciLCAibDlxSUo5SlRRd0xHN09MRUlDVEZCVnhtQXJ3OFBqeTY1ZEQ2bXRRVkc1YyIsICJvMVNBc0ozM1lNaW9POXBYNVZlQU0xbHh1SEY2aFpXMmtHZGtLS0JuVmxvIiwgInFxdmNxbmN6QU1nWXg3RXlrSTZ3d3RzcHl2eXZLNzkwZ2U3TUJiUS1OdXMiXSwgImlzcyI6ICJodHRwczovL2V4YW1wbGUuY29tL2lzc3VlciIsICJpYXQiOiAxNTE2MjM5MDIyLCAiZXhwIjogMTUxNjI0NzAyMiwgIl9zZF9hbGciOiAic2hhLTI1NiIsICJjbmYiOiB7Imp3ayI6IHsia3R5IjogIlJTQSIsICJuIjogInBtNGJPSEJnLW9ZaEF5UFd6UjU2QVdYM3JVSVhwMTFfSUNEa0dnUzZXM1pXTHRzLWh6d0kzeDY1NjU5a2c0aFZvOWRiR29DSkUzWkdGX2VhZXRFMzBVaEJVRWdwR3dyRHJRaUo5enFwcm1jRmZyM3F2dmtHanR0aDhaZ2wxZU0yYkpjT3dFN1BDQkhXVEtXWXMxNTJSN2c2SmcyT1ZwaC1hOHJxLXE3OU1oS0c1UW9XX21UejEwUVRfNkg0YzdQaldHMWZqaDhocFdObmJQX3B2NmQxelN3WmZjNWZsNnlWUkwwRFYwVjNsR0hLZTJXcWZfZU5HakJyQkxWa2xEVGs4LXN0WF9NV0xjUi1FR21YQU92MFVCV2l0U19kWEpLSnUtdlhKeXcxNG5IU0d1eFRJSzJoeDFwdHRNZnQ5Q3N2cWltWEtlRFRVMTRxUUwxZUU3aWhjdyIsICJlIjogIkFRQUIifX19.xqgKrDO6dK_oBL3fiqdcq_elaIGxM6Z-RyuysglGyddR1O1IiE3mIk8kCpoqcRLR88opkVWN2392K_XYfAuAmeT9kJVisD8ZcgNcv-MQlWW9s8WaViXxBRe7EZWkWRQcQVR6jf95XZ5H2-_KA54POq3L42xjk0y5vDr8yc08Reak6vvJVvjXpp-Wk6uxsdEEAKFspt_EYIvISFJhfTuQqyhCjnaW13X312MSQBPwjbHn74ylUqVLljDvqcemxeqjh42KWJq4C3RqNJ7anA2i3FU1kB4-KNZWsijY7-op49iL7BrnIBxdlAMrbHEkoGTbFWdl7Ki17GHtDxxa1jaxQg~WyJkcVR2WE14UzBHYTNEb2FHbmU5eDBRIiwgInN1YiIsICJqb2huX2RvZV80MiJd~WyIzanFjYjY3ejl3a3MwOHp3aUs3RXlRIiwgImdpdmVuX25hbWUiLCAiSm9obiJd~WyJxUVdtakpsMXMxUjRscWhFTkxScnJ3IiwgImZhbWlseV9uYW1lIiwgIkRvZSJd~WyJLVXhTNWhFX1hiVmFjckdBYzdFRnd3IiwgImVtYWlsIiwgImpvaG5kb2VAZXhhbXBsZS5jb20iXQ~WyIzcXZWSjFCQURwSERTUzkzOVEtUml3IiwgInBob25lX251bWJlciIsICIrMS0yMDItNTU1LTAxMDEiXQ~WyIweEd6bjNNaXFzY3RaSV9PcERsQWJRIiwgImFkZHJlc3MiLCB7InN0cmVldF9hZGRyZXNzIjogIjEyMyBNYWluIFN0IiwgImxvY2FsaXR5IjogIkFueXRvd24iLCAicmVnaW9uIjogIkFueXN0YXRlIiwgImNvdW50cnkiOiAiVVMifV0~WyJFUktNMENOZUZKa2FENW1UWFZfWDh3IiwgImJpcnRoZGF0ZSIsICIxOTQwLTAxLTAxIl0`

--- a/pkg/doc/sdjwt/integration_test.go
+++ b/pkg/doc/sdjwt/integration_test.go
@@ -45,26 +45,28 @@ func TestSDJWTFlow(t *testing.T) {
 		r.NoError(e)
 
 		// TODO: Should we have one call instead of two (designed based on JWT)
-		sdJWTSerialized, e := token.Serialize(false)
+		combinedFormatForIssuance, e := token.Serialize(false)
 		r.NoError(e)
 
-		fmt.Println(fmt.Sprintf("issuer SD-JWT: %s", sdJWTSerialized))
+		fmt.Println(fmt.Sprintf("issuer SD-JWT: %s", combinedFormatForIssuance))
 
-		// Holder will parse issuer SD-JWT and hold on to that SD-JWT and the claims that can be selected.
-		claims, err := holder.Parse(sdJWTSerialized, holder.WithSignatureVerifier(signatureVerifier))
+		// Holder will parse combined format for issuance and hold on to that
+		// combined format for issuance and the claims that can be selected.
+		claims, err := holder.Parse(combinedFormatForIssuance, holder.WithSignatureVerifier(signatureVerifier))
 		r.NoError(err)
 
 		// expected disclosures given_name and last_name
 		r.Equal(2, len(claims))
 
 		// Holder will disclose only sub-set of claims to verifier.
-		sdJWTDisclosed, err := holder.DiscloseClaims(sdJWTSerialized, []string{"given_name"})
+		combinedFormatForPresentation, err := holder.DiscloseClaims(combinedFormatForIssuance, []string{"given_name"})
 		r.NoError(err)
 
-		fmt.Println(fmt.Sprintf("holder SD-JWT: %s", sdJWTDisclosed))
+		fmt.Println(fmt.Sprintf("holder SD-JWT: %s", combinedFormatForPresentation))
 
-		// Verifier will validate holder SD-JWT and create verified claims.
-		verifiedClaims, err := verifier.Parse(sdJWTDisclosed, verifier.WithSignatureVerifier(signatureVerifier))
+		// Verifier will validate combined format for presentation and create verified claims.
+		verifiedClaims, err := verifier.Parse(combinedFormatForPresentation,
+			verifier.WithSignatureVerifier(signatureVerifier))
 		r.NoError(err)
 
 		// expected claims iss, exp, iat, nbf, given_name; last_name was not disclosed

--- a/pkg/doc/sdjwt/issuer/issuer.go
+++ b/pkg/doc/sdjwt/issuer/issuer.go
@@ -248,12 +248,12 @@ func (j *SelectiveDisclosureJWT) Serialize(detached bool) (string, error) {
 		return "", err
 	}
 
-	combinedFormatForPresentation := signedJWT
-	for _, disclosure := range j.Disclosures {
-		combinedFormatForPresentation += common.DisclosureSeparator + disclosure
+	cf := common.CombinedFormatForIssuance{
+		SDJWT:       signedJWT,
+		Disclosures: j.Disclosures,
 	}
 
-	return combinedFormatForPresentation, nil
+	return cf.Serialize(), nil
 }
 
 func createDisclosures(claims map[string]interface{}, opts *newOpts) ([]string, error) {

--- a/pkg/doc/sdjwt/issuer/issuer_test.go
+++ b/pkg/doc/sdjwt/issuer/issuer_test.go
@@ -48,16 +48,16 @@ func TestNew(t *testing.T) {
 				return sampleSalt, nil
 			}))
 		r.NoError(err)
-		sdJWTSerialized, err := token.Serialize(false)
+		combinedFormatForIssuance, err := token.Serialize(false)
 		require.NoError(t, err)
 
-		fmt.Printf(sdJWTSerialized)
+		fmt.Printf(combinedFormatForIssuance)
 
-		sdJWT := common.ParseSDJWT(sdJWTSerialized)
-		require.Equal(t, 1, len(sdJWT.Disclosures))
+		cfi := common.ParseCombinedFormatForIssuance(combinedFormatForIssuance)
+		require.Equal(t, 1, len(cfi.Disclosures))
 
 		var parsedClaims map[string]interface{}
-		err = verifyEd25519ViaGoJose(sdJWT.JWTSerialized, pubKey, &parsedClaims)
+		err = verifyEd25519ViaGoJose(cfi.SDJWT, pubKey, &parsedClaims)
 		r.NoError(err)
 
 		parsedClaimsBytes, err := json.Marshal(parsedClaims)
@@ -70,7 +70,7 @@ func TestNew(t *testing.T) {
 
 		require.True(t, existsInDisclosures(parsedClaims, expectedHashWithSpaces))
 
-		err = verifyEd25519(sdJWT.JWTSerialized, pubKey)
+		err = verifyEd25519(cfi.SDJWT, pubKey)
 		r.NoError(err)
 	})
 
@@ -88,14 +88,14 @@ func TestNew(t *testing.T) {
 				return sampleSalt, nil
 			}))
 		r.NoError(err)
-		sdJWTSerialized, err := token.Serialize(false)
+		combinedFormatForIssuance, err := token.Serialize(false)
 		require.NoError(t, err)
 
-		sdJWT := common.ParseSDJWT(sdJWTSerialized)
-		require.Equal(t, 1, len(sdJWT.Disclosures))
+		cfi := common.ParseCombinedFormatForIssuance(combinedFormatForIssuance)
+		require.Equal(t, 1, len(cfi.Disclosures))
 
 		var parsedClaims map[string]interface{}
-		err = verifyRS256ViaGoJose(sdJWT.JWTSerialized, pubKey, &parsedClaims)
+		err = verifyRS256ViaGoJose(cfi.SDJWT, pubKey, &parsedClaims)
 		r.NoError(err)
 
 		parsedClaimsBytes, err := json.Marshal(parsedClaims)
@@ -109,7 +109,7 @@ func TestNew(t *testing.T) {
 		expectedHashWithSpaces := expectedHashWithSpaces
 		require.True(t, existsInDisclosures(parsedClaims, expectedHashWithSpaces))
 
-		err = verifyRS256(sdJWT.JWTSerialized, pubKey)
+		err = verifyRS256(cfi.SDJWT, pubKey)
 		r.NoError(err)
 	})
 
@@ -141,16 +141,16 @@ func TestNew(t *testing.T) {
 
 		token, err := New(issuer, complexClaims, nil, afjwt.NewEd25519Signer(privKey), newOpts...)
 		r.NoError(err)
-		sdJWTSerialized, err := token.Serialize(false)
+		combinedFormatForIssuance, err := token.Serialize(false)
 		require.NoError(t, err)
 
-		fmt.Printf(sdJWTSerialized)
+		fmt.Printf(combinedFormatForIssuance)
 
-		sdJWT := common.ParseSDJWT(sdJWTSerialized)
-		require.Equal(t, 7, len(sdJWT.Disclosures))
+		cfi := common.ParseCombinedFormatForIssuance(combinedFormatForIssuance)
+		require.Equal(t, 7, len(cfi.Disclosures))
 
 		var parsedClaims map[string]interface{}
-		err = verifyEd25519ViaGoJose(sdJWT.JWTSerialized, pubKey, &parsedClaims)
+		err = verifyEd25519ViaGoJose(cfi.SDJWT, pubKey, &parsedClaims)
 		r.NoError(err)
 
 		parsedClaimsBytes, err := json.Marshal(parsedClaims)
@@ -161,7 +161,7 @@ func TestNew(t *testing.T) {
 
 		fmt.Println(prettyJSON)
 
-		err = verifyEd25519(sdJWT.JWTSerialized, pubKey)
+		err = verifyEd25519(cfi.SDJWT, pubKey)
 		r.NoError(err)
 	})
 
@@ -177,13 +177,13 @@ func TestNew(t *testing.T) {
 		token, err := New(issuer, claims, nil, afjwt.NewEd25519Signer(privKey),
 			WithDecoyDigests(true))
 		r.NoError(err)
-		sdJWTSerialized, err := token.Serialize(false)
+		combinedFormatForIssuance, err := token.Serialize(false)
 		r.NoError(err)
 
-		sdJWT := common.ParseSDJWT(sdJWTSerialized)
-		r.Equal(1, len(sdJWT.Disclosures))
+		cfi := common.ParseCombinedFormatForIssuance(combinedFormatForIssuance)
+		r.Equal(1, len(cfi.Disclosures))
 
-		afjwtToken, err := afjwt.Parse(sdJWT.JWTSerialized, afjwt.WithSignatureVerifier(verifier))
+		afjwtToken, err := afjwt.Parse(cfi.SDJWT, afjwt.WithSignatureVerifier(verifier))
 		r.NoError(err)
 
 		var parsedClaims map[string]interface{}


### PR DESCRIPTION
Fix: Presentation Without Holder Binding should end with ~

Also, rename SDJWT to CombinedPresentation and JWTSerialized to SDJWT to follow spec terms.

And add parsing and serializing of combined presentation parts with holder binding. 

Holder Binding functionality will be added in separate PRs. 

Closes #3467

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>

