### PR TITLE
feat: embed claim format designations

### DIFF
--- a/pkg/doc/presexch/schema.go
+++ b/pkg/doc/presexch/schema.go
@@ -538,8 +538,35 @@ const DefinitionJSONSchemaV2 = `
         "name": { "type": "string" },
         "purpose": { "type": "string" },
         "format": {
-          "$ref": "http://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json"
-        },
+		  "$schema": "http://json-schema.org/draft-07/schema#",
+		  "title": "Presentation Definition Claim Format Designations",
+		  "type": "object",
+		  "additionalProperties": false,
+		  "patternProperties": {
+			"^jwt$|^jwt_vc$|^jwt_vp$": {
+			  "type": "object",
+			  "additionalProperties": false,
+			  "properties": {
+				"alg": {
+				  "type": "array",
+				  "minItems": 1,
+				  "items": { "type": "string" }
+				}
+			  }
+			},
+			"^ldp_vc$|^ldp_vp$|^ldp$": {
+			  "type": "object",
+			  "additionalProperties": false,
+			  "properties": {
+				"proof_type": {
+				  "type": "array",
+				  "minItems": 1,
+				  "items": { "type": "string" }
+				}
+			  }
+			}
+		  }
+		},
         "group": { "type": "array", "items": { "type": "string" } },
         "constraints": {
           "type": "object",
@@ -651,8 +678,35 @@ const DefinitionJSONSchemaV2 = `
         "name": { "type": "string" },
         "purpose": { "type": "string" },
         "format": {
-          "$ref": "http://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json#"
-        },
+		  "$schema": "http://json-schema.org/draft-07/schema#",
+		  "title": "Presentation Definition Claim Format Designations",
+		  "type": "object",
+		  "additionalProperties": false,
+		  "patternProperties": {
+			"^jwt$|^jwt_vc$|^jwt_vp$": {
+			  "type": "object",
+			  "additionalProperties": false,
+			  "properties": {
+				"alg": {
+				  "type": "array",
+				  "minItems": 1,
+				  "items": { "type": "string" }
+				}
+			  }
+			},
+			"^ldp_vc$|^ldp_vp$|^ldp$": {
+			  "type": "object",
+			  "additionalProperties": false,
+			  "properties": {
+				"proof_type": {
+				  "type": "array",
+				  "minItems": 1,
+				  "items": { "type": "string" }
+				}
+			  }
+			}
+		  }
+		},
         "frame": {
           "type": "object",
           "additionalProperties": true


### PR DESCRIPTION
Signed-off-by: Stas D <stanislav.dmytryshyn@securekey.com>

During stress testing for vcs, we realized some slowness inside CreateVP method.
After some research, we find out that the performance issue is related to gojsonschema as it will request https://identity.foundation/claim-format-registry/schemas/presentation-definition-claim-format-designations.json every time https://github.com/xeipuuv/gojsonschema/blob/b076d39a02e5015af0a2a96636e4cc479ecd9f45/jsonLoader.go#L188

gojsonschema, by default, has a possibility to cache some records, https://github.com/xeipuuv/gojsonschema/blob/b076d39a02e5015af0a2a96636e4cc479ecd9f45/draft.go but there is no possibility to add additional records to the cache.

also with the current approach we have one additional failure point (if identity.foundation fails - our code will also fail), so embedding content inside will also remove that failure point
