### PR TITLE
feat: ParseCredential recognizes if SD-JWT VC is issuance or presentation

### DIFF
--- a/pkg/doc/verifiable/credential_sdjwt_test.go
+++ b/pkg/doc/verifiable/credential_sdjwt_test.go
@@ -58,18 +58,16 @@ func TestParseSDJWT(t *testing.T) {
 		require.NoError(t, e)
 
 		newVC, e := ParseCredential([]byte(modifiedCred),
-			WithPublicKeyFetcher(createDIDKeyFetcher(t, ed25519Signer.PublicKeyBytes(), issuerID)),
-			WithSDJWTPresentation())
+			WithPublicKeyFetcher(createDIDKeyFetcher(t, ed25519Signer.PublicKeyBytes(), issuerID)))
 		require.NoError(t, e)
 		require.NotNil(t, newVC)
 	})
 
 	t.Run("success with mock holder binding", func(t *testing.T) {
-		mockHolderBinding := "<mock holder binding>"
+		mockHolderBinding := "e30.e30.mockHolderBinding"
 
 		newVC, e := ParseCredential([]byte(sdJWTString+common.CombinedFormatSeparator+mockHolderBinding),
-			WithPublicKeyFetcher(createDIDKeyFetcher(t, pubKey, issuerID)),
-			WithSDJWTPresentation())
+			WithPublicKeyFetcher(createDIDKeyFetcher(t, pubKey, issuerID)))
 		require.NoError(t, e)
 		require.Equal(t, mockHolderBinding, newVC.SDHolderBinding)
 	})

--- a/pkg/doc/verifiable/credential_test.go
+++ b/pkg/doc/verifiable/credential_test.go
@@ -733,7 +733,7 @@ func TestCredential_MarshalJSON(t *testing.T) {
 
 		// convert SD-JWT json string to verifiable credential
 		cred2, err := ParseCredential(byteCred,
-			WithPublicKeyFetcher(createDIDKeyFetcher(t, pubKey, issuerID)), WithSDJWTPresentation())
+			WithPublicKeyFetcher(createDIDKeyFetcher(t, pubKey, issuerID)))
 		require.NoError(t, err)
 		require.NotEmpty(t, cred2)
 

--- a/pkg/doc/verifiable/presentation.go
+++ b/pkg/doc/verifiable/presentation.go
@@ -493,7 +493,6 @@ func decodeCredentials(rawCred interface{}, opts *presentationOpts) ([]interface
 			bCred := []byte(sCred)
 
 			credOpts := []CredentialOpt{
-				WithSDJWTPresentation(),
 				WithPublicKeyFetcher(opts.publicKeyFetcher),
 				WithEmbeddedSignatureSuites(opts.ldpSuites...),
 				WithJSONLDDocumentLoader(opts.jsonldCredentialOpts.jsonldDocumentLoader),


### PR DESCRIPTION
without needing the caller to specify.

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>