### PR TITLE
feat: added data integrity jsonld context

### DIFF
--- a/component/models/dataintegrity/suite/ecdsa2019/ecdsa2019.go
+++ b/component/models/dataintegrity/suite/ecdsa2019/ecdsa2019.go
@@ -164,6 +164,7 @@ func (s *Suite) CreateProof(doc []byte, opts *models.ProofOptions) (*models.Proo
 		Challenge:          opts.Challenge,
 		VerificationMethod: opts.VerificationMethod.ID,
 		ProofValue:         sigStr,
+		Created:            opts.Created.Format(models.DateTimeFormat),
 	}
 
 	return p, nil

--- a/component/models/dataintegrity/verifier.go
+++ b/component/models/dataintegrity/verifier.go
@@ -124,7 +124,9 @@ func (v *Verifier) VerifyProof(doc []byte, opts *models.ProofOptions) error { //
 	}
 
 	if opts.Created.IsZero() {
-		parsedCreatedTime, err := time.Parse(models.DateTimeFormat, proof.Created)
+		var parsedCreatedTime time.Time
+
+		parsedCreatedTime, err = time.Parse(models.DateTimeFormat, proof.Created)
 		if err != nil {
 			return ErrMalformedProof
 		}

--- a/component/models/dataintegrity/verifier.go
+++ b/component/models/dataintegrity/verifier.go
@@ -123,6 +123,15 @@ func (v *Verifier) VerifyProof(doc []byte, opts *models.ProofOptions) error { //
 		return ErrMalformedProof
 	}
 
+	if opts.Created.IsZero() {
+		parsedCreatedTime, err := time.Parse(models.DateTimeFormat, proof.Created)
+		if err != nil {
+			return ErrMalformedProof
+		}
+
+		opts.Created = parsedCreatedTime
+	}
+
 	if proof.ProofPurpose != opts.Purpose {
 		return ErrMismatchedPurpose
 	}

--- a/component/models/dataintegrity/verifier_test.go
+++ b/component/models/dataintegrity/verifier_test.go
@@ -289,6 +289,7 @@ func TestVerifier_VerifyProof(t *testing.T) {
 			require.NoError(t, err)
 
 			err = v.VerifyProof(signedDoc, &models.ProofOptions{
+				Created: time.Now(),
 				Purpose: "different-purpose",
 			})
 			require.ErrorIs(t, err, ErrMismatchedPurpose)
@@ -316,6 +317,7 @@ func TestVerifier_VerifyProof(t *testing.T) {
 
 			err = v.VerifyProof(signedDoc, &models.ProofOptions{
 				Purpose: "mock-purpose",
+				Created: time.Now(),
 				MaxAge:  1000,
 			})
 			require.Error(t, err)
@@ -348,6 +350,7 @@ func TestVerifier_VerifyProof(t *testing.T) {
 
 			err = v.VerifyProof(signedDoc, &models.ProofOptions{
 				Purpose: "mock-purpose",
+				Created: time.Now(),
 				MaxAge:  1000,
 			})
 			require.Error(t, err)
@@ -386,6 +389,7 @@ func TestVerifier_VerifyProof(t *testing.T) {
 
 			err = v.VerifyProof(signedDoc, &models.ProofOptions{
 				Purpose: "mock-purpose",
+				Created: time.Now(),
 			})
 			require.ErrorIs(t, err, errExpected)
 		})
@@ -492,6 +496,7 @@ func TestVerifier_VerifyProof(t *testing.T) {
 			err = v.VerifyProof(signedDoc, &models.ProofOptions{
 				Purpose: "mock-purpose",
 				Domain:  "mock-domain",
+				Created: time.Now(),
 			})
 			require.ErrorIs(t, err, ErrInvalidDomain)
 		})
@@ -527,6 +532,7 @@ func TestVerifier_VerifyProof(t *testing.T) {
 			err = v.VerifyProof(signedDoc, &models.ProofOptions{
 				Purpose:   "mock-purpose",
 				Challenge: "mock-challenge",
+				Created:   time.Now(),
 			})
 			require.ErrorIs(t, err, ErrInvalidChallenge)
 		})

--- a/component/models/ld/testutil/contexts/third_party/w3id.org/data-integrity-v1.jsonld
+++ b/component/models/ld/testutil/contexts/third_party/w3id.org/data-integrity-v1.jsonld
@@ -1,0 +1,74 @@
+{
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+    "@protected": true,
+    "proof": {
+      "@id": "https://w3id.org/security#proof",
+      "@type": "@id",
+      "@container": "@graph"
+    },
+    "DataIntegrityProof": {
+      "@id": "https://w3id.org/security#DataIntegrityProof",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "nonce": "https://w3id.org/security#nonce",
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "cryptosuite": "https://w3id.org/security#cryptosuite",
+        "proofValue": {
+          "@id": "https://w3id.org/security#proofValue",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
+      }
+    }
+  }
+}

