### PR TITLE
fix: Wallet query multi-descriptor fix

### DIFF
--- a/pkg/doc/presexch/definition.go
+++ b/pkg/doc/presexch/definition.go
@@ -1216,7 +1216,7 @@ func merge(presentationFormat string, setOfCredentials map[string][]*verifiable.
 			if _, ok := setOfCreds[credential.ID]; !ok {
 				credential.ID = trimTmpID(credential.ID)
 				result = append(result, credential)
-				setOfCreds[credential.ID] = len(descriptors)
+				setOfCreds[credential.ID] = len(result) - 1
 			}
 
 			vcFormat := FormatLDPVC

--- a/pkg/internal/ldtestutil/contexts/third_party/w3c-ccg.github.io/revocation-list-2021.jsonld
+++ b/pkg/internal/ldtestutil/contexts/third_party/w3c-ccg.github.io/revocation-list-2021.jsonld
@@ -1,0 +1,50 @@
+{
+  "@context": {
+    "@protected": true,
+    "StatusList2021Credential": {
+      "@id": "https://w3id.org/vc/status-list#StatusList2021Credential",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "description": "http://schema.org/description",
+        "name": "http://schema.org/name"
+      }
+    },
+    "RevocationList2021": {
+      "@id": "https://w3id.org/vc/status-list#RevocationList2021",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "encodedList": "https://w3id.org/vc/status-list#encodedList"
+      }
+    },
+    "RevocationList2021Status": {
+      "@id": "https://w3id.org/vc/status-list#RevocationList2021Status",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "statusListCredential": {
+          "@id": "https://w3id.org/vc/status-list#statusListCredential",
+          "@type": "@id"
+        },
+        "statusListIndex": "https://w3id.org/vc/status-list#statusListIndex"
+      }
+    },
+    "SuspensionList2021Status": {
+      "@id": "https://w3id.org/vc/status-list#SuspensionList2021Status",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "statusListCredential": {
+          "@id": "https://w3id.org/vc/status-list#statusListCredential",
+          "@type": "@id"
+        },
+        "statusListIndex": "https://w3id.org/vc/status-list#statusListIndex"
+      }
+    }
+  }
+}

--- a/pkg/internal/ldtestutil/document_loader.go
+++ b/pkg/internal/ldtestutil/document_loader.go
@@ -24,6 +24,8 @@ import (
 var (
 	//go:embed contexts/third_party/w3c-ccg.github.io/citizenship_v1.jsonld
 	citizenship []byte
+	//go:embed contexts/third_party/w3c-ccg.github.io/revocation-list-2021.jsonld
+	revocationList2021 []byte
 	//go:embed contexts/third_party/w3.org/odrl.jsonld
 	odrl []byte
 	//go:embed contexts/third_party/w3.org/credentials-examples_v1.jsonld
@@ -55,6 +57,11 @@ var testContexts = []ldcontext.Document{ //nolint:gochecknoglobals // embedded t
 	{
 		URL:     "https://trustbloc.github.io/context/vc/authorization-credential-v1.jsonld",
 		Content: authCred,
+	},
+	{
+		URL:         "https://w3c-ccg.github.io/vc-revocation-list-2021/contexts/v1.jsonld",
+		DocumentURL: "https://raw.githubusercontent.com/w3c-ccg/vc-status-list-2021/343b8b59cddba4525e1ef355356ae760fc75904e/contexts/v1.jsonld", //nolint:lll
+		Content:     revocationList2021,
 	},
 }
 


### PR DESCRIPTION
If we have two input descriptors with two credentials and one descriptor is satisfied with two credentials then we have failure depending on the order of processing.

Closes #3543



