### PR TITLE
feat: SD-JWT Issuer: Add Holder Public Key Claim (JWK)

### DIFF
--- a/pkg/doc/sdjwt/common/common.go
+++ b/pkg/doc/sdjwt/common/common.go
@@ -41,6 +41,8 @@ type Payload struct {
 	NotBefore *jwt.NumericDate `json:"nbf,omitempty"`
 	IssuedAt  *jwt.NumericDate `json:"iat,omitempty"`
 
+	CNF map[string]interface{} `json:"cnf,omitempty"`
+
 	SD    []string `json:"_sd,omitempty"`
 	SDAlg string   `json:"_sd_alg,omitempty"`
 }


### PR DESCRIPTION
If the Issuer wants to enable Holder Binding, it MAY include a public key associated with the Holder, or a reference thereto.

We use confirmation "cnf" claim to include raw public key by value in SD-JWT.

In this first iteration of "cnf" claim we will use "jwk" confirmation method and include public key information in JWK format. Other confirmation methods such as "jwe", "kid" and "jku" may be implemented at later time (if required).

Closes #3469 

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>

