### PR TITLE
ci: complete release 0.1.9 and prepare 0.2.0

### DIFF
--- a/.github/workflows/version_var.sh
+++ b/.github/workflows/version_var.sh
@@ -5,7 +5,7 @@
 #
 
 # Release Parameters
-BASE_VERSION=0.1.9
+BASE_VERSION=0.2.0
 IS_RELEASE=false
 
 ARCH=$(go env GOARCH)


### PR DESCRIPTION
https://github.com/hyperledger/aries-framework-go/releases/tag/v0.1.9