### PR TITLE
feat: SD-JWT: Add option for non-selectively disclosable claims (issuer)

### DIFF
--- a/pkg/doc/sdjwt/common/common.go
+++ b/pkg/doc/sdjwt/common/common.go
@@ -337,7 +337,7 @@ func GetDisclosureDigests(claims map[string]interface{}) (map[string]bool, error
 		return nil, fmt.Errorf("get disclosure digests: %w", err)
 	}
 
-	return sliceToMap(disclosures), nil
+	return SliceToMap(disclosures), nil
 }
 
 // GetDisclosedClaims returns disclosed claims only.
@@ -414,7 +414,8 @@ func stringArray(entry interface{}) ([]string, error) {
 	return result, nil
 }
 
-func sliceToMap(ids []string) map[string]bool {
+// SliceToMap converts slice to map.
+func SliceToMap(ids []string) map[string]bool {
 	// convert slice to map
 	values := make(map[string]bool)
 	for _, id := range ids {

--- a/pkg/doc/sdjwt/holder/holder.go
+++ b/pkg/doc/sdjwt/holder/holder.go
@@ -139,7 +139,7 @@ func CreatePresentation(combinedFormatForIssuance string, claimsToDisclose []str
 		return "", fmt.Errorf("no disclosures found in SD-JWT")
 	}
 
-	disclosuresMap := sliceToMap(cfi.Disclosures)
+	disclosuresMap := common.SliceToMap(cfi.Disclosures)
 
 	for _, ctd := range claimsToDisclose {
 		if _, ok := disclosuresMap[ctd]; !ok {
@@ -175,16 +175,6 @@ func CreateHolderBinding(info *BindingInfo) (string, error) {
 	}
 
 	return hbJWT.Serialize(false)
-}
-
-func sliceToMap(ids []string) map[string]bool {
-	// convert slice to map
-	values := make(map[string]bool)
-	for _, id := range ids {
-		values[id] = true
-	}
-
-	return values
 }
 
 // NoopSignatureVerifier is no-op signature verifier (signature will not get checked).

--- a/pkg/doc/sdjwt/integration_test.go
+++ b/pkg/doc/sdjwt/integration_test.go
@@ -381,9 +381,10 @@ func TestSDJWTFlow(t *testing.T) {
 		r.NoError(err)
 
 		token, err := issuer.NewFromVC(vc, nil, signer,
-			issuer.WithID("did:example:ebfeb1f712ebc6f1c276e12ec21"),
 			issuer.WithHolderPublicKey(holderPublicJWK),
-			issuer.WithStructuredClaims(true))
+			issuer.WithStructuredClaims(true),
+			issuer.WithNonSelectivelyDisclosableClaims([]string{"id", "degree.type"}),
+		)
 		r.NoError(err)
 
 		var decoded map[string]interface{}
@@ -410,7 +411,7 @@ func TestSDJWTFlow(t *testing.T) {
 
 		holderSigner := afjwt.NewEd25519Signer(holderPrivateKey)
 
-		selectedDisclosures := getDisclosuresFromClaimNames([]string{"degree", "name", "spouse"}, claims)
+		selectedDisclosures := getDisclosuresFromClaimNames([]string{"degree", "id", "name"}, claims)
 
 		// Holder will disclose only sub-set of claims to verifier.
 		combinedFormatForPresentation, err := holder.CreatePresentation(vcCombinedFormatForIssuance, selectedDisclosures,
@@ -551,8 +552,10 @@ const sampleVCFull = `
 		"credentialSubject": {
 			"degree": {
 				"degree": "MIT",
-				"type": "BachelorDegree"
+				"type": "BachelorDegree",
+				"id": "some-id"
 			},
+			"id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
 			"name": "Jayden Doe",
 			"spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
 		},


### PR DESCRIPTION
From spec: The Issuer may also make certain claims or sub-claims non-selectively disclosable. 

Added option WithNonSelectivelyDisclosableClaims() for specifying non-selectively disclosable claims to issuer.

Closes: #3497

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>

