### PR TITLE
Threshold wallet

### DIFF
--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/bbsplusthreshold_test.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/bbsplusthreshold_test.go
@@ -1,0 +1,370 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bbsplusthresholdpub_test
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	mathrand "math/rand"
+	"testing"
+	"time"
+
+	ml "github.com/IBM/mathlib"
+	"github.com/hyperledger/aries-framework-go/component/kmscrypto/crypto/primitive/bbsplusthresholdpub"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	threshold = 2 // Security threshold (t-out-of-n)
+	n         = 3 // Number of servers
+	k         = 1 // Presignature to create
+)
+
+// nolint:gochecknoglobals
+var curve = ml.Curves[ml.BLS12_381_BBS]
+
+//nolint:lll
+func TestBlsG2Pub_Verify(t *testing.T) {
+	pkBase64 := "lOpN7uGZWivVIjs0325N/V0dAhoPomrgfXVpg7pZNdRWwFwJDVxoE7TvRyOx/Qr7GMtShNuS2Px/oScD+SMf08t8eAO78QRNErPzwNpfkP4ppcSTShStFDfFbsv9L9yb"
+	pkBytes, err := base64.RawStdEncoding.DecodeString(pkBase64)
+	require.NoError(t, err)
+
+	sigBase64 := "hPbLkeMZZ6KKzkjWoTVHeMeuLJfYWjmdAU1Vg5fZ/VZnIXxxeXBB+q0/EL8XQmWkOMMwEGA/D2dCb4MDuntKZpvHEHlvaFR6l1A4bYj0t2Jd6bYwGwCwirNbmSeIoEmJeRzJ1cSvsL+jxvLixdDPnw=="
+	sigBytes, err := base64.StdEncoding.DecodeString(sigBase64)
+	require.NoError(t, err)
+
+	messagesBytes := [][]byte{[]byte("message1"), []byte("message2")}
+
+	bls := bbsplusthresholdpub.New()
+
+	t.Run("valid signature", func(t *testing.T) {
+		err = bls.Verify(messagesBytes, sigBytes, pkBytes)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid signature", func(t *testing.T) {
+		// swap messages order
+		invalidMessagesBytes := [][]byte{[]byte("message2"), []byte("message1")}
+
+		err = bls.Verify(invalidMessagesBytes, sigBytes, pkBytes)
+		require.Error(t, err)
+		require.EqualError(t, err, "invalid BLS12-381 signature")
+	})
+
+	t.Run("invalid input public key", func(t *testing.T) {
+		err = bls.Verify(messagesBytes, sigBytes, []byte("invalid"))
+		require.Error(t, err)
+		require.EqualError(t, err, "parse public key: invalid size of public key")
+
+		pkBytesInvalid := make([]byte, len(pkBytes))
+
+		_, err = rand.Read(pkBytesInvalid)
+		require.NoError(t, err)
+
+		err = bls.Verify(messagesBytes, sigBytes, pkBytesInvalid)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parse public key: deserialize public key")
+	})
+
+	t.Run("invalid input signature", func(t *testing.T) {
+		err = bls.Verify(messagesBytes, []byte("invalid"), pkBytes)
+		require.Error(t, err)
+		require.EqualError(t, err, "parse signature: invalid size of signature")
+
+		sigBytesInvalid := make([]byte, len(sigBytes))
+
+		_, err = rand.Read(sigBytesInvalid)
+		require.NoError(t, err)
+
+		err = bls.Verify(messagesBytes, sigBytesInvalid, pkBytes)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parse signature: deserialize G1 compressed signature")
+	})
+}
+
+func TestBBSPlusPub_SignWithPartialSignatures(t *testing.T) {
+	pubKey, privKey, precomputations, err := generateKeyPairRandom(threshold, n, k)
+	require.NoError(t, err)
+	bls := bbsplusthresholdpub.New()
+
+	messagesBytes := [][]byte{
+		[]byte("_:c14n0 <http://purl.org/dc/terms/created> \"2023-10-19T13:25:42.654172871+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ."),
+		[]byte("_:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#BbsBlsSignature2020> ."),
+		[]byte("_:c14n0 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> ."),
+		[]byte("_:c14n0 <https://w3id.org/security#verificationMethod> <did:example:123456#key1> ."),
+		[]byte("<did:example:b34ca6cd37bbf23> <http://schema.org/birthDate> \"1958-07-17\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ."),
+		[]byte("<did:example:b34ca6cd37bbf23> <http://schema.org/familyName> \"SMITH\" ."),
+		[]byte("<did:example:b34ca6cd37bbf23> <http://schema.org/gender> \"Male\" ."),
+		[]byte("<did:example:b34ca6cd37bbf23> <http://schema.org/givenName> \"JOHN\" ."),
+		[]byte("<did:example:b34ca6cd37bbf23> <http://schema.org/image> <data:image/png;base64,iVBORw0KGgokJggg==> ."),
+		[]byte("<did:example:b34ca6cd37bbf23> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> ."),
+		[]byte("<did:example:b34ca6cd37bbf23> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/citizenship#PermanentResident> ."),
+		[]byte("<did:example:b34ca6cd37bbf23> <https://w3id.org/citizenship#birthCountry> \"Bahamas\" ."),
+		[]byte("<did:example:b34ca6cd37bbf23> <https://w3id.org/citizenship#commuterClassification> \"C1\" ."),
+		[]byte("<did:example:b34ca6cd37bbf23> <https://w3id.org/citizenship#lprCategory> \"C09\" ."),
+		[]byte("<did:example:b34ca6cd37bbf23> <https://w3id.org/citizenship#lprNumber> \"999-999-999\" ."),
+		[]byte("<did:example:b34ca6cd37bbf23> <https://w3id.org/citizenship#residentSince> \"2015-01-01\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ."),
+		[]byte("<https://issuer.oidp.uscis.gov/credentials/83627465> <http://schema.org/description> \"Government of Example Permanent Resident Card.\" ."),
+		[]byte("<https://issuer.oidp.uscis.gov/credentials/83627465> <http://schema.org/identifier> \"83627465\" ."),
+		[]byte("<https://issuer.oidp.uscis.gov/credentials/83627465> <http://schema.org/name> \"Permanent Resident Card\" ."),
+		[]byte("<https://issuer.oidp.uscis.gov/credentials/83627465> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/citizenship#PermanentResidentCard> ."),
+		[]byte("<https://issuer.oidp.uscis.gov/credentials/83627465> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> ."),
+		[]byte("<https://issuer.oidp.uscis.gov/credentials/83627465> <https://www.w3.org/2018/credentials#credentialSubject> <did:example:b34ca6cd37bbf23> ."),
+		[]byte("<https://issuer.oidp.uscis.gov/credentials/83627465> <https://www.w3.org/2018/credentials#expirationDate> \"2029-12-03T12:19:52Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ."),
+		[]byte("<https://issuer.oidp.uscis.gov/credentials/83627465> <https://www.w3.org/2018/credentials#issuanceDate> \"2019-12-03T12:19:52Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ."),
+		[]byte("<https://issuer.oidp.uscis.gov/credentials/83627465> <https://www.w3.org/2018/credentials#issuer> <did:example:489398593> ."),
+	}
+	indices := generateRandomIndices(threshold, n)
+	partialSignatures := make([][]byte, threshold)
+	for i := 0; i < threshold; i++ {
+		index := indices[i] - 1
+		partyPrivKey := precomputations[index].PartyPrivateKey()
+		partyPrivKeyBytes, err := partyPrivKey.Marshal()
+		require.NoError(t, err)
+		require.NotNil(t, partyPrivKeyBytes)
+
+		partyBBS := bbsplusthresholdpub.NewParty()
+		partialSignatureBytes, err := partyBBS.SignWithPresignature(messagesBytes,
+			partyPrivKeyBytes,
+			indices,
+			precomputations[index].Presignatures[0])
+		require.NoError(t, err)
+		require.NotNil(t, partialSignatureBytes)
+
+		partialSignature, err := bbsplusthresholdpub.ParsePartialSignature(partialSignatureBytes)
+		require.NoError(t, err)
+		require.NotNil(t, partialSignature)
+
+		partialSignatureBytes2, err := partialSignature.ToBytes()
+		require.NoError(t, err)
+		require.NotNil(t, partialSignatureBytes2)
+		require.Equal(t, partialSignatureBytes, partialSignatureBytes2)
+
+		partialSignatures[i] = partialSignatureBytes
+	}
+
+	signatureBytes, err := bls.SignWithPartialSignatures(partialSignatures)
+	require.NoError(t, err)
+	require.NotEmpty(t, signatureBytes)
+	require.Len(t, signatureBytes, 112)
+
+	signatureBytes2, err := bls.SignWithKey(messagesBytes, privKey)
+	require.NoError(t, err)
+	require.NotEmpty(t, signatureBytes2)
+	require.Len(t, signatureBytes2, 112)
+
+	pubKeyBytes, err := pubKey.Marshal()
+	require.NoError(t, err)
+
+	require.NoError(t, bls.Verify(messagesBytes, signatureBytes2, pubKeyBytes))
+	require.NoError(t, bls.Verify(messagesBytes, signatureBytes, pubKeyBytes))
+}
+
+func TestBBSPlusThresholdPub_SignWithKeyPair(t *testing.T) {
+	pubKey, privKey, _, err := generateKeyPairRandom(threshold, n, k)
+	require.NoError(t, err)
+
+	bls := bbsplusthresholdpub.New()
+
+	messagesBytes := [][]byte{[]byte("message1"), []byte("message2")}
+
+	signatureBytes, err := bls.SignWithKey(messagesBytes, privKey)
+	require.NoError(t, err)
+	require.NotEmpty(t, signatureBytes)
+	require.Len(t, signatureBytes, 112)
+
+	pubKeyBytes, err := pubKey.Marshal()
+	require.NoError(t, err)
+
+	require.NoError(t, bls.Verify(messagesBytes, signatureBytes, pubKeyBytes))
+}
+
+func TestBBSPlusThresholdPub_Sign(t *testing.T) {
+	pubKey, privKey, _, err := generateKeyPairRandom(threshold, n, k)
+	require.NoError(t, err)
+
+	bls := bbsplusthresholdpub.New()
+
+	messagesBytes := [][]byte{[]byte("message1"), []byte("message2")}
+
+	privKeyBytes, err := privKey.Marshal()
+	require.NoError(t, err)
+
+	signatureBytes, err := bls.Sign(messagesBytes, privKeyBytes)
+	require.NoError(t, err)
+	require.NotEmpty(t, signatureBytes)
+	require.Len(t, signatureBytes, 112)
+
+	pubKeyBytes, err := pubKey.Marshal()
+	require.NoError(t, err)
+
+	require.NoError(t, bls.Verify(messagesBytes, signatureBytes, pubKeyBytes))
+
+	// invalid private key bytes
+	signatureBytes, err = bls.Sign(messagesBytes, []byte("invalid"))
+	require.Error(t, err)
+	require.EqualError(t, err, "unmarshal private key: invalid size of private key")
+	require.Nil(t, signatureBytes)
+
+	// at least one message must be passed
+	signatureBytes, err = bls.Sign([][]byte{}, privKeyBytes)
+	require.Error(t, err)
+	require.EqualError(t, err, "messages are not defined")
+	require.Nil(t, signatureBytes)
+}
+
+//nolint:lll
+func TestBBSPlusThresholdPub_VerifyProof(t *testing.T) {
+	pkBase64 := "sVEbbh9jDPGSBK/oT/EeXQwFvNuC+47rgq9cxXKrwo6G7k4JOY/vEcfgZw9Vf/TpArbIdIAJCFMDyTd7l2atS5zExAKX0B/9Z3E/mgIZeQJ81iZ/1HUnUCT2Om239KFx"
+	pkBytes, err := base64.RawStdEncoding.DecodeString(pkBase64)
+	require.NoError(t, err)
+
+	proofBase64 := "AAIBiN4EL9psRsIUlwQah7a5VROD369PPt09Z+jfzamP+/114a5RfWVMju3NCUl2Yv6ahyIdHGdEfxhC985ShlGQrRPLa+crFRiu2pfnAk+L6QMNooVMQhzJc2yYgktHen4QhsKV3IGoRRUs42zqPTP3BdqIPQeLgjDVi1d1LXEnP+WFQGEQmTKWTja4u1MsERdmAAAAdIb6HuFznhE3OByXN0Xp3E4hWQlocCdpExyNlSLh3LxK5duCI/WMM7ETTNS0Ozxe3gAAAAIuALkiwplgKW6YmvrEcllWSkG3H+uHEZzZGL6wq6Ac0SuktQ4n84tZPtMtR9vC1Rsu8f7Kwtbq1Kv4v02ct9cvj7LGcitzg3u/ZO516qLz+iitKeGeJhtFB8ggALcJOEsebPFl12cYwkieBbIHCBt4AAAAAxgEHt3iqKIyIQbTYJvtrMjGjT4zuimiZbtE3VXnqFmGaxVTeR7dh89PbPtsBI8LLMrCvFFpks9D/oTzxnw13RBmMgMlc1bcfQOmE9DZBGB7NCdwOnT7q4TVKhswOITKTQ=="
+	proofBytes, err := base64.StdEncoding.DecodeString(proofBase64)
+	require.NoError(t, err)
+
+	nonce := []byte("nonce")
+
+	messagesBytes := [][]byte{[]byte("message1"), []byte("message2")}
+	revealedMessagesBytes := messagesBytes[:1]
+
+	bls := bbsplusthresholdpub.New()
+
+	t.Run("valid signature proof", func(t *testing.T) {
+		err = bls.VerifyProof(revealedMessagesBytes, proofBytes, nonce, pkBytes)
+		require.NoError(t, err)
+	})
+
+	t.Run("test payload revealed bigger from messages", func(t *testing.T) {
+		wrongProofBytes, errDecode := base64.StdEncoding.DecodeString(`AAwP/4nFun/RtaXtUVTppUimMRTcEROs3gbjh9iqjGQAsvD+ne2uzME26gY4zNBcMKpvyLD4I6UGm8ATKLQI4OUiBXHNCQZI4YEM5hWI7AzhFXLEEVDFL0Gzr4S04PvcJsmV74BqST8iI1HUO2TCjdT1LkhgPabP/Zy8IpnbWUtLZO1t76NFwCV8+R1YpOozTNKRQQAAAHSpyGry6Rx3PRuOZUeqk4iGFq67iHSiBybjo6muud7aUyCxd9AW3onTlV2Nxz8AJD0AAAACB3FmuAUcklAj5cdSdw7VY57y7p4VmfPCKaEp1SSJTJRZXiE2xUqDntend+tkq+jjHhLCk56zk5GoZzr280IeuLne4WgpB2kNN7n5dqRpy4+UkS5+kiorLtKiJuWhk+OFTiB8jFlTbm0dH3O3tm5CzQAAAAIhY6I8vQ96tdSoyGy09wEMCdWzB06GElVHeQhWVw8fukq1dUAwWRXmZKT8kxDNAlp2NS7fXpEGXZ9fF7+c1IJp`)
+		require.NoError(t, errDecode)
+		err = bls.VerifyProof(revealedMessagesBytes, wrongProofBytes, nonce, pkBytes)
+		require.Error(t, err)
+		require.EqualError(t, err, "payload revealed bigger from messages")
+	})
+
+	t.Run("invalid size of signature proof payload", func(t *testing.T) {
+		err = bls.VerifyProof(revealedMessagesBytes, []byte("?"), nonce, pkBytes)
+		require.Error(t, err)
+		require.EqualError(t, err, "parse signature proof: invalid size of PoK payload")
+	})
+
+	t.Run("invalid size of signature proof", func(t *testing.T) {
+		proofBytesCopy := make([]byte, 5)
+
+		copy(proofBytesCopy, proofBytes)
+
+		err = bls.VerifyProof(revealedMessagesBytes, proofBytesCopy, nonce, pkBytes)
+		require.Error(t, err)
+		require.EqualError(t, err, "parse signature proof: invalid size of signature proof")
+	})
+
+	t.Run("invalid proof", func(t *testing.T) {
+		proofBytesCopy := make([]byte, len(proofBytes))
+
+		copy(proofBytesCopy, proofBytes)
+		proofBytesCopy[21] = 255 - proofBytesCopy[21]
+
+		err = bls.VerifyProof(revealedMessagesBytes, proofBytesCopy, nonce, pkBytes)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "parse signature proof: parse G1 point: failure [set bytes failed")
+	})
+
+	t.Run("invalid input public key", func(t *testing.T) {
+		err = bls.VerifyProof(revealedMessagesBytes, proofBytes, nonce, []byte("invalid public key"))
+		require.Error(t, err)
+		require.EqualError(t, err, "parse public key: invalid size of public key")
+	})
+}
+
+//nolint:lll
+func TestBBSPlusThresholdPub_VerifyProof_SeveralDisclosedMessages(t *testing.T) {
+	pkBase64 := "l0Wtf3gy5f140G5vCoCJw2420hwk6Xw65/DX3ycv1W7/eMky8DyExw+o1s2bmq3sEIJatkiN8f5D4k0766x0UvfbupFX+vVkeqnlOvT6o2cag2osQdMFbBQqAybOM4Gm"
+	pkBytes, err := base64.RawStdEncoding.DecodeString(pkBase64)
+	require.NoError(t, err)
+
+	proofBase64 := "AAQFpAE2VALtmriOzSMk/oqid4uJhPQRUVUuyenL/L4w4ykdyh0jCX64EFqCdLP+n8VrkOKXhHPKPoCOdHBOMv96aM15NFg867/MToMeNN0IFzZkzhs37qk1vWWFKReMF+cRsCAmkHO6An1goNHdY/4XquSV3LwykezraWt8+8bLvVn6ciaXBVxVcYkbIXRsVjqbAAAAdIl/C/W5G1pDbLMrUrBAYdpvzGHG25gktAuUFZb/SkIyy0uhtWJk2v6A+D3zkoEBsgAAAAJY/jfJR9kpGbSY5pfz+qPkqyNOTJbs6OEpfBwYGsyC7hspvBGUOYyvuKlS8SvKAXW7hVawAhYJbvnRwzeiP6P9kbZKtLQZIkRQB+mxRSbMk/0JgE1jApHOlPtgbqI9yIouhK9xT2wVZl79qTAwifonAAAABDTDo5VtXR2gloy+au7ai0wcnnzjMJ6ztQHRI1ApV5VuOQ19TYL7SW+C90p3QSZFQ5gtl90PHaUuEAHIb+7ZgbJvh5sc1DjKfThwPx0Ao0w8+xTbLhNlxvo6VE1cfbiuME+miCAibLgHjksQ8ctl322qnblYJLXiS4lvx/jtGvA3"
+	proofBytes, err := base64.StdEncoding.DecodeString(proofBase64)
+	require.NoError(t, err)
+
+	nonce := []byte("nonce")
+
+	messagesBytes := [][]byte{
+		[]byte("message1"),
+		[]byte("message2"),
+		[]byte("message3"),
+		[]byte("message4"),
+	}
+	revealedMessagesBytes := [][]byte{messagesBytes[0], messagesBytes[2]}
+
+	bls := bbsplusthresholdpub.New()
+
+	t.Run("valid signature", func(t *testing.T) {
+		err = bls.VerifyProof(revealedMessagesBytes, proofBytes, nonce, pkBytes)
+		require.NoError(t, err)
+	})
+}
+
+func TestBBSPlusThresholdPub_DeriveProof(t *testing.T) {
+	pubKey, privKey, _, err := generateKeyPairRandom(threshold, n, k)
+	require.NoError(t, err)
+
+	privKeyBytes, err := privKey.Marshal()
+	require.NoError(t, err)
+
+	messagesBytes := [][]byte{
+		[]byte("message1"),
+		[]byte("message2"),
+		[]byte("message3"),
+		[]byte("message4"),
+	}
+	bls := bbsplusthresholdpub.New()
+
+	signatureBytes, err := bls.Sign(messagesBytes, privKeyBytes)
+	require.NoError(t, err)
+
+	pubKeyBytes, err := pubKey.Marshal()
+	require.NoError(t, err)
+
+	require.NoError(t, bls.Verify(messagesBytes, signatureBytes, pubKeyBytes))
+
+	nonce := []byte("nonce")
+	revealedIndexes := []int{0, 2}
+	proofBytes, err := bls.DeriveProof(messagesBytes, signatureBytes, nonce, pubKeyBytes, revealedIndexes)
+	require.NoError(t, err)
+	require.NotEmpty(t, proofBytes)
+
+	revealedMessages := make([][]byte, len(revealedIndexes))
+	for i, ind := range revealedIndexes {
+		revealedMessages[i] = messagesBytes[ind]
+	}
+
+	require.NoError(t, bls.VerifyProof(revealedMessages, proofBytes, nonce, pubKeyBytes))
+
+	t.Run("DeriveProof with revealedIndexes larger than revealedMessages count", func(t *testing.T) {
+		revealedIndexes = []int{0, 2, 4, 7, 9, 11}
+		_, err = bls.DeriveProof(messagesBytes, signatureBytes, nonce, pubKeyBytes, revealedIndexes)
+		require.EqualError(t, err, "init proof of knowledge signature: invalid size: 6 revealed indexes is "+
+			"larger than 4 messages")
+	})
+}
+
+func generateRandomIndices(threshold, numOfParties int) []int {
+	rng := mathrand.New(mathrand.NewSource(time.Now().UnixNano()))
+
+	used := make(map[int]bool)
+
+	indices := make([]int, 0)
+	for len(indices) < threshold {
+		r := rng.Intn(numOfParties) + 1
+		if !used[r] {
+			used[r] = true
+			indices = append(indices, r)
+		}
+	}
+	return indices
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/bbsplusthresholdpartypub.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/bbsplusthresholdpartypub.go
@@ -1,0 +1,215 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package bbsplusthresholdpub contains BBS+ threshold signing primitives and keys. Although it can be used directly, it is recommended
+// to use BBS+ keys created by the kms along with the framework's Crypto service.
+//
+// The default local Crypto service is found at:
+// "github.com/hyperledger/aries-framework-go/component/kmscrypto/crypto/tinkcrypto"
+//
+// While the remote Crypto service is found at:
+// "github.com/hyperledger/aries-framework-go/component/kmscrypto/crypto/webkms"
+package bbsplusthresholdpub
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// BBSThresholdPartyPub defines Threshold BBS+ signature scheme where public key is a point in the field of G2.
+// BBS+ signature scheme (as defined in https://eprint.iacr.org/2016/663.pdf, section 4.3).
+type BBSThresholdPartyPub struct{}
+
+// New creates a new BBSThresholdPub.
+func NewParty() *BBSThresholdPartyPub {
+	return &BBSThresholdPartyPub{}
+}
+
+var (
+	// nolint:gochecknoglobals
+	// Partial signature length.
+	bbsplusPartialSignatureLen = curve.CompressedG1ByteSize + 3*frCompressedSize
+
+	// nolint:gochecknoglobals
+	// Partial signature length.
+	bbsplusThresholdLivePresignatureLen = curve.CompressedG1ByteSize + 3*frCompressedSize
+)
+
+// SignWithPresignature signs the one or more messages using BBS+ key pair.
+func (*BBSThresholdPartyPub) SignWithPresignature(
+	messages [][]byte,
+	partyPrivKey []byte,
+	indices []int,
+	presignature *PerPartyPresignature) ([]byte, error) {
+
+	var err error
+	privKey, err := UnmarshalPartyPrivateKey(partyPrivKey)
+	if err != nil {
+		return nil, err
+	}
+
+	pubKey := privKey.PublicKey()
+	messagesCount := len(messages)
+
+	pubKeyWithGenerators, err := pubKey.ToPublicKeyWithGenerators(messagesCount)
+	if err != nil {
+		return nil, fmt.Errorf("build generators from public key: %w", err)
+	}
+
+	messagesFr := make([]*SignatureMessage, len(messages))
+	for i := range messages {
+		messagesFr[i] = ParseSignatureMessage(messages[i])
+	}
+
+	livePresignature := NewLivePresignature(privKey.Index+1, indices, presignature)
+	// message-dependent term
+	basis := curve.GenG1
+	basis = basis.Mul(curve.NewZrFromInt(1))
+
+	for i := 0; i < len(pubKeyWithGenerators.h); i++ {
+		tmp := pubKeyWithGenerators.h[i].Copy()
+		tmp = tmp.Mul(messagesFr[i].FR)
+		basis.Add(tmp)
+	}
+
+	// Share of A
+	capitalAShare := basis.Copy()
+	capitalAShare = capitalAShare.Mul(livePresignature.AShare)
+	tmp := pubKeyWithGenerators.h0.Copy()
+	tmp = tmp.Mul(livePresignature.AlphaShare)
+	capitalAShare.Add(tmp)
+
+	partialSignature := &PartialSignature{
+		CapitalAShare: capitalAShare,
+		DeltaShare:    livePresignature.DeltaShare,
+		EShare:        livePresignature.EShare,
+		SShare:        livePresignature.SShare,
+	}
+
+	return partialSignature.ToBytes()
+}
+
+// Verify makes BLS BBS12-381 signature verification.
+func (bbs *BBSThresholdPartyPub) Verify(messages [][]byte, sigBytes, pubKeyBytes []byte) error {
+	signature, err := ParseSignature(sigBytes)
+	if err != nil {
+		return fmt.Errorf("parse signature: %w", err)
+	}
+
+	pubKey, err := UnmarshalPublicKey(pubKeyBytes)
+	if err != nil {
+		return fmt.Errorf("parse public key: %w", err)
+	}
+
+	messagesCount := len(messages)
+
+	publicKeyWithGenerators, err := pubKey.ToPublicKeyWithGenerators(messagesCount)
+	if err != nil {
+		return fmt.Errorf("build generators from public key: %w", err)
+	}
+
+	messagesFr := messagesToFr(messages)
+
+	return signature.Verify(messagesFr, publicKeyWithGenerators)
+}
+
+// VerifyProof verifies BBS+ signature proof for one ore more revealed messages.
+func (bbs *BBSThresholdPartyPub) VerifyProof(messagesBytes [][]byte, proof, nonce, pubKeyBytes []byte) error {
+	payload, err := parsePoKPayload(proof)
+	if err != nil {
+		return fmt.Errorf("parse signature proof: %w", err)
+	}
+
+	signatureProof, err := ParseSignatureProof(proof[payload.lenInBytes():])
+	if err != nil {
+		return fmt.Errorf("parse signature proof: %w", err)
+	}
+
+	messages := messagesToFr(messagesBytes)
+
+	pubKey, err := UnmarshalPublicKey(pubKeyBytes)
+	if err != nil {
+		return fmt.Errorf("parse public key: %w", err)
+	}
+
+	publicKeyWithGenerators, err := pubKey.ToPublicKeyWithGenerators(payload.messagesCount)
+	if err != nil {
+		return fmt.Errorf("build generators from public key: %w", err)
+	}
+
+	if len(payload.revealed) > len(messages) {
+		return fmt.Errorf("payload revealed bigger from messages")
+	}
+
+	revealedMessages := make(map[int]*SignatureMessage)
+	for i := range payload.revealed {
+		revealedMessages[payload.revealed[i]] = messages[i]
+	}
+
+	challengeBytes := signatureProof.GetBytesForChallenge(revealedMessages, publicKeyWithGenerators)
+	proofNonce := ParseProofNonce(nonce)
+	proofNonceBytes := proofNonce.ToBytes()
+	challengeBytes = append(challengeBytes, proofNonceBytes...)
+	proofChallenge := frFromOKM(challengeBytes)
+
+	return signatureProof.Verify(proofChallenge, publicKeyWithGenerators, revealedMessages, messages)
+}
+
+// DeriveProof derives a proof of BBS+ signature with some messages disclosed.
+func (bbs *BBSThresholdPartyPub) DeriveProof(messages [][]byte, sigBytes, nonce, pubKeyBytes []byte,
+	revealedIndexes []int) ([]byte, error) {
+	if len(revealedIndexes) == 0 {
+		return nil, errors.New("no message to reveal")
+	}
+
+	sort.Ints(revealedIndexes)
+
+	messagesCount := len(messages)
+
+	messagesFr := messagesToFr(messages)
+
+	pubKey, err := UnmarshalPublicKey(pubKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse public key: %w", err)
+	}
+
+	publicKeyWithGenerators, err := pubKey.ToPublicKeyWithGenerators(messagesCount)
+	if err != nil {
+		return nil, fmt.Errorf("build generators from public key: %w", err)
+	}
+
+	signature, err := ParseSignature(sigBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse signature: %w", err)
+	}
+
+	pokSignature, err := NewPoKOfSignature(signature, messagesFr, revealedIndexes, publicKeyWithGenerators)
+	if err != nil {
+		return nil, fmt.Errorf("init proof of knowledge signature: %w", err)
+	}
+
+	challengeBytes := pokSignature.ToBytes()
+
+	proofNonce := ParseProofNonce(nonce)
+	proofNonceBytes := proofNonce.ToBytes()
+	challengeBytes = append(challengeBytes, proofNonceBytes...)
+
+	proofChallenge := frFromOKM(challengeBytes)
+
+	proof := pokSignature.GenerateProof(proofChallenge)
+
+	payload := newPoKPayload(messagesCount, revealedIndexes)
+
+	payloadBytes, err := payload.toBytes()
+	if err != nil {
+		return nil, fmt.Errorf("derive proof: paylod to bytes: %w", err)
+	}
+
+	signatureProofBytes := append(payloadBytes, proof.ToBytes()...)
+
+	return signatureProofBytes, nil
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/bbsplusthresholdpub.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/bbsplusthresholdpub.go
@@ -1,0 +1,357 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package bbsplusthresholdpub contains BBS+ threshold signing primitives and keys. Although it can be used directly, it is recommended
+// to use BBS+ keys created by the kms along with the framework's Crypto service.
+//
+// The default local Crypto service is found at:
+// "github.com/hyperledger/aries-framework-go/component/kmscrypto/crypto/tinkcrypto"
+//
+// While the remote Crypto service is found at:
+// "github.com/hyperledger/aries-framework-go/component/kmscrypto/crypto/webkms"
+package bbsplusthresholdpub
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	ml "github.com/IBM/mathlib"
+)
+
+// nolint:gochecknoglobals
+var curve = ml.Curves[ml.BLS12_381_BBS]
+
+// BBSThresholdPub defines Threshold BBS+ signature scheme where public key is a point in the field of G2.
+// BBS+ signature scheme (as defined in https://eprint.iacr.org/2016/663.pdf, section 4.3).
+type BBSThresholdPub struct{}
+
+// New creates a new BBSThresholdPub.
+func New() *BBSThresholdPub {
+	return &BBSThresholdPub{}
+}
+
+// Number of bytes in scalar compressed form.
+const frCompressedSize = 32
+
+var (
+	// nolint:gochecknoglobals
+	// Signature length.
+	bbsplusThresholdSignatureLen = curve.CompressedG1ByteSize + 2*frCompressedSize
+
+	// nolint:gochecknoglobals
+	// Default BLS 12-381 public key length in G2 field.
+	bbsplusThresholdPublicKeyLen = curve.CompressedG2ByteSize
+
+	// nolint:gochecknoglobals
+	// Number of bytes in G1 X coordinate.
+	g1CompressedSize = curve.CompressedG1ByteSize
+
+	// nolint:gochecknoglobals
+	// Number of bytes in G1 X and Y coordinates.
+	g1UncompressedSize = curve.G1ByteSize
+
+	// nolint:gochecknoglobals
+	// Number of bytes in G2 X(a, b) and Y(a, b) coordinates.
+	g2UncompressedSize = curve.G2ByteSize
+
+	// nolint:gochecknoglobals
+	// Number of bytes in G2 X(a, b) coordinate.
+	g2CompressedSize = curve.CompressedG2ByteSize
+
+	// nolint:gochecknoglobals
+	// Number of bytes in scalar uncompressed form.
+	frUncompressedSize = curve.ScalarByteSize
+
+	// nolint:gochecknoglobals
+	// Number of bytes to stored integers.
+	intSize = 4
+)
+
+// Verify makes BLS BBS12-381 signature verification.
+func (bbs *BBSThresholdPub) Verify(messages [][]byte, sigBytes, pubKeyBytes []byte) error {
+	signature, err := ParseSignature(sigBytes)
+	if err != nil {
+		return fmt.Errorf("parse signature: %w", err)
+	}
+
+	pubKey, err := UnmarshalPublicKey(pubKeyBytes)
+	if err != nil {
+		return fmt.Errorf("parse public key: %w", err)
+	}
+
+	messagesCount := len(messages)
+
+	publicKeyWithGenerators, err := pubKey.ToPublicKeyWithGenerators(messagesCount)
+	if err != nil {
+		return fmt.Errorf("build generators from public key: %w", err)
+	}
+
+	messagesFr := messagesToFr(messages)
+
+	return signature.Verify(messagesFr, publicKeyWithGenerators)
+}
+
+// Sign signs the one or more messages using private key in compressed form.
+func (bbs *BBSThresholdPub) Sign(messages [][]byte, privKeyBytes []byte) ([]byte, error) {
+	privKey, err := UnmarshalPrivateKey(privKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal private key: %w", err)
+	}
+
+	if len(messages) == 0 {
+		return nil, errors.New("messages are not defined")
+	}
+
+	return bbs.SignWithKey(messages, privKey)
+}
+
+// VerifyProof verifies BBS+ signature proof for one ore more revealed messages.
+func (bbs *BBSThresholdPub) VerifyProof(messagesBytes [][]byte, proof, nonce, pubKeyBytes []byte) error {
+	payload, err := parsePoKPayload(proof)
+	if err != nil {
+		return fmt.Errorf("parse signature proof: %w", err)
+	}
+
+	signatureProof, err := ParseSignatureProof(proof[payload.lenInBytes():])
+	if err != nil {
+		return fmt.Errorf("parse signature proof: %w", err)
+	}
+
+	messages := messagesToFr(messagesBytes)
+
+	pubKey, err := UnmarshalPublicKey(pubKeyBytes)
+	if err != nil {
+		return fmt.Errorf("parse public key: %w", err)
+	}
+
+	publicKeyWithGenerators, err := pubKey.ToPublicKeyWithGenerators(payload.messagesCount)
+	if err != nil {
+		return fmt.Errorf("build generators from public key: %w", err)
+	}
+
+	if len(payload.revealed) > len(messages) {
+		return fmt.Errorf("payload revealed bigger from messages")
+	}
+
+	revealedMessages := make(map[int]*SignatureMessage)
+	for i := range payload.revealed {
+		revealedMessages[payload.revealed[i]] = messages[i]
+	}
+
+	challengeBytes := signatureProof.GetBytesForChallenge(revealedMessages, publicKeyWithGenerators)
+	proofNonce := ParseProofNonce(nonce)
+	proofNonceBytes := proofNonce.ToBytes()
+	challengeBytes = append(challengeBytes, proofNonceBytes...)
+	proofChallenge := frFromOKM(challengeBytes)
+
+	return signatureProof.Verify(proofChallenge, publicKeyWithGenerators, revealedMessages, messages)
+}
+
+// DeriveProof derives a proof of BBS+ signature with some messages disclosed.
+func (bbs *BBSThresholdPub) DeriveProof(messages [][]byte, sigBytes, nonce, pubKeyBytes []byte,
+	revealedIndexes []int) ([]byte, error) {
+	if len(revealedIndexes) == 0 {
+		return nil, errors.New("no message to reveal")
+	}
+
+	sort.Ints(revealedIndexes)
+
+	messagesCount := len(messages)
+
+	messagesFr := messagesToFr(messages)
+
+	pubKey, err := UnmarshalPublicKey(pubKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse public key: %w", err)
+	}
+
+	publicKeyWithGenerators, err := pubKey.ToPublicKeyWithGenerators(messagesCount)
+	if err != nil {
+		return nil, fmt.Errorf("build generators from public key: %w", err)
+	}
+
+	signature, err := ParseSignature(sigBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse signature: %w", err)
+	}
+
+	pokSignature, err := NewPoKOfSignature(signature, messagesFr, revealedIndexes, publicKeyWithGenerators)
+	if err != nil {
+		return nil, fmt.Errorf("init proof of knowledge signature: %w", err)
+	}
+
+	challengeBytes := pokSignature.ToBytes()
+
+	proofNonce := ParseProofNonce(nonce)
+	proofNonceBytes := proofNonce.ToBytes()
+	challengeBytes = append(challengeBytes, proofNonceBytes...)
+
+	proofChallenge := frFromOKM(challengeBytes)
+
+	proof := pokSignature.GenerateProof(proofChallenge)
+
+	payload := newPoKPayload(messagesCount, revealedIndexes)
+
+	payloadBytes, err := payload.toBytes()
+	if err != nil {
+		return nil, fmt.Errorf("derive proof: paylod to bytes: %w", err)
+	}
+
+	signatureProofBytes := append(payloadBytes, proof.ToBytes()...)
+
+	return signatureProofBytes, nil
+}
+
+// SignWithKey signs the one or more messages using BBS+ key pair.
+func (bbs *BBSThresholdPub) SignWithKey(messages [][]byte, privKey *PrivateKey) ([]byte, error) {
+	var err error
+
+	pubKey := privKey.PublicKey()
+	messagesCount := len(messages)
+
+	pubKeyWithGenerators, err := pubKey.ToPublicKeyWithGenerators(messagesCount)
+	if err != nil {
+		return nil, fmt.Errorf("build generators from public key: %w", err)
+	}
+
+	messagesFr := make([]*SignatureMessage, len(messages))
+	for i := range messages {
+		messagesFr[i] = ParseSignatureMessage(messages[i])
+	}
+
+	e, s := createRandSignatureFr(), createRandSignatureFr()
+	exp := privKey.FR.Copy()
+	exp = exp.Plus(e)
+	exp.InvModP(curve.GroupOrder)
+
+	b := computeB(s, messagesFr, pubKeyWithGenerators)
+
+	sig := b.Mul(frToRepr(exp))
+
+	signature := &Signature{
+		A: sig,
+		E: e,
+		S: s,
+	}
+
+	return signature.ToBytes()
+}
+
+func (bbs *BBSThresholdPub) SignWithPartialSignatures(partialSignaturesBytes [][]byte) ([]byte, error) {
+	var a *ml.G1
+	delta := curve.NewZrFromInt(0)
+	e := curve.NewZrFromInt(0)
+	s := curve.NewZrFromInt(0)
+
+	for _, partialSignatureBytes := range partialSignaturesBytes {
+		partialSignature, err := ParsePartialSignature(partialSignatureBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		if a == nil {
+			a = partialSignature.CapitalAShare.Copy()
+		} else {
+			a.Add(partialSignature.CapitalAShare)
+		}
+		delta = delta.Plus(partialSignature.DeltaShare)
+		e = e.Plus(partialSignature.EShare)
+		s = s.Plus(partialSignature.SShare)
+	}
+	delta.Mod(curve.GroupOrder)
+	e.Mod(curve.GroupOrder)
+	s.Mod(curve.GroupOrder)
+	exp := delta.Copy()
+	exp.InvModP(curve.GroupOrder)
+	a = a.Mul(exp)
+
+	signature := &Signature{
+		A: a,
+		E: e,
+		S: s,
+	}
+	return signature.ToBytes()
+}
+
+func computeB(s *ml.Zr, messages []*SignatureMessage, key *PublicKeyWithGenerators) *ml.G1 {
+	const basesOffset = 2
+
+	cb := newCommitmentBuilder(len(messages) + basesOffset)
+
+	cb.add(curve.GenG1, curve.NewZrFromInt(1))
+	cb.add(key.h0, s)
+
+	for i := 0; i < len(messages); i++ {
+		cb.add(key.h[i], messages[i].FR)
+	}
+
+	return cb.build()
+}
+
+type commitmentBuilder struct {
+	bases   []*ml.G1
+	scalars []*ml.Zr
+}
+
+func newCommitmentBuilder(expectedSize int) *commitmentBuilder {
+	return &commitmentBuilder{
+		bases:   make([]*ml.G1, 0, expectedSize),
+		scalars: make([]*ml.Zr, 0, expectedSize),
+	}
+}
+
+func (cb *commitmentBuilder) add(base *ml.G1, scalar *ml.Zr) {
+	cb.bases = append(cb.bases, base)
+	cb.scalars = append(cb.scalars, scalar)
+}
+
+func (cb *commitmentBuilder) build() *ml.G1 {
+	return sumOfG1Products(cb.bases, cb.scalars)
+}
+
+func sumOfG1Products(bases []*ml.G1, scalars []*ml.Zr) *ml.G1 {
+	var res *ml.G1
+
+	for i := 0; i < len(bases); i++ {
+		b := bases[i]
+		s := scalars[i]
+
+		g := b.Mul(frToRepr(s))
+		if res == nil {
+			res = g
+		} else {
+			res.Add(g)
+		}
+	}
+
+	return res
+}
+
+func compareTwoPairings(p1 *ml.G1, q1 *ml.G2,
+	p2 *ml.G1, q2 *ml.G2) bool {
+	p := curve.Pairing2(q1, p1, q2, p2)
+	p = curve.FExp(p)
+
+	return p.IsUnity()
+}
+
+// ProofNonce is a nonce for Proof of Knowledge proof.
+type ProofNonce struct {
+	fr *ml.Zr
+}
+
+// ParseProofNonce creates a new ProofNonce from bytes.
+func ParseProofNonce(proofNonceBytes []byte) *ProofNonce {
+	return &ProofNonce{
+		frFromOKM(proofNonceBytes),
+	}
+}
+
+// ToBytes converts ProofNonce into bytes.
+func (pn *ProofNonce) ToBytes() []byte {
+	return frToRepr(pn.fr).Bytes()
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/fr.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/fr.go
@@ -1,0 +1,71 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bbsplusthresholdpub
+
+import (
+	"crypto/rand"
+
+	ml "github.com/IBM/mathlib"
+	"golang.org/x/crypto/blake2b"
+)
+
+func parseFr(data []byte) *ml.Zr {
+	return curve.NewZrFromBytes(data)
+}
+
+// nolint:gochecknoglobals
+var f2192Bytes = []byte{
+	0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
+	0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+	0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+	0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+}
+
+func f2192() *ml.Zr {
+	return curve.NewZrFromBytes(f2192Bytes)
+}
+
+func frFromOKM(message []byte) *ml.Zr {
+	const (
+		eightBytes = 8
+		okmMiddle  = 24
+	)
+
+	// We pass a null key so error is impossible here.
+	h, _ := blake2b.New384(nil) //nolint:errcheck
+
+	// blake2b.digest() does not return an error.
+	_, _ = h.Write(message)
+	okm := h.Sum(nil)
+	emptyEightBytes := make([]byte, eightBytes)
+
+	elm := curve.NewZrFromBytes(append(emptyEightBytes, okm[:okmMiddle]...))
+	elm = elm.Mul(f2192())
+
+	fr := curve.NewZrFromBytes(append(emptyEightBytes, okm[okmMiddle:]...))
+	elm = elm.Plus(fr)
+
+	return elm
+}
+
+func frToRepr(fr *ml.Zr) *ml.Zr {
+	return fr.Copy()
+}
+
+func messagesToFr(messages [][]byte) []*SignatureMessage {
+	messagesFr := make([]*SignatureMessage, len(messages))
+
+	for i := range messages {
+		messagesFr[i] = ParseSignatureMessage(messages[i])
+	}
+
+	return messagesFr
+}
+
+func createRandSignatureFr() *ml.Zr {
+	return curve.NewRandomZr(rand.Reader)
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/keys.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/keys.go
@@ -1,0 +1,245 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bbsplusthresholdpub
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+
+	ml "github.com/IBM/mathlib"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+var (
+	// nolint:gochecknoglobals
+	seedSize = frCompressedSize
+
+	// nolint:gochecknoglobals
+	generateKeySalt = "BBS-SIG-KEYGEN-SALT-"
+)
+
+// PublicKey defines BLS Public Key.
+type PublicKey struct {
+	PointG2 *ml.G2
+}
+
+// PrivateKey defines BLS Public Key.
+type PrivateKey struct {
+	FR *ml.Zr
+}
+
+type PartyPrivateKey struct {
+	SKShare   *ml.Zr
+	publicKey *ml.G2
+	Index     int
+}
+
+func (ppk *PartyPrivateKey) Marshal() ([]byte, error) {
+	skShareBytes := ppk.SKShare.Bytes()
+	pkBytes := ppk.publicKey.Compressed()
+	indexBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(indexBytes, uint32(ppk.Index))
+	bytes := append(skShareBytes, pkBytes...)
+	bytes = append(bytes, indexBytes...)
+	return bytes, nil
+}
+
+func UnmarshalPartyPrivateKey(partyPrivKeyBytes []byte) (*PartyPrivateKey, error) {
+	if len(partyPrivKeyBytes) != frCompressedSize+g2CompressedSize+intSize {
+		return nil, errors.New("invalid size of party private key")
+	}
+
+	publicKey, err := curve.NewG2FromCompressed(partyPrivKeyBytes[frCompressedSize : frCompressedSize+g2CompressedSize])
+	if err != nil {
+		return nil, err
+	}
+
+	return &PartyPrivateKey{
+		SKShare:   parseFr(partyPrivKeyBytes[:frCompressedSize]),
+		publicKey: publicKey,
+		Index:     int(binary.LittleEndian.Uint32(partyPrivKeyBytes[frCompressedSize+g2CompressedSize:])),
+	}, nil
+}
+
+func (ppk *PartyPrivateKey) PublicKey() *PublicKey {
+	return &PublicKey{ppk.publicKey}
+}
+
+// PublicKeyWithGenerators extends PublicKey with a blinding generator h0, a commitment to the secret key w,
+// and a generator for each message h.
+type PublicKeyWithGenerators struct {
+	h0 *ml.G1
+	h  []*ml.G1
+
+	w *ml.G2
+
+	messagesCount int
+}
+
+// ToPublicKeyWithGenerators creates PublicKeyWithGenerators from the PublicKey.
+func (pk *PublicKey) ToPublicKeyWithGenerators(messagesCount int) (*PublicKeyWithGenerators, error) {
+	offset := g2UncompressedSize + 1
+
+	data := calcData(pk, messagesCount)
+
+	h0 := hashToG1(data)
+
+	h := make([]*ml.G1, messagesCount)
+
+	for i := 1; i <= messagesCount; i++ {
+		dataCopy := make([]byte, len(data))
+		copy(dataCopy, data)
+
+		iBytes := uint32ToBytes(uint32(i))
+
+		for j := 0; j < len(iBytes); j++ {
+			dataCopy[j+offset] = iBytes[j]
+		}
+
+		h[i-1] = hashToG1(dataCopy)
+	}
+
+	return &PublicKeyWithGenerators{
+		h0:            h0,
+		h:             h,
+		w:             pk.PointG2,
+		messagesCount: messagesCount,
+	}, nil
+}
+
+func calcData(key *PublicKey, messagesCount int) []byte {
+	data := key.PointG2.Bytes()
+
+	data = append(data, 0, 0, 0, 0, 0, 0)
+
+	mcBytes := uint32ToBytes(uint32(messagesCount))
+
+	data = append(data, mcBytes...)
+
+	return data
+}
+
+func hashToG1(data []byte) *ml.G1 {
+	var dstG1 = []byte("BLS12381G1_XMD:BLAKE2B_SSWU_RO_BBS+_SIGNATURES:1_0_0")
+
+	return curve.HashToG1WithDomain(data, dstG1)
+}
+
+// UnmarshalPrivateKey unmarshals PrivateKey.
+func UnmarshalPrivateKey(privKeyBytes []byte) (*PrivateKey, error) {
+	if len(privKeyBytes) != frCompressedSize {
+		return nil, errors.New("invalid size of private key")
+	}
+
+	fr := parseFr(privKeyBytes)
+
+	return &PrivateKey{
+		FR: fr,
+	}, nil
+}
+
+// Marshal marshals PrivateKey.
+func (k *PrivateKey) Marshal() ([]byte, error) {
+	bytes := k.FR.Bytes()
+	return bytes, nil
+}
+
+// PublicKey returns a Public Key as G2 point generated from the Private Key.
+func (k *PrivateKey) PublicKey() *PublicKey {
+	pointG2 := curve.GenG2.Mul(frToRepr(k.FR))
+
+	return &PublicKey{pointG2}
+}
+
+// UnmarshalPublicKey parses a PublicKey from bytes.
+func UnmarshalPublicKey(pubKeyBytes []byte) (*PublicKey, error) {
+	if len(pubKeyBytes) != bbsplusThresholdPublicKeyLen {
+		return nil, errors.New("invalid size of public key")
+	}
+
+	pointG2, err := curve.NewG2FromCompressed(pubKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("deserialize public key: %w", err)
+	}
+
+	return &PublicKey{
+		PointG2: pointG2,
+	}, nil
+}
+
+// Marshal marshals PublicKey.
+func (pk *PublicKey) Marshal() ([]byte, error) {
+	pkBytes := pk.PointG2.Compressed()
+
+	return pkBytes, nil
+}
+
+// GenerateKeyPair generates BBS+ PublicKey and PrivateKey pair.
+func GenerateKeyPair(h func() hash.Hash, seed []byte, t, n, k int) (*PublicKey, *PrivateKey, []*PerPartyPrecomputations, error) {
+	if len(seed) != 0 && len(seed) != seedSize {
+		return nil, nil, nil, errors.New("invalid size of seed")
+	}
+
+	okm, err := generateOKM(seed, h)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	privKeyFr := frFromOKM(okm)
+	privKey := &PrivateKey{privKeyFr}
+	pubKey := privKey.PublicKey()
+	output := GeneratePCFPCGOutputFromPrivKey(privKeyFr, t, k, n)
+	precomputations := CreatePPPrecomputationFromVOLEEvaluation(k, n,
+		pubKey.PointG2,
+		output.SkShares,
+		output.AShares,
+		output.EShares,
+		output.SShares,
+		output.AeTerms,
+		output.AsTerms,
+		output.AskTerms,
+	)
+
+	return pubKey, privKey, precomputations, nil
+}
+
+func generateOKM(ikm []byte, h func() hash.Hash) ([]byte, error) {
+	salt := []byte(generateKeySalt)
+	info := make([]byte, 2)
+
+	if ikm != nil {
+		ikm = append(ikm, 0)
+	} else {
+		ikm = make([]byte, seedSize+1)
+
+		_, err := rand.Read(ikm)
+		if err != nil {
+			return nil, err
+		}
+
+		ikm[seedSize] = 0
+	}
+
+	return newHKDF(h, ikm, salt, info, frUncompressedSize)
+}
+
+func newHKDF(h func() hash.Hash, ikm, salt, info []byte, length int) ([]byte, error) {
+	reader := hkdf.New(h, ikm, salt, info)
+	result := make([]byte, length)
+
+	_, err := io.ReadFull(reader, result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/keys_test.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/keys_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bbsplusthresholdpub_test
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	bbs "github.com/hyperledger/aries-framework-go/component/kmscrypto/crypto/primitive/bbsplusthresholdpub"
+)
+
+func TestGenerateKeyPair(t *testing.T) {
+	h := sha256.New
+
+	seed := make([]byte, 32)
+
+	pubKey, privKey, precomputations, err := bbs.GenerateKeyPair(h, seed, threshold, n, k)
+
+	require.NoError(t, err)
+	require.NotNil(t, pubKey)
+	require.NotNil(t, privKey)
+	require.NotNil(t, precomputations)
+
+	lenPrecomputations := len(precomputations)
+	require.Equal(t, lenPrecomputations, n)
+	for _, precomputation := range precomputations {
+		require.NotNil(t, precomputation)
+		require.NotNil(t, precomputation.PublicKey)
+		require.NotNil(t, precomputation.SkShare)
+		require.NotNil(t, precomputation.Presignatures)
+		numOfPresigs := len(precomputation.Presignatures)
+		require.Equal(t, numOfPresigs, k)
+	}
+
+	// use random seed
+	pubKey, privKey, precomputations, err = bbs.GenerateKeyPair(h, nil, threshold, n, k)
+	require.NoError(t, err)
+	require.NotNil(t, pubKey)
+	require.NotNil(t, privKey)
+	require.NotNil(t, precomputations)
+
+	lenPrecomputations = len(precomputations)
+	require.Equal(t, lenPrecomputations, n)
+	for _, precomputation := range precomputations {
+		require.NotNil(t, precomputation)
+		require.NotNil(t, precomputation.Presignatures)
+		numOfPresigs := len(precomputation.Presignatures)
+		require.Equal(t, numOfPresigs, k)
+	}
+
+	// invalid size of seed
+	pubKey, privKey, precomputations, err = bbs.GenerateKeyPair(h, make([]byte, 31), threshold, n, k)
+	require.Error(t, err)
+	require.EqualError(t, err, "invalid size of seed")
+	require.Nil(t, pubKey)
+	require.Nil(t, privKey)
+	require.Nil(t, precomputations)
+}
+
+func TestPrivateKey_Marshal(t *testing.T) {
+	_, privKey, _, err := generateKeyPairRandom(threshold, n, k)
+	require.NoError(t, err)
+
+	privKeyBytes, err := privKey.Marshal()
+	require.NoError(t, err)
+	require.NotNil(t, privKeyBytes)
+
+	privKeyUnmarshalled, err := bbs.UnmarshalPrivateKey(privKeyBytes)
+	require.NoError(t, err)
+	require.NotNil(t, privKeyUnmarshalled)
+	require.Equal(t, privKey, privKeyUnmarshalled)
+}
+
+func TestPrivateKey_PublicKey(t *testing.T) {
+	pubKey, privKey, precomputations, err := generateKeyPairRandom(threshold, n, k)
+	require.NoError(t, err)
+
+	require.Equal(t, pubKey, privKey.PublicKey())
+	for _, precomputation := range precomputations {
+		require.Equal(t, pubKey, precomputation.PartyPrivateKey().PublicKey())
+	}
+
+}
+
+func TestPublicKey_Marshal(t *testing.T) {
+	pubKey, _, _, err := generateKeyPairRandom(threshold, n, k)
+	require.NoError(t, err)
+
+	pubKeyBytes, err := pubKey.Marshal()
+	require.NoError(t, err)
+	require.NotNil(t, pubKeyBytes)
+
+	pubKeyUnmarshalled, err := bbs.UnmarshalPublicKey(pubKeyBytes)
+	require.NoError(t, err)
+	require.NotNil(t, pubKeyUnmarshalled)
+	require.Equal(t, pubKey, pubKeyUnmarshalled)
+}
+
+func TestPartyPrivateKey_Marshal(t *testing.T) {
+
+	_, _, precomputations, err := generateKeyPairRandom(threshold, n, k)
+	require.NoError(t, err)
+
+	for _, precomputation := range precomputations {
+		partyPrivateKeyBytes, err := precomputation.PartyPrivateKey().Marshal()
+		require.NoError(t, err)
+		require.NotNil(t, partyPrivateKeyBytes)
+
+		partyPrivateKeyUnmarshalled, err := bbs.UnmarshalPartyPrivateKey(partyPrivateKeyBytes)
+		require.NoError(t, err)
+		require.NotNil(t, partyPrivateKeyUnmarshalled)
+		require.Equal(t, precomputation.PartyPrivateKey(), partyPrivateKeyUnmarshalled)
+	}
+}
+
+func TestPresignature_Marshal(t *testing.T) {
+
+	_, _, precomputations, err := generateKeyPairRandom(threshold, n, k)
+	require.NoError(t, err)
+
+	for _, precomputation := range precomputations {
+		for _, presignature := range precomputation.Presignatures {
+			presigBytes, err := presignature.ToBytes()
+			require.NoError(t, err)
+			require.NotNil(t, presigBytes)
+
+			presignatureUnmarshalled, err := bbs.ParsePerPartyPresignature(presigBytes)
+			require.NoError(t, err)
+			require.NotNil(t, presignatureUnmarshalled)
+
+			presigBytes2, err := presignatureUnmarshalled.ToBytes()
+			require.NoError(t, err)
+			require.NotNil(t, presigBytes2)
+			require.Equal(t, presigBytes, presigBytes2)
+		}
+	}
+}
+
+func TestPrecomputation_Marshal(t *testing.T) {
+
+	_, _, precomputations, err := generateKeyPairRandom(threshold, n, k)
+	require.NoError(t, err)
+
+	for _, precomputation := range precomputations {
+		precomputationBytes, err := precomputation.ToBytes()
+		require.NoError(t, err)
+		require.NotNil(t, precomputationBytes)
+
+		precomputationUnmarshalled, err := bbs.ParsePerPartyPrecomputations(precomputationBytes)
+		require.NoError(t, err)
+		require.NotNil(t, precomputationUnmarshalled)
+
+		precomputationBytes2, err := precomputationUnmarshalled.ToBytes()
+		require.NoError(t, err)
+		require.NotNil(t, precomputationBytes2)
+		require.Equal(t, precomputationBytes, precomputationBytes2)
+	}
+}
+
+func generateKeyPairRandom(t, n, k int) (*bbs.PublicKey, *bbs.PrivateKey, []*bbs.PerPartyPrecomputations, error) {
+	seed := make([]byte, 32)
+
+	_, err := rand.Read(seed)
+	if err != nil {
+		panic(err)
+	}
+
+	return bbs.GenerateKeyPair(sha256.New, seed, t, n, k)
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/ole_correlation.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/ole_correlation.go
@@ -1,0 +1,80 @@
+package bbsplusthresholdpub
+
+import (
+	"crypto/rand"
+
+	ml "github.com/IBM/mathlib"
+)
+
+type OLECorrelation struct {
+	U *ml.Zr
+	V *ml.Zr
+}
+
+// MakeAllPartiesOLE generates OLE correlations for all parties based on input data.
+func MakeAllPartiesOLE(k, n int, x, y [][]*ml.Zr) [][][]*OLECorrelation {
+	if k != len(x) {
+		panic("make_all_parties_vole got ill-structured input format x.len() != k")
+	}
+
+	if k != len(y) {
+		panic("make_all_parties_vole got ill-structured input format y.len() != k")
+	}
+
+	voleCorrelation := make([][][]*OLECorrelation, k)
+
+	for i := 0; i < k; i++ {
+		if n != len(x[i]) {
+			panic("MakeAllPartiesOLE got ill-structured input format x[i_k].len() != n")
+		}
+		if n != len(y[i]) {
+			panic("MakeAllPartiesOLE got ill-structured input format y[i].len() != n")
+		}
+
+		voleCorrelation[i] = make([][]*OLECorrelation, n)
+		for j := 0; j < n; j++ {
+			voleCorrelation[i][j] = make([]*OLECorrelation, n)
+			for l := 0; l < n; l++ {
+				voleCorrelation[i][j][l] = makeOLESingle(x[i][j], y[i][l])
+			}
+		}
+	}
+	return voleCorrelation
+}
+
+// MakeAllPartiesVOLE Gets t elements and one scalar of each party (x[i_k][i]: element i_k of party i, y[i]: scalar of party i)
+func MakeAllPartiesVOLE(k, n int, x [][]*ml.Zr, y []*ml.Zr) [][][]*OLECorrelation {
+	if k != len(x) {
+		panic("make_all_parties_vole got ill-structured input format x.len() != k")
+	}
+	if n != len(y) {
+		panic("make_all_parties_vole got ill-structured input format y.len() != n")
+	}
+	voleCorrelation := make([][][]*OLECorrelation, k)
+	for i := 0; i < k; i++ {
+		if n != len(x[i]) {
+			panic("make_all_parties_vole got ill-structured input format x[i_k].len() != n")
+		}
+		voleCorrelation[i] = make([][]*OLECorrelation, n)
+		for j := 0; j < n; j++ {
+			if n != len(y) {
+				panic("make_all_parties_vole got ill-structured input format y[i].len() != n")
+			}
+			voleCorrelation[i][j] = make([]*OLECorrelation, n)
+			for l := 0; l < n; l++ {
+				voleCorrelation[i][j][l] = makeOLESingle(x[i][j], y[l])
+			}
+		}
+	}
+	return voleCorrelation
+}
+
+// makeOLESingle computes the OLE correlation for a single pair of field elements.
+// For inputs x and y, it generates u,v such that x*y = u+v.
+func makeOLESingle(x, y *ml.Zr) *OLECorrelation {
+	u := curve.NewRandomZr(rand.Reader)
+	v := x.Mul(y)
+	v = v.Minus(u)
+	v.Mod(curve.GroupOrder)
+	return &OLECorrelation{u, v}
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/partial_signature.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/partial_signature.go
@@ -1,0 +1,48 @@
+package bbsplusthresholdpub
+
+import (
+	"errors"
+	"fmt"
+
+	ml "github.com/IBM/mathlib"
+)
+
+type PartialSignature struct {
+	CapitalAShare *ml.G1
+	DeltaShare    *ml.Zr
+	EShare        *ml.Zr
+	SShare        *ml.Zr
+}
+
+func ParsePartialSignature(partSigBytes []byte) (*PartialSignature, error) {
+	if len(partSigBytes) != bbsplusPartialSignatureLen {
+		return nil, errors.New("invalid size of partial signature")
+	}
+
+	pointG1, err := curve.NewG1FromCompressed(partSigBytes[:g1CompressedSize])
+	if err != nil {
+		return nil, fmt.Errorf("deserialize G1 compressed signature: %w", err)
+	}
+
+	delta := parseFr(partSigBytes[g1CompressedSize : g1CompressedSize+frCompressedSize])
+	e := parseFr(partSigBytes[g1CompressedSize+frCompressedSize : g1CompressedSize+frCompressedSize*2])
+	s := parseFr(partSigBytes[g1CompressedSize+frCompressedSize*2:])
+
+	return &PartialSignature{
+		CapitalAShare: pointG1,
+		DeltaShare:    delta,
+		EShare:        e,
+		SShare:        s,
+	}, nil
+}
+
+func (ps *PartialSignature) ToBytes() ([]byte, error) {
+	bytes := make([]byte, bbsplusPartialSignatureLen)
+
+	copy(bytes, ps.CapitalAShare.Compressed())
+	copy(bytes[g1CompressedSize:g1CompressedSize+frCompressedSize], ps.DeltaShare.Bytes())
+	copy(bytes[g1CompressedSize+frCompressedSize:g1CompressedSize+frCompressedSize*2], ps.EShare.Bytes())
+	copy(bytes[g1CompressedSize+frCompressedSize*2:], ps.SShare.Bytes())
+
+	return bytes, nil
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/pcfpcg.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/pcfpcg.go
@@ -1,0 +1,122 @@
+package bbsplusthresholdpub
+
+import (
+	ml "github.com/IBM/mathlib"
+)
+
+type PCFPCGOutput struct {
+	Sk       *ml.Zr
+	SkShares []*ml.Zr
+	AShares  [][]*ml.Zr
+	EShares  [][]*ml.Zr
+	SShares  [][]*ml.Zr
+	AeTerms  [][][]*OLECorrelation
+	AsTerms  [][][]*OLECorrelation
+	AskTerms [][][]*OLECorrelation
+}
+
+func GeneratePPPrecomputation(t, k, n int) (*ml.Zr, []*PerPartyPrecomputations) {
+	output := GeneratePCFPCGOutput(t, k, n)
+	pk := curve.GenG2.Mul(frToRepr(output.Sk))
+	return output.Sk, CreatePPPrecomputationFromVOLEEvaluation(k, n,
+		pk,
+		output.SkShares,
+		output.AShares,
+		output.EShares,
+		output.SShares,
+		output.AeTerms,
+		output.AsTerms,
+		output.AskTerms,
+	)
+}
+
+func GeneratePCFPCGOutput(t int, k int, n int) PCFPCGOutput {
+	sk, skShares := GetShamirSharedRandomElement(t, n)
+	aShares := GetRandomElements(k, n)
+	eShares := GetRandomElements(k, n)
+	sShares := GetRandomElements(k, n)
+	aeTerms := MakeAllPartiesOLE(k, n, aShares, eShares)
+	asTerms := MakeAllPartiesOLE(k, n, aShares, sShares)
+	askTerms := MakeAllPartiesVOLE(k, n, aShares, skShares)
+
+	return PCFPCGOutput{sk, skShares, aShares, eShares, sShares, aeTerms, asTerms, askTerms}
+}
+
+func CreatePPPrecomputationFromVOLEEvaluation(
+	k int,
+	n int,
+	publicKey *ml.G2,
+	skShares []*ml.Zr,
+	aShares, eShares, sShares [][]*ml.Zr,
+	aeTerms, asTerms, askTerms [][][]*OLECorrelation,
+) []*PerPartyPrecomputations {
+	precomputations := make([]*PerPartyPrecomputations, n)
+	for iN := 0; iN < n; iN++ {
+		presignaturesList := make([]*PerPartyPresignature, k)
+
+		for iK := 0; iK < k; iK++ {
+			aeTermOwn := aShares[iK][iN].Copy()
+			aeTermOwn = aeTermOwn.Mul(eShares[iK][iN])
+			aeTermOwn.Mod(curve.GroupOrder)
+
+			asTermOwn := aShares[iK][iN].Copy()
+			asTermOwn = asTermOwn.Mul(sShares[iK][iN])
+			asTermOwn.Mod(curve.GroupOrder)
+
+			askTermOwn := aShares[iK][iN].Copy()
+			askTermOwn = askTermOwn.Mul(skShares[iN])
+			askTermOwn.Mod(curve.GroupOrder)
+
+			aeTermsA := make([]*ml.Zr, n)
+			aeTermsE := make([]*ml.Zr, n)
+			asTermsA := make([]*ml.Zr, n)
+			asTermsS := make([]*ml.Zr, n)
+			askTermsA := make([]*ml.Zr, n)
+			askTermsSK := make([]*ml.Zr, n)
+
+			for jN := 0; jN < n; jN++ {
+				aeTermsA[jN] = aeTerms[iK][iN][jN].U.Copy()
+				aeTermsE[jN] = aeTerms[iK][jN][iN].V.Copy()
+				asTermsA[jN] = asTerms[iK][iN][jN].U.Copy()
+				asTermsS[jN] = asTerms[iK][jN][iN].V.Copy()
+				askTermsA[jN] = askTerms[iK][iN][jN].U.Copy()
+				askTermsSK[jN] = askTerms[iK][jN][iN].V.Copy()
+			}
+
+			presignaturesList[iK] = &PerPartyPresignature{
+				AShare:     aShares[iK][iN],
+				EShare:     eShares[iK][iN],
+				SShare:     sShares[iK][iN],
+				AeTermOwn:  aeTermOwn,
+				AsTermOwn:  asTermOwn,
+				AskTermOwn: askTermOwn,
+				AeTermsA:   aeTermsA,
+				AeTermsE:   aeTermsE,
+				AsTermsA:   asTermsA,
+				AsTermsS:   asTermsS,
+				AskTermsA:  askTermsA,
+				AskTermsSK: askTermsSK,
+			}
+		}
+
+		precomputations[iN] = &PerPartyPrecomputations{
+			Index:         iN,
+			SkShare:       skShares[iN],
+			PublicKey:     publicKey,
+			Presignatures: presignaturesList,
+		}
+	}
+
+	return precomputations
+}
+
+func GeneratePCFPCGOutputFromPrivKey(sk *ml.Zr, t int, k int, n int) PCFPCGOutput {
+	skShares := GetShamirSharedRandomElementFromPrivKey(sk, t, n)
+	aShares := GetRandomElements(k, n)
+	eShares := GetRandomElements(k, n)
+	sShares := GetRandomElements(k, n)
+	aeTerms := MakeAllPartiesOLE(k, n, aShares, eShares)
+	asTerms := MakeAllPartiesOLE(k, n, aShares, sShares)
+	askTerms := MakeAllPartiesVOLE(k, n, aShares, skShares)
+	return PCFPCGOutput{sk, skShares, aShares, eShares, sShares, aeTerms, asTerms, askTerms}
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/precomputation_generation_test.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/precomputation_generation_test.go
@@ -1,0 +1,276 @@
+package bbsplusthresholdpub_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	ml "github.com/IBM/mathlib"
+	"github.com/hyperledger/aries-framework-go/component/kmscrypto/crypto/primitive/bbsplusthresholdpub"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllPrecomputationGeneration(t *testing.T) {
+	seed := make([]byte, 32)
+
+	_, err := rand.Read(seed)
+	if err != nil {
+		panic(err)
+	}
+
+	indices := make([][]int, k)
+	for i := 0; i < k; i++ {
+		indices[i] = generateRandomIndices(threshold, n)
+	}
+	pubKey, privKey, _, err := generateKeyPairRandom(threshold, n, k)
+	require.NoError(t, err)
+
+	output := bbsplusthresholdpub.GeneratePCFPCGOutputFromPrivKey(privKey.FR, threshold, k, n)
+
+	sk := output.Sk
+	skShares := output.SkShares
+	aShares := output.AShares
+	eShares := output.EShares
+	sShares := output.SShares
+	aeTerms := output.AeTerms
+	asTerms := output.AsTerms
+	askTerms := output.AskTerms
+	precomputations := bbsplusthresholdpub.CreatePPPrecomputationFromVOLEEvaluation(k, n,
+		pubKey.PointG2,
+		output.SkShares,
+		output.AShares,
+		output.EShares,
+		output.SShares,
+		output.AeTerms,
+		output.AsTerms,
+		output.AskTerms,
+	)
+
+	testPCFPCGOutputAeAsAsk(t, k, indices, sk, aShares, eShares, sShares, aeTerms, asTerms, askTerms)
+
+	for iK := 0; iK < k; iK++ {
+		testInterpolationForSk(t, sk, skShares, indices[iK])
+	}
+
+	testPerPartyPrecomputationsWithoutCoefficients(t, k, indices, precomputations,
+		sk, aShares, eShares, sShares)
+}
+
+func testPCFPCGOutputAeAsAsk(t *testing.T,
+	k int,
+	indices [][]int,
+	sk *ml.Zr,
+	aShares, eShares, sShares [][]*ml.Zr,
+	aeTerms, asTerms, askTerms [][][]*bbsplusthresholdpub.OLECorrelation,
+) {
+	for iK := 0; iK < k; iK++ {
+		a := curve.NewZrFromInt(0)
+		e := curve.NewZrFromInt(0)
+		s := curve.NewZrFromInt(0)
+
+		aeIndirect := curve.NewZrFromInt(0)
+		asIndirect := curve.NewZrFromInt(0)
+		askIndirect := curve.NewZrFromInt(0)
+
+		for _, iN := range indices[iK] {
+			a = a.Plus(aShares[iK][iN-1])
+			e = e.Plus(eShares[iK][iN-1])
+			s = s.Plus(sShares[iK][iN-1])
+		}
+		a.Mod(curve.GroupOrder)
+		e.Mod(curve.GroupOrder)
+		s.Mod(curve.GroupOrder)
+		aIndirect := aShares[0][0].Plus(aShares[0][1])
+		aIndirect.Mod(curve.GroupOrder)
+		eIndirect := eShares[0][0].Plus(eShares[0][1])
+		eIndirect.Mod(curve.GroupOrder)
+
+		aeDirect := a.Mul(e)
+		aeDirect.Mod(curve.GroupOrder)
+
+		asDirect := a.Mul(s)
+		asDirect.Mod(curve.GroupOrder)
+		askDirect := a.Mul(sk)
+		askDirect.Mod(curve.GroupOrder)
+
+		for _, iN := range indices[iK] {
+			for _, jN := range indices[iK] {
+				tmpAE := aeTerms[iK][iN-1][jN-1].U.Plus(aeTerms[iK][iN-1][jN-1].V)
+				tmpAE.Mod(curve.GroupOrder)
+				tmpAS := asTerms[iK][iN-1][jN-1].U.Plus(asTerms[iK][iN-1][jN-1].V)
+				tmpAS.Mod(curve.GroupOrder)
+				tmpASK := askTerms[iK][iN-1][jN-1].U.Plus(askTerms[iK][iN-1][jN-1].V)
+				tmpASK.Mod(curve.GroupOrder)
+				lagrangeCoeff := bbsplusthresholdpub.Get0LagrangeCoefficientFr(indices[iK], jN)
+				tmpASK = tmpASK.Mul(lagrangeCoeff)
+				tmpASK.Mod(curve.GroupOrder)
+				aeIndirect = aeIndirect.Plus(tmpAE)
+				aeIndirect.Mod(curve.GroupOrder)
+
+				asIndirect = asIndirect.Plus(tmpAS)
+				asIndirect.Mod(curve.GroupOrder)
+
+				askIndirect = askIndirect.Plus(tmpASK)
+				askIndirect.Mod(curve.GroupOrder)
+			}
+		}
+
+		if !aeDirect.Equals(aeIndirect) {
+			t.Errorf("Computation of AE is not consistent")
+		}
+
+		if !asDirect.Equals(asIndirect) {
+			t.Errorf("Computation of AS is not consistent")
+		}
+
+		if !askDirect.Equals(askIndirect) {
+			t.Errorf("Computation of ASK is not consistent")
+		}
+	}
+}
+
+func testInterpolationForSk(t *testing.T, sk *ml.Zr, skShares []*ml.Zr, indices []int) {
+	interpolationResult := curve.NewZrFromInt(0)
+	for _, i := range indices {
+		tmp := skShares[i-1].Copy()
+		tmp = tmp.Mul(bbsplusthresholdpub.Get0LagrangeCoefficientFr(indices, i))
+		interpolationResult = interpolationResult.Plus(tmp)
+		interpolationResult.Mod(curve.GroupOrder)
+	}
+	if !sk.Equals(interpolationResult) {
+		t.Errorf("Problems with interpolation")
+	}
+}
+
+func testPerPartyPrecomputationsWithoutCoefficients(t *testing.T, k int, indices [][]int,
+	precomputations []*bbsplusthresholdpub.PerPartyPrecomputations, sk *ml.Zr,
+	aShares, eShares, sShares [][]*ml.Zr) {
+
+	coefficients := make([][]*ml.Zr, len(indices))
+	for i, idx := range indices {
+		coefficients[i] = bbsplusthresholdpub.Get0LagrangeCoefficientSetFr(idx)
+	}
+
+	testPerPartyPrecomputationsWithCoefficients(
+		t,
+		k,
+		indices,
+		coefficients,
+		precomputations,
+		sk, aShares, eShares, sShares)
+}
+
+func testPerPartyPrecomputationsWithCoefficients(
+	t *testing.T,
+	k int,
+	indices [][]int,
+	coefficients [][]*ml.Zr,
+	precomputations []*bbsplusthresholdpub.PerPartyPrecomputations,
+	sk *ml.Zr,
+	aShares, eShares, sShares [][]*ml.Zr,
+) {
+	for iK := 0; iK < k; iK++ {
+		aDirect := curve.NewZrFromInt(0)
+		eDirect := curve.NewZrFromInt(0)
+		sDirect := curve.NewZrFromInt(0)
+		aIndirect := curve.NewZrFromInt(0)
+		eIndirect := curve.NewZrFromInt(0)
+		sIndirect := curve.NewZrFromInt(0)
+		aeIndirect := curve.NewZrFromInt(0)
+		asIndirect := curve.NewZrFromInt(0)
+		askIndirect := curve.NewZrFromInt(0)
+
+		for _, elI := range indices[iK] {
+			aDirect = aDirect.Plus(aShares[iK][elI-1])
+			eDirect = eDirect.Plus(eShares[iK][elI-1])
+			sDirect = sDirect.Plus(sShares[iK][elI-1])
+
+			aIndirect = aIndirect.Plus(precomputations[elI-1].Presignatures[iK].AShare)
+			eIndirect = eIndirect.Plus(precomputations[elI-1].Presignatures[iK].EShare)
+			sIndirect = sIndirect.Plus(precomputations[elI-1].Presignatures[iK].SShare)
+		}
+
+		aDirect.Mod(curve.GroupOrder)
+		eDirect.Mod(curve.GroupOrder)
+		sDirect.Mod(curve.GroupOrder)
+		aIndirect.Mod(curve.GroupOrder)
+		eIndirect.Mod(curve.GroupOrder)
+		sIndirect.Mod(curve.GroupOrder)
+
+		aeDirect := aDirect.Copy()
+		aeDirect = aeDirect.Mul(eDirect)
+		aeDirect.Mod(curve.GroupOrder)
+
+		asDirect := aDirect.Copy()
+		asDirect = asDirect.Mul(sDirect)
+		asDirect.Mod(curve.GroupOrder)
+
+		askDirect := aDirect.Copy()
+		askDirect = askDirect.Mul(sk)
+		askDirect.Mod(curve.GroupOrder)
+
+		//Compute share of each party and add it to the total
+		for indI, elI := range indices[iK] {
+			//For (ae,as)-shares start with the multiplication of both own shares
+			shareOfAE := precomputations[elI-1].Presignatures[iK].AeTermOwn.Copy()
+			shareOfAS := precomputations[elI-1].Presignatures[iK].AsTermOwn.Copy()
+
+			// ASK-Share is split into a part which is to multiplied with own-index-lagrange and one which directly gets other-index-lagrange
+			shareOfAsk := curve.NewZrFromInt(0)
+			tmpAskOwnLagrange := precomputations[elI-1].Presignatures[iK].AskTermOwn.Copy() // Own-index-lagrange starts with multiplication of both own shares
+
+			for indJ, elJ := range indices[iK] {
+				if elJ != elI {
+					// Add shares of a_i * e/s_j (ae/sTermsA), a_j * e_i (ae/sTermsA/s)
+					shareOfAE = shareOfAE.Plus(precomputations[elI-1].Presignatures[iK].AeTermsA[elJ-1])
+					shareOfAE = shareOfAE.Plus(precomputations[elI-1].Presignatures[iK].AeTermsE[elJ-1])
+					shareOfAE.Mod(curve.GroupOrder)
+					shareOfAS = shareOfAS.Plus(precomputations[elI-1].Presignatures[iK].AsTermsA[elJ-1])
+					shareOfAS = shareOfAS.Plus(precomputations[elI-1].Presignatures[iK].AsTermsS[elJ-1])
+					shareOfAS.Mod(curve.GroupOrder)
+					// Share of a_i * sk_j (using j's lagrange coefficient) is added to shareOfAsk
+					tmp := precomputations[elI-1].Presignatures[iK].AskTermsA[elJ-1].Copy()
+					tmp = tmp.Mul(coefficients[iK][indJ])
+					tmp.Mod(curve.GroupOrder)
+					shareOfAsk = shareOfAsk.Plus(tmp)
+					shareOfAsk.Mod(curve.GroupOrder)
+					//Share of a_j * sk_i (using i's lagrange coefficeint) is added to tmp_ask_own_lagrange (coefficient is applied later for all at once)
+					tmpAskOwnLagrange = tmpAskOwnLagrange.Plus(precomputations[elI-1].Presignatures[iK].AskTermsSK[elJ-1])
+					tmpAskOwnLagrange.Mod(curve.GroupOrder)
+				}
+			}
+
+			//Apply i's lagrange coefficient to sum of share of all cross-terms incoperating sk_i and add result to share of ask
+			tmpAskOwnLagrange = tmpAskOwnLagrange.Mul(coefficients[iK][indI])
+			tmpAskOwnLagrange.Mod(curve.GroupOrder)
+			shareOfAsk = shareOfAsk.Plus(tmpAskOwnLagrange)
+			shareOfAsk.Mod(curve.GroupOrder)
+			// Add computed share of ae/as/ask to the computation of ae/as/ask
+			aeIndirect = aeIndirect.Plus(shareOfAE)
+			aeIndirect.Mod(curve.GroupOrder)
+			asIndirect = asIndirect.Plus(shareOfAS)
+			asIndirect.Mod(curve.GroupOrder)
+			askIndirect = askIndirect.Plus(shareOfAsk)
+			askIndirect.Mod(curve.GroupOrder)
+		}
+
+		if !aDirect.Equals(aIndirect) {
+			t.Errorf("Computation of A is not consistent")
+		}
+		if !eDirect.Equals(eIndirect) {
+			t.Errorf("Computation of E is not consistent")
+		}
+		if !sDirect.Equals(sIndirect) {
+			t.Errorf("Computation of S is not consistent")
+		}
+		if !aeDirect.Equals(aeIndirect) {
+			t.Errorf("Computation of AE is not consistent")
+		}
+		if !asDirect.Equals(asIndirect) {
+			t.Errorf("Computation of AS is not consistent")
+		}
+		if !askDirect.Equals(askIndirect) {
+			t.Errorf("Computation of ASK is not consistent")
+		}
+	}
+
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/precomputations.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/precomputations.go
@@ -1,0 +1,428 @@
+package bbsplusthresholdpub
+
+import (
+	"encoding/binary"
+	"errors"
+
+	ml "github.com/IBM/mathlib"
+)
+
+type PerPartyPresignature struct {
+	AShare     *ml.Zr   // a^k_i for k in [t].
+	EShare     *ml.Zr   // e^k_i for k in [t].
+	SShare     *ml.Zr   // s^k_i for k in [t].
+	AeTermOwn  *ml.Zr   // a^k_i * e^k_i for k in [t].   // Might not be necessary.
+	AsTermOwn  *ml.Zr   // a^k_i * s^k_i for k in [t]   // Might not be necessary.
+	AskTermOwn *ml.Zr   // a^k_i * sk_i for k in [t]    // Might not be necessary.
+	AeTermsA   []*ml.Zr // Share of a^k_i * e^k_j for k in [t], j in [n] (j can also be i).
+	AeTermsE   []*ml.Zr // Share of a^k_j * e^k_i for k in [t], j in [n] (j can also be i -- this time other share).
+	AsTermsA   []*ml.Zr // Share of a^k_i * s^k_j for k in [t], j in [n] (j can also be i).
+	AsTermsS   []*ml.Zr // Share of a^k_j * s^k_i for k in [t], j in [n] (j can also be i -- this time other share).
+	AskTermsA  []*ml.Zr // Share of a^k_i * sk_j for k in [t], j in [n] (j can also be i).
+	AskTermsSK []*ml.Zr // Share of a^k_j * sk_i for k in [t], j in [n] (j can also be i -- this time other share).
+}
+
+func ParsePerPartyPresignature(presigBytes []byte) (*PerPartyPresignature, error) {
+	if len(presigBytes) < 6*intSize {
+		return nil, errors.New("input presigBytes is too short to represent the PerPartyPresignature")
+	}
+
+	// Deserialize slices' lengths
+	aeTermsALen := int(binary.LittleEndian.Uint32(presigBytes[:4]))
+	aeTermsELen := int(binary.LittleEndian.Uint32(presigBytes[4:8]))
+	asTermsALen := int(binary.LittleEndian.Uint32(presigBytes[8:12]))
+	asTermsSLen := int(binary.LittleEndian.Uint32(presigBytes[12:16]))
+	askTermsALen := int(binary.LittleEndian.Uint32(presigBytes[16:20]))
+	askTermsSKLen := int(binary.LittleEndian.Uint32(presigBytes[20:24]))
+
+	presigBytes = presigBytes[24:]
+	if len(presigBytes) != frCompressedSize*
+		(6+aeTermsALen+aeTermsELen+
+			asTermsALen+asTermsSLen+
+			askTermsALen+askTermsSKLen) {
+		return nil, errors.New("input presigBytes is too short to represent the PerPartyPreSignature")
+	}
+
+	// Deserialize AShare
+	aShareBytes := presigBytes[:frCompressedSize]
+	presigBytes = presigBytes[frCompressedSize:]
+	aShare := parseFr(aShareBytes)
+
+	// Deserialize EShare
+	eShareBytes := presigBytes[:frCompressedSize]
+	presigBytes = presigBytes[frCompressedSize:]
+	eShare := parseFr(eShareBytes)
+
+	// Deserialize SShare
+	sShareBytes := presigBytes[:frCompressedSize]
+	presigBytes = presigBytes[frCompressedSize:]
+	sShare := parseFr(sShareBytes)
+
+	// Deserialize AeTermOwn
+	aeTermOwnBytes := presigBytes[:frCompressedSize]
+	presigBytes = presigBytes[frCompressedSize:]
+	aeTermOwn := parseFr(aeTermOwnBytes)
+
+	// Deserialize AsTermOwn
+	asTermOwnBytes := presigBytes[:frCompressedSize]
+	presigBytes = presigBytes[frCompressedSize:]
+	asTermOwn := parseFr(asTermOwnBytes)
+
+	// Deserialize AskTermOwn
+	askTermOwnBytes := presigBytes[:frCompressedSize]
+	presigBytes = presigBytes[frCompressedSize:]
+	askTermOwn := parseFr(askTermOwnBytes)
+
+	// Deserialise AeTermsA
+	aeTermsABytes := presigBytes[:frCompressedSize*aeTermsALen]
+	presigBytes = presigBytes[frCompressedSize*aeTermsALen:]
+	aeTermsA := make([]*ml.Zr, aeTermsALen)
+	for i := 0; i < aeTermsALen; i++ {
+		offset := i * frCompressedSize
+		aeTermABytes := aeTermsABytes[offset : offset+frCompressedSize]
+		aeTermsA[i] = parseFr(aeTermABytes)
+	}
+
+	// Deserialise AeTermsE
+	aeTermsEBytes := presigBytes[:frCompressedSize*aeTermsELen]
+	presigBytes = presigBytes[frCompressedSize*aeTermsELen:]
+	aeTermsE := make([]*ml.Zr, aeTermsELen)
+	for i := 0; i < aeTermsELen; i++ {
+		offset := i * frCompressedSize
+		aeTermEBytes := aeTermsEBytes[offset : offset+frCompressedSize]
+		aeTermsE[i] = parseFr(aeTermEBytes)
+	}
+
+	// Deserialise AsTermsA
+	asTermsABytes := presigBytes[:frCompressedSize*asTermsALen]
+	presigBytes = presigBytes[frCompressedSize*asTermsALen:]
+	asTermsA := make([]*ml.Zr, asTermsALen)
+	for i := 0; i < asTermsALen; i++ {
+		offset := i * frCompressedSize
+		asTermABytes := asTermsABytes[offset : offset+frCompressedSize]
+		asTermsA[i] = parseFr(asTermABytes)
+	}
+
+	// Deserialise AsTermsS
+	asTermsSBytes := presigBytes[:frCompressedSize*asTermsSLen]
+	presigBytes = presigBytes[frCompressedSize*asTermsSLen:]
+	asTermsS := make([]*ml.Zr, asTermsSLen)
+	for i := 0; i < asTermsSLen; i++ {
+		offset := i * frCompressedSize
+		asTermSBytes := asTermsSBytes[offset : offset+frCompressedSize]
+		asTermsS[i] = parseFr(asTermSBytes)
+	}
+
+	// Deserialise AskTermsA
+	askTermsABytes := presigBytes[:frCompressedSize*askTermsALen]
+	presigBytes = presigBytes[frCompressedSize*askTermsALen:]
+	askTermsA := make([]*ml.Zr, askTermsALen)
+	for i := 0; i < askTermsALen; i++ {
+		offset := i * frCompressedSize
+		askTermABytes := askTermsABytes[offset : offset+frCompressedSize]
+		askTermsA[i] = parseFr(askTermABytes)
+	}
+	// Deserialise AskTermsSK
+	askTermsSKBytes := presigBytes[:frCompressedSize*askTermsSKLen]
+	askTermsSK := make([]*ml.Zr, askTermsSKLen)
+	for i := 0; i < askTermsSKLen; i++ {
+		offset := i * frCompressedSize
+		askTermSKBytes := askTermsSKBytes[offset : offset+frCompressedSize]
+		askTermsSK[i] = parseFr(askTermSKBytes)
+	}
+
+	return &PerPartyPresignature{
+		AShare:     aShare,
+		EShare:     eShare,
+		SShare:     sShare,
+		AeTermOwn:  aeTermOwn,
+		AsTermOwn:  asTermOwn,
+		AskTermOwn: askTermOwn,
+		AeTermsA:   aeTermsA,
+		AeTermsE:   aeTermsE,
+		AsTermsA:   asTermsA,
+		AsTermsS:   asTermsS,
+		AskTermsA:  askTermsA,
+		AskTermsSK: askTermsSK,
+	}, nil
+}
+
+func (ppp *PerPartyPresignature) ToBytes() ([]byte, error) {
+	// Serialize AShare
+	aShareBytes := ppp.AShare.Bytes()
+
+	// Serialize EShare
+	eShareBytes := ppp.EShare.Bytes()
+
+	// Serialize sShare
+	sShareBytes := ppp.SShare.Bytes()
+
+	// Serialize AeTermOwn
+	aeTermOwnBytes := ppp.AeTermOwn.Bytes()
+
+	// Serialize AsTermOwn
+	asTermOwnBytes := ppp.AsTermOwn.Bytes()
+
+	// Serialize AskTermOwn
+	askTermOwnBytes := ppp.AskTermOwn.Bytes()
+
+	// Serialize AeTermsA
+	aeTermsALenBytes := make([]byte, intSize)
+	binary.LittleEndian.PutUint32(aeTermsALenBytes, uint32(len(ppp.AeTermsA)))
+	var aeTermsABytes []byte
+	for _, aeTermA := range ppp.AeTermsA {
+		aeTermsABytes = append(aeTermsABytes, aeTermA.Bytes()...)
+	}
+
+	// Serialize AeTermsE
+	aeTermsELenBytes := make([]byte, intSize)
+	binary.LittleEndian.PutUint32(aeTermsELenBytes, uint32(len(ppp.AeTermsE)))
+	var aeTermsEBytes []byte
+	for _, aeTermE := range ppp.AeTermsE {
+		aeTermsEBytes = append(aeTermsEBytes, aeTermE.Bytes()...)
+	}
+	// Serialize AsTermsA
+	asTermsALenBytes := make([]byte, intSize)
+	binary.LittleEndian.PutUint32(asTermsALenBytes, uint32(len(ppp.AsTermsA)))
+	var asTermsABytes []byte
+	for _, asTermA := range ppp.AsTermsA {
+		asTermsABytes = append(asTermsABytes, asTermA.Bytes()...)
+	}
+
+	// Serialize AsTermsS
+	asTermsSLenBytes := make([]byte, intSize)
+	binary.LittleEndian.PutUint32(asTermsSLenBytes, uint32(len(ppp.AsTermsS)))
+	var asTermsSBytes []byte
+	for _, asTermS := range ppp.AsTermsS {
+		asTermsSBytes = append(asTermsSBytes, asTermS.Bytes()...)
+	}
+
+	// Serialize AskTermsA
+	askTermsALenBytes := make([]byte, intSize)
+	binary.LittleEndian.PutUint32(askTermsALenBytes, uint32(len(ppp.AskTermsA)))
+	var askTermsABytes []byte
+	for _, askTermA := range ppp.AskTermsA {
+		askTermsABytes = append(askTermsABytes, askTermA.Bytes()...)
+	}
+
+	// Serialize AskTermsSK
+	askTermsSKLenBytes := make([]byte, intSize)
+	binary.LittleEndian.PutUint32(askTermsSKLenBytes, uint32(len(ppp.AskTermsSK)))
+	var askTermsSKBytes []byte
+	for _, askTermSK := range ppp.AskTermsSK {
+		askTermsSKBytes = append(askTermsSKBytes, askTermSK.Bytes()...)
+	}
+
+	serialized := append(aeTermsALenBytes, aeTermsELenBytes...)
+	serialized = append(serialized, asTermsALenBytes...)
+	serialized = append(serialized, asTermsSLenBytes...)
+	serialized = append(serialized, askTermsALenBytes...)
+	serialized = append(serialized, askTermsSKLenBytes...)
+	serialized = append(serialized, aShareBytes...)
+	serialized = append(serialized, eShareBytes...)
+	serialized = append(serialized, sShareBytes...)
+	serialized = append(serialized, aeTermOwnBytes...)
+	serialized = append(serialized, asTermOwnBytes...)
+	serialized = append(serialized, askTermOwnBytes...)
+	serialized = append(serialized, aeTermsABytes...)
+	serialized = append(serialized, aeTermsEBytes...)
+	serialized = append(serialized, asTermsABytes...)
+	serialized = append(serialized, asTermsSBytes...)
+	serialized = append(serialized, askTermsABytes...)
+	serialized = append(serialized, askTermsSKBytes...)
+
+	if len(serialized) < intSize*6+frCompressedSize*
+		(6+len(ppp.AeTermsA)+len(ppp.AeTermsE)+
+			len(ppp.AsTermsA)+len(ppp.AsTermsS)+
+			len(ppp.AskTermsA)+len(ppp.AskTermsSK)) {
+		return nil, errors.New("invalid size of presignature")
+	}
+	return serialized, nil
+}
+
+type PerPartyPrecomputations struct {
+	Index         int // Position at which sk-polynomial for own secret key share is evaluated.
+	SkShare       *ml.Zr
+	PublicKey     *ml.G2
+	Presignatures []*PerPartyPresignature
+}
+
+func ParsePerPartyPrecomputations(pppBytes []byte) (*PerPartyPrecomputations, error) {
+	if len(pppBytes) < 2*intSize+frCompressedSize+g2CompressedSize {
+		return nil, errors.New("input data is too short to represent the PerPartyPrecomputation")
+	}
+
+	preSigsLen := int(binary.LittleEndian.Uint32(pppBytes[:4]))
+	index := int(binary.LittleEndian.Uint32(pppBytes[4:8]))
+	skShare := parseFr(pppBytes[8 : 8+frCompressedSize])
+	publicKey, err := curve.NewG2FromCompressed(pppBytes[8+frCompressedSize : 8+frCompressedSize+g2CompressedSize])
+	if err != nil {
+		return nil, err
+	}
+	var presignatures []*PerPartyPresignature
+
+	preSigsBytes := pppBytes[8+frCompressedSize+g2CompressedSize:]
+	if len(preSigsBytes) < 4*preSigsLen {
+		return nil, errors.New("input presignatures too short")
+	}
+	for i := 0; i < preSigsLen; i++ {
+		preSigLen := int(binary.LittleEndian.Uint32(preSigsBytes[:intSize]))
+		presignature, err := ParsePerPartyPresignature(preSigsBytes[intSize : intSize+preSigLen])
+		if err != nil {
+			return nil, err
+		}
+		preSigsBytes = preSigsBytes[intSize+preSigLen:]
+		presignatures = append(presignatures, presignature)
+	}
+
+	return &PerPartyPrecomputations{
+		Index:         index,
+		SkShare:       skShare,
+		PublicKey:     publicKey,
+		Presignatures: presignatures,
+	}, nil
+}
+
+func (ppp *PerPartyPrecomputations) ToBytes() ([]byte, error) {
+	preSigsLenBytes := make([]byte, intSize)
+	binary.LittleEndian.PutUint32(preSigsLenBytes, uint32(len(ppp.Presignatures)))
+	indexBytes := make([]byte, intSize)
+	binary.LittleEndian.PutUint32(indexBytes, uint32(ppp.Index))
+
+	skShareBytes := ppp.SkShare.Bytes()
+
+	pubKeyBytes := ppp.PublicKey.Compressed()
+
+	var preSigsBytes []byte
+	for _, presignature := range ppp.Presignatures {
+		preSigBytes, err := presignature.ToBytes()
+		if err != nil {
+			return nil, err
+		}
+		preSigLenBytes := make([]byte, intSize)
+		binary.LittleEndian.PutUint32(preSigLenBytes, uint32(len(preSigBytes)))
+		preSigsBytes = append(preSigsBytes, preSigLenBytes...)
+		preSigsBytes = append(preSigsBytes, preSigBytes...)
+	}
+
+	result := append(preSigsLenBytes, indexBytes...)
+	result = append(result, skShareBytes...)
+	result = append(result, pubKeyBytes...)
+	result = append(result, preSigsBytes...)
+	return result, nil
+}
+
+func (ppp *PerPartyPrecomputations) PartyPrivateKey() *PartyPrivateKey {
+	return &PartyPrivateKey{
+		SKShare:   ppp.SkShare,
+		publicKey: ppp.PublicKey,
+		Index:     ppp.Index,
+	}
+}
+
+type LivePresignature struct {
+	AShare     *ml.Zr
+	EShare     *ml.Zr
+	SShare     *ml.Zr
+	DeltaShare *ml.Zr
+	AlphaShare *ml.Zr
+}
+
+func ParseLivePresignature(livePresigBytes []byte) (*LivePresignature, error) {
+	if len(livePresigBytes) != bbsplusThresholdLivePresignatureLen {
+		return nil, errors.New("invalid size of live presignature")
+	}
+
+	aShare := parseFr(livePresigBytes[:frCompressedSize])
+	eShare := parseFr(livePresigBytes[frCompressedSize : frCompressedSize*2])
+	sShare := parseFr(livePresigBytes[frCompressedSize*2 : frCompressedSize*3])
+	deltaShare := parseFr(livePresigBytes[frCompressedSize*3 : frCompressedSize*4])
+	alphaShare := parseFr(livePresigBytes[frCompressedSize*4 : frCompressedSize*5])
+
+	return &LivePresignature{
+		AShare:     aShare,
+		EShare:     eShare,
+		SShare:     sShare,
+		DeltaShare: deltaShare,
+		AlphaShare: alphaShare,
+	}, nil
+}
+
+func (lp *LivePresignature) ToBytes() ([]byte, error) {
+	bytes := make([]byte, bbsplusThresholdLivePresignatureLen)
+	copy(bytes, lp.AShare.Bytes())
+	copy(bytes[frCompressedSize:frCompressedSize*2], lp.EShare.Bytes())
+	copy(bytes[frCompressedSize*2:frCompressedSize*3], lp.SShare.Bytes())
+	copy(bytes[frCompressedSize*3:frCompressedSize*4], lp.DeltaShare.Bytes())
+	copy(bytes[frCompressedSize*4:frCompressedSize*5], lp.AlphaShare.Bytes())
+	return bytes, nil
+}
+
+func NewLivePresignature(
+	ownIndex int,
+	indices []int,
+	presignature *PerPartyPresignature) *LivePresignature {
+	lagrangeCoefficients := Get0LagrangeCoefficientSetFr(indices)
+	return newLivePresignatureWithCoefficients(ownIndex, indices, presignature, lagrangeCoefficients)
+}
+
+func newLivePresignatureWithCoefficients(
+	ownIndex int,
+	indices []int,
+	presignature *PerPartyPresignature,
+	lagrangeCoefficients []*ml.Zr) *LivePresignature {
+
+	// For (ae,as = alpha)-shares start with the multiplication of both own shares
+	alphaShare := presignature.AsTermOwn.Copy()
+	aeShare := presignature.AeTermOwn.Copy()
+
+	// ASK-Share is split into a part which is to multiplied with own-index-lagrange and one which directly gets
+	// other-index-lagrange.
+	askShare := curve.NewZrFromInt(0)
+	tmpAskOwnCoefficient := presignature.AskTermOwn.Copy()
+
+	indI := 0
+	for indJ, elJ := range indices {
+		if elJ != ownIndex {
+			// Add shares of a_i * e/s_j (ae/s_terms_a), a_j * e_i (ae/s_terms_a/s)
+			aeShare = aeShare.Plus(presignature.AeTermsA[elJ-1])
+			aeShare = aeShare.Plus(presignature.AeTermsE[elJ-1])
+			aeShare.Mod(curve.GroupOrder)
+			alphaShare = alphaShare.Plus(presignature.AsTermsA[elJ-1])
+			alphaShare = alphaShare.Plus(presignature.AsTermsS[elJ-1])
+			alphaShare.Mod(curve.GroupOrder)
+
+			// Share of  a_i * sk_j (using j's lagrange coefficient) is added to share_of_ask
+			tmp := presignature.AskTermsA[elJ-1].Copy()
+			tmp = tmp.Mul(lagrangeCoefficients[indJ])
+			tmp.Mod(curve.GroupOrder)
+
+			askShare = askShare.Plus(tmp)
+			askShare.Mod(curve.GroupOrder)
+			// Share of a_j * sk_i (using i's lagrange coefficient) is added to tmp_ask_own_lagrange (coefficient is
+			// applied later for all at once).
+			tmpAskOwnCoefficient = tmpAskOwnCoefficient.Plus(presignature.AskTermsSK[elJ-1])
+			tmpAskOwnCoefficient.Mod(curve.GroupOrder)
+		} else {
+			indI = indJ
+		}
+	}
+	// Apply i's lagrange coefficient to sum of share of all cross-terms incorporating sk_i and add result to share of ask.
+	tmpAskOwnCoefficient = tmpAskOwnCoefficient.Mul(lagrangeCoefficients[indI])
+	tmpAskOwnCoefficient.Mod(curve.GroupOrder)
+	askShare = askShare.Plus(tmpAskOwnCoefficient)
+	askShare.Mod(curve.GroupOrder)
+
+	// Compute delta_share
+	deltaShare := aeShare.Copy()
+	deltaShare = deltaShare.Plus(askShare)
+	deltaShare.Mod(curve.GroupOrder)
+
+	return &LivePresignature{
+		AShare:     presignature.AShare,
+		EShare:     presignature.EShare,
+		SShare:     presignature.SShare,
+		DeltaShare: deltaShare,
+		AlphaShare: alphaShare,
+	}
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/proof_of_knowledge.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/proof_of_knowledge.go
@@ -1,0 +1,230 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bbsplusthresholdpub
+
+import (
+	"fmt"
+
+	ml "github.com/IBM/mathlib"
+)
+
+// PoKOfSignature is Proof of Knowledge of a Signature that is used by the prover to construct PoKOfSignatureProof.
+type PoKOfSignature struct {
+	aPrime *ml.G1
+	aBar   *ml.G1
+	d      *ml.G1
+
+	pokVC1   *ProverCommittedG1
+	secrets1 []*ml.Zr
+
+	pokVC2   *ProverCommittedG1
+	secrets2 []*ml.Zr
+
+	revealedMessages map[int]*SignatureMessage
+}
+
+// NewPoKOfSignature creates a new PoKOfSignature.
+func NewPoKOfSignature(signature *Signature, messages []*SignatureMessage, revealedIndexes []int,
+	pubKey *PublicKeyWithGenerators) (*PoKOfSignature, error) {
+	err := signature.Verify(messages, pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("verify input signature: %w", err)
+	}
+
+	r1, r2 := createRandSignatureFr(), createRandSignatureFr()
+	b := computeB(signature.S, messages, pubKey)
+	aPrime := signature.A.Mul(frToRepr(r1))
+
+	aBarDenom := aPrime.Mul(frToRepr(signature.E))
+
+	aBar := b.Mul(frToRepr(r1))
+	aBar.Sub(aBarDenom)
+
+	r2D := r2.Copy()
+	r2D.Neg()
+
+	commitmentBasesCount := 2
+	cb := newCommitmentBuilder(commitmentBasesCount)
+	cb.add(b, r1)
+	cb.add(pubKey.h0, r2D)
+
+	d := cb.build()
+	r3 := r1.Copy()
+	r3.InvModP(curve.GroupOrder)
+
+	sPrime := r2.Mul(r3)
+	sPrime.Neg()
+	sPrime = sPrime.Plus(signature.S)
+
+	pokVC1, secrets1 := newVC1Signature(aPrime, pubKey.h0, signature.E, r2)
+
+	revealedMessages := make(map[int]*SignatureMessage, len(revealedIndexes))
+
+	if len(messages) < len(revealedIndexes) {
+		return nil, fmt.Errorf("invalid size: %d revealed indexes is larger than %d messages", len(revealedIndexes),
+			len(messages))
+	}
+
+	for _, ind := range revealedIndexes {
+		revealedMessages[ind] = messages[ind]
+	}
+
+	pokVC2, secrets2 := newVC2Signature(d, r3, pubKey, sPrime, messages, revealedMessages)
+
+	return &PoKOfSignature{
+		aPrime:           aPrime,
+		aBar:             aBar,
+		d:                d,
+		pokVC1:           pokVC1,
+		secrets1:         secrets1,
+		pokVC2:           pokVC2,
+		secrets2:         secrets2,
+		revealedMessages: revealedMessages,
+	}, nil
+}
+
+func newVC1Signature(aPrime *ml.G1, h0 *ml.G1,
+	e, r2 *ml.Zr) (*ProverCommittedG1, []*ml.Zr) {
+	committing1 := NewProverCommittingG1()
+	secrets1 := make([]*ml.Zr, 2)
+
+	committing1.Commit(aPrime)
+
+	sigE := e.Copy()
+	sigE.Neg()
+	secrets1[0] = sigE
+
+	committing1.Commit(h0)
+
+	secrets1[1] = r2
+	pokVC1 := committing1.Finish()
+
+	return pokVC1, secrets1
+}
+
+func newVC2Signature(d *ml.G1, r3 *ml.Zr, pubKey *PublicKeyWithGenerators, sPrime *ml.Zr,
+	messages []*SignatureMessage, revealedMessages map[int]*SignatureMessage) (*ProverCommittedG1, []*ml.Zr) {
+	messagesCount := len(messages)
+	committing2 := NewProverCommittingG1()
+	baseSecretsCount := 2
+	secrets2 := make([]*ml.Zr, 0, baseSecretsCount+messagesCount)
+
+	committing2.Commit(d)
+
+	r3D := r3.Copy()
+	r3D.Neg()
+
+	secrets2 = append(secrets2, r3D)
+
+	committing2.Commit(pubKey.h0)
+
+	secrets2 = append(secrets2, sPrime)
+
+	for i := 0; i < messagesCount; i++ {
+		if _, ok := revealedMessages[i]; ok {
+			continue
+		}
+
+		committing2.Commit(pubKey.h[i])
+
+		sourceFR := messages[i].FR
+		hiddenFRCopy := sourceFR.Copy()
+
+		secrets2 = append(secrets2, hiddenFRCopy)
+	}
+
+	pokVC2 := committing2.Finish()
+
+	return pokVC2, secrets2
+}
+
+// ToBytes converts PoKOfSignature to bytes.
+func (pos *PoKOfSignature) ToBytes() []byte {
+	challengeBytes := pos.aBar.Bytes()
+	challengeBytes = append(challengeBytes, pos.pokVC1.ToBytes()...)
+	challengeBytes = append(challengeBytes, pos.pokVC2.ToBytes()...)
+
+	return challengeBytes
+}
+
+// GenerateProof generates PoKOfSignatureProof proof from PoKOfSignature signature.
+func (pos *PoKOfSignature) GenerateProof(challengeHash *ml.Zr) *PoKOfSignatureProof {
+	return &PoKOfSignatureProof{
+		aPrime:   pos.aPrime,
+		aBar:     pos.aBar,
+		d:        pos.d,
+		proofVC1: pos.pokVC1.GenerateProof(challengeHash, pos.secrets1),
+		proofVC2: pos.pokVC2.GenerateProof(challengeHash, pos.secrets2),
+	}
+}
+
+// ProverCommittedG1 helps to generate a ProofG1.
+type ProverCommittedG1 struct {
+	bases           []*ml.G1
+	blindingFactors []*ml.Zr
+	commitment      *ml.G1
+}
+
+// ToBytes converts ProverCommittedG1 to bytes.
+func (g *ProverCommittedG1) ToBytes() []byte {
+	bytes := make([]byte, 0)
+
+	for _, base := range g.bases {
+		bytes = append(bytes, base.Bytes()...)
+	}
+
+	return append(bytes, g.commitment.Bytes()...)
+}
+
+// GenerateProof generates proof ProofG1 for all secrets.
+func (g *ProverCommittedG1) GenerateProof(challenge *ml.Zr, secrets []*ml.Zr) *ProofG1 {
+	responses := make([]*ml.Zr, len(g.bases))
+
+	for i := range g.blindingFactors {
+		c := challenge.Mul(secrets[i])
+
+		s := g.blindingFactors[i].Minus(c)
+		responses[i] = s
+	}
+
+	return &ProofG1{
+		commitment: g.commitment,
+		responses:  responses,
+	}
+}
+
+// ProverCommittingG1 is a proof of knowledge of messages in a vector commitment.
+type ProverCommittingG1 struct {
+	bases           []*ml.G1
+	blindingFactors []*ml.Zr
+}
+
+// NewProverCommittingG1 creates a new ProverCommittingG1.
+func NewProverCommittingG1() *ProverCommittingG1 {
+	return &ProverCommittingG1{
+		bases:           make([]*ml.G1, 0),
+		blindingFactors: make([]*ml.Zr, 0),
+	}
+}
+
+// Commit append a base point and randomly generated blinding factor.
+func (pc *ProverCommittingG1) Commit(base *ml.G1) {
+	pc.bases = append(pc.bases, base)
+	r := createRandSignatureFr()
+	pc.blindingFactors = append(pc.blindingFactors, r)
+}
+
+// Finish helps to generate ProverCommittedG1 after commitment of all base points.
+func (pc *ProverCommittingG1) Finish() *ProverCommittedG1 {
+	commitment := sumOfG1Products(pc.bases, pc.blindingFactors)
+
+	return &ProverCommittedG1{
+		bases:           pc.bases,
+		blindingFactors: pc.blindingFactors,
+		commitment:      commitment,
+	}
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/secret_sharing.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/secret_sharing.go
@@ -1,0 +1,102 @@
+package bbsplusthresholdpub
+
+import (
+	"crypto/rand"
+
+	ml "github.com/IBM/mathlib"
+)
+
+// GetLagrangeCoefficientFr computes the lagrange coefficient that is to be applied to the evaluation of the polynomial
+// at position evaluation_x for an interpolation to position interpolation_x if the available evaluated positions are
+// defined by indices.
+func GetLagrangeCoefficientFr(indices []int, evaluationX int, interpolationX int) *ml.Zr {
+	top := curve.NewZrFromInt(1)
+	bot := curve.NewZrFromInt(1)
+
+	for _, index := range indices {
+		if index != evaluationX {
+			tmpTop := curve.NewZrFromInt(int64(interpolationX))
+			tmpTop = tmpTop.Minus(curve.NewZrFromInt(int64(index)))
+			top = top.Mul(tmpTop)
+
+			tmpBot := curve.NewZrFromInt(int64(evaluationX))
+			tmpBot = tmpBot.Minus(curve.NewZrFromInt(int64(index)))
+			bot = bot.Mul(tmpBot)
+		}
+	}
+	botInv := bot.Copy()
+	botInv.InvModP(curve.GroupOrder)
+	top = top.Mul(botInv)
+
+	return top
+}
+
+// Get0LagrangeCoefficientFr computes the lagrange coefficient that is to be applied to the evaluation of the polynomial
+// at position evaluation_x for an interpolation to position 0 if the available evaluated positions are defined by indices.
+func Get0LagrangeCoefficientFr(indices []int, evaluationX int) *ml.Zr {
+	return GetLagrangeCoefficientFr(indices, evaluationX, 0)
+}
+
+// Get0LagrangeCoefficientSetFr computes all lagrange coefficients for an interpolation to position 0 if the available
+// evaluated positions are defined by indices.
+func Get0LagrangeCoefficientSetFr(indices []int) []*ml.Zr {
+	coefficients := make([]*ml.Zr, len(indices))
+	for i, idx := range indices {
+		coefficients[i] = Get0LagrangeCoefficientFr(indices, idx)
+	}
+	return coefficients
+}
+
+// GetShamirSharedRandomElement generates a t-out-of-n shamir secret sharing of a random element.
+func GetShamirSharedRandomElement(t, n int) (*ml.Zr, []*ml.Zr) {
+	// Generate the secret key element
+	secretKeyElement := curve.NewRandomZr(rand.Reader)
+
+	// Shamir Coefficients
+	coefficients := make([]*ml.Zr, t-1)
+	for i := 0; i < t-1; i++ {
+		coefficients[i] = curve.NewRandomZr(rand.Reader)
+	}
+
+	// Shares
+	shares := make([]*ml.Zr, n)
+	for i := 0; i < n; i++ {
+		share := secretKeyElement.Copy() // Share initialized with secret key element
+
+		incrExponentiation := curve.NewZrFromInt(1)
+
+		for j := 0; j < t-1; j++ {
+			incrExponentiation = incrExponentiation.Mul(curve.NewZrFromInt(int64(i + 1)))
+			tmp := coefficients[j].Copy()
+			tmp = tmp.Mul(incrExponentiation)
+			share = share.Plus(tmp)
+		}
+		share.Mod(curve.GroupOrder)
+		shares[i] = share
+	}
+	return secretKeyElement, shares
+}
+
+func GetShamirSharedRandomElementFromPrivKey(privKey *ml.Zr, t, n int) []*ml.Zr {
+	// Shamir Coefficients
+	coefficients := make([]*ml.Zr, t-1)
+	for i := 0; i < t-1; i++ {
+		coefficients[i] = curve.NewRandomZr(rand.Reader)
+	}
+
+	// Shares
+	shares := make([]*ml.Zr, n)
+	for i := 0; i < n; i++ {
+		share := privKey.Copy() // Share initialized with secret key element
+		incrExponentiation := curve.NewZrFromInt(1)
+		for j := 0; j < t-1; j++ {
+			incrExponentiation = incrExponentiation.Mul(curve.NewZrFromInt(int64(i + 1)))
+			tmp := coefficients[j].Copy()
+			tmp = tmp.Mul(incrExponentiation)
+			share = share.Plus(tmp)
+		}
+		share.Mod(curve.GroupOrder)
+		shares[i] = share
+	}
+	return shares
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/signature.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/signature.go
@@ -1,0 +1,70 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bbsplusthresholdpub
+
+import (
+	"errors"
+	"fmt"
+
+	ml "github.com/IBM/mathlib"
+)
+
+// Signature defines BLS signature.
+type Signature struct {
+	A *ml.G1
+	E *ml.Zr
+	S *ml.Zr
+}
+
+// ParseSignature parses a Signature from bytes.
+func ParseSignature(sigBytes []byte) (*Signature, error) {
+	if len(sigBytes) != bbsplusThresholdSignatureLen {
+		return nil, errors.New("invalid size of signature")
+	}
+
+	pointG1, err := curve.NewG1FromCompressed(sigBytes[:g1CompressedSize])
+	if err != nil {
+		return nil, fmt.Errorf("deserialize G1 compressed signature: %w", err)
+	}
+
+	e := parseFr(sigBytes[g1CompressedSize : g1CompressedSize+frCompressedSize])
+	s := parseFr(sigBytes[g1CompressedSize+frCompressedSize:])
+
+	return &Signature{
+		A: pointG1,
+		E: e,
+		S: s,
+	}, nil
+}
+
+// ToBytes converts signature to bytes using compression of G1 point and E, S FR points.
+func (s *Signature) ToBytes() ([]byte, error) {
+	bytes := make([]byte, bbsplusThresholdSignatureLen)
+
+	copy(bytes, s.A.Compressed())
+	copy(bytes[g1CompressedSize:g1CompressedSize+frCompressedSize], s.E.Bytes())
+	copy(bytes[g1CompressedSize+frCompressedSize:], s.S.Bytes())
+
+	return bytes, nil
+}
+
+// Verify is used for signature verification.
+func (s *Signature) Verify(messages []*SignatureMessage, pubKey *PublicKeyWithGenerators) error {
+	p1 := s.A
+
+	q1 := curve.GenG2.Mul(frToRepr(s.E))
+	q1.Add(pubKey.w)
+
+	p2 := computeB(s.S, messages, pubKey)
+	p2.Neg()
+
+	if compareTwoPairings(p1, q1, p2, curve.GenG2) {
+		return nil
+	}
+
+	return errors.New("invalid BLS12-381 signature")
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/signature_message.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/signature_message.go
@@ -1,0 +1,25 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bbsplusthresholdpub
+
+import (
+	ml "github.com/IBM/mathlib"
+)
+
+// SignatureMessage defines a message to be used for a signature check.
+type SignatureMessage struct {
+	FR *ml.Zr
+}
+
+// ParseSignatureMessage parses SignatureMessage from bytes.
+func ParseSignatureMessage(message []byte) *SignatureMessage {
+	elm := frFromOKM(message)
+
+	return &SignatureMessage{
+		FR: elm,
+	}
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/signature_proof.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/signature_proof.go
@@ -1,0 +1,276 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bbsplusthresholdpub
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	ml "github.com/IBM/mathlib"
+)
+
+// PoKOfSignatureProof defines BLS signature proof.
+// It is the actual proof that is sent from prover to verifier.
+type PoKOfSignatureProof struct {
+	aPrime *ml.G1
+	aBar   *ml.G1
+	d      *ml.G1
+
+	proofVC1 *ProofG1
+	proofVC2 *ProofG1
+}
+
+// GetBytesForChallenge creates bytes for proof challenge.
+func (sp *PoKOfSignatureProof) GetBytesForChallenge(revealedMessages map[int]*SignatureMessage,
+	pubKey *PublicKeyWithGenerators) []byte {
+	hiddenCount := pubKey.messagesCount - len(revealedMessages)
+
+	bytesLen := (7 + hiddenCount) * g1UncompressedSize //nolint:gomnd
+	bytes := make([]byte, 0, bytesLen)
+
+	bytes = append(bytes, sp.aBar.Bytes()...)
+	bytes = append(bytes, sp.aPrime.Bytes()...)
+	bytes = append(bytes, pubKey.h0.Bytes()...)
+	bytes = append(bytes, sp.proofVC1.commitment.Bytes()...)
+	bytes = append(bytes, sp.d.Bytes()...)
+	bytes = append(bytes, pubKey.h0.Bytes()...)
+
+	for i := range pubKey.h {
+		if _, ok := revealedMessages[i]; !ok {
+			bytes = append(bytes, pubKey.h[i].Bytes()...)
+		}
+	}
+
+	bytes = append(bytes, sp.proofVC2.commitment.Bytes()...)
+
+	return bytes
+}
+
+// Verify verifies PoKOfSignatureProof.
+func (sp *PoKOfSignatureProof) Verify(challenge *ml.Zr, pubKey *PublicKeyWithGenerators,
+	revealedMessages map[int]*SignatureMessage, messages []*SignatureMessage) error {
+	aBar := sp.aBar.Copy()
+	aBar.Neg()
+
+	ok := compareTwoPairings(sp.aPrime, pubKey.w, aBar, curve.GenG2)
+	if !ok {
+		return errors.New("bad signature")
+	}
+
+	err := sp.verifyVC1Proof(challenge, pubKey)
+	if err != nil {
+		return err
+	}
+
+	return sp.verifyVC2Proof(challenge, pubKey, revealedMessages, messages)
+}
+
+func (sp *PoKOfSignatureProof) verifyVC1Proof(challenge *ml.Zr, pubKey *PublicKeyWithGenerators) error {
+	basesVC1 := []*ml.G1{sp.aPrime, pubKey.h0}
+	aBarD := sp.aBar.Copy()
+	aBarD.Sub(sp.d)
+
+	err := sp.proofVC1.Verify(basesVC1, aBarD, challenge)
+	if err != nil {
+		return errors.New("bad signature")
+	}
+
+	return nil
+}
+
+func (sp *PoKOfSignatureProof) verifyVC2Proof(challenge *ml.Zr, pubKey *PublicKeyWithGenerators,
+	revealedMessages map[int]*SignatureMessage, messages []*SignatureMessage) error {
+	revealedMessagesCount := len(revealedMessages)
+
+	basesVC2 := make([]*ml.G1, 0, 2+pubKey.messagesCount-revealedMessagesCount)
+	basesVC2 = append(basesVC2, sp.d, pubKey.h0)
+
+	basesDisclosed := make([]*ml.G1, 0, 1+revealedMessagesCount)
+	exponents := make([]*ml.Zr, 0, 1+revealedMessagesCount)
+
+	basesDisclosed = append(basesDisclosed, curve.GenG1)
+	exponents = append(exponents, curve.NewZrFromInt(1))
+
+	revealedMessagesInd := 0
+
+	for i := range pubKey.h {
+		if _, ok := revealedMessages[i]; ok {
+			basesDisclosed = append(basesDisclosed, pubKey.h[i])
+			exponents = append(exponents, messages[revealedMessagesInd].FR)
+			revealedMessagesInd++
+		} else {
+			basesVC2 = append(basesVC2, pubKey.h[i])
+		}
+	}
+
+	// TODO: expose 0
+	pr := curve.GenG1.Copy()
+	pr.Sub(curve.GenG1)
+
+	for i := 0; i < len(basesDisclosed); i++ {
+		b := basesDisclosed[i]
+		s := exponents[i]
+
+		g := b.Mul(frToRepr(s))
+		pr.Add(g)
+	}
+
+	pr.Neg()
+
+	err := sp.proofVC2.Verify(basesVC2, pr, challenge)
+	if err != nil {
+		return errors.New("bad signature")
+	}
+
+	return nil
+}
+
+// ToBytes converts PoKOfSignatureProof to bytes.
+func (sp *PoKOfSignatureProof) ToBytes() []byte {
+	bytes := make([]byte, 0)
+
+	bytes = append(bytes, sp.aPrime.Compressed()...)
+	bytes = append(bytes, sp.aBar.Compressed()...)
+	bytes = append(bytes, sp.d.Compressed()...)
+
+	proof1Bytes := sp.proofVC1.ToBytes()
+	lenBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenBytes, uint32(len(proof1Bytes)))
+	bytes = append(bytes, lenBytes...)
+	bytes = append(bytes, proof1Bytes...)
+
+	bytes = append(bytes, sp.proofVC2.ToBytes()...)
+
+	return bytes
+}
+
+// ProofG1 is a proof of knowledge of a signature and hidden messages.
+type ProofG1 struct {
+	commitment *ml.G1
+	responses  []*ml.Zr
+}
+
+// NewProofG1 creates a new ProofG1.
+func NewProofG1(commitment *ml.G1, responses []*ml.Zr) *ProofG1 {
+	return &ProofG1{
+		commitment: commitment,
+		responses:  responses,
+	}
+}
+
+// Verify verifies the ProofG1.
+func (pg1 *ProofG1) Verify(bases []*ml.G1, commitment *ml.G1, challenge *ml.Zr) error {
+	contribution := pg1.getChallengeContribution(bases, commitment, challenge)
+	contribution.Sub(pg1.commitment)
+
+	if !contribution.IsInfinity() {
+		return errors.New("contribution is not zero")
+	}
+
+	return nil
+}
+
+func (pg1 *ProofG1) getChallengeContribution(bases []*ml.G1, commitment *ml.G1,
+	challenge *ml.Zr) *ml.G1 {
+	points := append(bases, commitment)
+	scalars := append(pg1.responses, challenge)
+
+	return sumOfG1Products(points, scalars)
+}
+
+// ToBytes converts ProofG1 to bytes.
+func (pg1 *ProofG1) ToBytes() []byte {
+	bytes := make([]byte, 0)
+
+	commitmentBytes := pg1.commitment.Compressed()
+	bytes = append(bytes, commitmentBytes...)
+
+	lenBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenBytes, uint32(len(pg1.responses)))
+	bytes = append(bytes, lenBytes...)
+
+	for i := range pg1.responses {
+		responseBytes := frToRepr(pg1.responses[i]).Bytes()
+		bytes = append(bytes, responseBytes...)
+	}
+
+	return bytes
+}
+
+// ParseSignatureProof parses a signature proof.
+func ParseSignatureProof(sigProofBytes []byte) (*PoKOfSignatureProof, error) {
+	if len(sigProofBytes) < g1CompressedSize*3 {
+		return nil, errors.New("invalid size of signature proof")
+	}
+
+	g1Points := make([]*ml.G1, 3)
+	offset := 0
+
+	for i := range g1Points {
+		g1Point, err := curve.NewG1FromCompressed(sigProofBytes[offset : offset+g1CompressedSize])
+		if err != nil {
+			return nil, fmt.Errorf("parse G1 point: %w", err)
+		}
+
+		g1Points[i] = g1Point
+		offset += g1CompressedSize
+	}
+
+	proof1BytesLen := int(uint32FromBytes(sigProofBytes[offset : offset+4]))
+	offset += 4
+
+	proofVc1, err := ParseProofG1(sigProofBytes[offset : offset+proof1BytesLen])
+	if err != nil {
+		return nil, fmt.Errorf("parse G1 proof: %w", err)
+	}
+
+	offset += proof1BytesLen
+
+	proofVc2, err := ParseProofG1(sigProofBytes[offset:])
+	if err != nil {
+		return nil, fmt.Errorf("parse G1 proof: %w", err)
+	}
+
+	return &PoKOfSignatureProof{
+		aPrime:   g1Points[0],
+		aBar:     g1Points[1],
+		d:        g1Points[2],
+		proofVC1: proofVc1,
+		proofVC2: proofVc2,
+	}, nil
+}
+
+// ParseProofG1 parses ProofG1 from bytes.
+func ParseProofG1(bytes []byte) (*ProofG1, error) {
+	if len(bytes) < g1CompressedSize+4 {
+		return nil, errors.New("invalid size of G1 signature proof")
+	}
+
+	offset := 0
+
+	commitment, err := curve.NewG1FromCompressed(bytes[:g1CompressedSize])
+	if err != nil {
+		return nil, fmt.Errorf("parse G1 point: %w", err)
+	}
+
+	offset += g1CompressedSize
+	length := int(uint32FromBytes(bytes[offset : offset+4]))
+	offset += 4
+
+	if len(bytes) < g1CompressedSize+4+length*frCompressedSize {
+		return nil, errors.New("invalid size of G1 signature proof")
+	}
+
+	responses := make([]*ml.Zr, length)
+	for i := 0; i < length; i++ {
+		responses[i] = parseFr(bytes[offset : offset+frCompressedSize])
+		offset += frCompressedSize
+	}
+
+	return NewProofG1(commitment, responses), nil
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/signature_test.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/signature_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bbsplusthresholdpub_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	bbs "github.com/hyperledger/aries-framework-go/component/kmscrypto/crypto/primitive/bbsplusthresholdpub"
+)
+
+func TestParseSignature(t *testing.T) {
+	sigBytes := []byte{179, 22, 156, 110, 6, 135, 216, 0, 253, 221, 34, 23, 84, 99, 206, 177, 70, 39, 227, 170, 31, 198, 153, 146, 254, 80, 87, 165, 43, 147, 216, 60, 240, 196, 31, 200, 191, 85, 46, 230, 229, 198, 52, 94, 39, 178, 132, 7, 20, 151, 53, 123, 253, 84, 174, 230, 112, 210, 136, 122, 249, 50, 146, 214, 210, 252, 142, 158, 39, 0, 128, 216, 193, 210, 12, 195, 20, 250, 40, 251, 3, 48, 32, 63, 3, 72, 128, 226, 173, 209, 93, 73, 253, 95, 122, 81, 60, 8, 9, 70, 136, 171, 193, 249, 190, 245, 171, 187, 253, 25, 107, 201} //nolint:lll
+
+	signature, err := bbs.ParseSignature(sigBytes)
+	require.NoError(t, err)
+
+	sigBytes2, err := signature.ToBytes()
+	require.NoError(t, err)
+	require.Equal(t, sigBytes, sigBytes2)
+
+	// invalid G1 signature part
+	invalidSigBytes := make([]byte, len(sigBytes))
+	signature, err = bbs.ParseSignature(invalidSigBytes)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "deserialize G1 compressed signature")
+	require.Nil(t, signature)
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/utils.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/utils.go
@@ -1,0 +1,141 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bbsplusthresholdpub
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+
+	ml "github.com/IBM/mathlib"
+)
+
+func uint32ToBytes(value uint32) []byte {
+	bytes := make([]byte, 4)
+
+	binary.BigEndian.PutUint32(bytes, value)
+
+	return bytes
+}
+
+func uint16FromBytes(bytes []byte) uint16 {
+	return binary.BigEndian.Uint16(bytes)
+}
+
+func uint32FromBytes(bytes []byte) uint32 {
+	return binary.BigEndian.Uint32(bytes)
+}
+
+func bitvectorToIndexes(data []byte) []int {
+	revealedIndexes := make([]int, 0)
+	scalar := 0
+
+	for _, v := range data {
+		remaining := 8
+
+		for v > 0 {
+			revealed := v & 1
+			if revealed == 1 {
+				revealedIndexes = append(revealedIndexes, scalar)
+			}
+
+			v >>= 1
+			scalar++
+			remaining--
+		}
+
+		scalar += remaining
+	}
+
+	return revealedIndexes
+}
+
+type pokPayload struct {
+	messagesCount int
+	revealed      []int
+}
+
+// nolint:gomnd
+func parsePoKPayload(bytes []byte) (*pokPayload, error) {
+	if len(bytes) < 2 {
+		return nil, errors.New("invalid size of PoK payload")
+	}
+
+	messagesCount := int(uint16FromBytes(bytes[0:2]))
+	offset := lenInBytes(messagesCount)
+
+	if len(bytes) < offset {
+		return nil, errors.New("invalid size of PoK payload")
+	}
+
+	revealed := bitvectorToIndexes(reverseBytes(bytes[2:offset]))
+
+	return &pokPayload{
+		messagesCount: messagesCount,
+		revealed:      revealed,
+	}, nil
+}
+
+// nolint:gomnd
+func (p *pokPayload) toBytes() ([]byte, error) {
+	bytes := make([]byte, p.lenInBytes())
+
+	binary.BigEndian.PutUint16(bytes, uint16(p.messagesCount))
+
+	bitvector := bytes[2:]
+
+	for _, r := range p.revealed {
+		idx := r / 8
+		bit := r % 8
+
+		if len(bitvector) <= idx {
+			return nil, errors.New("invalid size of PoK payload")
+		}
+
+		bitvector[idx] |= 1 << bit
+	}
+
+	reverseBytes(bitvector)
+
+	return bytes, nil
+}
+
+func (p *pokPayload) lenInBytes() int {
+	return lenInBytes(p.messagesCount)
+}
+
+func lenInBytes(messagesCount int) int {
+	return 2 + (messagesCount / 8) + 1 //nolint:gomnd
+}
+
+func newPoKPayload(messagesCount int, revealed []int) *pokPayload {
+	return &pokPayload{
+		messagesCount: messagesCount,
+		revealed:      revealed,
+	}
+}
+
+func reverseBytes(s []byte) []byte {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
+	}
+
+	return s
+}
+
+// GetRandomElements creates a k-size vector of n-size vectors of random field elements
+func GetRandomElements(k, n int) [][]*ml.Zr {
+	result := make([][]*ml.Zr, k)
+	for i := 0; i < k; i++ {
+		result[i] = make([]*ml.Zr, n)
+		for j := 0; j < n; j++ {
+			fr := curve.NewRandomZr(rand.Reader)
+			result[i][j] = fr
+		}
+	}
+	return result
+}

--- a/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/utils_test.go
+++ b/component/kmscrypto/crypto/primitive/bbsplusthresholdpub/utils_test.go
@@ -1,0 +1,37 @@
+package bbsplusthresholdpub
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_pokPayload(t *testing.T) {
+	payload := newPoKPayload(4, []int{0, 2})
+	require.Equal(t, 3, payload.lenInBytes())
+
+	bytes, err := payload.toBytes()
+	require.NoError(t, err)
+	require.Len(t, bytes, 3)
+
+	payloadParsed, err := parsePoKPayload(bytes)
+	require.NoError(t, err)
+	require.Equal(t, payload, payloadParsed)
+
+	payloadParsed, err = parsePoKPayload([]byte{})
+	require.Error(t, err)
+	require.Nil(t, payloadParsed)
+}
+
+func Test_pokPayloadFail(t *testing.T) {
+	payload := newPoKPayload(1, []int{0, 2, 4, 5, 9})
+	require.Equal(t, 3, payload.lenInBytes())
+
+	_, err := payload.toBytes()
+	require.EqualError(t, err, "invalid size of PoK payload")
+
+	bytes := []byte{9, 0}
+	payloadParsed, err := parsePoKPayload(bytes)
+	require.EqualError(t, err, "invalid size of PoK payload")
+	require.Nil(t, payloadParsed)
+}

--- a/component/models/signature/signer/threshold_bbs_signer.go
+++ b/component/models/signature/signer/threshold_bbs_signer.go
@@ -1,0 +1,156 @@
+package signer
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/hyperledger/aries-framework-go/component/kmscrypto/crypto/primitive/bbsplusthresholdpub"
+)
+
+type baseSignatureSigner struct {
+	keyType   string
+	curve     string
+	algorithm string
+}
+
+func (sv baseSignatureSigner) KeyType() string {
+	return sv.keyType
+}
+
+func (sv baseSignatureSigner) Curve() string {
+	return sv.curve
+}
+
+func (sv baseSignatureSigner) Algorithm() string {
+	return sv.algorithm
+}
+
+type ThresholdBBSG2SignaturePartySigner struct {
+	partyPrivKeyBytes []byte
+	indices           [][]int
+	presignatures     []*bbsplusthresholdpub.PerPartyPresignature
+	msgIndex          int // Index of the current message/presignature.
+	baseSignatureSigner
+}
+
+func NewThresholdBBSG2SignaturePartySigner(precomputationBytes []byte) (*ThresholdBBSG2SignaturePartySigner, error) {
+	precomputation, err := bbsplusthresholdpub.ParsePerPartyPrecomputations(precomputationBytes)
+	if err != nil {
+		return nil, err
+	}
+	partyPrivKey := precomputation.PartyPrivateKey()
+	partyPrivKeyBytes, err := partyPrivKey.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	numOfPresigs := len(precomputation.Presignatures)
+	return &ThresholdBBSG2SignaturePartySigner{
+		partyPrivKeyBytes: partyPrivKeyBytes,
+		indices:           make([][]int, numOfPresigs),
+		presignatures:     precomputation.Presignatures,
+		baseSignatureSigner: baseSignatureSigner{
+			keyType:   "EC",
+			curve:     "BLS12381_G2",
+			algorithm: "party_threshold_bbs+",
+		},
+	}, nil
+}
+
+func (tbps *ThresholdBBSG2SignaturePartySigner) SetIndices(indices []int, index int) {
+	tbps.indices[index] = indices
+}
+
+func (tbps *ThresholdBBSG2SignaturePartySigner) SetNexMsgIndex(msgIndex int) {
+	tbps.msgIndex = msgIndex
+}
+
+func (tbps *ThresholdBBSG2SignaturePartySigner) Alg() string {
+	return tbps.Algorithm()
+}
+
+// Sign will sign create signature of each message and aggregate it
+// into a single partial signature using the signer's precomputation.
+// returns:
+//
+//	partial signature in []byte
+//	error in case of errors
+func (tbps *ThresholdBBSG2SignaturePartySigner) Sign(data []byte) ([]byte, error) {
+	party_bbs := bbsplusthresholdpub.NewParty()
+	if tbps.msgIndex >= len(tbps.presignatures) || tbps.msgIndex < 0 {
+		return nil, errors.New("out of presignatures")
+	}
+	if tbps.indices[tbps.msgIndex] == nil {
+		return nil, errors.New("missing indices")
+	}
+	partialSigBytes, err := party_bbs.SignWithPresignature(splitMessageIntoLines(string(data)),
+		tbps.partyPrivKeyBytes,
+		tbps.indices[tbps.msgIndex],
+		tbps.presignatures[tbps.msgIndex])
+	if err != nil {
+		return nil, err
+	}
+	return partialSigBytes, nil
+}
+
+type ThresholdBBSG2SignatureSigner struct {
+	threshold         int
+	msgIndex          int
+	partialSignatures [][]byte
+	baseSignatureSigner
+}
+
+func NewThresholdBBSG2SignatureSigner(threshold, msgIndex int,
+	partialSignatures [][]byte) *ThresholdBBSG2SignatureSigner {
+	return &ThresholdBBSG2SignatureSigner{
+		threshold:         threshold,
+		msgIndex:          msgIndex,
+		partialSignatures: partialSignatures,
+		baseSignatureSigner: baseSignatureSigner{
+			keyType:   "EC",
+			curve:     "BLS12381_G2",
+			algorithm: "main_threshold_bbs+",
+		},
+	}
+}
+
+func (tbs *ThresholdBBSG2SignatureSigner) Sign(data []byte) ([]byte, error) {
+	main_bbs := bbsplusthresholdpub.New()
+	sigBytes, err := main_bbs.SignWithPartialSignatures(tbs.partialSignatures)
+	if err != nil {
+		return nil, err
+	}
+	return sigBytes, nil
+}
+
+func (tbs *ThresholdBBSG2SignatureSigner) Alg() string {
+	return tbs.Algorithm()
+}
+
+func textToLines(txt string) [][]byte {
+	lines := strings.Split(txt, "\n")
+	linesBytes := make([][]byte, 0, len(lines))
+
+	for i := range lines {
+		if strings.TrimSpace(lines[i]) != "" {
+			linesBytes = append(linesBytes, []byte(lines[i]))
+		}
+	}
+
+	return linesBytes
+}
+
+func splitMessageIntoLines(msg string) [][]byte {
+	rows := strings.Split(msg, "\n")
+
+	msgs := make([][]byte, 0, len(rows))
+
+	for _, row := range rows {
+		if strings.TrimSpace(row) == "" {
+			continue
+		}
+
+		msgs = append(msgs, []byte(row))
+	}
+
+	return msgs
+}

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/hyperledger/ursa-wrapper-go v0.3.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiformats/go-multibase v0.1.1
-	github.com/perun-network/bbs-plus-threshold-wallet v0.0.0-20230927092152-14474bfdc486
 	github.com/piprate/json-gold v0.5.1-0.20230111113000-6ddbe6e6f19f
 	github.com/pkg/errors v0.9.1
 	github.com/rs/cors v1.7.0
@@ -83,3 +82,5 @@ require (
 )
 
 replace github.com/hyperledger/aries-framework-go/component/models => ./component/models
+
+replace github.com/hyperledger/aries-framework-go/component/kmscrypto => ./component/kmscrypto

--- a/go.mod
+++ b/go.mod
@@ -32,11 +32,13 @@ require (
 	github.com/hyperledger/ursa-wrapper-go v0.3.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiformats/go-multibase v0.1.1
+	github.com/perun-network/bbs-plus-threshold-wallet v0.0.0-20230927092152-14474bfdc486
 	github.com/piprate/json-gold v0.5.1-0.20230111113000-6ddbe6e6f19f
 	github.com/pkg/errors v0.9.1
 	github.com/rs/cors v1.7.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/crypto v0.1.0
+	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	nhooyr.io/websocket v1.8.3
 )
 
@@ -73,8 +75,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
-	golang.org/x/exp v0.0.0-20230728194245-b0cb94b80691 // indirect
-	golang.org/x/sys v0.2.0 // indirect
+	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/time v0.1.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,6 @@ github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hyperledger/aries-framework-go/component/didconfig v0.0.0-20230622211121-852ce35730b4 h1:6pkyx5TMJEZpau/HsDNSndZy+MrX9hJmWAtGM1UaGuI=
 github.com/hyperledger/aries-framework-go/component/didconfig v0.0.0-20230622211121-852ce35730b4/go.mod h1:SCS+CWl/U4qRgy540BAKvSlLHAUXrw29pmuhp3nMzbY=
-github.com/hyperledger/aries-framework-go/component/kmscrypto v0.0.0-20230622082138-3ffab1691857 h1:x7Lt4FAPmMNyKQCUhnUOYeDpskaHnRNrtZj4rKfSKfU=
-github.com/hyperledger/aries-framework-go/component/kmscrypto v0.0.0-20230622082138-3ffab1691857/go.mod h1:xgNlHAVQjqwoknzHbXkeHkAJgUxRWKfHXPT3nhVhH3Q=
 github.com/hyperledger/aries-framework-go/component/log v0.0.0-20230427134832-0c9969493bd3 h1:x5qFQraTX86z9GCwF28IxfnPm6QH5YgHaX+4x97Jwvw=
 github.com/hyperledger/aries-framework-go/component/log v0.0.0-20230427134832-0c9969493bd3/go.mod h1:CvYs4l8X2NrrF93weLOu5RTOIJeVdoZITtjEflyuTyM=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20221025204933-b807371b6f1e h1:/hrQfwJvHJrwV2FSmfnRp5L6yKY9DqDFqwYyb+oVuDU=
@@ -130,8 +128,6 @@ github.com/multiformats/go-varint v0.0.5/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXS
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/perun-network/bbs-plus-threshold-wallet v0.0.0-20230927092152-14474bfdc486 h1:AM+br2N8uaYK1MNcV7tEhUxjeuX2jYpOh5u/i2f88Os=
-github.com/perun-network/bbs-plus-threshold-wallet v0.0.0-20230927092152-14474bfdc486/go.mod h1:WjRbnozv0YGLMGYhp7zh2SUZvcdGMKFekqMRl0J2rGQ=
 github.com/piprate/json-gold v0.5.1-0.20230111113000-6ddbe6e6f19f h1:HlPa7RcxTCrva5izPfTEfvYecO7LTahgmMRD1Qp13xg=
 github.com/piprate/json-gold v0.5.1-0.20230111113000-6ddbe6e6f19f/go.mod h1:WZ501QQMbZZ+3pXFPhQKzNwS1+jls0oqov3uQ2WasLs=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/multiformats/go-varint v0.0.5/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXS
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/perun-network/bbs-plus-threshold-wallet v0.0.0-20230927092152-14474bfdc486 h1:AM+br2N8uaYK1MNcV7tEhUxjeuX2jYpOh5u/i2f88Os=
+github.com/perun-network/bbs-plus-threshold-wallet v0.0.0-20230927092152-14474bfdc486/go.mod h1:WjRbnozv0YGLMGYhp7zh2SUZvcdGMKFekqMRl0J2rGQ=
 github.com/piprate/json-gold v0.5.1-0.20230111113000-6ddbe6e6f19f h1:HlPa7RcxTCrva5izPfTEfvYecO7LTahgmMRD1Qp13xg=
 github.com/piprate/json-gold v0.5.1-0.20230111113000-6ddbe6e6f19f/go.mod h1:WZ501QQMbZZ+3pXFPhQKzNwS1+jls0oqov3uQ2WasLs=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -180,8 +182,8 @@ golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
-golang.org/x/exp v0.0.0-20230728194245-b0cb94b80691 h1:/yRP+0AN7mf5DkD3BAI6TOFnd51gEoDEb8o35jIFtgw=
-golang.org/x/exp v0.0.0-20230728194245-b0cb94b80691/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -191,8 +193,8 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
-golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.1.0 h1:xYY+Bajn2a7VBmTM5GikTmnK8ZuX8YgnQCqZpbBNtmA=

--- a/pkg/client/vcwallet/client.go
+++ b/pkg/client/vcwallet/client.go
@@ -160,12 +160,11 @@ func (c *Client) Close() bool {
 //	Returns exported locked wallet.
 //
 // Supported data models:
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Collection
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Credential
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#DIDResolutionResponse
-//	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#meta-data
-//	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
-//
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#Collection
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#Credential
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#DIDResolutionResponse
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#meta-data
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
 func (c *Client) Export(auth string) (json.RawMessage, error) {
 	// TODO to be added #2433
 	return nil, fmt.Errorf("to be implemented")
@@ -179,13 +178,12 @@ func (c *Client) Export(auth string) (json.RawMessage, error) {
 //		- auth: token used while exporting the wallet.
 //
 // Supported data models:
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Collection
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Credential
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#DIDResolutionResponse
-//	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#meta-data
-//	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
-//	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Key
-//
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#Collection
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#Credential
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#DIDResolutionResponse
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#meta-data
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#Key
 func (c *Client) Import(auth string, contents json.RawMessage) error {
 	// TODO to be added #2433
 	return fmt.Errorf("to be implemented")
@@ -194,12 +192,12 @@ func (c *Client) Import(auth string, contents json.RawMessage) error {
 // Add adds given data model to wallet contents store.
 //
 // Supported data models:
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Collection
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Credential
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#DIDResolutionResponse
-//	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#meta-data
-//	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
-//	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Key
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#Collection
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#Credential
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#DIDResolutionResponse
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#meta-data
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#Key
 //
 // TODO: (#2433) support for correlation between wallet contents (ex: credentials to a profile/collection).
 func (c *Client) Add(contentType wallet.ContentType, content json.RawMessage, options ...wallet.AddContentOptions) error { //nolint: lll
@@ -214,12 +212,11 @@ func (c *Client) Add(contentType wallet.ContentType, content json.RawMessage, op
 // Remove removes wallet content by content ID.
 //
 // Supported data models:
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Collection
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Credential
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#DIDResolutionResponse
-//	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#meta-data
-//	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
-//
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#Collection
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#Credential
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#DIDResolutionResponse
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#meta-data
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
 func (c *Client) Remove(contentType wallet.ContentType, contentID string) error {
 	auth, err := c.auth()
 	if err != nil {
@@ -232,12 +229,11 @@ func (c *Client) Remove(contentType wallet.ContentType, contentID string) error 
 // Get fetches a wallet content by content ID.
 //
 // Supported data models:
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Collection
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Credential
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#DIDResolutionResponse
-//	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#meta-data
-//	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
-//
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#Collection
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#Credential
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#DIDResolutionResponse
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#meta-data
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
 func (c *Client) Get(contentType wallet.ContentType, contentID string) (json.RawMessage, error) {
 	auth, err := c.auth()
 	if err != nil {
@@ -250,12 +246,11 @@ func (c *Client) Get(contentType wallet.ContentType, contentID string) (json.Raw
 // GetAll fetches all wallet contents of given type.
 //
 // Supported data models:
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Collection
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#Credential
-// 	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#DIDResolutionResponse
-//	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#meta-data
-//	- https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
-//
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#Collection
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#Credential
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#DIDResolutionResponse
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#meta-data
+//   - https://w3c-ccg.github.io/universal-wallet-interop-spec/#connection
 func (c *Client) GetAll(contentType wallet.ContentType, options ...wallet.GetAllContentsOptions) (map[string]json.RawMessage, error) { //nolint: lll
 	auth, err := c.auth()
 	if err != nil {
@@ -270,10 +265,9 @@ func (c *Client) GetAll(contentType wallet.ContentType, options ...wallet.GetAll
 // https://w3c-ccg.github.io/universal-wallet-interop-spec/#query
 //
 // Supported Query Types:
-// 	- https://www.w3.org/TR/json-ld11-framing
-// 	- https://identity.foundation/presentation-exchange
-// 	- https://w3c-ccg.github.io/vp-request-spec/#query-by-example
-//
+//   - https://www.w3.org/TR/json-ld11-framing
+//   - https://identity.foundation/presentation-exchange
+//   - https://w3c-ccg.github.io/vp-request-spec/#query-by-example
 func (c *Client) Query(params ...*wallet.QueryParams) ([]*verifiable.Presentation, error) {
 	auth, err := c.auth()
 	if err != nil {
@@ -288,7 +282,6 @@ func (c *Client) Query(params ...*wallet.QueryParams) ([]*verifiable.Presentatio
 //	Args:
 //		- A verifiable credential with or without proof
 //		- Proof options
-//
 func (c *Client) Issue(credential json.RawMessage,
 	options *wallet.ProofOptions) (*verifiable.Credential, error) {
 	auth, err := c.auth()
@@ -305,7 +298,6 @@ func (c *Client) Issue(credential json.RawMessage,
 //		- list of interfaces (string of credential IDs which can be resolvable to stored credentials in wallet or
 //		raw credential).
 //		- proof options
-//
 func (c *Client) Prove(opts *wallet.ProofOptions, creds ...wallet.ProveOptions) (*verifiable.Presentation, error) { //nolint: lll
 	auth, err := c.auth()
 	if err != nil {
@@ -335,7 +327,6 @@ func (c *Client) Verify(option wallet.VerificationOption) (bool, error) {
 //	Args:
 //		- credential to derive (ID of the stored credential, raw credential or credential instance).
 //		- derive options.
-//
 func (c *Client) Derive(credential wallet.CredentialToDerive, options *wallet.DeriveOptions) (*verifiable.Credential, error) { //nolint: lll
 	auth, err := c.auth()
 	if err != nil {
@@ -350,7 +341,6 @@ func (c *Client) Derive(credential wallet.CredentialToDerive, options *wallet.De
 //	Args:
 //		- authToken: authorization for performing create key pair operation.
 //		- keyType: type of the key to be created.
-//
 func (c *Client) CreateKeyPair(keyType kms.KeyType) (*wallet.KeyPair, error) {
 	auth, err := c.auth()
 	if err != nil {
@@ -363,13 +353,12 @@ func (c *Client) CreateKeyPair(keyType kms.KeyType) (*wallet.KeyPair, error) {
 // Connect accepts out-of-band invitations and performs DID exchange.
 //
 // Args:
-// 		- invitation: out-of-band invitation.
-// 		- options: connection options.
+//   - invitation: out-of-band invitation.
+//   - options: connection options.
 //
 // Returns:
-// 		- connection ID if DID exchange is successful.
-// 		- error if operation false.
-//
+//   - connection ID if DID exchange is successful.
+//   - error if operation false.
 func (c *Client) Connect(invitation *outofband.Invitation, options ...wallet.ConnectOptions) (string, error) {
 	auth, err := c.auth()
 	if err != nil {
@@ -388,13 +377,12 @@ func (c *Client) Connect(invitation *outofband.Invitation, options ...wallet.Con
 // [0454-present-proof-v2](https://github.com/hyperledger/aries-rfcs/tree/master/features/0454-present-proof-v2)
 //
 // Args:
-// 		- invitation: out-of-band invitation from relying party.
-// 		- options: options for accepting invitation and send propose presentation message.
+//   - invitation: out-of-band invitation from relying party.
+//   - options: options for accepting invitation and send propose presentation message.
 //
 // Returns:
-// 		- DIDCommMsgMap containing request presentation message if operation is successful.
-// 		- error if operation fails.
-//
+//   - DIDCommMsgMap containing request presentation message if operation is successful.
+//   - error if operation fails.
 func (c *Client) ProposePresentation(invitation *wallet.GenericInvitation, options ...wallet.InitiateInteractionOption) (*service.DIDCommMsgMap, error) { //nolint: lll
 	auth, err := c.auth()
 	if err != nil {
@@ -411,13 +399,12 @@ func (c *Client) ProposePresentation(invitation *wallet.GenericInvitation, optio
 // [0454-present-proof-v2](https://github.com/hyperledger/aries-rfcs/tree/master/features/0454-present-proof-v2)
 //
 // Args:
-// 		- thID: thread ID (action ID) of request presentation.
-// 		- presentation: presentation to be sent.
+//   - thID: thread ID (action ID) of request presentation.
+//   - presentation: presentation to be sent.
 //
 // Returns:
-// 		- Credential interaction status containing status, redirectURL.
-// 		- error if operation fails.
-//
+//   - Credential interaction status containing status, redirectURL.
+//   - error if operation fails.
 func (c *Client) PresentProof(thID string, presentProofFrom ...wallet.ConcludeInteractionOptions) (*wallet.CredentialInteractionStatus, error) { //nolint: lll
 	auth, err := c.auth()
 	if err != nil {
@@ -434,13 +421,12 @@ func (c *Client) PresentProof(thID string, presentProofFrom ...wallet.ConcludeIn
 // https://github.com/hyperledger/aries-rfcs/blob/main/features/0453-issue-credential-v2/README.md
 //
 // Args:
-// 		- invitation: out-of-band invitation from issuer.
-// 		- options: options for accepting invitation and send propose credential message.
+//   - invitation: out-of-band invitation from issuer.
+//   - options: options for accepting invitation and send propose credential message.
 //
 // Returns:
-// 		- DIDCommMsgMap containing offer credential message if operation is successful.
-// 		- error if operation fails.
-//
+//   - DIDCommMsgMap containing offer credential message if operation is successful.
+//   - error if operation fails.
 func (c *Client) ProposeCredential(invitation *wallet.GenericInvitation, options ...wallet.InitiateInteractionOption) (*service.DIDCommMsgMap, error) { // nolint: lll
 	auth, err := c.auth()
 	if err != nil {
@@ -458,13 +444,12 @@ func (c *Client) ProposeCredential(invitation *wallet.GenericInvitation, options
 // https://github.com/hyperledger/aries-rfcs/blob/main/features/0453-issue-credential-v2/README.md
 //
 // Args:
-// 		- thID: thread ID (action ID) of offer credential message previously received.
-// 		- concludeInteractionOptions: options to conclude interaction like presentation to be shared etc.
+//   - thID: thread ID (action ID) of offer credential message previously received.
+//   - concludeInteractionOptions: options to conclude interaction like presentation to be shared etc.
 //
 // Returns:
-// 		- Credential interaction status containing status, redirectURL.
-// 		- error if operation fails.
-//
+//   - Credential interaction status containing status, redirectURL.
+//   - error if operation fails.
 func (c *Client) RequestCredential(thID string, options ...wallet.ConcludeInteractionOptions) (*wallet.CredentialInteractionStatus, error) { // nolint: lll
 	auth, err := c.auth()
 	if err != nil {
@@ -478,14 +463,13 @@ func (c *Client) RequestCredential(thID string, options ...wallet.ConcludeIntera
 // Supports: https://identity.foundation/credential-manifest/
 //
 // Args:
-// 		- authToken: authorization for performing operation.
-// 		- manifest: Credential manifest data model in raw format.
-// 		- resolve: options to provide credential response or credential to resolve.
+//   - authToken: authorization for performing operation.
+//   - manifest: Credential manifest data model in raw format.
+//   - resolve: options to provide credential response or credential to resolve.
 //
 // Returns:
-// 		- list of resolved descriptors.
-// 		- error if operation fails.
-//
+//   - list of resolved descriptors.
+//   - error if operation fails.
 func (c *Client) ResolveCredentialManifest(manifest json.RawMessage, resolve wallet.ResolveManifestOption) ([]*cm.ResolvedDescriptor, error) { // nolint: lll
 	auth, err := c.auth()
 	if err != nil {

--- a/pkg/client/vcwallet/thresholdwallet/aries_wallet.go
+++ b/pkg/client/vcwallet/thresholdwallet/aries_wallet.go
@@ -1,0 +1,340 @@
+package thresholdwallet
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hyperledger/aries-framework-go/pkg/client/vcwallet"
+	"github.com/hyperledger/aries-framework-go/pkg/crypto"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/hyperledger/aries-framework-go/pkg/wallet"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+	bls12381 "github.com/kilic/bls12-381"
+	"github.com/perun-network/bbs-plus-threshold-wallet/fhks_bbs_plus"
+	thwallet "github.com/perun-network/bbs-plus-threshold-wallet/wallet"
+	"github.com/piprate/json-gold/ld"
+	"golang.org/x/exp/slices"
+)
+
+const (
+	walletExpiry = 10 * time.Minute
+)
+
+// provider contains dependencies for the verifiable credential wallet client
+// and is typically created by using aries.Context().
+type provider interface {
+	StorageProvider() storage.Provider
+	VDRegistry() vdr.Registry
+	Crypto() crypto.Crypto
+	JSONLDDocumentLoader() ld.DocumentLoader
+	MediaTypeProfiles() []string
+	didCommProvider // to be used only if wallet needs to be participated in DIDComm.
+}
+
+// didCommProvider to be used only if wallet needs to be participated in DIDComm operation.
+// TODO: using wallet KMS instead of provider KMS.
+// TODO: reconcile Protocol storage with wallet store.
+type didCommProvider interface {
+	KMS() kms.KeyManager
+	ServiceEndpoint() string
+	ProtocolStateStorageProvider() storage.Provider
+	Service(id string) (interface{}, error)
+	KeyType() kms.KeyType
+	KeyAgreementType() kms.KeyType
+}
+
+type Client struct {
+	userID        string
+	vcwallet      *vcwallet.Client
+	isExpired     bool
+	collectionIDs []string
+}
+
+func New(userID string, ctx provider, options ...wallet.UnlockOptions) (*Client, error) {
+	vcwallet, err := vcwallet.New(userID, ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		userID:        userID,
+		vcwallet:      vcwallet,
+		isExpired:     true,
+		collectionIDs: make([]string, 0),
+	}, nil
+}
+
+// CreateProfile creates a new verifiable credential wallet profile for given user.
+// returns error if wallet profile is already created.
+// Use `UpdateProfile()` for replacing an already created verifiable credential wallet profile.
+func CreateProfile(userID string, ctx provider, options ...wallet.ProfileOptions) error {
+	return wallet.CreateProfile(userID, ctx, options...)
+}
+
+// UpdateProfile updates existing verifiable credential wallet profile.
+// Will create new profile if no profile exists for given user.
+// Caution: you might lose your existing keys if you change kms options.
+func UpdateProfile(userID string, ctx provider, options ...wallet.ProfileOptions) error {
+	return wallet.UpdateProfile(userID, ctx, options...)
+}
+
+// ProfileExists checks if profile exists for given wallet user, returns error if not found.
+func ProfileExists(userID string, ctx provider) error {
+	return wallet.ProfileExists(userID, ctx)
+}
+
+func (c *Client) Open() error {
+	if err := c.vcwallet.Open(wallet.WithUnlockExpiry(walletExpiry)); err != nil {
+		return err
+	}
+	c.isExpired = false
+	c.watchExpiry()
+	return nil
+}
+
+func (c *Client) Close() error {
+	if !c.isExpired {
+		c.vcwallet.Close()
+		c.isExpired = true
+	}
+	return nil
+}
+
+func (c *Client) Store(document *thwallet.Document) error {
+	// Check if the document's collection is already stored.
+	if !slices.Contains(c.collectionIDs, document.CollectionID) {
+		collection := newCollection(document.CollectionID, c.userID)
+		collectionBytes, err := json.Marshal(collection)
+		if err != nil {
+			return fmt.Errorf("marshal collection: %w", err)
+		}
+		err = c.vcwallet.Add(wallet.Collection, collectionBytes)
+		if err != nil {
+			return fmt.Errorf("add a new collection to wallet: %w", err)
+		}
+		c.collectionIDs = append(c.collectionIDs, collection.ID)
+	}
+
+	// Store document based on its type.
+	switch document.Type {
+	case thwallet.Credential:
+		cred, err := newCredential(document)
+		if err != nil {
+			return fmt.Errorf("create credential: %w", err)
+		}
+		credBytes, err := cred.MarshalJSON()
+		if err != nil {
+			return fmt.Errorf("marshal credential: %w", err)
+		}
+		err = c.vcwallet.Add(wallet.Credential,
+			credBytes,
+			wallet.AddByCollection(document.CollectionID))
+		if err != nil {
+			return fmt.Errorf("add new credential to wallet: %w", err)
+		}
+	case thwallet.Signature, thwallet.Presignature, thwallet.PartialSignature, thwallet.SecretKey, thwallet.PublicKey:
+		metadata, err := newMetadata(document)
+		if err != nil {
+			return fmt.Errorf("create signature: %w", err)
+		}
+		metadataBytes, err := json.Marshal(metadata)
+		if err != nil {
+			return fmt.Errorf("marshal signature: %w", err)
+		}
+		err = c.vcwallet.Add(wallet.Metadata,
+			metadataBytes,
+			wallet.AddByCollection(document.CollectionID))
+		if err != nil {
+			return fmt.Errorf("add metadata to collection: %w", err)
+		}
+	default:
+		return errors.New("unknown document type")
+	}
+	return nil
+}
+
+func (c *Client) AddCollection(collectionID string) error {
+	collection := newCollection(collectionID, c.userID)
+	collectionBytes, err := json.Marshal(collection)
+	if err != nil {
+		return fmt.Errorf("marshal collection: %w", err)
+	}
+	err = c.vcwallet.Add(wallet.Collection, collectionBytes)
+	if err != nil {
+		return fmt.Errorf("add a new collection to wallet: %w", err)
+	}
+	c.collectionIDs = append(c.collectionIDs, collection.ID)
+	return nil
+}
+
+func (c *Client) Get(contentType thwallet.ContentType, documentID string) (*thwallet.Document, error) {
+	switch contentType {
+	case thwallet.Credential:
+		credentialBytes, err := c.vcwallet.Get(wallet.Credential, documentID)
+		if err != nil {
+			return nil, err
+		}
+		var credential verifiable.Credential
+		err = json.Unmarshal(credentialBytes, &credential)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshal credential bytes: %w", err)
+		}
+		document, err := documentFromSubject(credential.Subject)
+		if err != nil {
+			return nil, fmt.Errorf("retrieve document from credential: %w", err)
+		}
+		if document.Type == thwallet.Credential {
+			return document, nil
+		}
+		return nil, errors.New("document has wrong type")
+	case thwallet.Signature, thwallet.Presignature, thwallet.PartialSignature, thwallet.PublicKey, thwallet.SecretKey:
+		metadataBytes, err := c.vcwallet.Get(wallet.Metadata, documentID)
+		if err != nil {
+			return nil, err
+		}
+		var metadata ThresholdWalletMetaData
+		err = json.Unmarshal(metadataBytes, &metadata)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshal metadata  bytes: %w", err)
+		}
+		document := metadata.Subject
+		if document.Type == contentType {
+			return document, nil
+		}
+		return nil, errors.New("document has wrong type")
+
+	default:
+		return nil, errors.New("unsupported document type")
+	}
+}
+
+func (c *Client) GetCollection(collectionID string) ([]*thwallet.Document, error) {
+	var collection []*thwallet.Document
+
+	// Get all credentials from the collection.
+	credentials, err := c.vcwallet.GetAll(wallet.Credential, wallet.FilterByCollection(collectionID+collectionID))
+	if err != nil {
+		return nil, fmt.Errorf("get credentials with collection id %s: %w", collectionID, err)
+	}
+	for key, value := range credentials {
+		var credential verifiable.Credential
+		err := json.Unmarshal(value, &credential)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshal credential %s: %w", key, err)
+		}
+		document, err := documentFromSubject(credential.Subject)
+		if err != nil {
+			return nil, fmt.Errorf("retrieve document from credential: %w", err)
+		}
+		collection = append(collection, document)
+	}
+
+	// Get all metadatas from the collection
+	metadatas, err := c.vcwallet.GetAll(wallet.Metadata, wallet.FilterByCollection(collectionID))
+	if err != nil {
+		return nil, fmt.Errorf("get signatures with collection id %s: %w", collectionID, err)
+	}
+	for key, value := range metadatas {
+		var metadata ThresholdWalletMetaData
+		err := json.Unmarshal(value, &metadata)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshal metadata %s: %w", key, err)
+		}
+
+		document := metadata.Subject
+		collection = append(collection, document)
+	}
+	return collection, nil
+}
+
+func (c *Client) Remove(contentType thwallet.ContentType, documentID string) error {
+	switch contentType {
+	case thwallet.Credential:
+		err := c.vcwallet.Remove(wallet.Credential, documentID)
+		if err != nil {
+			return err
+		}
+		return nil
+	case thwallet.Signature, thwallet.Presignature, thwallet.PartialSignature, thwallet.SecretKey, thwallet.PublicKey:
+		err := c.vcwallet.Remove(wallet.Metadata, documentID)
+		if err != nil {
+			return err
+		}
+		return nil
+	default:
+		return errors.New("remove content type not supported")
+	}
+}
+
+func (c *Client) VerifyThresholdSignature(
+	credentials []*thwallet.Document,
+	signature *thwallet.Document,
+	publicKey *thwallet.Document) (bool, error) {
+
+	if credentials[0] == nil {
+		return false, errors.New("empty credentials list")
+	}
+	var messages []*bls12381.Fr
+	collectionID := credentials[0].CollectionID
+	for _, credential := range credentials {
+		if credential.Type != thwallet.Credential {
+			return false, errors.New("unsupported document type")
+		}
+		if collectionID != credential.CollectionID {
+			return false, errors.New("unmatching collection ID")
+		}
+		message := bls12381.NewFr().FromBytes(credential.Content)
+		messages = append(messages, message)
+	}
+	if signature.Type != thwallet.Signature {
+		return false, errors.New("type failed signature")
+	}
+	if publicKey.Type != thwallet.PublicKey {
+		return false, errors.New("type failed public key")
+	}
+
+	thresholdSig := fhks_bbs_plus.NewThresholdSignature()
+	err := thresholdSig.FromBytes(signature.Content)
+	if err != nil {
+		return false, fmt.Errorf("decode threshold signature: %w", err)
+	}
+
+	pk := &fhks_bbs_plus.PublicKey{}
+	err = pk.FromBytes(publicKey.Content)
+	if err != nil {
+		return false, fmt.Errorf("decode public key: %w", err)
+	}
+
+	return thresholdSig.Verify(messages, pk), nil
+}
+
+func (c *Client) RemoveCollection(collectionID string) error {
+	err := c.vcwallet.Remove(wallet.Collection, collectionID)
+	if err != nil {
+		return fmt.Errorf("remove collection from wallet: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) watchExpiry() {
+	timeout := time.After(walletExpiry)
+	expiredSignal := make(chan bool)
+	for {
+		if c.isExpired {
+			expiredSignal <- c.isExpired
+		}
+		select {
+		case <-timeout:
+			c.isExpired = true
+			log.Print("Wallet expired!")
+			return
+		case <-expiredSignal:
+			log.Print("Wallet is closed.")
+			return
+		}
+	}
+}

--- a/pkg/client/vcwallet/thresholdwallet/holder.go
+++ b/pkg/client/vcwallet/thresholdwallet/holder.go
@@ -1,0 +1,385 @@
+package thresholdwallet
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"time"
+
+	jsonld "github.com/hyperledger/aries-framework-go/component/models/ld/processor"
+	ldproof "github.com/hyperledger/aries-framework-go/component/models/ld/proof"
+	"github.com/hyperledger/aries-framework-go/component/models/signature/signer"
+	"github.com/hyperledger/aries-framework-go/pkg/client/vcwallet"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/bbsblssignature2020"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/hyperledger/aries-framework-go/pkg/wallet"
+	"golang.org/x/exp/slices"
+)
+
+type Holder struct {
+	userID        string
+	vcwallet      *vcwallet.Client
+	context       provider
+	collectionIDs []string
+	threshold     int
+	msgIndex      int
+	maxIndex      int
+	partySigners  []*PartySigner
+}
+
+func NewHolder(userID string, k int, ctx provider, options ...wallet.UnlockOptions) (*Holder, error) {
+	vcwallet, err := vcwallet.New(userID, ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &Holder{
+		userID:        userID,
+		vcwallet:      vcwallet,
+		context:       ctx,
+		collectionIDs: make([]string, 0),
+		threshold:     -1,
+		maxIndex:      k,
+		msgIndex:      0,
+		partySigners:  make([]*PartySigner, 0),
+	}, nil
+}
+
+func (c *Holder) Open(options ...wallet.UnlockOptions) error {
+	if err := c.vcwallet.Open(options...); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Holder) Close() error {
+	c.vcwallet.Close()
+	return nil
+}
+
+func (c *Holder) Store(document *Document) error {
+	// Check if the document's collection is already stored.
+	if !slices.Contains(c.collectionIDs, document.CollectionID) {
+		collection := newCollection(document.CollectionID, c.userID)
+		collectionBytes, err := json.Marshal(collection)
+		if err != nil {
+			return fmt.Errorf("marshal collection: %w", err)
+		}
+		err = c.vcwallet.Add(wallet.Collection, collectionBytes)
+		if err != nil {
+			return fmt.Errorf("add a new collection to wallet: %w", err)
+		}
+		c.collectionIDs = append(c.collectionIDs, collection.ID)
+	}
+
+	// Store document based on its type.
+	switch document.Type {
+	case Credential:
+		cred, err := credentialFromDocument(document)
+		if err != nil {
+			return fmt.Errorf("create credential: %w", err)
+		}
+		credBytes, err := cred.MarshalJSON()
+		if err != nil {
+			return fmt.Errorf("marshal credential: %w", err)
+		}
+		err = c.vcwallet.Add(wallet.Credential,
+			credBytes,
+			wallet.AddByCollection(document.CollectionID))
+		if err != nil {
+			return fmt.Errorf("add new credential to wallet: %w", err)
+		}
+	case Precomputation, PublicKey:
+		metadata, err := newMetadata(document)
+		if err != nil {
+			return fmt.Errorf("create signature: %w", err)
+		}
+		metadataBytes, err := json.Marshal(metadata)
+		if err != nil {
+			return fmt.Errorf("marshal signature: %w", err)
+		}
+		err = c.vcwallet.Add(wallet.Metadata,
+			metadataBytes,
+			wallet.AddByCollection(document.CollectionID))
+		if err != nil {
+			return fmt.Errorf("add metadata to collection: %w", err)
+		}
+	default:
+		return errors.New("unknown document type")
+	}
+	return nil
+}
+
+func (c *Holder) AddCollection(collectionID string) error {
+	collection := newCollection(collectionID, c.userID)
+	collectionBytes, err := json.Marshal(collection)
+	if err != nil {
+		return fmt.Errorf("marshal collection: %w", err)
+	}
+	err = c.vcwallet.Add(wallet.Collection, collectionBytes)
+	if err != nil {
+		return fmt.Errorf("add a new collection to wallet: %w", err)
+	}
+	c.collectionIDs = append(c.collectionIDs, collection.ID)
+	return nil
+}
+
+func (c *Holder) Get(contentType ContentType, documentID string, collectionID string) (*Document, error) {
+	switch contentType {
+	case Credential:
+		credentialsBytes, err := c.vcwallet.GetAll(wallet.Credential, wallet.FilterByCollection(collectionID))
+		if err != nil {
+			return nil, err
+		}
+		document, err := documentFromCredential(credentialsBytes[documentID], collectionID)
+		if err != nil {
+			return nil, fmt.Errorf("retrieve document from credential: %w", err)
+		}
+		return document, nil
+	case Precomputation, PublicKey:
+		metadatasBytes, err := c.vcwallet.GetAll(wallet.Metadata, wallet.FilterByCollection(collectionID))
+		if err != nil {
+			return nil, err
+		}
+		var metadata ThresholdWalletMetaData
+		err = json.Unmarshal(metadatasBytes[documentID], &metadata)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshal metadata  bytes: %w", err)
+		}
+		document := metadata.Subject
+		if document.Type == contentType {
+			return document, nil
+		}
+		return nil, errors.New("document has wrong type")
+
+	default:
+		return nil, errors.New("unsupported document type")
+	}
+}
+
+func (c *Holder) GetCollection(collectionID string) ([]*Document, error) {
+	var collection []*Document
+
+	// Get all credentials from the collection.
+	credentials, err := c.vcwallet.GetAll(wallet.Credential, wallet.FilterByCollection(collectionID+collectionID))
+	if err != nil {
+		return nil, fmt.Errorf("get credentials with collection id %s: %w", collectionID, err)
+	}
+	for _, value := range credentials {
+		document, err := documentFromCredential(value, collectionID)
+		if err != nil {
+			return nil, fmt.Errorf("retrieve document from credential: %w", err)
+		}
+		collection = append(collection, document)
+	}
+
+	// Get all metadatas from the collection
+	metadatas, err := c.vcwallet.GetAll(wallet.Metadata, wallet.FilterByCollection(collectionID))
+	if err != nil {
+		return nil, fmt.Errorf("get signatures with collection id %s: %w", collectionID, err)
+	}
+	for key, value := range metadatas {
+		var metadata ThresholdWalletMetaData
+		err := json.Unmarshal(value, &metadata)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshal metadata %s: %w", key, err)
+		}
+
+		document := metadata.Subject
+		collection = append(collection, document)
+	}
+	return collection, nil
+}
+
+func (c *Holder) Remove(contentType ContentType, documentID string) error {
+	switch contentType {
+	case Credential:
+		err := c.vcwallet.Remove(wallet.Credential, documentID)
+		if err != nil {
+			return err
+		}
+		return nil
+	case Precomputation, PublicKey:
+		err := c.vcwallet.Remove(wallet.Metadata, documentID)
+		if err != nil {
+			return err
+		}
+		return nil
+	default:
+		return errors.New("remove content type not supported")
+	}
+}
+
+func (c *Holder) RemoveCollection(collectionID string) error {
+	err := c.vcwallet.Remove(wallet.Collection, collectionID)
+	if err != nil {
+		return fmt.Errorf("remove collection from wallet: %w", err)
+	}
+	return nil
+}
+
+func (c *Holder) Sign(credential *Document) (*Document, error) {
+	vc, err := verifiable.ParseCredential(credential.Content,
+		verifiable.WithJSONLDDocumentLoader(c.context.JSONLDDocumentLoader()),
+		verifiable.WithCredDisableValidation(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	created := time.Now()
+	indices := generateRandomIndices(c.threshold, len(c.partySigners))
+	partialSignatures := make([][]byte, c.threshold)
+	for i := 0; i < c.threshold; i++ {
+		partialCredential := NewDocument(Credential, credential.Content, credential.CollectionID)
+		partialCredential.Indices = indices
+		partialCredential.MsgIndex = c.msgIndex
+		partialCredential.Created = &created
+		partialSignedCredential, err := c.partySigners[indices[i]-1].Sign(partialCredential)
+		if err != nil {
+			return nil, err
+		}
+
+		partialSignedVC, err := verifiable.ParseCredential(partialSignedCredential.Content,
+			verifiable.WithJSONLDDocumentLoader(c.context.JSONLDDocumentLoader()),
+			verifiable.WithCredDisableValidation(),
+			verifiable.WithDisabledProofCheck(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		partialSignature, err := validatePartialSignature(partialSignedVC.Proofs[0])
+		if err != nil {
+			return nil, err
+		}
+
+		partialSignatures[i] = partialSignature
+	}
+
+	thresholdSigner := signer.NewThresholdBBSG2SignatureSigner(c.threshold, credential.MsgIndex, partialSignatures)
+	sigSuite := bbsblssignature2020.New(
+		suite.WithSigner(thresholdSigner),
+		suite.WithVerifier(bbsblssignature2020.NewG2PublicKeyVerifier()))
+
+	ldpContext := &verifiable.LinkedDataProofContext{
+		SignatureType:           "BbsBlsSignature2020",
+		SignatureRepresentation: verifiable.SignatureProofValue,
+		Suite:                   sigSuite,
+		VerificationMethod:      "did:bbspublickey#key",
+		Created:                 &created,
+	}
+
+	err = vc.AddLinkedDataProof(ldpContext, jsonld.WithDocumentLoader(c.context.JSONLDDocumentLoader()))
+	if err != nil {
+		return nil, err
+	}
+
+	vcSignedBytes, err := json.Marshal(vc)
+	if err != nil {
+		return nil, err
+	}
+	credential.Content = vcSignedBytes
+	return credential, nil
+}
+
+func (c *Holder) Verify(signedCredential *Document, publicKey *Document) (bool, error) {
+	_, err := verifiable.ParseCredential(signedCredential.Content,
+		verifiable.WithJSONLDDocumentLoader(c.context.JSONLDDocumentLoader()),
+		verifiable.WithPublicKeyFetcher(verifiable.SingleKey(publicKey.Content, "Bls12381G2Key2020")))
+	if err != nil {
+		return false, fmt.Errorf("credential verification failed: %w", err)
+	}
+	return true, nil
+}
+
+func (c *Holder) AddPartySigner(ps *PartySigner) error {
+	if ps == nil {
+		return errors.New("nil pointer party signer")
+	}
+	if c.partySigners == nil {
+		c.partySigners = make([]*PartySigner, 0)
+	}
+	c.partySigners = append(c.partySigners, ps)
+	return nil
+}
+
+func (c *Holder) RemovePartySigner(psID string) error {
+	var newPartySigners []*PartySigner
+
+	for _, party := range c.partySigners {
+		if party.userID != psID {
+			newPartySigners = append(newPartySigners, party)
+		}
+	}
+
+	if len(newPartySigners) == len(c.partySigners) {
+		return fmt.Errorf("party wallet with ID %s not found", psID)
+	}
+
+	c.partySigners = newPartySigners
+	return nil
+}
+
+func (c *Holder) SetThreshold(threshold int) error {
+	if len(c.partySigners) < threshold {
+		return errors.New("threshold out of bound")
+	}
+	c.threshold = threshold
+	return nil
+}
+
+func (c *Holder) SetNexMsgIndex(nextMsgIndex int) error {
+	if nextMsgIndex >= c.maxIndex {
+		return errors.New("next message out of bound")
+	}
+	c.msgIndex = nextMsgIndex
+	return nil
+}
+
+func generateRandomIndices(threshold, numOfParties int) []int {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	used := make(map[int]bool)
+
+	indices := make([]int, 0)
+	for len(indices) < threshold {
+		r := rng.Intn(numOfParties) + 1
+		if !used[r] {
+			used[r] = true
+			indices = append(indices, r)
+		}
+	}
+	return indices
+}
+
+// validatePartialSignature checks the verifiable proof,
+// and returns the actual partial signature if the format is correct.
+func validatePartialSignature(proof verifiable.Proof) ([]byte, error) {
+
+	sigType, ok := proof["type"].(string)
+	if !ok {
+		return nil, errors.New("missing type")
+	}
+	if sigType != "BbsBlsSignature2020" {
+		return nil, errors.New("false signature type")
+	}
+
+	verificationMethod, ok := proof["verificationMethod"].(string)
+	if !ok {
+		return nil, errors.New("missing verfication method")
+	}
+	if verificationMethod != "did:bbspublickey#key" {
+		return nil, errors.New("false verification method")
+	}
+
+	proofValue, ok := proof["proofValue"].(string)
+	if !ok {
+		return nil, errors.New("missing proofValue")
+	}
+
+	partialSignatureBytes, err := ldproof.DecodeProofValue(proofValue, "BbsBlsSignature2020")
+	if err != nil {
+		return nil, err
+	}
+	return partialSignatureBytes, nil
+}

--- a/pkg/client/vcwallet/thresholdwallet/issue_credential_test.go
+++ b/pkg/client/vcwallet/thresholdwallet/issue_credential_test.go
@@ -1,0 +1,171 @@
+package thresholdwallet
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/didexchange"
+	"github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/mediator"
+	"github.com/hyperledger/aries-framework-go/pkg/internal/ldtestutil"
+	"github.com/hyperledger/aries-framework-go/pkg/wallet"
+	"github.com/stretchr/testify/require"
+
+	issuecredentialsvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/issuecredential"
+	outofbandSvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/outofband"
+	oobv2 "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/outofbandv2"
+	presentproofSvc "github.com/hyperledger/aries-framework-go/pkg/didcomm/protocol/presentproof"
+	mockoutofbandv2 "github.com/hyperledger/aries-framework-go/pkg/internal/gomocks/client/outofbandv2"
+	mockdidexchange "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/didexchange"
+	mockissuecredential "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/issuecredential"
+	mockmediator "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/mediator"
+	mockoutofband "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/outofband"
+	mockpresentproof "github.com/hyperledger/aries-framework-go/pkg/mock/didcomm/protocol/presentproof"
+	mockprovider "github.com/hyperledger/aries-framework-go/pkg/mock/provider"
+	mockstorage "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
+)
+
+const (
+	sampleHolderID = "sample-holder"
+	sampleSignerID = "sample-signer%d"
+
+	samplePassPhrase = "fakepassphrase"
+
+	threshold = 2 // threshold number t (-out of n)
+	n         = 3 // number of participating servers
+	k         = 1 // number of generated precomputations
+
+)
+
+func TestIssueThresholdCredential(t *testing.T) {
+	vcJSON := `
+	{
+	 "@context": [
+	   "https://www.w3.org/2018/credentials/v1",
+	   "https://w3id.org/citizenship/v1",
+	   "https://w3id.org/security/bbs/v1"
+	 ],
+	 "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
+	 "type": [
+	   "VerifiableCredential",
+	   "PermanentResidentCard"
+	 ],
+	 "issuer": "did:example:489398593",
+	 "identifier": "83627465",
+	 "name": "Permanent Resident Card",
+	 "description": "Government of Example Permanent Resident Card.",
+	 "issuanceDate": "2019-12-03T12:19:52Z",
+	 "expirationDate": "2029-12-03T12:19:52Z",
+	 "credentialSubject": {
+	   "id": "did:example:b34ca6cd37bbf23",
+	   "type": [
+	     "PermanentResident",
+	     "Person"
+	   ],
+	   "givenName": "JOHN",
+	   "familyName": "SMITH",
+	   "gender": "Male",
+	   "image": "data:image/png;base64,iVBORw0KGgokJggg==",
+	   "residentSince": "2015-01-01",
+	   "lprCategory": "C09",
+	   "lprNumber": "999-999-999",
+	   "commuterClassification": "C1",
+	   "birthCountry": "Bahamas",
+	   "birthDate": "1958-07-17"
+	 }
+	}
+	`
+	t.Run("test simple issue credential protocol between holder and partial signers", func(t *testing.T) {
+		// Init Holder's wallet.
+		mockctxHolder := newMockProvider(t)
+		err := CreateProfile(sampleHolderID, mockctxHolder, wallet.WithPassphrase(samplePassPhrase))
+		require.NoError(t, err)
+		holder, err := NewHolder(sampleHolderID, k, mockctxHolder, wallet.WithUnlockByPassphrase(samplePassPhrase))
+		require.NoError(t, err)
+		require.NotNil(t, holder)
+
+		// Init Party Signers' wallets.
+		signers := make([]*PartySigner, n)
+		for i := 0; i < n; i++ {
+			mockctxSigner := newMockProvider(t)
+			err = CreateProfile(fmt.Sprintf(sampleSignerID, i), mockctxSigner, wallet.WithPassphrase(samplePassPhrase))
+			require.NoError(t, err)
+			signers[i], err = NewPartySigner(fmt.Sprintf(sampleSignerID, i), mockctxSigner, wallet.WithUnlockByPassphrase(samplePassPhrase))
+			require.NoError(t, err)
+			require.NotNil(t, signers[i])
+
+			// holder adds contacts of signers.
+			err = holder.AddPartySigner(signers[i])
+			require.NoError(t, err)
+		}
+
+		// Set threshold after all signers have been added.
+		err = holder.SetThreshold(threshold)
+		require.NoError(t, err)
+
+		// Init Precomputation's generator.
+		thresholdbbsplusGenerator := NewThresholdBBSPlusGenerator()
+		seed := make([]byte, 32)
+		_, err = rand.Read(seed)
+		require.NoError(t, err)
+
+		collectionID, publicKeyDoc, precomputationDocs, err := thresholdbbsplusGenerator.GeneratePrecomputation(sha256.New, seed, threshold, n, k)
+		require.NoError(t, err)
+		for idx, signer := range signers {
+			err := signer.AddCollection(collectionID)
+			require.NoError(t, err)
+
+			err = signer.Store(publicKeyDoc)
+			require.NoError(t, err)
+
+			err = signer.Store(precomputationDocs[idx])
+			require.NoError(t, err)
+		}
+
+		// Generate credential Document
+		credentialDoc, err := documentFromCredential([]byte(vcJSON), collectionID)
+		require.NoError(t, err)
+		require.NotNil(t, credentialDoc)
+
+		// Set credential's index
+		nextMsgIndex, err := thresholdbbsplusGenerator.NextMsgIndex()
+		require.NoError(t, err)
+		err = holder.SetNexMsgIndex(nextMsgIndex)
+		require.NoError(t, err)
+		signedCredentialDoc, err := holder.Sign(credentialDoc)
+		require.NoError(t, err)
+		require.NotNil(t, signedCredentialDoc)
+
+		signedCredential, err := credentialFromDocument(signedCredentialDoc)
+		require.NoError(t, err)
+		require.NotNil(t, signedCredential.Proofs)
+
+		verificationResult, err := holder.Verify(signedCredentialDoc, publicKeyDoc)
+		require.NoError(t, err)
+		require.True(t, verificationResult)
+	})
+}
+
+func newMockProvider(t *testing.T) *mockprovider.Provider {
+	t.Helper()
+
+	loader, err := ldtestutil.DocumentLoader()
+	require.NoError(t, err)
+
+	serviceMap := map[string]interface{}{
+		presentproofSvc.Name:    &mockpresentproof.MockPresentProofSvc{},
+		outofbandSvc.Name:       &mockoutofband.MockOobService{},
+		didexchange.DIDExchange: &mockdidexchange.MockDIDExchangeSvc{},
+		mediator.Coordination:   &mockmediator.MockMediatorSvc{},
+		issuecredentialsvc.Name: &mockissuecredential.MockIssueCredentialSvc{},
+		oobv2.Name:              &mockoutofbandv2.MockOobService{},
+	}
+
+	return &mockprovider.Provider{
+		StorageProviderValue:              mockstorage.NewMockStoreProvider(),
+		ProtocolStateStorageProviderValue: mockstorage.NewMockStoreProvider(),
+		DocumentLoaderValue:               loader,
+		ServiceMap:                        serviceMap,
+	}
+}

--- a/pkg/client/vcwallet/thresholdwallet/metadata.go
+++ b/pkg/client/vcwallet/thresholdwallet/metadata.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
-	"github.com/perun-network/bbs-plus-threshold-wallet/wallet"
 )
 
 type ThresholdWalletCollection struct {
@@ -15,10 +14,10 @@ type ThresholdWalletCollection struct {
 }
 
 type ThresholdWalletMetaData struct {
-	Context []string         `json:"@context,omitempty"`
-	ID      string           `json:"id,omitempty"`
-	Type    string           `json:"type,omitempty"`
-	Subject *wallet.Document `json:"subject,omitempty"`
+	Context []string  `json:"@context,omitempty"`
+	ID      string    `json:"id,omitempty"`
+	Type    string    `json:"type,omitempty"`
+	Subject *Document `json:"subject,omitempty"`
 }
 
 func newCollection(id, name string) *ThresholdWalletCollection {
@@ -30,25 +29,37 @@ func newCollection(id, name string) *ThresholdWalletCollection {
 	}
 }
 
-func newCredential(document *wallet.Document) (*verifiable.Credential, error) {
+func credentialFromDocument(document *Document) (*verifiable.Credential, error) {
 	if document == nil {
 		return nil, errors.New("nil pointer to document")
 	}
-	if document.Type != wallet.Credential {
+	if document.Type != Credential {
 		return nil, errors.New("incorrect type of document")
 	}
-	return &verifiable.Credential{
-		Context: []string{verifiable.ContextURI},
-		ID:      document.ID,
-		Types:   []string{"ThresholdCredential"},
-		Subject: document,
-		Issuer: verifiable.Issuer{
-			ID: document.Author,
-		},
+	vc, err := verifiable.ParseCredential(document.Content,
+		verifiable.WithCredDisableValidation(),
+		verifiable.WithDisabledProofCheck(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return vc, nil
+}
+
+func documentFromCredential(vcByte []byte, collectionID string) (*Document, error) {
+	vc, err := verifiable.ParseCredential(vcByte, verifiable.WithCredDisableValidation())
+	if err != nil {
+		return nil, err
+	}
+	return &Document{
+		ID:           vc.ID,
+		Type:         Credential,
+		Content:      vcByte,
+		CollectionID: collectionID,
 	}, nil
 }
 
-func newMetadata(document *wallet.Document) (*ThresholdWalletMetaData, error) {
+func newMetadata(document *Document) (*ThresholdWalletMetaData, error) {
 	if document == nil {
 		return nil, errors.New("nil pointer to document")
 	}
@@ -57,44 +68,5 @@ func newMetadata(document *wallet.Document) (*ThresholdWalletMetaData, error) {
 		ID:      document.ID,
 		Type:    string(document.Type),
 		Subject: document,
-	}, nil
-}
-
-func documentFromSubject(subject interface{}) (*wallet.Document, error) {
-	subjectMap, ok := subject.(map[string]interface{})
-	if !ok {
-		return nil, errors.New("incorrect interface type: not a map[string]interface{}")
-	}
-
-	documentID, ok := subjectMap["id"].(string)
-	if !ok {
-		return nil, errors.New("missing id")
-	}
-
-	contentType, ok := subjectMap["type"].(string)
-	if !ok {
-		return nil, errors.New("missing content type")
-	}
-
-	content, ok := subjectMap["content"].(string)
-	if !ok {
-		return nil, errors.New("missing content")
-	}
-
-	collectionID, ok := subjectMap["collectionID"].(string)
-	if !ok {
-		return nil, errors.New("missing collectionID")
-	}
-
-	author, ok := subjectMap["author"].(string)
-	if !ok {
-		return nil, errors.New("missing author")
-	}
-	return &wallet.Document{
-		ID:           documentID,
-		Type:         wallet.ContentType(contentType),
-		Content:      []byte(content),
-		CollectionID: collectionID,
-		Author:       author,
 	}, nil
 }

--- a/pkg/client/vcwallet/thresholdwallet/metadata.go
+++ b/pkg/client/vcwallet/thresholdwallet/metadata.go
@@ -1,0 +1,100 @@
+package thresholdwallet
+
+import (
+	"errors"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/perun-network/bbs-plus-threshold-wallet/wallet"
+)
+
+type ThresholdWalletCollection struct {
+	Context []string `json:"@context,omitempty"`
+	ID      string   `json:"id,omitempty"`
+	Type    string   `json:"type,omitempty"`
+	Name    string   `json:"name,omitempty"`
+}
+
+type ThresholdWalletMetaData struct {
+	Context []string         `json:"@context,omitempty"`
+	ID      string           `json:"id,omitempty"`
+	Type    string           `json:"type,omitempty"`
+	Subject *wallet.Document `json:"subject,omitempty"`
+}
+
+func newCollection(id, name string) *ThresholdWalletCollection {
+	return &ThresholdWalletCollection{
+		Context: []string{"https://w3id.org/wallet/v1"},
+		ID:      id,
+		Type:    "collection",
+		Name:    name,
+	}
+}
+
+func newCredential(document *wallet.Document) (*verifiable.Credential, error) {
+	if document == nil {
+		return nil, errors.New("nil pointer to document")
+	}
+	if document.Type != wallet.Credential {
+		return nil, errors.New("incorrect type of document")
+	}
+	return &verifiable.Credential{
+		Context: []string{verifiable.ContextURI},
+		ID:      document.ID,
+		Types:   []string{"ThresholdCredential"},
+		Subject: document,
+		Issuer: verifiable.Issuer{
+			ID: document.Author,
+		},
+	}, nil
+}
+
+func newMetadata(document *wallet.Document) (*ThresholdWalletMetaData, error) {
+	if document == nil {
+		return nil, errors.New("nil pointer to document")
+	}
+	return &ThresholdWalletMetaData{
+		Context: []string{"https://w3id.org/wallet/v1"},
+		ID:      document.ID,
+		Type:    string(document.Type),
+		Subject: document,
+	}, nil
+}
+
+func documentFromSubject(subject interface{}) (*wallet.Document, error) {
+	subjectMap, ok := subject.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("incorrect interface type: not a map[string]interface{}")
+	}
+
+	documentID, ok := subjectMap["id"].(string)
+	if !ok {
+		return nil, errors.New("missing id")
+	}
+
+	contentType, ok := subjectMap["type"].(string)
+	if !ok {
+		return nil, errors.New("missing content type")
+	}
+
+	content, ok := subjectMap["content"].(string)
+	if !ok {
+		return nil, errors.New("missing content")
+	}
+
+	collectionID, ok := subjectMap["collectionID"].(string)
+	if !ok {
+		return nil, errors.New("missing collectionID")
+	}
+
+	author, ok := subjectMap["author"].(string)
+	if !ok {
+		return nil, errors.New("missing author")
+	}
+	return &wallet.Document{
+		ID:           documentID,
+		Type:         wallet.ContentType(contentType),
+		Content:      []byte(content),
+		CollectionID: collectionID,
+		Author:       author,
+	}, nil
+}

--- a/pkg/client/vcwallet/thresholdwallet/precomputation_generator.go
+++ b/pkg/client/vcwallet/thresholdwallet/precomputation_generator.go
@@ -1,0 +1,8 @@
+package thresholdwallet
+
+import "hash"
+
+type PrecomputationsGenerator interface {
+	GeneratePrecomputation(h func() hash.Hash, seed []byte, t, n, k int) (*Document, []*Document, error)
+	NextMsgIndex() (int, error)
+}

--- a/pkg/client/vcwallet/thresholdwallet/precomputation_generator.go
+++ b/pkg/client/vcwallet/thresholdwallet/precomputation_generator.go
@@ -3,6 +3,11 @@ package thresholdwallet
 import "hash"
 
 type PrecomputationsGenerator interface {
+	// GeneratePrecomputation generate the precomputations for each party
+	// and returns the public key and precomputations for each party as a Document.
 	GeneratePrecomputation(h func() hash.Hash, seed []byte, t, n, k int) (*Document, []*Document, error)
+	
+	// NextMsgIndex returns the next to be used presignature index.
+	// Returns an error if there are no presignatures left.
 	NextMsgIndex() (int, error)
 }

--- a/pkg/client/vcwallet/thresholdwallet/threshold_document.go
+++ b/pkg/client/vcwallet/thresholdwallet/threshold_document.go
@@ -1,0 +1,45 @@
+package thresholdwallet
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ContentType is the document content type.
+type ContentType string
+
+const (
+	Credential     ContentType = "credential"
+	Precomputation ContentType = "precomputation"
+	PublicKey      ContentType = "public_key"
+
+	// ID templates
+	CollectionIDTemplate string = "did:collection:%s"
+	DocumentIDTemplate   string = "did:%s:%s"
+)
+
+type Document struct {
+	ID           string      `json:"id"`           // Unique Identifier for the document.
+	Type         ContentType `json:"type"`         // Type of the document.
+	Content      []byte      `json:"content"`      // The content of the document.
+	CollectionID string      `json:"collectionID"` // Identifier for linking documents.
+	Indices      []int       `json:"indices,omitempty"`
+	MsgIndex     int         `json:"msgIndex,omitempty"`
+	Created      *time.Time
+}
+
+func NewDocument(
+	contentType ContentType,
+	content []byte,
+	collectionID string) *Document {
+	return &Document{
+		ID:           fmt.Sprintf(DocumentIDTemplate, contentType, uuid.New().URN()),
+		Type:         contentType,
+		Content:      content,
+		CollectionID: collectionID,
+		Indices:      nil,
+		MsgIndex:     -1,
+	}
+}

--- a/pkg/client/vcwallet/thresholdwallet/thresholdbbsplus_generator.go
+++ b/pkg/client/vcwallet/thresholdwallet/thresholdbbsplus_generator.go
@@ -1,0 +1,63 @@
+package thresholdwallet
+
+import (
+	"errors"
+	"fmt"
+	"hash"
+
+	"github.com/google/uuid"
+	"github.com/hyperledger/aries-framework-go/component/kmscrypto/crypto/primitive/bbsplusthresholdpub"
+)
+
+// ThresholdBBSGenetor implemented precomputation generator
+// using the threshold bbs plus algorithm at /component/kmscrypto/primitive/bbsplusthresholdpub
+type ThresholdBBSGenerator struct {
+	nextMsgIndex int
+	maxMsgIndex  int
+}
+
+// NewThresholdBBSPlusGenerator returns a new instance of Precomputation generator
+// implementing the threshold bbs+ algorithm.
+func NewThresholdBBSPlusGenerator() *ThresholdBBSGenerator {
+	return &ThresholdBBSGenerator{
+		nextMsgIndex: 0,
+		maxMsgIndex:  0,
+	}
+}
+
+func (tbg *ThresholdBBSGenerator) GeneratePrecomputation(h func() hash.Hash, seed []byte, t, n, k int) (string, *Document, []*Document, error) {
+	pubKey, _, precomputations, err := bbsplusthresholdpub.GenerateKeyPair(h, seed, t, n, k)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	collectionID := fmt.Sprintf(CollectionIDTemplate, uuid.New().URN())
+	pubKeyByte, err := pubKey.Marshal()
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	publicKeyDoc := NewDocument(PublicKey, pubKeyByte, collectionID)
+	precomputationDocs := make([]*Document, 0)
+	for _, precomputation := range precomputations {
+		precomputationByte, err := precomputation.ToBytes()
+		if err != nil {
+			return "", nil, nil, err
+		}
+		precomputationDoc := NewDocument(Precomputation, precomputationByte, collectionID)
+		precomputationDocs = append(precomputationDocs, precomputationDoc)
+	}
+
+	tbg.nextMsgIndex = 0
+	tbg.maxMsgIndex = k
+
+	return collectionID, publicKeyDoc, precomputationDocs, nil
+}
+
+func (tbg *ThresholdBBSGenerator) NextMsgIndex() (int, error) {
+	nextMsgIndex := tbg.nextMsgIndex
+	if nextMsgIndex >= tbg.maxMsgIndex {
+		return -1, errors.New("out of precomputations")
+	}
+	tbg.nextMsgIndex++
+	return nextMsgIndex, nil
+}

--- a/pkg/client/vcwallet/thresholdwallet/wallet.go
+++ b/pkg/client/vcwallet/thresholdwallet/wallet.go
@@ -1,0 +1,33 @@
+package thresholdwallet
+
+type Wallet interface {
+	// Open opens makes the wallet's services available.
+	Open() error
+
+	// Close shutdowns the wallet's services.
+	Close() error
+
+	// Store adds a new document to wallet.
+	Store(document *Document) error
+
+	// AddCollection adds a new collection to wallet.
+	AddCollection(collectionID string) error
+
+	// Get retrieves a document from the wallet based on its content type and ID.
+	Get(contentType ContentType, documentID string) (*Document, error)
+
+	// GetCollection retrieves all documents from a collection based on the collectionID.
+	GetCollection(collectionID string) ([]*Document, error)
+
+	// Remove removes a document from the wallet based on its ID.
+	Remove(contentType ContentType, documentID string) error
+
+	// RemoveCollection removes an entire collection from the wallet.
+	RemoveCollection(collectionID string) error
+
+	// Sign signs the credential and produces a signed credential.
+	Sign(credential *Document) (*Document, error)
+
+	// Verify verifies the signature of the credential with the provided public key.
+	Verify(signedCredential *Document, publicKey *Document) (bool, error)
+}


### PR DESCRIPTION


**Integration of Threshold BBS+ with VCWallet:**
The goal is to implement Threshold Wallet Client for Aries with the use of VCWallet package and Threshold BBS+ as signature scheme.


**Description:**
The primitive  implementation of threshold bbs+ can be found in `component/crypto/primitive`, while the implementation of threshold wallet clients is in `pkg/client/vcwallet/thresholdwallet`.

The signer for the threshold bbs+ scheme is located in `component/models/signature/signer/threshold_bbs_signer.go`. The verifier for threshold bb+ can be reused from the normal bbs+ verifier.

**Summary:**

- Implementation of threshold bbs+ signature schemes in Aries.
- Implementation of partial signature signers.
- Implementation of Threshold Wallet clients (Holder and Partial Signers) 
- Interfaces and Implementation of Documents, Threshold Wallet Clients, Precomputation Generator.
- Simple Issue Credential Protocol Test (`pkg/client/vcwallet/thresholdwallet/issue_credential_test.go`).

**Future Changes**

- [ ] Unit tests for threshold wallet clients.
- [ ] Fail cases for issue credential test.
- [ ] Partial signers unit test.
- [ ] Documentation of implemented code.
