### PR TITLE
chore: make some JWT related methods exportable

### DIFF
--- a/pkg/doc/verifiable/common.go
+++ b/pkg/doc/verifiable/common.go
@@ -80,8 +80,8 @@ func KeyTypeToJWSAlgo(keyType kmsapi.KeyType) (JWSAlgorithm, error) {
 	}
 }
 
-// name return the name of the signature algorithm.
-func (ja JWSAlgorithm) name() (string, error) {
+// Name return the name of the signature algorithm.
+func (ja JWSAlgorithm) Name() (string, error) {
 	switch ja {
 	case RS256:
 		return "RS256", nil

--- a/pkg/doc/verifiable/common_test.go
+++ b/pkg/doc/verifiable/common_test.go
@@ -19,16 +19,16 @@ import (
 )
 
 func TestJwtAlgorithm_Name(t *testing.T) {
-	alg, err := RS256.name()
+	alg, err := RS256.Name()
 	require.NoError(t, err)
 	require.Equal(t, "RS256", alg)
 
-	alg, err = EdDSA.name()
+	alg, err = EdDSA.Name()
 	require.NoError(t, err)
 	require.Equal(t, "EdDSA", alg)
 
 	// not supported alg
-	sa, err := JWSAlgorithm(-1).name()
+	sa, err := JWSAlgorithm(-1).Name()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported algorithm")
 	require.Empty(t, sa)

--- a/pkg/doc/verifiable/jws.go
+++ b/pkg/doc/verifiable/jws.go
@@ -24,7 +24,7 @@ type jwtSigner struct {
 	headers map[string]interface{}
 }
 
-func getJWTSigner(signer Signer, algorithm string) *jwtSigner {
+func GetJWTSigner(signer Signer, algorithm string) *jwtSigner {
 	headers := map[string]interface{}{
 		jose.HeaderAlgorithm: algorithm,
 	}
@@ -50,7 +50,7 @@ func (v noVerifier) Verify(_ jose.Headers, _, _, _ []byte) error {
 
 // MarshalJWS serializes JWT presentation claims into signed form (JWS).
 func marshalJWS(jwtClaims interface{}, signatureAlg JWSAlgorithm, signer Signer, keyID string) (string, error) {
-	algName, err := signatureAlg.name()
+	algName, err := signatureAlg.Name()
 	if err != nil {
 		return "", err
 	}
@@ -59,7 +59,7 @@ func marshalJWS(jwtClaims interface{}, signatureAlg JWSAlgorithm, signer Signer,
 		jose.HeaderKeyID: keyID,
 	}
 
-	token, err := jwt.NewSigned(jwtClaims, headers, getJWTSigner(signer, algName))
+	token, err := jwt.NewSigned(jwtClaims, headers, GetJWTSigner(signer, algName))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Signed-off-by: Mykhailo Sizov <mykhailo.sizov@securekey.com>


**Title:**
Made some JWT related methods exportable.

**Summary:**
To be able to use SD-JWT  package against VC in related repositories I need to have  methods `JWSAlgorithm.Name()` and `GetJWTSigner()` as exportable in order to refrain from code duplication.

