### PR TITLE
chore: Add audience option to issuer

### DIFF
--- a/pkg/doc/presexch/definition_test.go
+++ b/pkg/doc/presexch/definition_test.go
@@ -522,7 +522,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 
 		require.Len(t, vc.SDJWTDisclosures, 3)
 
-		require.Len(t, vc.Subject.([]verifiable.Subject)[0].CustomFields["_sd"].([]interface{}), 7)
+		require.Len(t, vc.Subject.([]verifiable.Subject)[0].CustomFields["_sd"].([]interface{}), 6)
 		require.NotNil(t, vc.Subject.([]verifiable.Subject)[0].CustomFields["address"])
 
 		_, ok = vc.Subject.([]verifiable.Subject)[0].CustomFields["email"]
@@ -593,7 +593,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 
 		require.Len(t, vc.SDJWTDisclosures, 3)
 
-		require.Len(t, vc.Subject.([]verifiable.Subject)[0].CustomFields["_sd"].([]interface{}), 7)
+		require.Len(t, vc.Subject.([]verifiable.Subject)[0].CustomFields["_sd"].([]interface{}), 6)
 		require.NotNil(t, vc.Subject.([]verifiable.Subject)[0].CustomFields["address"])
 
 		_, ok = vc.Subject.([]verifiable.Subject)[0].CustomFields["email"]
@@ -652,7 +652,7 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 		// there is only one non-SD claim path is in the fields array - hence no selective disclosures
 		require.Len(t, vc.SDJWTDisclosures, 0)
 
-		require.Len(t, vc.Subject.([]verifiable.Subject)[0].CustomFields["_sd"].([]interface{}), 7)
+		require.Len(t, vc.Subject.([]verifiable.Subject)[0].CustomFields["_sd"].([]interface{}), 6)
 
 		displayVC, err := vc.CreateDisplayCredential(verifiable.DisplayAllDisclosures())
 		require.NoError(t, err)
