### PR TITLE
fix: ParseCredential handles SD-JWT VCs with _sd_alg in subject

### DIFF
--- a/pkg/doc/verifiable/credential_sdjwt.go
+++ b/pkg/doc/verifiable/credential_sdjwt.go
@@ -393,3 +393,20 @@ func clearEmpty(claims map[string]interface{}) {
 		}
 	}
 }
+
+func getSubKey(object map[string]interface{}, key string) (interface{}, error) {
+	for name, value := range object {
+		if name == key {
+			return value, nil
+		}
+
+		if valueObj, ok := value.(map[string]interface{}); ok {
+			res, err := getSubKey(valueObj, key)
+			if err == nil {
+				return res, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("key '%s' not found in given map or children", key)
+}

--- a/pkg/doc/verifiable/credential_sdjwt_test.go
+++ b/pkg/doc/verifiable/credential_sdjwt_test.go
@@ -61,6 +61,7 @@ func TestParseSDJWT(t *testing.T) {
 			WithPublicKeyFetcher(createDIDKeyFetcher(t, ed25519Signer.PublicKeyBytes(), issuerID)))
 		require.NoError(t, e)
 		require.NotNil(t, newVC)
+		require.Equal(t, vc.stringJSON(t), newVC.stringJSON(t))
 	})
 
 	t.Run("success with mock holder binding", func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>