### PR TITLE
feat: Credential.MarshalJSON now marshals all SD-JWT disclosures

### DIFF
--- a/pkg/doc/verifiable/credential.go
+++ b/pkg/doc/verifiable/credential.go
@@ -1662,6 +1662,15 @@ func typedIDsToRaw(typedIDs []TypedID) ([]byte, error) {
 // MarshalJSON converts Verifiable Credential to JSON bytes.
 func (vc *Credential) MarshalJSON() ([]byte, error) {
 	if vc.JWT != "" {
+		if vc.SDJWTHashAlg != "" {
+			sdJWT, err := vc.MarshalWithDisclosure(DiscloseAll())
+			if err != nil {
+				return nil, err
+			}
+
+			return []byte("\"" + sdJWT + "\""), nil
+		}
+
 		// If vc.JWT exists, marshal only the JWT, since all other values should be unchanged
 		// from when the JWT was parsed.
 		return []byte("\"" + vc.JWT + "\""), nil

--- a/pkg/doc/verifiable/credential_sdjwt.go
+++ b/pkg/doc/verifiable/credential_sdjwt.go
@@ -110,8 +110,9 @@ func filterSDJWTVC(vc *Credential, options *marshalDisclosureOpts) (string, erro
 	}
 
 	cf := common.CombinedFormatForPresentation{
-		SDJWT:       vc.JWT,
-		Disclosures: disclosureCodes,
+		SDJWT:         vc.JWT,
+		Disclosures:   disclosureCodes,
+		HolderBinding: vc.SDHolderBinding,
 	}
 
 	if options.holderBinding != nil {


### PR DESCRIPTION
Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>