### PR TITLE
chore: Additional hash algorithms; check for _sd claim

### DIFF
--- a/pkg/doc/sdjwt/common/common.go
+++ b/pkg/doc/sdjwt/common/common.go
@@ -256,11 +256,18 @@ func GetCryptoHash(sdAlg string) (crypto.Hash, error) {
 
 	var cryptoHash crypto.Hash
 
+	// From spec: the hash algorithms MD2, MD4, MD5, RIPEMD-160, and SHA-1 revealed fundamental weaknesses
+	// and they MUST NOT be used.
+
 	switch strings.ToUpper(sdAlg) {
 	case crypto.SHA256.String():
 		cryptoHash = crypto.SHA256
+	case crypto.SHA384.String():
+		cryptoHash = crypto.SHA384
+	case crypto.SHA512.String():
+		cryptoHash = crypto.SHA512
 	default:
-		err = fmt.Errorf("%s '%s 'not supported", SDAlgorithmKey, sdAlg)
+		err = fmt.Errorf("%s '%s' not supported", SDAlgorithmKey, sdAlg)
 	}
 
 	return cryptoHash, err

--- a/pkg/doc/sdjwt/common/common_test.go
+++ b/pkg/doc/sdjwt/common/common_test.go
@@ -237,7 +237,7 @@ func TestVerifyDisclosuresInSDJWT(t *testing.T) {
 
 		err = VerifyDisclosuresInSDJWT(nil, signedJWT)
 		r.Error(err)
-		r.Contains(err.Error(), "_sd_alg 'SHA-XXX 'not supported")
+		r.Contains(err.Error(), "_sd_alg 'SHA-XXX' not supported")
 	})
 
 	t.Run("error - algorithm is not a string", func(t *testing.T) {
@@ -443,6 +443,31 @@ func TestGetDisclosedClaims(t *testing.T) {
 
 		r.Contains(err.Error(),
 			"hash function not available for: 0")
+	})
+}
+
+func TestGetCryptoHash(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("success", func(t *testing.T) {
+		hash, err := GetCryptoHash("sha-256")
+		r.NoError(err)
+		r.Equal(crypto.SHA256, hash)
+
+		hash, err = GetCryptoHash("sha-384")
+		r.NoError(err)
+		r.Equal(crypto.SHA384, hash)
+
+		hash, err = GetCryptoHash("sha-512")
+		r.NoError(err)
+		r.Equal(crypto.SHA512, hash)
+	})
+
+	t.Run("error - not supported", func(t *testing.T) {
+		hash, err := GetCryptoHash("invalid")
+		r.Error(err)
+		r.Equal(crypto.Hash(0), hash)
+		r.Contains(err.Error(), "_sd_alg 'invalid' not supported")
 	})
 }
 

--- a/pkg/doc/sdjwt/integration_test.go
+++ b/pkg/doc/sdjwt/integration_test.go
@@ -8,6 +8,7 @@ package sdjwt
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
@@ -111,6 +112,7 @@ func TestSDJWTFlow(t *testing.T) {
 
 		// Issuer will issue SD-JWT for specified claims and holder public key.
 		token, err := issuer.New(testIssuer, claims, nil, signer,
+			issuer.WithHashAlgorithm(crypto.SHA512),
 			issuer.WithNotBefore(jwt.NewNumericDate(now)),
 			issuer.WithIssuedAt(jwt.NewNumericDate(now)),
 			issuer.WithExpiry(jwt.NewNumericDate(now.Add(year))),


### PR DESCRIPTION
Add SHA-384 and SHA-512 algorithms to SHA-256.
Also, check for _sd claim in claims before creating SD-JWT.

Closes #3502

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>
