### PR TITLE
feat: change KMS interface for Data Integrity

### DIFF
--- a/component/kmscrypto/kms/localkms/localkms.go
+++ b/component/kmscrypto/kms/localkms/localkms.go
@@ -311,7 +311,7 @@ func (l *LocalKMS) CreateAndExportPubKeyBytes(kt kmsapi.KeyType, opts ...kmsapi.
 // Note: The key handle created is not stored in the KMS, it's only useful to execute the crypto primitive
 // associated with it.
 func (l *LocalKMS) PubKeyBytesToHandle(pubKey []byte, kt kmsapi.KeyType, opts ...kmsapi.KeyOpts) (interface{}, error) {
-	return publicKeyBytesToHandle(pubKey, kt, opts...)
+	return PublicKeyBytesToHandle(pubKey, kt, opts...)
 }
 
 // ImportPrivateKey will import privKey into the KMS storage for the given keyType then returns the new key id and

--- a/component/kmscrypto/kms/localkms/pubkey_export_import_test.go
+++ b/component/kmscrypto/kms/localkms/pubkey_export_import_test.go
@@ -94,7 +94,7 @@ func TestPubKeyExportAndRead(t *testing.T) {
 		t.Run(tt.tcName, func(t *testing.T) {
 			exportedKeyBytes, origKH := exportRawPublicKeyBytes(t, tt.keyTemplate, false)
 
-			kh, err := publicKeyBytesToHandle(exportedKeyBytes, tt.keyType)
+			kh, err := PublicKeyBytesToHandle(exportedKeyBytes, tt.keyType)
 			require.NoError(t, err)
 			require.NotEmpty(t, kh)
 
@@ -179,49 +179,49 @@ func exportRawPublicKeyBytes(t *testing.T, keyTemplate *tinkpb.KeyTemplate, expe
 
 func TestNegativeCases(t *testing.T) {
 	t.Run("test publicKeyBytesToHandle with empty pubKey", func(t *testing.T) {
-		kh, err := publicKeyBytesToHandle([]byte{}, kms.ECDSAP256TypeIEEEP1363)
+		kh, err := PublicKeyBytesToHandle([]byte{}, kms.ECDSAP256TypeIEEEP1363)
 		require.EqualError(t, err, "pubKey is empty")
 		require.Empty(t, kh)
 	})
 
 	t.Run("test publicKeyBytesToHandle with empty KeyType", func(t *testing.T) {
-		kh, err := publicKeyBytesToHandle([]byte{1}, "")
+		kh, err := PublicKeyBytesToHandle([]byte{1}, "")
 		require.EqualError(t, err, "error getting marshalled proto key: invalid key type")
 		require.Empty(t, kh)
 	})
 
 	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP256TypeDER", func(t *testing.T) {
-		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP256TypeDER)
+		kh, err := PublicKeyBytesToHandle([]byte{1}, kms.ECDSAP256TypeDER)
 		require.EqualError(t, err, "error getting marshalled proto key: asn1: syntax error: truncated tag or length")
 		require.Empty(t, kh)
 	})
 
 	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP256TypeIEEEP1363", func(t *testing.T) {
-		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP256TypeIEEEP1363)
+		kh, err := PublicKeyBytesToHandle([]byte{1}, kms.ECDSAP256TypeIEEEP1363)
 		require.EqualError(t, err, "error getting marshalled proto key: failed to unamrshal public ecdsa key")
 		require.Empty(t, kh)
 	})
 
 	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP384TypeDER", func(t *testing.T) {
-		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP384TypeDER)
+		kh, err := PublicKeyBytesToHandle([]byte{1}, kms.ECDSAP384TypeDER)
 		require.EqualError(t, err, "error getting marshalled proto key: asn1: syntax error: truncated tag or length")
 		require.Empty(t, kh)
 	})
 
 	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP384TypeIEEEP1363", func(t *testing.T) {
-		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP384TypeIEEEP1363)
+		kh, err := PublicKeyBytesToHandle([]byte{1}, kms.ECDSAP384TypeIEEEP1363)
 		require.EqualError(t, err, "error getting marshalled proto key: failed to unamrshal public ecdsa key")
 		require.Empty(t, kh)
 	})
 
 	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP521TypeDER", func(t *testing.T) {
