### PR TITLE
perf: remove extra parsing

### DIFF
--- a/pkg/doc/jwt/verifier.go
+++ b/pkg/doc/jwt/verifier.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-jose/go-jose/v3/json"
 	"golang.org/x/crypto/ed25519"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
@@ -142,14 +141,7 @@ func getPublicKeyVerifier(publicKey *verifier.PublicKey, v verifier.SignatureVer
 }
 
 func verifySignature(resolver KeyResolver, signatureVerifier signatureVerifier,
-	joseHeaders jose.Headers, payload, signingInput, signature []byte) error {
-	claims := make(map[string]interface{})
-
-	err := json.Unmarshal(payload, &claims)
-	if err != nil {
-		return fmt.Errorf("read claims from JSON Web Token: %w", err)
-	}
-
+	joseHeaders jose.Headers, _, signingInput, signature []byte) error {
 	kid, _ := joseHeaders.KeyID()
 
 	if !strings.HasPrefix(kid, "did:") {

--- a/pkg/doc/jwt/verifier_test.go
+++ b/pkg/doc/jwt/verifier_test.go
@@ -102,11 +102,6 @@ func TestBasicVerifier_Verify(t *testing.T) { // error corner cases
 		"kid": "did:123#key1",
 	}
 
-	// Invalid claims
-	err = v.Verify(validHeaders, []byte("invalid JSON claims"), nil, nil)
-	r.Error(err)
-	r.Contains(err.Error(), "read claims from JSON Web Token")
-
 	validClaims, err := json.Marshal(map[string]interface{}{"iss": "Bob"})
 	r.NoError(err)
 

--- a/pkg/doc/jwt/verifier_test.go
+++ b/pkg/doc/jwt/verifier_test.go
@@ -88,15 +88,6 @@ func TestNewVerifier(t *testing.T) {
 
 func TestBasicVerifier_Verify(t *testing.T) { // error corner cases
 	r := require.New(t)
-
-	pubKey, _, err := ed25519.GenerateKey(rand.Reader)
-	r.NoError(err)
-
-	v := NewVerifier(getTestKeyResolver(&verifier.PublicKey{
-		Type:  kms.RSARS256,
-		Value: pubKey,
-	}, nil))
-
 	validHeaders := map[string]interface{}{
 		"alg": "EdDSA",
 		"kid": "did:123#key1",
@@ -106,7 +97,7 @@ func TestBasicVerifier_Verify(t *testing.T) { // error corner cases
 	r.NoError(err)
 
 	// key resolver error
-	v = NewVerifier(getTestKeyResolver(nil, errors.New("failed to resolve public key")))
+	v := NewVerifier(getTestKeyResolver(nil, errors.New("failed to resolve public key")))
 	err = v.Verify(validHeaders, validClaims, nil, nil)
 	r.Error(err)
 	r.Contains(err.Error(), "failed to resolve public key")

--- a/pkg/doc/signature/verifier/verifier.go
+++ b/pkg/doc/signature/verifier/verifier.go
@@ -75,11 +75,11 @@ func (dv *DocumentVerifier) Verify(jsonLdDoc []byte, opts ...jsonld.ProcessorOpt
 		return fmt.Errorf("failed to unmarshal json ld document: %w", err)
 	}
 
-	return dv.verifyObject(jsonLdObject, opts...)
+	return dv.VerifyObject(jsonLdObject, opts...)
 }
 
-// verifyObject will verify document proofs for JSON LD object.
-func (dv *DocumentVerifier) verifyObject(jsonLdObject map[string]interface{}, opts ...jsonld.ProcessorOpts) error {
+// VerifyObject will verify document proofs for JSON LD object.
+func (dv *DocumentVerifier) VerifyObject(jsonLdObject map[string]interface{}, opts ...jsonld.ProcessorOpts) error {
 	proofs, err := proof.GetProofs(jsonLdObject)
 	if err != nil {
 		return err

--- a/pkg/doc/verifiable/embedded_proof.go
+++ b/pkg/doc/verifiable/embedded_proof.go
@@ -89,15 +89,12 @@ func checkEmbeddedProof(docBytes []byte, opts *embeddedProofCheckOpts) error {
 		return errors.New("public key fetcher is not defined")
 	}
 
-	checkedDoc := docBytes
-
 	if len(opts.externalContext) > 0 {
 		// Use external contexts for check of the linked data proofs to enrich JSON-LD context vocabulary.
 		jsonldDoc["@context"] = jsonld.AppendExternalContexts(jsonldDoc["@context"], opts.externalContext...)
-		checkedDoc, _ = json.Marshal(jsonldDoc) //nolint:errcheck
 	}
 
-	err = checkLinkedDataProof(checkedDoc, ldpSuites, opts.publicKeyFetcher, &opts.jsonldCredentialOpts)
+	err = checkLinkedDataProof(jsonldDoc, ldpSuites, opts.publicKeyFetcher, &opts.jsonldCredentialOpts)
 	if err != nil {
 		return fmt.Errorf("check embedded proof: %w", err)
 	}

--- a/pkg/doc/verifiable/linked_data_proof.go
+++ b/pkg/doc/verifiable/linked_data_proof.go
@@ -66,7 +66,7 @@ type LinkedDataProofContext struct {
 	CapabilityChain []interface{}
 }
 
-func checkLinkedDataProof(jsonldBytes []byte, suites []verifier.SignatureSuite,
+func checkLinkedDataProof(jsonldBytes map[string]interface{}, suites []verifier.SignatureSuite,
 	pubKeyFetcher PublicKeyFetcher, jsonldOpts *jsonldCredentialOpts) error {
 	documentVerifier, err := verifier.New(&keyResolverAdapter{pubKeyFetcher}, suites...)
 	if err != nil {
@@ -75,7 +75,7 @@ func checkLinkedDataProof(jsonldBytes []byte, suites []verifier.SignatureSuite,
 
 	processorOpts := mapJSONLDProcessorOpts(jsonldOpts)
 
-	err = documentVerifier.Verify(jsonldBytes, processorOpts...)
+	err = documentVerifier.VerifyObject(jsonldBytes, processorOpts...)
 	if err != nil {
 		return fmt.Errorf("check linked data proof: %w", err)
 	}


### PR DESCRIPTION
verifySignature does not require parsed claims to do that functionality. we already parsing claims in many other places.
![image](https://user-images.githubusercontent.com/3065048/234279813-37d7d469-fec9-4e60-8565-ed4a40ce6903.png)
