### PR TITLE
fix: Release claims by claim disclosure not by claim name

### DIFF
--- a/pkg/doc/sdjwt/integration_test.go
+++ b/pkg/doc/sdjwt/integration_test.go
@@ -63,7 +63,8 @@ func TestSDJWTFlow(t *testing.T) {
 		r.Equal(2, len(claims))
 
 		// Holder will disclose only sub-set of claims to verifier.
-		combinedFormatForPresentation, err := holder.DiscloseClaims(combinedFormatForIssuance, []string{"given_name"})
+		combinedFormatForPresentation, err := holder.CreatePresentation(combinedFormatForIssuance,
+			[]string{claims[0].Disclosure})
 		r.NoError(err)
 
 		fmt.Println(fmt.Sprintf("holder SD-JWT: %s", combinedFormatForPresentation))
@@ -110,7 +111,8 @@ func TestSDJWTFlow(t *testing.T) {
 		const testNonce = "nonce"
 
 		// Holder will disclose only sub-set of claims to verifier and add holder binding.
-		combinedFormatForPresentation, err := holder.DiscloseClaims(combinedFormatForIssuance, []string{"given_name"},
+		combinedFormatForPresentation, err := holder.CreatePresentation(combinedFormatForIssuance,
+			[]string{claims[0].Disclosure},
 			holder.WithHolderBinding(&holder.BindingInfo{
 				Payload: holder.BindingPayload{
 					Nonce:    testNonce,


### PR DESCRIPTION
Currently the holder releases disclosures based on claim name. If we have same name in different objects within claims this will not work.

Closes #3484

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>