-		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP521TypeDER)
+		kh, err := PublicKeyBytesToHandle([]byte{1}, kms.ECDSAP521TypeDER)
 		require.EqualError(t, err, "error getting marshalled proto key: asn1: syntax error: truncated tag or length")
 		require.Empty(t, kh)
 	})
 
 	t.Run("test publicKeyBytesToHandle with bad pubKey and ECDSAP521TypeIEEEP1363", func(t *testing.T) {
-		kh, err := publicKeyBytesToHandle([]byte{1}, kms.ECDSAP521TypeIEEEP1363)
+		kh, err := PublicKeyBytesToHandle([]byte{1}, kms.ECDSAP521TypeIEEEP1363)
 		require.EqualError(t, err, "error getting marshalled proto key: failed to unamrshal public ecdsa key")
 		require.Empty(t, kh)
 	})

--- a/component/kmscrypto/kms/localkms/pubkey_reader.go
+++ b/component/kmscrypto/kms/localkms/pubkey_reader.go
@@ -29,7 +29,11 @@ import (
 	secp256k1subtle "github.com/hyperledger/aries-framework-go/component/kmscrypto/crypto/tinkcrypto/primitive/secp256k1/subtle"
 )
 
-func publicKeyBytesToHandle(pubKey []byte, kt kms.KeyType, opts ...kms.KeyOpts) (*keyset.Handle, error) {
+// PublicKeyBytesToHandle will create and return a key handle for pubKey of type kt
+// it returns an error if it failed creating the key handle
+// Note: The key handle created is not stored in the KMS, it's only useful to execute the crypto primitive
+// associated with it.
+func PublicKeyBytesToHandle(pubKey []byte, kt kms.KeyType, opts ...kms.KeyOpts) (*keyset.Handle, error) {
 	if len(pubKey) == 0 {
 		return nil, fmt.Errorf("pubKey is empty")
 	}

--- a/component/models/dataintegrity/models/models.go
+++ b/component/models/dataintegrity/models/models.go
@@ -18,6 +18,15 @@ const (
 	DataIntegrityProof = "DataIntegrityProof"
 )
 
+// KeyManager manages keys and their storage for the aries framework.
+type KeyManager interface {
+	// Get key handle for the given keyID
+	// Returns:
+	//  - handle instance (to private key)
+	//  - error if failure
+	Get(keyID string) (interface{}, error)
+}
+
 // VerificationMethod implements the data integrity verification method model:
 // https://www.w3.org/TR/vc-data-integrity/#verification-methods
 type VerificationMethod = did.VerificationMethod

--- a/component/models/dataintegrity/suite/ecdsa2019/ecdsa2019_test.go
+++ b/component/models/dataintegrity/suite/ecdsa2019/ecdsa2019_test.go
@@ -285,17 +285,6 @@ func TestSuite_VerifyProof(t *testing.T) {
 			testVerify(t, tc)
 		})
 
-		t.Run("get kms key handle", func(t *testing.T) {
-			tc := successCase(t)
-
-			errExpected := errors.New("expected error")
-
-			tc.kms.PubKeyBytesToHandleErr = errExpected
-			tc.errIs = errExpected
-
-			testVerify(t, tc)
-		})
-
 		t.Run("crypto verify", func(t *testing.T) {
 			tc := successCase(t)
 

--- a/component/models/go.mod
+++ b/component/models/go.mod
@@ -61,3 +61,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
+
+replace github.com/hyperledger/aries-framework-go/component/kmscrypto => ../kmscrypto


### PR DESCRIPTION
**Title:**
Change KMS interface for Data Integrity.

**Summary:**
1. Introduced private KMS interface for ecdsa2019 Data integrity suite with only onte method.
2. Made `publicKeyBytesToHandle` function as exported from localkms package and used it in ecdsa2019 Data integrity suite verifier. The reason for it is that method
```
func (l *LocalKMS) PubKeyBytesToHandle(pubKey []byte, kt kmsapi.KeyType, opts ...kmsapi.KeyOpts) (interface{}, error) {
	return publicKeyBytesToHandle(pubKey, kt, opts...)
}
```
does not use receiver and func `PublicKeyBytesToHandle` can be used independently.


