### PR TITLE
ci: update ubuntu runner to 22.04 as 18.4 is deprecated in GitHub Actions

### DIFF
--- a/.github/workflows/bbs-interop.yml
+++ b/.github/workflows/bbs-interop.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   bbsInteropTest:
     name: BBS+ interop test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ubuntu-18.04, macOS-10.15]
+        os: [ubuntu-22.04, macOS-10.15]
     steps:
 
     - name: Setup Go 1.19
@@ -37,14 +37,14 @@ jobs:
 
     - name: Upload coverage to Codecov
       timeout-minutes: 10
-      if: matrix.os == 'ubuntu-18.04' && github.repository == 'hyperledger/aries-framework-go'
+      if: matrix.os == 'ubuntu-22.04' && github.repository == 'hyperledger/aries-framework-go'
       uses: codecov/codecov-action@v2.1.0
       with:
         file: ./coverage.out
 
   unitTestUrsa:
     name: Unit test (Ursa/CL)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/hyperledger/ursa-wrapper-go/uwg-build # a container with libursa installed
     timeout-minutes: 15
@@ -63,7 +63,7 @@ jobs:
 
   unitTestMobile:
     name: Unit test (mobile)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
 
@@ -81,7 +81,7 @@ jobs:
 
   unitTestWasm:
     name: Unit test wasm
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
 
@@ -99,7 +99,7 @@ jobs:
 
   bddTest:
     name: BDD test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
 
@@ -129,7 +129,7 @@ jobs:
 
   repoLint:
     name: repolint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: repolinter
@@ -140,7 +140,7 @@ jobs:
   checks:
     name: Checks
     timeout-minutes: 10
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Setup Go 1.19
         uses: actions/setup-go@v2
@@ -157,7 +157,7 @@ jobs:
     name: Publish images and npm packages
     if: github.event_name == 'push' && ((github.repository == 'hyperledger/aries-framework-go' && github.ref == 'refs/heads/main') || (github.repository != 'hyperledger/aries-framework-go' && github.ref == 'refs/heads/afg-publish'))
     needs: [repoLint, checks, unitTest, unitTestWasm, bddTest]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - name: Setup Go 1.19

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   vcTestSuite:
     name: VC test suite
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
 


### PR DESCRIPTION
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/