### PR TITLE
chore: Additional validation when creating disclosed claims (verifier)

### DIFF
--- a/pkg/doc/sdjwt/issuer/issuer.go
+++ b/pkg/doc/sdjwt/issuer/issuer.go
@@ -200,7 +200,7 @@ func New(issuer string, claims interface{}, headers jose.Headers,
 	}
 
 	// check for the presence of the _sd claim in claims map
-	found := keyExistsInMap(common.SDKey, claimsMap)
+	found := common.KeyExistsInMap(common.SDKey, claimsMap)
 	if found {
 		return nil, fmt.Errorf("key '%s' cannot be present in the claims", common.SDKey)
 	}
@@ -452,23 +452,6 @@ func generateSalt() (string, error) {
 
 	// it is RECOMMENDED to base64url-encode the salt value, producing a string.
 	return base64.RawURLEncoding.EncodeToString(salt), nil
-}
-
-func keyExistsInMap(key string, claims map[string]interface{}) bool {
-	for k, v := range claims {
-		if k == key {
-			return true
-		}
-
-		if obj, ok := v.(map[string]interface{}); ok {
-			exists := keyExistsInMap(key, obj)
-			if exists {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 // payload represents SD-JWT payload.


### PR DESCRIPTION
Additional validation when processing disclosures to assemble disclosed claims:

- If there is more than one place where the digest is included, the Verifier MUST reject the Presentation.
- If the claim name already exists at the same level, the Verifier MUST reject the Presentation.
- If the claim value contains an object with an _sd key (at the top level or nested deeper), the Verifier MUST reject the Presentation.

Closes #3519