--- a/component/models/ld/testutil/document_loader.go
+++ b/component/models/ld/testutil/document_loader.go
@@ -34,6 +34,8 @@ var (
 	vcExamples []byte
 	//go:embed contexts/third_party/trustbloc.github.io/trustbloc-authorization-credential_v1.jsonld
 	authCred []byte
+	//go:embed contexts/third_party/w3id.org/data-integrity-v1.jsonld
+	dataIntegrity []byte
 )
 
 var testContexts = []ldcontext.Document{ //nolint:gochecknoglobals // embedded test contexts
@@ -62,6 +64,10 @@ var testContexts = []ldcontext.Document{ //nolint:gochecknoglobals // embedded t
 		URL:         "https://w3c-ccg.github.io/vc-revocation-list-2021/contexts/v1.jsonld",
 		DocumentURL: "https://raw.githubusercontent.com/w3c-ccg/vc-status-list-2021/343b8b59cddba4525e1ef355356ae760fc75904e/contexts/v1.jsonld", //nolint:lll
 		Content:     revocationList2021,
+	},
+	{
+		URL:     "https://w3id.org/security/data-integrity/v1",
+		Content: dataIntegrity,
 	},
 }
 

--- a/component/models/verifiable/data_integrity_proof_test.go
+++ b/component/models/verifiable/data_integrity_proof_test.go
@@ -26,7 +26,8 @@ func Test_DataIntegrity_SignVerify(t *testing.T) {
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://www.w3.org/2018/credentials/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1",
+	"https://w3id.org/security/data-integrity/v1"
   ],
   "id": "https://example.com/credentials/1872",
   "type": [
@@ -64,7 +65,7 @@ func Test_DataIntegrity_SignVerify(t *testing.T) {
 
 	const vmID = "#key-1"
 
-	vm, err := did.NewVerificationMethodFromJWK(vmID, "JsonWebKey2020", signingDID, key)
+	vm, err := did.NewVerificationMethodFromJWK(signingDID+vmID, "JsonWebKey2020", signingDID, key)
 	require.NoError(t, err)
 
 	resolver := resolveFunc(func(id string) (*did.DocResolution, error) {
@@ -103,7 +104,7 @@ func Test_DataIntegrity_SignVerify(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("credential", func(t *testing.T) {
-		vc, e := parseTestCredential(t, []byte(vcJSON), WithDisabledProofCheck())
+		vc, e := parseTestCredential(t, []byte(vcJSON), WithDisabledProofCheck(), WithStrictValidation())
 		require.NoError(t, e)
 
 		e = vc.AddDataIntegrityProof(signContext, signer)
@@ -112,7 +113,7 @@ func Test_DataIntegrity_SignVerify(t *testing.T) {
 		vcBytes, e := vc.MarshalJSON()
 		require.NoError(t, e)
 
-		_, e = parseTestCredential(t, vcBytes, WithDataIntegrityVerifier(verifier))
+		_, e = parseTestCredential(t, vcBytes, WithDataIntegrityVerifier(verifier), WithStrictValidation())
 		require.NoError(t, e)
 
 		t.Run("fail if not provided verifier", func(t *testing.T) {


### PR DESCRIPTION
**Title:**
Added data integrity JSON-LD context

**Description:**
Because of the missed DI JSON LD context (and disabled strict validation), Aries on issuance stage generated invalid `canonicalProofConfig` considering only `type` field.
Example:
```
_:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <DataIntegrityProof> .
```
Verification part was successful because Aries considered same `type` field. And because of that, Unit tests did not catch the typo that on verification stage field `created` was empty.

According to [Spec](https://www.w3.org/TR/vc-di-ecdsa/#base-proof-configuration-ecdsa-sd-2023), another fields must be also included in `canonicalProofConfig`.

After this PR, Aries generates the following `canonicalProofConfig`:
```
_:c14n0 <http://purl.org/dc/terms/created> "2023-08-23T16:57:33+03:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
_:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#DataIntegrityProof> .
_:c14n0 <https://w3id.org/security#cryptosuite> "ecdsa-2019" .
_:c14n0 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> .
_:c14n0 <https://w3id.org/security#verificationMethod> <did:foo:bar#key-1> .
```


