### PR TITLE
feat: change DI VM purpose resolution

### DIFF
--- a/component/models/dataintegrity/integration_test.go
+++ b/component/models/dataintegrity/integration_test.go
@@ -77,10 +77,10 @@ func TestIntegration(t *testing.T) {
 	p384JWK, err := jwkkid.BuildJWK(p384Bytes, kmsapi.ECDSAP384IEEEP1363)
 	require.NoError(t, err)
 
-	p256VM, err := did.NewVerificationMethodFromJWK(mockVMID, "JsonWebKey2020", mockDID, p256JWK)
+	p256VM, err := did.NewVerificationMethodFromJWK(mockKID, "JsonWebKey2020", mockDID, p256JWK)
 	require.NoError(t, err)
 
-	p384VM, err := did.NewVerificationMethodFromJWK(mockVMID2, "JsonWebKey2020", mockDID2, p384JWK)
+	p384VM, err := did.NewVerificationMethodFromJWK(mockKID2, "JsonWebKey2020", mockDID2, p384JWK)
 	require.NoError(t, err)
 
 	resolver := resolveFunc(func(id string) (*did.DocResolution, error) {
@@ -105,14 +105,13 @@ func TestIntegration(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Run("P-256 key", func(t *testing.T) {
 			signOpts := &models.ProofOptions{
-				VerificationMethod:       p256VM,
-				VerificationMethodID:     p256VM.ID,
-				SuiteType:                ecdsa2019.SuiteType,
-				Purpose:                  "assertionMethod",
-				VerificationRelationship: "assertionMethod",
-				ProofType:                models.DataIntegrityProof,
-				Created:                  time.Now(),
-				MaxAge:                   100,
+				VerificationMethod:   p256VM,
+				VerificationMethodID: p256VM.ID,
+				SuiteType:            ecdsa2019.SuiteType,
+				Purpose:              AssertionMethod,
+				ProofType:            models.DataIntegrityProof,
+				Created:              time.Now(),
+				MaxAge:               100,
 			}
 
 			signedCred, err := signer.AddProof(validCredential, signOpts)
@@ -121,7 +120,7 @@ func TestIntegration(t *testing.T) {
 			verifyOpts := &models.ProofOptions{
 				VerificationMethodID: mockKID,
 				SuiteType:            ecdsa2019.SuiteType,
-				Purpose:              "assertionMethod",
+				Purpose:              AssertionMethod,
 				ProofType:            models.DataIntegrityProof,
 				Created:              time.Now(),
 				MaxAge:               100,
@@ -133,14 +132,13 @@ func TestIntegration(t *testing.T) {
 
 		t.Run("P-384 key", func(t *testing.T) {
 			signOpts := &models.ProofOptions{
-				VerificationMethod:       p384VM,
-				VerificationMethodID:     mockKID2,
-				SuiteType:                ecdsa2019.SuiteType,
-				Purpose:                  "assertionMethod",
-				VerificationRelationship: "assertionMethod",
-				ProofType:                models.DataIntegrityProof,
-				Created:                  time.Now(),
-				MaxAge:                   100,
+				VerificationMethod:   p384VM,
+				VerificationMethodID: mockKID2,
+				SuiteType:            ecdsa2019.SuiteType,
+				Purpose:              AssertionMethod,
+				ProofType:            models.DataIntegrityProof,
+				Created:              time.Now(),
+				MaxAge:               100,
 			}
 
 			signedCred, err := signer.AddProof(validCredential, signOpts)
@@ -149,7 +147,7 @@ func TestIntegration(t *testing.T) {
 			verifyOpts := &models.ProofOptions{
 				VerificationMethodID: mockKID2,
 				SuiteType:            ecdsa2019.SuiteType,
-				Purpose:              "assertionMethod",
+				Purpose:              AssertionMethod,
 				ProofType:            models.DataIntegrityProof,
 				Created:              time.Now(),
 				MaxAge:               100,
@@ -163,23 +161,21 @@ func TestIntegration(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		t.Run("wrong key", func(t *testing.T) {
 			signOpts := &models.ProofOptions{
-				VerificationMethod:       p256VM,
-				VerificationMethodID:     p256VM.ID,
-				SuiteType:                ecdsa2019.SuiteType,
-				Purpose:                  "assertionMethod",
-				VerificationRelationship: "assertionMethod",
-				ProofType:                models.DataIntegrityProof,
-				Created:                  time.Now(),
+				VerificationMethod:   p256VM,
+				VerificationMethodID: p256VM.ID,
+				SuiteType:            ecdsa2019.SuiteType,
+				Purpose:              AssertionMethod,
+				ProofType:            models.DataIntegrityProof,
+				Created:              time.Now(),
 			}
 
 			verifyOpts := &models.ProofOptions{
-				VerificationMethod:       p384VM,
-				VerificationMethodID:     p384VM.ID,
-				SuiteType:                ecdsa2019.SuiteType,
-				Purpose:                  "assertionMethod",
-				VerificationRelationship: "assertionMethod",
-				ProofType:                models.DataIntegrityProof,
-				MaxAge:                   100,
+				VerificationMethod:   p384VM,
+				VerificationMethodID: p384VM.ID,
+				SuiteType:            ecdsa2019.SuiteType,
+				Purpose:              AssertionMethod,
+				ProofType:            models.DataIntegrityProof,
+				MaxAge:               100,
 			}
 
 			signedCred, err := signer.AddProof(validCredential, signOpts)
@@ -191,24 +187,22 @@ func TestIntegration(t *testing.T) {
 		})
 		t.Run("malformed proof created", func(t *testing.T) {
 			signOpts := &models.ProofOptions{
-				VerificationMethod:       p256VM,
-				VerificationMethodID:     p256VM.ID,
-				SuiteType:                ecdsa2019.SuiteType,
-				Purpose:                  "assertionMethod",
-				VerificationRelationship: "assertionMethod",
-				ProofType:                models.DataIntegrityProof,
-				Created:                  time.Now(),
+				VerificationMethod:   p256VM,
+				VerificationMethodID: p256VM.ID,
+				SuiteType:            ecdsa2019.SuiteType,
+				Purpose:              "assertionMethod",
+				ProofType:            models.DataIntegrityProof,
+				Created:              time.Now(),
 			}
 
 			verifyOpts := &models.ProofOptions{
-				VerificationMethod:       p384VM,
-				VerificationMethodID:     p384VM.ID,
-				SuiteType:                ecdsa2019.SuiteType,
-				Purpose:                  "assertionMethod",
-				VerificationRelationship: "assertionMethod",
-				ProofType:                models.DataIntegrityProof,
-				MaxAge:                   100,
-				Created:                  time.Time{},
+				VerificationMethod:   p384VM,
+				VerificationMethodID: p384VM.ID,
+				SuiteType:            ecdsa2019.SuiteType,
+				Purpose:              "assertionMethod",
+				ProofType:            models.DataIntegrityProof,
+				MaxAge:               100,
+				Created:              time.Time{},
 			}
 
 			signedCred, err := signer.AddProof(validCredential, signOpts)

--- a/component/models/dataintegrity/models/models.go
+++ b/component/models/dataintegrity/models/models.go
@@ -48,17 +48,16 @@ type Proof struct {
 
 // ProofOptions provides options for signing or verifying a data integrity proof.
 type ProofOptions struct {
-	Purpose                  string
-	VerificationMethodID     string
-	VerificationMethod       *VerificationMethod
-	VerificationRelationship string
-	ProofType                string
-	SuiteType                string
-	Domain                   string
-	Challenge                string
-	Created                  time.Time
-	MaxAge                   int64
-	CustomFields             map[string]interface{}
+	Purpose              string
+	VerificationMethodID string
+	VerificationMethod   *VerificationMethod
+	ProofType            string
+	SuiteType            string
+	Domain               string
+	Challenge            string
+	Created              time.Time
+	MaxAge               int64
+	CustomFields         map[string]interface{}
 }
 
 // DateTimeFormat is the date-time format used by the data integrity

--- a/component/models/dataintegrity/signer_test.go
+++ b/component/models/dataintegrity/signer_test.go
@@ -64,16 +64,16 @@ func TestSigner_AddProof(t *testing.T) {
 			&Options{
 				DIDResolver: &mockResolver{
 					vm: &did.VerificationMethod{
-						ID: "#key-1",
+						ID: "did:foo:bar#key-1",
 					},
-					vr: did.AssertionMethod,
+					vr: did.Authentication,
 				},
 			},
 			&mockSuiteInitializer{
 				mockSuite: &mockSuite{
 					CreateProofVal: &models.Proof{
 						Type:               mockSuiteType,
-						ProofPurpose:       "mock-purpose",
+						ProofPurpose:       Authentication,
 						VerificationMethod: "mock-vm",
 						Domain:             "mock-domain",
 						Challenge:          "mock-challenge",
@@ -91,18 +91,19 @@ func TestSigner_AddProof(t *testing.T) {
 			Domain:               "mock-domain",
 			Challenge:            "mock-challenge",
 			MaxAge:               1000,
+			Purpose:              Authentication,
 		})
 		require.NoError(t, err)
 
 		expectProof := []byte(fmt.Sprintf(`{
 			"type": "mock-suite-2023",
-			"proofPurpose": "mock-purpose",
+			"proofPurpose": "%s",
 			"verificationMethod":"mock-vm",
 			"proofValue":"",
 			"created": "%s",
 			"domain": "mock-domain",
 			"challenge":"mock-challenge"
-		}`, createdTime))
+		}`, Authentication, createdTime))
 
 		proofBytes, unsignedDoc := extractProof(t, signedDoc)
 
@@ -154,11 +155,10 @@ func TestSigner_AddProof(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = s.AddProof(mockDoc, &models.ProofOptions{
-				SuiteType:                mockSuiteType,
-				VerificationRelationship: "assertionMethod",
-				Domain:                   "mock-domain",
-				Challenge:                "mock-challenge",
-				MaxAge:                   1000,
+				SuiteType: mockSuiteType,
+				Domain:    "mock-domain",
+				Challenge: "mock-challenge",
+				MaxAge:    1000,
 			})
 			require.ErrorIs(t, err, ErrNoResolver)
 		})
@@ -176,7 +176,7 @@ func TestSigner_AddProof(t *testing.T) {
 					mockSuite: &mockSuite{
 						CreateProofVal: &models.Proof{
 							Type:               mockSuiteType,
-							ProofPurpose:       "mock-purpose",
+							ProofPurpose:       CapabilityDelegation,
 							VerificationMethod: "mock-vm",
 							Domain:             "mock-domain",
 							Challenge:          "mock-challenge",
@@ -189,11 +189,12 @@ func TestSigner_AddProof(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = s.AddProof(mockDoc, &models.ProofOptions{
-				SuiteType:                mockSuiteType,
-				VerificationRelationship: "assertionMethod",
-				Domain:                   "mock-domain",
-				Challenge:                "mock-challenge",
-				MaxAge:                   1000,
+				SuiteType:            mockSuiteType,
+				VerificationMethodID: "did:foo:bar#key-1",
+				Purpose:              CapabilityDelegation,
+				Domain:               "mock-domain",
+				Challenge:            "mock-challenge",
+				MaxAge:               1000,
 			})
 			require.ErrorIs(t, err, errExpected)
 			require.ErrorIs(t, err, ErrVMResolution)
@@ -212,9 +213,8 @@ func TestSigner_AddProof(t *testing.T) {
 			require.NoError(t, err)
 
 			signedDoc, err := s.AddProof(mockDoc, &models.ProofOptions{
-				VerificationMethod:       &did.VerificationMethod{},
-				VerificationRelationship: "assertionMethod",
-				SuiteType:                mockSuiteType,
+				VerificationMethod: &did.VerificationMethod{},
+				SuiteType:          mockSuiteType,
 			})
 			require.ErrorIs(t, err, ErrProofGeneration)
 			require.Nil(t, signedDoc)
@@ -238,9 +238,8 @@ func TestSigner_AddProof(t *testing.T) {
 				require.NoError(t, err)
 
 				signedDoc, err := s.AddProof(mockDoc, &models.ProofOptions{
-					SuiteType:                mockSuiteType,
-					VerificationMethod:       &did.VerificationMethod{},
-					VerificationRelationship: "assertionMethod",
+					SuiteType:          mockSuiteType,
+					VerificationMethod: &did.VerificationMethod{},
 				})
 				require.ErrorIs(t, err, ErrProofGeneration)
 				require.Nil(t, signedDoc)
@@ -252,8 +251,7 @@ func TestSigner_AddProof(t *testing.T) {
 					&mockSuiteInitializer{
 						mockSuite: &mockSuite{
 							CreateProofVal: &models.Proof{
-								Type: mockSuiteType,
-								// ProofPurpose:       "mock-purpose",
+								Type:               mockSuiteType,
 								VerificationMethod: "mock-vm",
 							},
 						},
@@ -263,9 +261,8 @@ func TestSigner_AddProof(t *testing.T) {
 				require.NoError(t, err)
 
 				signedDoc, err := s.AddProof(mockDoc, &models.ProofOptions{
-					SuiteType:                mockSuiteType,
-					VerificationMethod:       &did.VerificationMethod{},
-					VerificationRelationship: "assertionMethod",
+					SuiteType:          mockSuiteType,
+					VerificationMethod: &did.VerificationMethod{},
 				})
 				require.ErrorIs(t, err, ErrProofGeneration)
 				require.Nil(t, signedDoc)
@@ -279,7 +276,6 @@ func TestSigner_AddProof(t *testing.T) {
 							CreateProofVal: &models.Proof{
 								Type:         mockSuiteType,
 								ProofPurpose: "mock-purpose",
-								// VerificationMethod: "mock-vm",
 							},
 						},
 						typeStr: mockSuiteType,
@@ -288,9 +284,8 @@ func TestSigner_AddProof(t *testing.T) {
 				require.NoError(t, err)
 
 				signedDoc, err := s.AddProof(mockDoc, &models.ProofOptions{
-					SuiteType:                mockSuiteType,
-					VerificationMethod:       &did.VerificationMethod{},
-					VerificationRelationship: "assertionMethod",
+					SuiteType:          mockSuiteType,
+					VerificationMethod: &did.VerificationMethod{},
 				})
 				require.ErrorIs(t, err, ErrProofGeneration)
 				require.Nil(t, signedDoc)
@@ -314,9 +309,8 @@ func TestSigner_AddProof(t *testing.T) {
 				require.NoError(t, err)
 
 				signedDoc, err := s.AddProof(mockDoc, &models.ProofOptions{
-					SuiteType:                mockSuiteType,
-					VerificationMethod:       &did.VerificationMethod{},
-					VerificationRelationship: "assertionMethod",
+					SuiteType:          mockSuiteType,
+					VerificationMethod: &did.VerificationMethod{},
 				})
 				require.ErrorIs(t, err, ErrProofGeneration)
 				require.Nil(t, signedDoc)
@@ -341,10 +335,9 @@ func TestSigner_AddProof(t *testing.T) {
 			require.NoError(t, err)
 
 			signedDoc, err := s.AddProof(mockDoc, &models.ProofOptions{
-				VerificationMethod:       &did.VerificationMethod{},
-				VerificationRelationship: "assertionMethod",
-				SuiteType:                mockSuiteType,
-				Domain:                   "expected-domain",
+				VerificationMethod: &did.VerificationMethod{},
+				SuiteType:          mockSuiteType,
+				Domain:             "expected-domain",
 			})
 			require.ErrorIs(t, err, ErrProofGeneration)
 			require.Nil(t, signedDoc)
@@ -369,11 +362,10 @@ func TestSigner_AddProof(t *testing.T) {
 			require.NoError(t, err)
 
 			signedDoc, err := s.AddProof(mockDoc, &models.ProofOptions{
-				SuiteType:                mockSuiteType,
-				Domain:                   "expected-domain",
-				Challenge:                "expected-challenge",
-				VerificationMethod:       &did.VerificationMethod{},
-				VerificationRelationship: "assertionMethod",
+				SuiteType:          mockSuiteType,
+				Domain:             "expected-domain",
+				Challenge:          "expected-challenge",
+				VerificationMethod: &did.VerificationMethod{},
 			})
 			require.ErrorIs(t, err, ErrProofGeneration)
 			require.Nil(t, signedDoc)

--- a/component/models/dataintegrity/suite/ecdsa2019/ecdsa2019.go
+++ b/component/models/dataintegrity/suite/ecdsa2019/ecdsa2019.go
@@ -250,10 +250,7 @@ func (s *Suite) transformAndHash(doc []byte, opts *models.ProofOptions) ([]byte,
 		return nil, nil, nil, errors.New("unsupported ECDSA curve")
 	}
 
-	confData, err := proofConfig(docData[ldCtxKey], opts)
-	if err != nil {
-		return nil, nil, nil, err
-	}
+	confData := proofConfig(docData[ldCtxKey], opts)
 
 	if opts.ProofType != "DataIntegrityProof" || opts.SuiteType != SuiteType {
 		return nil, nil, nil, suite.ErrProofTransformation
@@ -321,24 +318,15 @@ func hashData(transformedDoc, confData []byte, h hash.Hash) []byte {
 	return result
 }
 
-func proofConfig(docCtx interface{}, opts *models.ProofOptions) (map[string]interface{}, error) {
-	if opts.Purpose != opts.VerificationRelationship {
-		return nil, fmt.Errorf(
-			"verification method %s is not suitable for purpose %s", opts.VerificationRelationship, opts.Purpose)
-	}
-
-	timeStr := opts.Created.Format(models.DateTimeFormat)
-
-	conf := map[string]interface{}{
+func proofConfig(docCtx interface{}, opts *models.ProofOptions) map[string]interface{} {
+	return map[string]interface{}{
 		ldCtxKey:             docCtx,
 		"type":               models.DataIntegrityProof,
 		"cryptosuite":        SuiteType,
 		"verificationMethod": opts.VerificationMethodID,
-		"created":            timeStr,
+		"created":            opts.Created.Format(models.DateTimeFormat),
 		"proofPurpose":       opts.Purpose,
 	}
-
-	return conf, nil
 }
 
 // TODO copied from kid_creator.go, should move there: https://github.com/hyperledger/aries-framework-go/issues/3614

--- a/component/models/dataintegrity/suite/ecdsa2019/ecdsa2019_test.go
+++ b/component/models/dataintegrity/suite/ecdsa2019/ecdsa2019_test.go
@@ -102,14 +102,13 @@ func successCase(t *testing.T) *testCase {
 	proofCreated := time.Now()
 
 	proofOpts := &models.ProofOptions{
-		VerificationMethod:       mockVM,
-		VerificationMethodID:     mockVM.ID,
-		SuiteType:                SuiteType,
-		Purpose:                  "assertionMethod",
-		VerificationRelationship: "assertionMethod",
-		ProofType:                models.DataIntegrityProof,
-		Created:                  proofCreated,
-		MaxAge:                   100,
+		VerificationMethod:   mockVM,
+		VerificationMethodID: mockVM.ID,
+		SuiteType:            SuiteType,
+		Purpose:              "assertionMethod",
+		ProofType:            models.DataIntegrityProof,
+		Created:              proofCreated,
+		MaxAge:               100,
 	}
 
 	mockSig, err := multibase.Encode(multibase.Base58BTC, []byte("mock signature"))
@@ -332,15 +331,6 @@ func TestSharedFailures(t *testing.T) {
 		tc.errStr = "unsupported ECDSA curve"
 
 		testVerify(t, tc)
-	})
-
-	t.Run("wrong purpose", func(t *testing.T) {
-		tc := successCase(t)
-
-		tc.proofOpts.Purpose = fooBar
-		tc.errStr = "verification method assertionMethod is not suitable for purpose foo bar"
-
-		testSign(t, tc)
 	})
 
 	t.Run("invalid proof/suite type", func(t *testing.T) {

--- a/component/models/dataintegrity/suite/ecdsa2019/integration_test.go
+++ b/component/models/dataintegrity/suite/ecdsa2019/integration_test.go
@@ -75,14 +75,13 @@ func TestIntegration(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Run("P-256 key", func(t *testing.T) {
 			proofOpts := &models.ProofOptions{
-				VerificationMethod:       p256VM,
-				VerificationMethodID:     p256VM.ID,
-				SuiteType:                SuiteType,
-				Purpose:                  "assertionMethod",
-				VerificationRelationship: "assertionMethod",
-				ProofType:                models.DataIntegrityProof,
-				Created:                  time.Now(),
-				MaxAge:                   100,
+				VerificationMethod:   p256VM,
+				VerificationMethodID: p256VM.ID,
+				SuiteType:            SuiteType,
+				Purpose:              "assertionMethod",
+				ProofType:            models.DataIntegrityProof,
+				Created:              time.Now(),
+				MaxAge:               100,
 			}
 
 			proof, err := signer.CreateProof(validCredential, proofOpts)
@@ -94,14 +93,13 @@ func TestIntegration(t *testing.T) {
 
 		t.Run("P-384 key", func(t *testing.T) {
 			proofOpts := &models.ProofOptions{
-				VerificationMethod:       p384VM,
-				VerificationMethodID:     p384VM.ID,
-				SuiteType:                SuiteType,
-				Purpose:                  "assertionMethod",
-				VerificationRelationship: "assertionMethod",
-				ProofType:                models.DataIntegrityProof,
-				Created:                  time.Now(),
-				MaxAge:                   100,
+				VerificationMethod:   p384VM,
+				VerificationMethodID: p384VM.ID,
+				SuiteType:            SuiteType,
+				Purpose:              "assertionMethod",
+				ProofType:            models.DataIntegrityProof,
+				Created:              time.Now(),
+				MaxAge:               100,
 			}
 
 			proof, err := signer.CreateProof(validCredential, proofOpts)
@@ -115,23 +113,21 @@ func TestIntegration(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		t.Run("wrong key", func(t *testing.T) {
 			signOpts := &models.ProofOptions{
-				VerificationMethod:       p256VM,
-				VerificationMethodID:     p256VM.ID,
-				SuiteType:                SuiteType,
-				Purpose:                  "assertionMethod",
-				VerificationRelationship: "assertionMethod",
-				ProofType:                models.DataIntegrityProof,
-				Created:                  time.Now(),
+				VerificationMethod:   p256VM,
+				VerificationMethodID: p256VM.ID,
+				SuiteType:            SuiteType,
+				Purpose:              "assertionMethod",
+				ProofType:            models.DataIntegrityProof,
+				Created:              time.Now(),
 			}
 
 			verifyOpts := &models.ProofOptions{
-				VerificationMethod:       p384VM,
-				VerificationMethodID:     p384VM.ID,
-				SuiteType:                SuiteType,
-				Purpose:                  "assertionMethod",
-				VerificationRelationship: "assertionMethod",
-				ProofType:                models.DataIntegrityProof,
-				MaxAge:                   100,
+				VerificationMethod:   p384VM,
+				VerificationMethodID: p384VM.ID,
+				SuiteType:            SuiteType,
+				Purpose:              "assertionMethod",
+				ProofType:            models.DataIntegrityProof,
+				MaxAge:               100,
 			}
 
 			proof, err := signer.CreateProof(validCredential, signOpts)

--- a/component/models/dataintegrity/support_test.go
+++ b/component/models/dataintegrity/support_test.go
@@ -178,6 +178,10 @@ func makeMockDIDResolution(id string, vm *did.VerificationMethod, vr did.Verific
 		doc.Authentication = ver
 	case did.AssertionMethod:
 		doc.AssertionMethod = ver
+	case did.CapabilityDelegation:
+		doc.CapabilityDelegation = ver
+	case did.CapabilityInvocation:
+		doc.CapabilityInvocation = ver
 	}
 
 	return &did.DocResolution{


### PR DESCRIPTION
Using [ResolveSigningVMWithRelationship](https://github.com/hyperledger/aries-framework-go/blob/50313f0971cff8b74e4ad0cb1ce45910f6653352/component/models/jwt/didsignjwt/signjwt.go#L189) function causes a bug in VM relationship verification for Data integrity.

1. For instance, let's take issuer's DID, that after resolving has the following structure:
```
{
  "verificationMethod": [
   ID: "abc",
   .....
  ],
  "authentication": [
   ID: "abc",
   .....
  ]
}
```
3. Function [docRes.DIDDocument.VerificationMethods()](https://github.com/hyperledger/aries-framework-go/blob/50313f0971cff8b74e4ad0cb1ce45910f6653352/component/models/jwt/didsignjwt/signjwt.go#L221) with empty arguments returns a map with 2 elements: key `VerificationRelationshipGeneral` and `Authentication`. 
Values for those keys are verification methods with the same `ID` field.
4. Because func [docRes.DIDDocument.VerificationMethods()](https://github.com/hyperledger/aries-framework-go/blob/50313f0971cff8b74e4ad0cb1ce45910f6653352/component/models/jwt/didsignjwt/signjwt.go#L221) returns a map, the order of elements in `for ... range` loop is not predictable. It might be a case, when first element will be `VerificationRelationshipGeneral`. 
5. In this case function [verificationRelationshipName()](https://github.com/hyperledger/aries-framework-go/blob/50313f0971cff8b74e4ad0cb1ce45910f6653352/component/models/jwt/didsignjwt/signjwt.go#L246) returns `""`
6. Then, [condition](https://github.com/hyperledger/aries-framework-go/blob/main/component/models/dataintegrity/signer.go#L139C3-L141C4) 

```
if rel == "" {
			rel = "assertionMethod"
		}
````
takes place and declares hardcoded relationship.

