### PR TITLE
fix: Match submission requirements not apply limited disclosure.

### DIFF
--- a/pkg/doc/presexch/match_submission_requirements_test.go
+++ b/pkg/doc/presexch/match_submission_requirements_test.go
@@ -77,8 +77,6 @@ func TestInstance_GetSubmissionRequirements(t *testing.T) {
 		requirements, err := pdQuery.MatchSubmissionRequirement(
 			credentials,
 			docLoader,
-			verifiable.WithDisabledProofCheck(),
-			verifiable.WithJSONLDDocumentLoader(docLoader),
 		)
 
 		require.NoError(t, err)
@@ -101,8 +99,6 @@ func TestInstance_GetSubmissionRequirements(t *testing.T) {
 		requirements, err := pdQuery.MatchSubmissionRequirement(
 			credentials,
 			docLoader,
-			verifiable.WithDisabledProofCheck(),
-			verifiable.WithJSONLDDocumentLoader(docLoader),
 		)
 
 		require.NoError(t, err)
@@ -125,8 +121,6 @@ func TestInstance_GetSubmissionRequirements(t *testing.T) {
 		requirements, err := pdQuery.MatchSubmissionRequirement(
 			credentials,
 			docLoader,
-			verifiable.WithDisabledProofCheck(),
-			verifiable.WithJSONLDDocumentLoader(docLoader),
 		)
 
 		require.NoError(t, err)


### PR DESCRIPTION
**Title:**

MatchSubmissionRequirement no longer applies limited disclosure on its results, now it just filters applicable credentials.

**Summary:**

Functionality that applies limited disclosure was factored from `filterConstraints` to separate function limitDisclosure.

