### PR TITLE
feat: SD-JWT Verifier: Verify Holder Binding

### DIFF
--- a/pkg/doc/jwt/jwt.go
+++ b/pkg/doc/jwt/jwt.go
@@ -287,7 +287,7 @@ func PayloadToMap(i interface{}) (map[string]interface{}, error) {
 	default:
 		b, err = json.Marshal(i)
 		if err != nil {
-			return nil, fmt.Errorf("convert to bytes: ")
+			return nil, fmt.Errorf("marshal interface[%T]: %w", i, err)
 		}
 	}
 

--- a/pkg/doc/jwt/jwt_test.go
+++ b/pkg/doc/jwt/jwt_test.go
@@ -453,7 +453,7 @@ func Test_toMap(t *testing.T) {
 	// pass invalid structure
 	resultMap, err = PayloadToMap(make(chan int))
 	r.Error(err)
-	r.Contains(err.Error(), "convert to bytes")
+	r.Contains(err.Error(), "marshal interface[chan int]: json: unsupported type: chan int")
 	r.Nil(resultMap)
 }
 

--- a/pkg/doc/sdjwt/holder/holder.go
+++ b/pkg/doc/sdjwt/holder/holder.go
@@ -8,7 +8,6 @@ package holder
 
 import (
 	"fmt"
-
 	"github.com/go-jose/go-jose/v3/jwt"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"

--- a/pkg/doc/sdjwt/issuer/issuer.go
+++ b/pkg/doc/sdjwt/issuer/issuer.go
@@ -159,7 +159,7 @@ func New(issuer string, claims interface{}, headers jose.Headers,
 
 	claimsMap, err := afgjwt.PayloadToMap(claims)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("convert payload to map: %w", err)
 	}
 
 	disclosures, err := createDisclosures(claimsMap, nOpts)
@@ -176,7 +176,7 @@ func New(issuer string, claims interface{}, headers jose.Headers,
 
 	signedJWT, err := afgjwt.NewSigned(payload, headers, signer)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create SD-JWT from payload[%+v]: %w", payload, err)
 	}
 
 	return &SelectiveDisclosureJWT{Disclosures: disclosures, SignedJWT: signedJWT}, nil


### PR DESCRIPTION
If Holder Binding is required, verify that the Holder Binding JWT is signed by the Holder and valid.

Closes #3471

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>

