### PR TITLE
refactor: cleanup messy code in pEx implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,8 @@ require (
 
 go 1.19
 
+replace github.com/hyperledger/aries-framework-go/components/models => ./components/models
+
 //replace github.com/square/go-jose/v3 => github.com/go-jose/go-jose/v3 v3.0.1-0.20221117193127-916db76e8214
 //
 //replace github.com/square/go-jose/v3/json => github.com/go-jose/go-jose/v3/json v1.0.1-0.20221117193127-916db76e8214


### PR DESCRIPTION
- pEx implementation no longer needs to replace Credential ID temporarily
- assorted cleanup