### PR TITLE
feat: support for optional field in presexch

### DIFF
--- a/pkg/doc/presexch/schema.go
+++ b/pkg/doc/presexch/schema.go
@@ -89,7 +89,24 @@ const DefinitionJSONSchemaV1 = `
             "not":{
                "type":"object",
                "minProperties":1
-            }
+            },
+			"contains":{
+				"type":"object",
+				"properties":{
+					"type":{
+					   "type":"string"
+					},
+					"pattern":{
+					   "type":"string"
+					},
+					"const":{
+					   "type":"string"
+					}
+				},
+				"required":[
+					"type"
+				]
+			}
          },
          "required":[
             "type"
@@ -390,6 +407,9 @@ const DefinitionJSONSchemaV1 = `
                   },
                   "filter":{
                      "$ref":"#/definitions/filter"
+                  },
+                  "optional":{
+                     "type":"boolean"
                   }
                },
                "required":[


### PR DESCRIPTION
**Title:**
Support for optional field in presexch.


**Summary:**
Extended PresentationDefinition JSON Schema V1 with field `optional` and `contains`
This filed is already exist in the [relevant struct](https://github.com/hyperledger/aries-framework-go/blob/main/pkg/doc/presexch/definition.go#L181), but wasn't a part of the Schema.


