### PR TITLE
chore: decode presentation credential in SD JWT format

### DIFF
--- a/pkg/doc/verifiable/presentation.go
+++ b/pkg/doc/verifiable/presentation.go
@@ -493,6 +493,7 @@ func decodeCredentials(rawCred interface{}, opts *presentationOpts) ([]interface
 			bCred := []byte(sCred)
 
 			credOpts := []CredentialOpt{
+				WithSDJWTPresentation(),
 				WithPublicKeyFetcher(opts.publicKeyFetcher),
 				WithEmbeddedSignatureSuites(opts.ldpSuites...),
 				WithJSONLDDocumentLoader(opts.jsonldCredentialOpts.jsonldDocumentLoader),


### PR DESCRIPTION
Signed-off-by: Mykhailo Sizov <mykhailo.sizov@securekey.com>


**Title:**
Fix decoding presentation credential in SD JWT combined format for presentation.

