### PR TITLE
fix: invalid creds IDs returned from match submission requirements.

### DIFF
--- a/pkg/doc/presexch/definition.go
+++ b/pkg/doc/presexch/definition.go
@@ -545,7 +545,7 @@ func (pd *PresentationDefinition) MatchSubmissionRequirement(credentials []*veri
 // ErrNoCredentials when any credentials do not satisfy requirements.
 var ErrNoCredentials = errors.New("credentials do not satisfy requirements")
 
-// nolint: funlen
+// nolint: funlen,gocyclo
 func (pd *PresentationDefinition) matchRequirement(req *requirement, creds []*verifiable.Credential,
 	documentLoader ld.DocumentLoader, opts *matchRequirementsOpts) (*MatchedSubmissionRequirement, error) {
 	matchedReq := &MatchedSubmissionRequirement{
@@ -583,6 +583,12 @@ func (pd *PresentationDefinition) matchRequirement(req *requirement, creds []*ve
 			matchedVCs, err = limitDisclosure(filtered, opts.credOpts...)
 			if err != nil {
 				return nil, err
+			}
+
+			// TODO: remove this workaround after refactoring "merge" function to get rid of
+			// TODO: the trick with the modification of credential id.
+			for _, cred := range matchedVCs {
+				cred.ID = trimTmpID(cred.ID)
 			}
 		} else {
 			for _, credRes := range filtered {

--- a/pkg/doc/presexch/match_submission_requirements_test.go
+++ b/pkg/doc/presexch/match_submission_requirements_test.go
@@ -238,6 +238,8 @@ func TestInstance_GetSubmissionRequirements(t *testing.T) {
 
 		matchedVC := matched[0].Descriptors[0].MatchedVCs[0]
 
+		require.Equal(t, vc.ID, matchedVC.ID)
+
 		subject := matchedVC.Subject.([]verifiable.Subject)[0]
 		degree := subject.CustomFields["degree"]
 		require.NotNil(t, degree)


### PR DESCRIPTION

**Title:**
Fix invalid creds IDs returned from MatchSubmissionRequirement.

**Summary:**

Credential returned MatchSubmissionRequirement had IDs with some random prefix. Now this is fixed.
