### PR TITLE
chore: Rename DisclosureSeparator to CombinedFormatSeparator

### DIFF
--- a/pkg/doc/sdjwt/common/common.go
+++ b/pkg/doc/sdjwt/common/common.go
@@ -13,14 +13,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-jose/go-jose/v3/jwt"
-
 	afgjwt "github.com/hyperledger/aries-framework-go/pkg/doc/jwt"
 )
 
-// DisclosureSeparator is disclosure separator.
+// CombinedFormatSeparator is disclosure separator.
 const (
-	DisclosureSeparator = "~"
+	CombinedFormatSeparator = "~"
 
 	SDAlgorithmKey = "_sd_alg"
 	SDKey          = "_sd"
@@ -30,22 +28,6 @@ const (
 	nameIndex       = 1
 	valueIndex      = 2
 )
-
-// Payload represents SD-JWT payload.
-type Payload struct {
-	Issuer  string `json:"iss,omitempty"`
-	Subject string `json:"sub,omitempty"`
-	ID      string `json:"jti,omitempty"`
-
-	Expiry    *jwt.NumericDate `json:"exp,omitempty"`
-	NotBefore *jwt.NumericDate `json:"nbf,omitempty"`
-	IssuedAt  *jwt.NumericDate `json:"iat,omitempty"`
-
-	CNF map[string]interface{} `json:"cnf,omitempty"`
-
-	SD    []string `json:"_sd,omitempty"`
-	SDAlg string   `json:"_sd_alg,omitempty"`
-}
 
 // CombinedFormatForIssuance holds SD-JWT and disclosures.
 type CombinedFormatForIssuance struct {
@@ -57,7 +39,7 @@ type CombinedFormatForIssuance struct {
 func (cf *CombinedFormatForIssuance) Serialize() string {
 	presentation := cf.SDJWT
 	for _, disclosure := range cf.Disclosures {
-		presentation += DisclosureSeparator + disclosure
+		presentation += CombinedFormatSeparator + disclosure
 	}
 
 	return presentation
@@ -74,11 +56,11 @@ type CombinedFormatForPresentation struct {
 func (cf *CombinedFormatForPresentation) Serialize() string {
 	presentation := cf.SDJWT
 	for _, disclosure := range cf.Disclosures {
-		presentation += DisclosureSeparator + disclosure
+		presentation += CombinedFormatSeparator + disclosure
 	}
 
 	if len(cf.Disclosures) > 0 || cf.HolderBinding != "" {
-		presentation += DisclosureSeparator
+		presentation += CombinedFormatSeparator
 	}
 
 	presentation += cf.HolderBinding
@@ -144,7 +126,7 @@ func getDisclosureClaim(disclosure string) (*DisclosureClaim, error) {
 
 // ParseCombinedFormatForIssuance parses combined format for issuance into CombinedFormatForIssuance parts.
 func ParseCombinedFormatForIssuance(combinedFormatForIssuance string) *CombinedFormatForIssuance {
-	parts := strings.Split(combinedFormatForIssuance, DisclosureSeparator)
+	parts := strings.Split(combinedFormatForIssuance, CombinedFormatSeparator)
 
 	var disclosures []string
 	if len(parts) > 1 {
@@ -158,7 +140,7 @@ func ParseCombinedFormatForIssuance(combinedFormatForIssuance string) *CombinedF
 
 // ParseCombinedFormatForPresentation parses combined format for presentation into CombinedFormatForPresentation parts.
 func ParseCombinedFormatForPresentation(combinedFormatForPresentation string) *CombinedFormatForPresentation {
-	parts := strings.Split(combinedFormatForPresentation, DisclosureSeparator)
+	parts := strings.Split(combinedFormatForPresentation, CombinedFormatSeparator)
 
 	var disclosures []string
 	if len(parts) > 2 {

--- a/pkg/doc/sdjwt/holder/holder_test.go
+++ b/pkg/doc/sdjwt/holder/holder_test.go
@@ -122,7 +122,7 @@ func TestDiscloseClaims(t *testing.T) {
 		combinedFormatForPresentation, err := DiscloseClaims(combinedFormatForIssuance, []string{"given_name"})
 		r.NoError(err)
 		require.NotNil(t, combinedFormatForPresentation)
-		require.Equal(t, combinedFormatForIssuance+common.DisclosureSeparator, combinedFormatForPresentation)
+		require.Equal(t, combinedFormatForIssuance+common.CombinedFormatSeparator, combinedFormatForPresentation)
 	})
 
 	t.Run("success - with holder binding", func(t *testing.T) {
@@ -142,7 +142,7 @@ func TestDiscloseClaims(t *testing.T) {
 			}))
 		r.NoError(err)
 		r.NotEmpty(combinedFormatForPresentation)
-		r.Contains(combinedFormatForPresentation, combinedFormatForIssuance+common.DisclosureSeparator)
+		r.Contains(combinedFormatForPresentation, combinedFormatForIssuance+common.CombinedFormatSeparator)
 	})
 
 	t.Run("error - failed to create holder binding due to signing error", func(t *testing.T) {

--- a/pkg/doc/sdjwt/issuer/issuer.go
+++ b/pkg/doc/sdjwt/issuer/issuer.go
@@ -182,14 +182,14 @@ func New(issuer string, claims interface{}, headers jose.Headers,
 	return &SelectiveDisclosureJWT{Disclosures: disclosures, SignedJWT: signedJWT}, nil
 }
 
-func createPayload(issuer string, digests []string, nOpts *newOpts) *common.Payload {
+func createPayload(issuer string, digests []string, nOpts *newOpts) *payload {
 	var cnf map[string]interface{}
 	if nOpts.HolderPublicKey != nil {
 		cnf = make(map[string]interface{})
 		cnf["jwk"] = nOpts.HolderPublicKey
 	}
 
-	payload := &common.Payload{
+	payload := &payload{
 		Issuer:    issuer,
 		ID:        nOpts.ID,
 		Subject:   nOpts.Subject,
@@ -320,4 +320,20 @@ func generateSalt() (string, error) {
 
 	// it is RECOMMENDED to base64url-encode the salt value, producing a string.
 	return base64.RawURLEncoding.EncodeToString(salt), nil
+}
+
+// payload represents SD-JWT payload.
+type payload struct {
+	Issuer  string `json:"iss,omitempty"`
+	Subject string `json:"sub,omitempty"`
+	ID      string `json:"jti,omitempty"`
+
+	Expiry    *jwt.NumericDate `json:"exp,omitempty"`
+	NotBefore *jwt.NumericDate `json:"nbf,omitempty"`
+	IssuedAt  *jwt.NumericDate `json:"iat,omitempty"`
+
+	CNF map[string]interface{} `json:"cnf,omitempty"`
+
+	SD    []string `json:"_sd,omitempty"`
+	SDAlg string   `json:"_sd_alg,omitempty"`
 }

--- a/pkg/doc/sdjwt/issuer/issuer_test.go
+++ b/pkg/doc/sdjwt/issuer/issuer_test.go
@@ -247,7 +247,7 @@ func TestNew(t *testing.T) {
 		r.Nil(token)
 
 		r.Contains(err.Error(),
-			"unmarshallable claims: marshal interface[*common.Payload]: json: error calling MarshalJSON for type *jwk.JWK: go-jose/go-jose: unknown key type 'string'") //nolint:lll
+			"unmarshallable claims: marshal interface[*issuer.payload]: json: error calling MarshalJSON for type *jwk.JWK: go-jose/go-jose: unknown key type 'string'") //nolint:lll
 	})
 
 	t.Run("error - create decoy disclosures failed", func(t *testing.T) {

--- a/pkg/doc/sdjwt/verifier/verifier_test.go
+++ b/pkg/doc/sdjwt/verifier/verifier_test.go
@@ -50,7 +50,7 @@ func TestParse(t *testing.T) {
 	combinedFormatForIssuance, e := token.Serialize(false)
 	r.NoError(e)
 
-	combinedFormatForPresentation := combinedFormatForIssuance + common.DisclosureSeparator
+	combinedFormatForPresentation := combinedFormatForIssuance + common.CombinedFormatSeparator
 
 	verifier, e := afjwt.NewEd25519Verifier(pubKey)
 	r.NoError(e)
@@ -77,7 +77,7 @@ func TestParse(t *testing.T) {
 		rsaCombinedFormatForIssuance, err := rsaToken.Serialize(false)
 		require.NoError(t, err)
 
-		cfp := fmt.Sprintf("%s%s", rsaCombinedFormatForIssuance, common.DisclosureSeparator)
+		cfp := fmt.Sprintf("%s%s", rsaCombinedFormatForIssuance, common.CombinedFormatSeparator)
 
 		claims, err := Parse(cfp, WithSignatureVerifier(v))
 		r.NoError(err)
@@ -97,7 +97,7 @@ func TestParse(t *testing.T) {
 		cfIssuance, e := tokenWithTimes.Serialize(false)
 		r.NoError(e)
 
-		cfPresentation := fmt.Sprintf("%s%s", cfIssuance, common.DisclosureSeparator)
+		cfPresentation := fmt.Sprintf("%s%s", cfIssuance, common.CombinedFormatSeparator)
 
 		claims, err := Parse(cfPresentation, WithSignatureVerifier(verifier))
 		r.NoError(err)
@@ -182,7 +182,7 @@ func TestParse(t *testing.T) {
 		cfIssuance, e := tokenWithTimes.Serialize(false)
 		r.NoError(e)
 
-		cfPresentation := fmt.Sprintf("%s%s", cfIssuance, common.DisclosureSeparator)
+		cfPresentation := fmt.Sprintf("%s%s", cfIssuance, common.CombinedFormatSeparator)
 
 		claims, err := Parse(cfPresentation, WithSignatureVerifier(verifier))
 		r.Error(err)
@@ -201,7 +201,7 @@ func TestParse(t *testing.T) {
 		cfIssuance, e := tokenWithTimes.Serialize(false)
 		r.NoError(e)
 
-		cfPresentation := fmt.Sprintf("%s%s", cfIssuance, common.DisclosureSeparator)
+		cfPresentation := fmt.Sprintf("%s%s", cfIssuance, common.CombinedFormatSeparator)
 
 		claims, err := Parse(cfPresentation, WithSignatureVerifier(verifier))
 		r.Error(err)
@@ -520,7 +520,7 @@ func TestHolderBinding(t *testing.T) {
 		sdJWT, err := buildJWS(signer, claims)
 		r.NoError(err)
 
-		cfpWithInvalidCNF := sdJWT + common.DisclosureSeparator + cfp.HolderBinding
+		cfpWithInvalidCNF := sdJWT + common.CombinedFormatSeparator + cfp.HolderBinding
 
 		verifiedClaims, err := Parse(cfpWithInvalidCNF, WithSignatureVerifier(signatureVerifier))
 		r.Error(err)
@@ -554,7 +554,7 @@ func TestHolderBinding(t *testing.T) {
 		sdJWT, err := buildJWS(signer, claims)
 		r.NoError(err)
 
-		cfpWithInvalidCNF := sdJWT + common.DisclosureSeparator + cfp.HolderBinding
+		cfpWithInvalidCNF := sdJWT + common.CombinedFormatSeparator + cfp.HolderBinding
 
 		verifiedClaims, err := Parse(cfpWithInvalidCNF, WithSignatureVerifier(signatureVerifier))
 		r.Error(err)
@@ -588,7 +588,7 @@ func TestHolderBinding(t *testing.T) {
 		sdJWT, err := buildJWS(signer, claims)
 		r.NoError(err)
 
-		cfpWithInvalidCNF := sdJWT + common.DisclosureSeparator + cfp.HolderBinding
+		cfpWithInvalidCNF := sdJWT + common.CombinedFormatSeparator + cfp.HolderBinding
 
 		verifiedClaims, err := Parse(cfpWithInvalidCNF, WithSignatureVerifier(signatureVerifier))
 		r.Error(err)
@@ -622,7 +622,7 @@ func TestHolderBinding(t *testing.T) {
 		sdJWT, err := buildJWS(signer, claims)
 		r.NoError(err)
 
-		cfpWithInvalidCNF := sdJWT + common.DisclosureSeparator + cfp.HolderBinding
+		cfpWithInvalidCNF := sdJWT + common.CombinedFormatSeparator + cfp.HolderBinding
 
 		verifiedClaims, err := Parse(cfpWithInvalidCNF, WithSignatureVerifier(signatureVerifier))
 		r.Error(err)
@@ -660,7 +660,7 @@ func TestHolderBinding(t *testing.T) {
 		sdJWT, err := buildJWS(signer, claims)
 		r.NoError(err)
 
-		cfpWithInvalidCNF := sdJWT + common.DisclosureSeparator + cfp.HolderBinding
+		cfpWithInvalidCNF := sdJWT + common.CombinedFormatSeparator + cfp.HolderBinding
 
 		verifiedClaims, err := Parse(cfpWithInvalidCNF, WithSignatureVerifier(signatureVerifier))
 		r.Error(err)


### PR DESCRIPTION
Clean-up task:

- rename DisclosureSeparator to CombinedFormatSeparator
- move issuer Payload struct from common to issuer package

Closes #3476

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>

