### PR TITLE
chore: release 0.2.0

### DIFF
--- a/.github/workflows/version_var.sh
+++ b/.github/workflows/version_var.sh
@@ -6,7 +6,7 @@
 
 # Release Parameters
 BASE_VERSION=0.2.0
-IS_RELEASE=false
+IS_RELEASE=true
 
 ARCH=$(go env GOARCH)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 0.2.0
+
+## Apr 5, 2023
+
+- Presentation Exchange improvements
+- SD-JWT documentation
+- CI : Ubuntu runner update to v22.04
+
+Refer https://github.com/hyperledger/aries-framework-go/releases/tag/v0.2.0 for new commits.
+
+# 0.1.9
+
+## Feb 24, 2023
+
+Refer https://github.com/hyperledger/aries-framework-go/releases/tag/v0.1.9 for new commits.
+
+
 # 0.1.8
 
 ## March 29, 2022


### PR DESCRIPTION
- Set release flag to true
- Add CHANGELOG for 0.2.0
- Add CHANGELOG for 0.1.9 (missed previously) : point to github release page
