### PR TITLE
chore: Remove test without loader for domain linkage

### DIFF
--- a/pkg/doc/didconfig/didconfig_test.go
+++ b/pkg/doc/didconfig/didconfig_test.go
@@ -53,10 +53,12 @@ func TestParseLinkedData(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	/* This test is accessing remote URL, and it is often failing in CI.
 	t.Run("success - default options", func(t *testing.T) {
 		err := VerifyDIDAndDomain([]byte(didCfgLinkedData), testDID, testDomain)
 		require.NoError(t, err)
 	})
+	*/
 
 	t.Run("success - loader provided", func(t *testing.T) {
 		err := VerifyDIDAndDomain([]byte(didCfgLinkedData), testDID, testDomain,


### PR DESCRIPTION
This test is accessing remote URL, and it is often failing in CI.

Closes #3548