@@ -705,9 +705,9 @@ func TestPresentationDefinition_CreateVP(t *testing.T) {
 		vc, ok := vp.Credentials()[0].(*verifiable.Credential)
 		require.True(t, ok)
 
-		require.Len(t, vc.SDJWTDisclosures, 11)
+		require.Len(t, vc.SDJWTDisclosures, 10)
 
-		require.Len(t, vc.Subject.([]verifiable.Subject)[0].CustomFields["_sd"].([]interface{}), 7)
+		require.Len(t, vc.Subject.([]verifiable.Subject)[0].CustomFields["_sd"].([]interface{}), 6)
 		require.NotNil(t, vc.Subject.([]verifiable.Subject)[0].CustomFields["address"])
 
 		_, ok = vc.Subject.([]verifiable.Subject)[0].CustomFields["email"]

--- a/pkg/doc/sdjwt/issuer/issuer.go
+++ b/pkg/doc/sdjwt/issuer/issuer.go
@@ -44,9 +44,10 @@ type Claims jwt.Claims
 
 // newOpts holds options for creating new SD-JWT.
 type newOpts struct {
-	Subject string
-	JTI     string
-	ID      string
+	Subject  string
+	Audience string
+	JTI      string
+	ID       string
 
 	Expiry    *jwt.NumericDate
 	NotBefore *jwt.NumericDate
@@ -86,6 +87,13 @@ func WithSaltFnc(fnc func() (string, error)) NewOpt {
 func WithIssuedAt(issuedAt *jwt.NumericDate) NewOpt {
 	return func(opts *newOpts) {
 		opts.IssuedAt = issuedAt
+	}
+}
+
+// WithAudience is an option for SD-JWT payload.
+func WithAudience(audience string) NewOpt {
+	return func(opts *newOpts) {
+		opts.Audience = audience
 	}
 }
 
@@ -277,6 +285,7 @@ func createPayload(issuer string, nOpts *newOpts) *payload {
 		JTI:       nOpts.JTI,
 		ID:        nOpts.ID,
 		Subject:   nOpts.Subject,
+		Audience:  nOpts.Audience,
 		IssuedAt:  nOpts.IssuedAt,
 		Expiry:    nOpts.Expiry,
 		NotBefore: nOpts.NotBefore,
@@ -464,18 +473,21 @@ func keyExistsInMap(key string, claims map[string]interface{}) bool {
 
 // payload represents SD-JWT payload.
 type payload struct {
-	Issuer  string `json:"iss,omitempty"`
-	Subject string `json:"sub,omitempty"`
-	ID      string `json:"id,omitempty"`
-	JTI     string `json:"jti,omitempty"`
-
+	// registered claim names
+	Issuer    string           `json:"iss,omitempty"`
+	Subject   string           `json:"sub,omitempty"`
+	Audience  string           `json:"aud,omitempty"`
+	JTI       string           `json:"jti,omitempty"`
 	Expiry    *jwt.NumericDate `json:"exp,omitempty"`
 	NotBefore *jwt.NumericDate `json:"nbf,omitempty"`
 	IssuedAt  *jwt.NumericDate `json:"iat,omitempty"`
 
-	CNF map[string]interface{} `json:"cnf,omitempty"`
+	// non-registered name that can be used for claims based holder binding
+	ID string `json:"id,omitempty"`
 
-	SDAlg string `json:"_sd_alg,omitempty"`
+	// SD-JWT specific
+	CNF   map[string]interface{} `json:"cnf,omitempty"`
+	SDAlg string                 `json:"_sd_alg,omitempty"`
 }
 
 type unsecuredJWTSigner struct{}

--- a/pkg/doc/sdjwt/issuer/issuer_test.go
+++ b/pkg/doc/sdjwt/issuer/issuer_test.go
@@ -158,6 +158,7 @@ func TestNew(t *testing.T) {
 			WithJTI("jti"),
 			WithID("id"),
 			WithSubject("subject"),
+			WithAudience("audience"),
 			WithSaltFnc(generateSalt),
 			WithJSONMarshaller(json.Marshal),
 			WithHashAlgorithm(crypto.SHA256),
@@ -177,13 +178,23 @@ func TestNew(t *testing.T) {
 		err = verifyEd25519ViaGoJose(cfi.SDJWT, pubKey, &parsedClaims)
 		r.NoError(err)
 
-		parsedClaimsBytes, err := json.Marshal(parsedClaims)
-		require.NoError(t, err)
+		printObject(t, "Parsed Claims:", parsedClaims)
 
-		prettyJSON, err := prettyPrint(parsedClaimsBytes)
-		require.NoError(t, err)
+		r.Equal(issuer, parsedClaims["iss"])
+		r.Equal("audience", parsedClaims["aud"])
+		r.Equal("subject", parsedClaims["sub"])
+		r.Equal("id", parsedClaims["id"])
+		r.Equal("jti", parsedClaims["jti"])
+		r.Equal("sha-256", parsedClaims["_sd_alg"])
 
-		fmt.Println(prettyJSON)
+		_, ok := parsedClaims["nbf"]
+		r.True(ok)
+
+		_, ok = parsedClaims["iat"]
+		r.True(ok)
+
+		_, ok = parsedClaims["exp"]
+		r.True(ok)
 
 		err = verifyEd25519(cfi.SDJWT, pubKey)
 		r.NoError(err)

--- a/pkg/doc/sdjwt/verifier/verifier_test.go
+++ b/pkg/doc/sdjwt/verifier/verifier_test.go
@@ -555,7 +555,7 @@ func TestHolderBinding(t *testing.T) {
 
 		claims := make(map[string]interface{})
 		claims["cnf"] = "abc"
-		claims["_sd_alg"] = testSDAlg // TODO: Should alg be mandatory if there are no selective disclosures
+		claims["_sd_alg"] = testSDAlg
 
 		sdJWT, err := buildJWS(signer, claims)
 		r.NoError(err)


### PR DESCRIPTION
Included:
- resolve merge conflict in unit-tests between Filip's id PR and add SD-JWT to presexch PR
- add audience option to issuer
- remove irrelevant to-do(s)
- remove one integration test (was replaced by NewFromVC)
- add sha-384 to integration tests

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>

